### PR TITLE
fix(agent): rescue text-emitted tool-call markup in native mode (#3220) + normalize judge verdict tokens

### DIFF
--- a/changelog.d/3220.fixed.md
+++ b/changelog.d/3220.fixed.md
@@ -1,0 +1,15 @@
+- **Native tool_format: tool calls emitted as chat-template text markup are no longer silently
+  dropped (#3220).** Cheap native-format models (observed live: qwen3.6 under long context) sometimes
+  fall back to their chat template's TEXT rendering of a tool call —
+  `<tool_call><function=edit><parameter=action>...</parameter></function></tool_call>` or the
+  `<invoke name="edit">` attribute spelling — which the native parse path ignored entirely, so the
+  turn read as a natural completion and the run ended with the call lost. The tagged text parser now
+  rescue-parses this markup into real calls (schema-typed parameter values: string params keep raw
+  bytes verbatim, non-string params parse as JSON; unknown tools and truncated `<parameter>` blocks
+  surface precise parse errors instead of dispatching partial values; prose mentions and fenced
+  examples never fire — the opener must be line-anchored outside a markdown fence). In native
+  sessions the existing `native_tool_fallback` contract then takes over: the default `reject` policy
+  injects "re-issue through the native tool channel" feedback and the loop continues; `allow`
+  dispatches the rescued call. A zero-call turn whose markup could not be promoted (parse error,
+  feedback queued) no longer reads as a native natural completion — the loop holds the turn open so
+  the parse guidance reaches the model.

--- a/changelog.d/judge-verdict-json-junk.fixed.md
+++ b/changelog.d/judge-verdict-json-junk.fixed.md
@@ -1,0 +1,8 @@
+- **Judge verdicts no longer carry trailing JSON junk.** When a structured completion/step judge
+  emits sloppy JSON (double commas, run-on key/value pairs) that the structured-call repair layer
+  salvages, the captured `verdict` string could include trailing junk — observed live in
+  `judge_decision` events as `continue",,` and `continue",  "reasoning":`. `__judge_classify_verdict`
+  now normalizes the captured verdict to its leading token (cut at the first JSON structural
+  character), so stored/emitted `judge_decision` / `step_judge_decision` verdicts are clean tokens
+  and a mangled PASS token (`done",,`) classifies as a pass instead of being wrongly vetoed.
+  Multi-word prose verdicts without JSON junk pass through unchanged.

--- a/conformance/tests/agents/agent_loop_native_text_markup_rescue.expected
+++ b/conformance/tests/agents/agent_loop_native_text_markup_rescue.expected
@@ -1,0 +1,12 @@
+done
+3
+true
+true
+1
+done
+true
+2
+done
+3
+true
+true

--- a/conformance/tests/agents/agent_loop_native_text_markup_rescue.harn
+++ b/conformance/tests/agents/agent_loop_native_text_markup_rescue.harn
@@ -1,0 +1,115 @@
+// #3220: in a NATIVE tool-format session, a model that falls back to its
+// chat template's TEXT rendering of a tool call (qwen style:
+// `<tool_call><function=NAME><parameter=KEY>...</parameter></function></tool_call>`)
+// must NOT end the run with the call silently dropped. The parser promotes
+// the markup into a parsed call; the loop's native-fallback contract then
+// either injects "re-issue natively" feedback (default `reject` policy) or
+// dispatches the rescued call (`allow`), and post-turn never reads the
+// markup turn as a natural completion.
+import { llm_text, with_llm_script } from "std/testing"
+
+fn lookup_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "lookup",
+    "Return release evidence",
+    {
+      handler: { args -> "evidence for " + args.query },
+      parameters: {query: {type: "string", description: "Lookup query"}},
+      returns: {type: "string"},
+      annotations: {kind: "read"},
+    },
+  )
+  return tools
+}
+
+const MARKUP_TURN = "<tool_call>\n<function=lookup>\n<parameter=query>\nfollow-up evidence\n</parameter>\n</function>\n</tool_call>"
+
+pipeline main() {
+  // Default policy (reject): the markup turn must continue the loop with
+  // native-contract feedback instead of completing — the live failure was a
+  // natural completion on exactly this turn shape, losing the call.
+  with_llm_script(
+    [
+      {tool_calls: [{id: "lookup_1", name: "lookup", arguments: {query: "release"}}]},
+      llm_text(MARKUP_TURN),
+      llm_text("Final answer: release evidence verified."),
+    ],
+    { ->
+      let result = agent_loop(
+        "Inspect evidence and finish.",
+        nil,
+        {
+          provider: "mock",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          done_judge: nil,
+          max_iterations: 6,
+        },
+      )
+      let calls = llm_mock_calls()
+      __io_println(result.status)
+      __io_println(len(calls))
+      let feedback_messages = json_stringify(calls[2].messages)
+      __io_println(contains(feedback_messages, "emitted text-mode tool calls"))
+      __io_println(contains(feedback_messages, "native tool channel"))
+      __io_println(len(result.tools.successful))
+    },
+  )
+  // `allow` policy: the rescued markup call dispatches this turn.
+  with_llm_script(
+    [llm_text(MARKUP_TURN), llm_text("All set.")],
+    { ->
+      let result = agent_loop(
+        "Look up the evidence.",
+        nil,
+        {
+          provider: "mock",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          done_judge: nil,
+          max_iterations: 4,
+          native_tool_fallback: "allow",
+        },
+      )
+      __io_println(result.status)
+      __io_println(contains(result.tools.successful, "lookup"))
+      __io_println(len(llm_mock_calls()))
+    },
+  )
+  // Truncated markup (output cut off mid-parameter): the parser refuses to
+  // dispatch the partial value and raises a parse error instead. The
+  // post-turn gate must hold the loop open so the queued parse-guidance
+  // feedback reaches the model — without it this zero-call turn reads as a
+  // natural completion and the feedback is lost.
+  with_llm_script(
+    [
+      {tool_calls: [{id: "lookup_1", name: "lookup", arguments: {query: "release"}}]},
+      llm_text("<tool_call>\n<function=lookup>\n<parameter=query>\nfollow-up evi"),
+      llm_text("Final answer: release evidence verified."),
+    ],
+    { ->
+      let result = agent_loop(
+        "Inspect evidence and finish.",
+        nil,
+        {
+          provider: "mock",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          done_judge: nil,
+          max_iterations: 6,
+        },
+      )
+      let calls = llm_mock_calls()
+      __io_println(result.status)
+      __io_println(len(calls))
+      let feedback_messages = json_stringify(calls[2].messages)
+      __io_println(contains(feedback_messages, "parse_guidance"))
+      __io_println(contains(feedback_messages, "TRUNCATED"))
+    },
+  )
+}

--- a/crates/harn-stdlib/src/stdlib/agent/judge_internals.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/judge_internals.harn
@@ -34,6 +34,42 @@ pub fn __judge_apply_llm_overrides(llm_opts, judge_cfg) {
 }
 
 /**
+ * JSON structural characters can never be part of a legitimate verdict
+ * token, so a captured verdict containing one was mangled upstream.
+ */
+const __JUDGE_VERDICT_JSON_JUNK = ["\"", ",", "{", "}", ":", "\\"]
+
+/**
+ * Normalize a captured judge verdict to its leading token. Structured
+ * judges occasionally emit sloppy JSON (double commas, run-on key/value
+ * pairs) that the structured-call repair layer salvages by capturing
+ * trailing JSON junk into the verdict string — observed live in
+ * `judge_decision` events as `continue",,` and `continue",  "reasoning":`.
+ * Cut at the first JSON structural character and trim; verdicts without
+ * JSON junk (including multi-word prose verdicts) pass through unchanged.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: internal
+ * @example: __judge_verdict_token("continue\",,")
+ */
+pub fn __judge_verdict_token(raw_verdict) {
+  let normalized = lowercase(trim(to_string(raw_verdict ?? "")))
+  var cut = len(normalized)
+  for junk in __JUDGE_VERDICT_JSON_JUNK {
+    let idx = normalized.index_of(junk)
+    if idx >= 0 && idx < cut {
+      cut = idx
+    }
+  }
+  if cut == len(normalized) {
+    return normalized
+  }
+  return trim(normalized[0:cut])
+}
+
+/**
  * Classify a raw verdict string against an allow-list of pass tokens and
  * compose the `{vetoed, feedback?}` outcome. `feedback_candidates` is
  * tried in order: the first non-nil, non-empty entry wins. Falls back
@@ -41,6 +77,9 @@ pub fn __judge_apply_llm_overrides(llm_opts, judge_cfg) {
  *
  * Used by `agent_step_judge` (pass tokens like "pass"/"yes"/"approve") and
  * by `agent_verify_or_continue` (pass tokens like "done"/"complete").
+ * The raw verdict is normalized through `__judge_verdict_token` first, so
+ * a verdict that captured trailing JSON junk still classifies correctly
+ * and the stored/emitted `verdict` field carries the clean token.
  *
  * @effects: []
  * @allocation: heap
@@ -49,7 +88,7 @@ pub fn __judge_apply_llm_overrides(llm_opts, judge_cfg) {
  * @example: __judge_classify_verdict("pass", ["pass", "yes"], [critique], default)
  */
 pub fn __judge_classify_verdict(raw_verdict, pass_tokens, feedback_candidates, feedback_default) {
-  let normalized = lowercase(trim(to_string(raw_verdict ?? "")))
+  let normalized = __judge_verdict_token(raw_verdict)
   if contains(pass_tokens, normalized) {
     return {vetoed: false, verdict: normalized}
   }

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -2881,6 +2881,8 @@ fn __agent_loop_run(message, session, initial_opts) {
         _consecutive_text_only: consecutive_text_only,
         _done_judge_invocations: done_judge_invocations,
         _done_judge_loop_state: cadence_loop_state,
+        _turn_tool_call_feedback: (fallback_outcome.triggered && !fallback_outcome.accepted)
+          || had_parse_errors,
       }
       let outcome = __agent_loop_with_llm_render_context(
         turn_llm_opts,
@@ -3133,6 +3135,11 @@ fn __agent_loop_run(message, session, initial_opts) {
   return unwrap(run)
 }
 
+// #3220: this turn attempted a tool call that did not dispatch — the
+// native-fallback contract rejected text-emitted calls (corrective
+// feedback queued), or the parser dropped every call and parse
+// guidance was injected. Post-turn must not read the turn's prose as
+// a completion signal.
 // A turn whose calls were all dropped by the parser gets the purpose-built
 // parse-guidance feedback (not the generic no-progress nudge), and is
 // excluded from the no-progress stall streak below.

--- a/crates/harn-stdlib/src/stdlib/agent/postturn.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/postturn.harn
@@ -182,6 +182,19 @@ fn __native_tool_text_completion(opts, has_tool_calls, text) {
   if !__native_completion_context(opts, has_tool_calls, text) {
     return false
   }
+  // #3220: a zero-dispatch turn that ATTEMPTED a tool call as text is a
+  // failed call, not a completion signal. The loop already queued the
+  // corrective feedback this turn (the native-fallback contract note, or
+  // parse guidance for markup the parser could not promote into a call), so
+  // give the model the next turn instead of reading the prose as "done".
+  // Live failure: in a native session qwen3.6 emitted a `<function=edit>`
+  // call as plain text on its final turn; the native path ignored the text,
+  // the turn read as a natural completion, and the run ended with the edit
+  // lost. An explicit done sentinel still wins (it is an intentional host
+  // contract); this only stops the implicit prose-means-done read.
+  if opts?._turn_tool_call_feedback ?? false {
+    return false
+  }
   if !__zero_tool_completion_context(opts, has_tool_calls, text) {
     return true
   }

--- a/crates/harn-vm/src/llm/tools/parse/tagged.rs
+++ b/crates/harn-vm/src/llm/tools/parse/tagged.rs
@@ -1,5 +1,6 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
+use super::super::type_expr::TypeExpr;
 use super::super::{text_tool_call_block, TEXT_TOOL_CALL_TAG, TEXT_TOOL_CALL_TAG_COMPACT};
 use super::bare::parse_bare_calls_in_body;
 use super::syntax::{
@@ -206,6 +207,34 @@ pub(crate) fn parse_text_tool_calls_with_tools(
                 // truncation diagnostic below.
                 Ok(None) => {}
             }
+            // Chat-template function markup with an unclosed wrapper (#3220):
+            // `<tool_call>` + `<function=edit>...` where the model never
+            // emitted `</tool_call>`. Complete parameter blocks make the call
+            // recoverable; a truncated parameter surfaces its precise error.
+            match parse_function_markup_body(body, tools_val) {
+                Ok(Some(call)) => {
+                    let name = call
+                        .get("name")
+                        .and_then(|name| name.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let args = call
+                        .get("arguments")
+                        .cloned()
+                        .unwrap_or(serde_json::json!({}));
+                    canonical_parts
+                        .push(text_tool_call_block(&render_canonical_call(&name, &args)));
+                    calls.push(call);
+                    cursor = bytes.len();
+                    continue;
+                }
+                Err(msg) => {
+                    errors.push(msg);
+                    cursor = bytes.len();
+                    continue;
+                }
+                Ok(None) => {}
+            }
             let recovered_name = leading_call_name(body, tools_val);
             match recovered_name {
                 Some(name) => errors.push(format!(
@@ -282,6 +311,39 @@ pub(crate) fn parse_text_tool_calls_with_tools(
                  subsequent turns."
             ));
             cursor = after_call;
+        } else if let Some(outcome) = try_parse_top_level_function_markup(src, cursor, tools_val) {
+            // Chat-template function markup with no `<tool_call>` wrapper
+            // (#3220): `<function=edit><parameter=...>...</parameter></function>`
+            // or `<invoke name="edit">...</invoke>` emitted as plain text.
+            // Line anchoring and the markdown-fence guard above keep prose
+            // mentioning the syntax and fenced examples out of this branch.
+            match outcome {
+                Ok((call, after)) => {
+                    let name = call
+                        .get("name")
+                        .and_then(|name| name.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let args = call
+                        .get("arguments")
+                        .cloned()
+                        .unwrap_or(serde_json::json!({}));
+                    canonical_parts
+                        .push(text_tool_call_block(&render_canonical_call(&name, &args)));
+                    calls.push(call);
+                    violations.push(format!(
+                        "Tool call `{name}` was emitted as chat-template function markup \
+                         instead of `<tool_call>{name}({{ ... }})</tool_call>`. Recovered \
+                         this turn so work moves forward; emit the canonical form on \
+                         subsequent turns."
+                    ));
+                    cursor = after;
+                }
+                Err((msg, after)) => {
+                    errors.push(msg);
+                    cursor = after;
+                }
+            }
         } else if let Some(skip) = stray_tool_call_close_len(src, cursor) {
             // A bare, orphaned `</tool_call>` (or `</toolcall>`). Weak value
             // models duplicate the close after a recovered nested-XML body
@@ -943,6 +1005,11 @@ fn parse_single_tool_call(
     if let Some(call) = parse_xml_wrapped_json_args_body(body, tools_val)? {
         return Ok(call);
     }
+    // Chat-template function markup inside the wrapper (#3220):
+    // `<tool_call><function=edit><parameter=action>...</parameter></function></tool_call>`.
+    if let Some(call) = parse_function_markup_body(body, tools_val)? {
+        return Ok(call);
+    }
     let inner = parse_bare_calls_in_body(body, tools_val);
     if let Some(err) = inner.errors.into_iter().next() {
         return Err(err);
@@ -1175,6 +1242,231 @@ fn balanced_json_object_len(src: &str) -> Option<usize> {
         }
     }
     None
+}
+
+/// Opening markers for the chat-template "function markup" rendering of a
+/// tool call. `<function=NAME>` is the qwen3 chat-template style; `<invoke
+/// name="NAME">` is the attribute spelling other templates use.
+const FUNCTION_MARKUP_OPEN: &str = "<function=";
+const INVOKE_MARKUP_OPEN: &str = "<invoke name=";
+
+/// Parse the chat-template "function markup" rendering of a tool call that
+/// native-format models (observed live: qwen3.6 under long context, #3220)
+/// sometimes emit as plain assistant text instead of using the provider's
+/// structured tool channel:
+///
+/// ```text
+/// <function=edit>
+/// <parameter=action>
+/// create
+/// </parameter>
+/// </function>
+/// ```
+///
+/// or the attribute spelling `<invoke name="edit">` +
+/// `<parameter name="action">create</parameter>` + `</invoke>`.
+///
+/// `body` is the markup WITHOUT the optional `<tool_call>` wrapper. Returns:
+/// * `Ok(None)` — body does not open with a plausible function-markup tag
+///   (the caller falls through to its other recovery paths);
+/// * `Ok(Some(call))` — a complete markup block for a registered tool. A
+///   missing `</function>` / `</invoke>` close is tolerated as long as every
+///   `<parameter ...>` block is itself properly closed (some emissions close
+///   only the outer `</tool_call>`);
+/// * `Err(msg)` — recognizably function markup but unusable: unknown tool,
+///   an unterminated `<parameter ...>` block (truncation — never dispatch a
+///   partial argument value), or a second call sharing the block. The message
+///   is model-facing parse feedback.
+///
+/// Parameter values are typed against the registered tool schema: parameters
+/// the schema declares as strings (or whose schema entry is missing) keep
+/// their raw bytes verbatim — code in an `edit` `content` value is never
+/// JSON-mangled — while non-string parameters are parsed as JSON with a
+/// fallback to the raw string.
+fn parse_function_markup_body(
+    body: &str,
+    tools_val: Option<&VmValue>,
+) -> Result<Option<serde_json::Value>, String> {
+    let trimmed = body.trim();
+    let (name, after_open, close_tag, style) =
+        if let Some(rest) = trimmed.strip_prefix(FUNCTION_MARKUP_OPEN) {
+            let Some(gt) = rest.find('>') else {
+                return Err(
+                    "TOOL CALL TRUNCATED: a `<function=` open tag was never closed with `>` — \
+                     the response appears to have been cut off. The call was NOT executed; \
+                     re-emit the complete call."
+                        .to_string(),
+                );
+            };
+            (
+                rest[..gt].trim().trim_matches('"'),
+                &rest[gt + 1..],
+                "</function>",
+                "`<function=...>`",
+            )
+        } else if let Some(rest) = trimmed.strip_prefix(INVOKE_MARKUP_OPEN) {
+            let Some(gt) = rest.find('>') else {
+                return Err(
+                    "TOOL CALL TRUNCATED: an `<invoke name=` open tag was never closed with \
+                     `>` — the response appears to have been cut off. The call was NOT \
+                     executed; re-emit the complete call."
+                        .to_string(),
+                );
+            };
+            (
+                rest[..gt].trim().trim_matches('"'),
+                &rest[gt + 1..],
+                "</invoke>",
+                "`<invoke name=...>`",
+            )
+        } else {
+            return Ok(None);
+        };
+    // Require a plausible tool identifier; anything else is not tool-call
+    // markup (e.g. prose like `<function=a tool of your choice>`), so let the
+    // caller's other paths classify it.
+    if name.is_empty()
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+    {
+        return Ok(None);
+    }
+    let known = known_tool_names_with_implicit(tools_val);
+    if !known.contains(name) {
+        let available: Vec<_> = known.iter().take(20).cloned().collect();
+        return Err(format!(
+            "Unknown tool '{name}' in chat-template {style} tool-call markup. \
+             Available tools: [{}]",
+            available.join(", ")
+        ));
+    }
+    // Anything after the close tag (a stray `</tool_call>`, whitespace) is
+    // tolerated slop. A missing close tag is tolerated only when every
+    // parameter block below is itself closed — see the leftover check.
+    let inner = match after_open.find(close_tag) {
+        Some(idx) => &after_open[..idx],
+        None => after_open,
+    };
+    let param_types: BTreeMap<String, TypeExpr> = collect_tool_schemas(tools_val, None)
+        .into_iter()
+        .find(|schema| schema.name == name)
+        .map(|schema| {
+            schema
+                .params
+                .into_iter()
+                .map(|param| (param.name, param.ty))
+                .collect()
+        })
+        .unwrap_or_default();
+    let param_re = regex::Regex::new(
+        r#"(?s)<parameter(?:=([A-Za-z0-9_][A-Za-z0-9_.-]*)|\s+name="([^"]+)")\s*>(.*?)</parameter>"#,
+    )
+    .expect("valid function-markup parameter regex");
+    let mut args = serde_json::Map::new();
+    let mut covered: Vec<(usize, usize)> = Vec::new();
+    for captures in param_re.captures_iter(inner) {
+        let whole = captures.get(0).expect("whole parameter match");
+        covered.push((whole.start(), whole.end()));
+        let key = captures
+            .get(1)
+            .or_else(|| captures.get(2))
+            .map(|m| m.as_str())
+            .unwrap_or("")
+            .to_string();
+        let raw = captures.get(3).map(|m| m.as_str()).unwrap_or("");
+        let value = function_markup_param_value(raw, param_types.get(&key));
+        args.insert(key, value);
+    }
+    let leftover = prose_without_ranges(inner, &covered);
+    if leftover.contains("<parameter") {
+        return Err(format!(
+            "TOOL CALL TRUNCATED: a `<parameter ...>` block in the {style} markup for \
+             `{name}` was never closed with `</parameter>` — the response appears to have \
+             been cut off. The call was NOT executed; re-emit the complete call."
+        ));
+    }
+    if leftover.contains(FUNCTION_MARKUP_OPEN) || leftover.contains(INVOKE_MARKUP_OPEN) {
+        return Err(format!(
+            "The {style} markup block for `{name}` contained more than one call; \
+             emit one call per <tool_call> block."
+        ));
+    }
+    Ok(Some(serde_json::json!({
+        "id": format!("tc_fnmarkup_{name}"),
+        "name": name,
+        "arguments": serde_json::Value::Object(args),
+    })))
+}
+
+/// Type a raw function-markup parameter value against its schema entry.
+///
+/// The chat-template markup carries no type information — values are raw
+/// text framed by the template's own newlines. Strip exactly one leading and
+/// one trailing newline (the template's framing, not the value's), then:
+/// string-typed (or schema-unknown) parameters keep the framed bytes
+/// verbatim; non-string parameters are parsed as JSON, falling back to the
+/// raw string when they don't parse.
+fn function_markup_param_value(raw: &str, ty: Option<&TypeExpr>) -> serde_json::Value {
+    let framed = raw
+        .strip_prefix("\r\n")
+        .or_else(|| raw.strip_prefix('\n'))
+        .unwrap_or(raw);
+    let framed = framed
+        .strip_suffix("\r\n")
+        .or_else(|| framed.strip_suffix('\n'))
+        .unwrap_or(framed);
+    let wants_string = ty.map(type_expr_wants_string).unwrap_or(true);
+    if wants_string {
+        return serde_json::Value::String(framed.to_string());
+    }
+    match serde_json::from_str::<serde_json::Value>(framed.trim()) {
+        Ok(value) => value,
+        Err(_) => serde_json::Value::String(framed.to_string()),
+    }
+}
+
+/// True when a schema type only admits string values, so a raw markup value
+/// must be kept verbatim rather than JSON-parsed.
+fn type_expr_wants_string(ty: &TypeExpr) -> bool {
+    match ty {
+        TypeExpr::Primitive(name) => name == "string",
+        TypeExpr::Literal(value) => value.is_string(),
+        TypeExpr::Union(items) => items.iter().all(type_expr_wants_string),
+        _ => false,
+    }
+}
+
+/// Try to parse top-level chat-template function markup (no `<tool_call>`
+/// wrapper) at `cursor`. Returns `None` when the cursor is not on a
+/// plausible function-markup opener; otherwise the parsed call or the
+/// model-facing diagnostic, each paired with the cursor position after the
+/// consumed block. Line anchoring and markdown-fence exclusion are enforced
+/// by the caller (the main scanner checks both before dispatching tags), so
+/// prose mentioning the syntax inline or fenced examples never reach this.
+#[allow(clippy::type_complexity)]
+fn try_parse_top_level_function_markup(
+    src: &str,
+    cursor: usize,
+    tools_val: Option<&VmValue>,
+) -> Option<Result<(serde_json::Value, usize), (String, usize)>> {
+    let rest = &src[cursor..];
+    let close_tag = if rest.starts_with(FUNCTION_MARKUP_OPEN) {
+        "</function>"
+    } else if rest.starts_with(INVOKE_MARKUP_OPEN) {
+        "</invoke>"
+    } else {
+        return None;
+    };
+    let end = rest
+        .find(close_tag)
+        .map(|idx| cursor + idx + close_tag.len())
+        .unwrap_or(src.len());
+    match parse_function_markup_body(&src[cursor..end], tools_val) {
+        Ok(Some(call)) => Some(Ok((call, end))),
+        Err(msg) => Some(Err((msg, end))),
+        Ok(None) => None,
+    }
 }
 
 fn parse_json_tool_call_body(

--- a/crates/harn-vm/src/llm/tools/tests/function_markup.rs
+++ b/crates/harn-vm/src/llm/tools/tests/function_markup.rs
@@ -1,0 +1,242 @@
+//! Rescue parsing for chat-template tool-call markup emitted as plain
+//! assistant text (#3220): the qwen3 `<function=NAME>` + `<parameter=KEY>`
+//! style and the `<invoke name="NAME">` attribute spelling. Native-format
+//! models fall back to this text rendering under long contexts; the parser
+//! must promote well-formed markup into real calls (so the loop's native
+//! fallback contract can act on them) and surface precise errors for
+//! truncated markup — and must NOT fire on prose or fenced examples.
+
+use super::{json, parse_text_tool_calls_with_tools, sample_tool_registry};
+
+/// The live failure shape from the 2026-06-09 Burin eval meter run: a
+/// complete, well-formed `edit` call in qwen's chat-template XML style,
+/// wrapped in `<tool_call>` tags, emitted as plain assistant text.
+fn live_qwen_markup() -> String {
+    [
+        "<tool_call>",
+        "<function=edit>",
+        "<parameter=action>",
+        "create",
+        "</parameter>",
+        "<parameter=path>",
+        "internal/handlers/health.go",
+        "</parameter>",
+        "<parameter=content>",
+        "package handlers",
+        "",
+        "// Health returns 200.",
+        "func Health() int { return 200 }",
+        "</parameter>",
+        "</function>",
+        "</tool_call>",
+    ]
+    .join("\n")
+}
+
+#[test]
+fn wrapped_function_markup_parses_into_edit_call() {
+    let tools = sample_tool_registry();
+    let parsed = parse_text_tool_calls_with_tools(&live_qwen_markup(), Some(&tools));
+    assert_eq!(parsed.errors, Vec::<String>::new());
+    assert_eq!(parsed.calls.len(), 1);
+    let call = &parsed.calls[0];
+    assert_eq!(call.get("name").and_then(|v| v.as_str()), Some("edit"));
+    let args = call.get("arguments").expect("arguments");
+    assert_eq!(args.get("action"), Some(&json!("create")));
+    assert_eq!(
+        args.get("path"),
+        Some(&json!("internal/handlers/health.go"))
+    );
+    // String-typed parameter bytes survive verbatim — including blank lines.
+    assert_eq!(
+        args.get("content").and_then(|v| v.as_str()),
+        Some("package handlers\n\n// Health returns 200.\nfunc Health() int { return 200 }")
+    );
+    // The canonical replay form is the tagged grammar, not the markup.
+    assert!(parsed.canonical.contains("<tool_call>"));
+    assert!(parsed.canonical.contains("edit({"));
+}
+
+#[test]
+fn unwrapped_function_markup_recovers_with_violation() {
+    let tools = sample_tool_registry();
+    let text = "<function=run>\n<parameter=command>\ngo test ./...\n</parameter>\n</function>";
+    let parsed = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert_eq!(parsed.errors, Vec::<String>::new());
+    assert_eq!(parsed.calls.len(), 1);
+    assert_eq!(
+        parsed.calls[0].get("name").and_then(|v| v.as_str()),
+        Some("run")
+    );
+    assert_eq!(
+        parsed.calls[0]
+            .get("arguments")
+            .and_then(|args| args.get("command")),
+        Some(&json!("go test ./..."))
+    );
+    assert!(
+        parsed
+            .violations
+            .iter()
+            .any(|violation| violation.contains("chat-template function markup")),
+        "expected a soft protocol violation steering back to the canonical form: {:?}",
+        parsed.violations
+    );
+}
+
+#[test]
+fn invoke_attribute_markup_parses() {
+    let tools = sample_tool_registry();
+    let text =
+        "<invoke name=\"run\">\n<parameter name=\"command\">cargo check</parameter>\n</invoke>";
+    let parsed = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert_eq!(parsed.errors, Vec::<String>::new());
+    assert_eq!(parsed.calls.len(), 1);
+    assert_eq!(
+        parsed.calls[0].get("name").and_then(|v| v.as_str()),
+        Some("run")
+    );
+    assert_eq!(
+        parsed.calls[0]
+            .get("arguments")
+            .and_then(|args| args.get("command")),
+        Some(&json!("cargo check"))
+    );
+}
+
+#[test]
+fn missing_function_close_with_closed_params_recovers() {
+    // Some emissions close only the outer `</tool_call>`. Every parameter is
+    // closed, so the values are complete and the call is recoverable.
+    let tools = sample_tool_registry();
+    let text = "<tool_call>\n<function=run>\n<parameter=command>\nls\n</parameter>\n</tool_call>";
+    let parsed = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert_eq!(parsed.errors, Vec::<String>::new());
+    assert_eq!(parsed.calls.len(), 1);
+    assert_eq!(
+        parsed.calls[0]
+            .get("arguments")
+            .and_then(|args| args.get("command")),
+        Some(&json!("ls"))
+    );
+}
+
+#[test]
+fn unclosed_wrapper_function_markup_recovers() {
+    // `<tool_call>` opened, function markup complete, `</tool_call>` never
+    // emitted (truncated tail after the close tag is tolerated slop).
+    let tools = sample_tool_registry();
+    let text = "<tool_call>\n<function=run>\n<parameter=command>\npwd\n</parameter>\n</function>";
+    let parsed = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert_eq!(parsed.errors, Vec::<String>::new());
+    assert_eq!(parsed.calls.len(), 1);
+    assert_eq!(
+        parsed.calls[0]
+            .get("arguments")
+            .and_then(|args| args.get("command")),
+        Some(&json!("pwd"))
+    );
+}
+
+#[test]
+fn truncated_parameter_errors_and_does_not_dispatch() {
+    // A `<parameter=content>` whose close tag never arrives is a truncation:
+    // dispatching a partial file body would corrupt the workspace, so the
+    // turn must surface an error (which drives parse feedback) and 0 calls.
+    let tools = sample_tool_registry();
+    let text = "<tool_call>\n<function=edit>\n<parameter=action>\ncreate\n</parameter>\n<parameter=content>\npackage handlers\n";
+    let parsed = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert_eq!(parsed.calls.len(), 0);
+    assert_eq!(parsed.errors.len(), 1);
+    assert!(
+        parsed.errors[0].contains("TRUNCATED"),
+        "{:?}",
+        parsed.errors
+    );
+    assert!(
+        parsed.errors[0].contains("NOT executed"),
+        "{:?}",
+        parsed.errors
+    );
+}
+
+#[test]
+fn unknown_tool_in_markup_errors() {
+    let tools = sample_tool_registry();
+    let text = "<function=frobnicate>\n<parameter=level>\n9\n</parameter>\n</function>";
+    let parsed = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert_eq!(parsed.calls.len(), 0);
+    assert_eq!(parsed.errors.len(), 1);
+    assert!(
+        parsed.errors[0].contains("Unknown tool 'frobnicate'"),
+        "{:?}",
+        parsed.errors
+    );
+}
+
+#[test]
+fn prose_mentioning_markup_does_not_fire() {
+    // Inline prose mention — the opener is not at the start of a line, so it
+    // is stray narration, never a call or a parse error.
+    let tools = sample_tool_registry();
+    let text = "I considered emitting <function=edit> markup but used the native channel.";
+    let parsed = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert_eq!(parsed.calls.len(), 0);
+    assert_eq!(parsed.errors, Vec::<String>::new());
+}
+
+#[test]
+fn fenced_example_does_not_fire() {
+    // A fenced code block *discussing* the markup syntax is documentation,
+    // not an attempted call.
+    let tools = sample_tool_registry();
+    let text = [
+        "<assistant_prose>",
+        "The legacy markup looks like this:",
+        "</assistant_prose>",
+        "```text",
+        "<function=edit>",
+        "<parameter=action>",
+        "create",
+        "</parameter>",
+        "</function>",
+        "```",
+    ]
+    .join("\n");
+    let parsed = parse_text_tool_calls_with_tools(&text, Some(&tools));
+    assert_eq!(parsed.calls.len(), 0);
+    assert_eq!(parsed.errors, Vec::<String>::new());
+}
+
+#[test]
+fn string_schema_parameter_keeps_numeric_looking_value_verbatim() {
+    // `content` is string-typed in the schema: a value that happens to parse
+    // as JSON must NOT be coerced.
+    let tools = sample_tool_registry();
+    let text = "<tool_call>\n<function=edit>\n<parameter=action>\ncreate\n</parameter>\n<parameter=path>\nversion.txt\n</parameter>\n<parameter=content>\n123\n</parameter>\n</function>\n</tool_call>";
+    let parsed = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert_eq!(parsed.errors, Vec::<String>::new());
+    assert_eq!(parsed.calls.len(), 1);
+    assert_eq!(
+        parsed.calls[0]
+            .get("arguments")
+            .and_then(|args| args.get("content")),
+        Some(&json!("123"))
+    );
+}
+
+#[test]
+fn non_string_schema_parameter_parses_as_json() {
+    // `ops` is list-typed in the schema, so its raw markup value is JSON.
+    let tools = sample_tool_registry();
+    let text = "<tool_call>\n<function=edit>\n<parameter=action>\npatch\n</parameter>\n<parameter=path>\nmain.go\n</parameter>\n<parameter=ops>\n[{\"op\": \"a\"}]\n</parameter>\n</function>\n</tool_call>";
+    let parsed = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert_eq!(parsed.errors, Vec::<String>::new());
+    assert_eq!(parsed.calls.len(), 1);
+    assert_eq!(
+        parsed.calls[0]
+            .get("arguments")
+            .and_then(|args| args.get("ops")),
+        Some(&json!([{"op": "a"}]))
+    );
+}

--- a/crates/harn-vm/src/llm/tools/tests/mod.rs
+++ b/crates/harn-vm/src/llm/tools/tests/mod.rs
@@ -19,6 +19,7 @@ pub(super) use serde_json::json;
 use std::collections::BTreeMap;
 
 mod core_parser;
+mod function_markup;
 mod heredoc_and_messages;
 mod native_tools;
 mod reserved_token;

--- a/tests/agent/judge_verdict_test.harn
+++ b/tests/agent/judge_verdict_test.harn
@@ -1,0 +1,58 @@
+// Run: harn test tests/agent/judge_verdict_test.harn
+//
+// Unit tests for the judge verdict-token normalization in
+// `std/agent/judge_internals`. Structured judges occasionally emit sloppy
+// JSON (double commas, run-on key/value pairs) that the structured-call
+// repair layer salvages by capturing trailing JSON junk into the verdict
+// string — observed live in `judge_decision` events as `continue",,` and
+// `continue",  "reasoning":`. The classifier must strip the junk so the
+// stored/emitted verdict is the clean token AND classification keys on the
+// real verdict (a mangled pass token must not read as a veto).
+import { __judge_classify_verdict, __judge_verdict_token } from "std/agent/judge_internals"
+
+const DONE_TOKENS = ["done", "complete"]
+
+pipeline test_clean_verdict_passes_through(task) {
+  assert_eq(__judge_verdict_token("done"), "done")
+  assert_eq(__judge_verdict_token("  Continue "), "continue")
+  let outcome = __judge_classify_verdict("done", DONE_TOKENS, [], "fallback")
+  assert_eq(outcome.vetoed, false)
+  assert_eq(outcome.verdict, "done")
+}
+
+pipeline test_live_mangled_continue_double_comma(task) {
+  // Exact live string: `continue",,`
+  assert_eq(__judge_verdict_token("continue\",,"), "continue")
+  let outcome = __judge_classify_verdict("continue\",,", DONE_TOKENS, ["critique"], "fallback")
+  assert_eq(outcome.vetoed, true)
+  assert_eq(outcome.verdict, "continue")
+}
+
+pipeline test_live_mangled_continue_runon_reasoning_key(task) {
+  // Exact live string: `continue",  "reasoning":`
+  assert_eq(__judge_verdict_token("continue\",  \"reasoning\":"), "continue")
+  let outcome = __judge_classify_verdict("continue\",  \"reasoning\":", DONE_TOKENS, [], "fallback")
+  assert_eq(outcome.vetoed, true)
+  assert_eq(outcome.verdict, "continue")
+}
+
+pipeline test_mangled_pass_token_still_classifies_as_pass(task) {
+  // The same junk on a PASS token must not flip the classification to veto.
+  let outcome = __judge_classify_verdict("done\",,", DONE_TOKENS, [], "fallback")
+  assert_eq(outcome.vetoed, false)
+  assert_eq(outcome.verdict, "done")
+}
+
+pipeline test_prose_verdict_without_json_junk_is_unchanged(task) {
+  // Multi-word prose verdicts carry signal; only JSON structural characters
+  // mark upstream mangling, so plain prose passes through verbatim.
+  assert_eq(__judge_verdict_token("not done yet"), "not done yet")
+  let outcome = __judge_classify_verdict("not done yet", DONE_TOKENS, [], "fallback")
+  assert_eq(outcome.vetoed, true)
+  assert_eq(outcome.verdict, "not done yet")
+}
+
+pipeline test_empty_and_nil_verdicts(task) {
+  assert_eq(__judge_verdict_token(nil), "")
+  assert_eq(__judge_verdict_token("\",,"), "")
+}


### PR DESCRIPTION
Two Harn-side fixes from 2026-06-09 Burin Code eval-meter evidence.

## 1. Native tool_format: rescue chat-template tool-call markup emitted as text (fixes #3220)

Live failure: in a NATIVE session qwen3.6 emitted a complete `edit` call as plain assistant text in its chat-template XML style (`<tool_call><function=edit><parameter=action>...`). The native path ignores assistant text, the turn read as `end_turn`, the run ended with the edit lost.

**Approach: rescue-parse primary, feedback fallback — riding existing machinery** (same class as #3057 parse-feedback/heredoc recovery and #3050 reserved-token funnel; the mistral `[TOOL_CALLS]` / DeepSeek DSML recoveries already live in the same parser file):

- **Parser** (`tagged.rs`): promote `<function=NAME>` + `<parameter=KEY>` markup (and the `<invoke name="NAME">` attribute spelling) into real parsed calls — inside `<tool_call>` wrappers, under unclosed wrappers, and line-anchored at top level. Guards: must be line-anchored outside a markdown fence (prose mentions and fenced examples never fire), tool must be registered, and a truncated `<parameter>` block surfaces a precise parse error instead of dispatching a partial value. Parameter values are typed against the tool schema (string params keep raw bytes verbatim; non-string params parse as JSON).
- **Native loop**: the rescued calls ride the existing `native_tool_fallback` contract — default `reject` injects the native-contract "re-issue through the provider tool channel" feedback and the loop continues; `allow`/`allow_once` dispatches the rescued call. Unparseable markup raises `tool_parse_errors` → the existing #3057 parse-guidance feedback fires.
- **Completion gate** (`postturn.harn`): a zero-call turn with tool-call feedback queued (`_turn_tool_call_feedback`, threaded from the fallback/parse-feedback outcome) no longer reads as a native natural completion. Verified empirically: without the gate the truncated-markup scenario completes at iteration 2 with the feedback dropped; with it the loop continues and delivers parse_guidance. Explicit done sentinels still win.

Complements burin-code#2114 (deterministic completion-gate veto, the belt) — this recovers mid-run rather than only at completion-proposal time.

## 2. Judge verdict JSON-junk normalization

`judge_decision` events recorded verdicts like `continue",,` and `continue",  "reasoning":` when the structured judge emitted sloppy JSON that the repair layer salvaged. `__judge_classify_verdict` now normalizes the captured verdict to its leading token (cut at the first JSON structural character). Bonus latent fix: a mangled PASS token (`done",,`) now classifies as a pass instead of being wrongly vetoed. Prose verdicts without JSON junk pass through unchanged.

## Verification

- 11 new parser unit tests (`tools/tests/function_markup.rs`) incl. the exact live markup, truncation, unknown-tool, prose/fence negatives, schema-typed coercion — `llm::tools` 190/190.
- New conformance `agent_loop_native_text_markup_rescue.harn`: reject → feedback + continue (3 model calls, not 2); allow → rescued call dispatches; truncated → parse_guidance + continue. Agents conformance suite **208/208**.
- New `tests/agent/judge_verdict_test.harn` (6 cases incl. both exact live mangled strings).
- `cargo fmt --check`, `cargo clippy -p harn-vm --all-targets -- -D warnings`, `harn fmt`/`harn lint` clean. The only `tests/agent` failures are the two pre-existing #3004 stall cases documented in #3057.

🤖 Generated with [Claude Code](https://claude.com/claude-code)