### PR TITLE
fix(agent): cause-name empty-args native tool calls + surface stop_reason in the observability transcript (burin-code#2121)

### DIFF
--- a/changelog.d/empty-args-finish-reason.fixed.md
+++ b/changelog.d/empty-args-finish-reason.fixed.md
@@ -1,0 +1,21 @@
+- **Empty-args native tool calls now get cause-named feedback, and the
+  provider `stop_reason` rides the observability transcript.** Two halves of
+  the same blind spot (burin-code#2121, observed live on the OpenRouter
+  native route: 13/165 edit calls arrived with literally `{}` arguments while
+  the model authored 549–5,056 output tokens those turns): (1) the
+  `provider_call_response` record in `llm_transcript.jsonl` dropped
+  `LlmResult.stop_reason` — the transport layer captured `finish_reason` on
+  both the streaming and non-streaming OpenAI-compatible paths, but transcript
+  mining saw `stop_reason=None` on every provider response, so truncation
+  analysis was blind; the record now carries it. (2) A tool call that arrives
+  with empty (`{}`/null) arguments and fails required-parameter validation was
+  misdiagnosed as `"missing required parameter(s): path"`, sending the model
+  into re-call loops. The agent loop now threads the turn's provider stop
+  reason into dispatch, and the feedback names the actual cause: on a length
+  truncation the model is told its arguments were TRUNCATED by the output
+  limit (re-issue shorter / split the change); on a clean stop it is told the
+  provider dropped the arguments (re-issue the same call in full). The
+  dispatch envelope and inner tool result also carry a machine-readable
+  `cause` (`empty_arguments_truncated` / `empty_arguments_dropped`) so host
+  harnesses can classify the fault without string-matching. Calls that did
+  deliver (incomplete) arguments keep the precise missing-parameter message.

--- a/conformance/tests/agents/agent_loop_empty_args_cause_feedback.expected
+++ b/conformance/tests/agents/agent_loop_empty_args_cause_feedback.expected
@@ -1,0 +1,10 @@
+done
+true
+true
+done
+true
+true
+true
+done
+true
+true

--- a/conformance/tests/agents/agent_loop_empty_args_cause_feedback.harn
+++ b/conformance/tests/agents/agent_loop_empty_args_cause_feedback.harn
@@ -1,0 +1,108 @@
+import { llm_text, with_llm_script } from "std/testing"
+
+/**
+ * Native tool calls can arrive with EMPTY `{}` arguments even though the model
+ * authored hundreds of output tokens that turn — a provider/template fault
+ * observed live on the OpenAI-compatible native route (burin-code#2121:
+ * 13/165 edit calls). The dispatch feedback must name the CAUSE instead of
+ * misdiagnosing it as "missing required parameter(s)" and sending the model
+ * into re-call loops:
+ *
+ *  - finish_reason `length` -> the arguments were TRUNCATED by the output cap;
+ *    coach a shorter / split re-issue.
+ *  - any clean stop -> the provider dropped the arguments; coach an identical
+ *    re-issue with the full arguments.
+ *
+ * A call that DID deliver (incomplete) arguments keeps the precise
+ * missing-parameter message.
+ */
+fn note_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "write_note",
+    "Write a note.",
+    {
+      handler: { args -> "wrote " + to_string(args?.path) },
+      parameters: {path: {type: "string", description: "Path to write"}},
+      returns: {type: "string"},
+      annotations: {kind: "edit", side_effect_level: "workspace_write"},
+    },
+  )
+  return tools
+}
+
+fn loop_opts() {
+  return {
+    provider: "mock",
+    tool_format: "native",
+    loop_until_done: true,
+    max_iterations: 5,
+    max_nudges: 5,
+    tools: note_tools(),
+  }
+}
+
+pipeline default() {
+  // (a) Empty args + finish_reason "length" -> the feedback names the
+  // output-cap truncation, never the misdiagnosing missing-parameter slip.
+  with_llm_script(
+    [
+      {tool_calls: [{id: "t1", name: "write_note", arguments: {}}], stop_reason: "length"},
+      {
+        tool_calls: [{id: "t2", name: "write_note", arguments: {path: "a.txt"}}],
+        stop_reason: "tool_calls",
+      },
+      llm_text("##DONE##"),
+    ],
+    { ->
+      let result = agent_loop("Write a.txt.", nil, loop_opts())
+      let calls = llm_mock_calls()
+      let feedback = json_stringify(calls[1].messages)
+      __io_println(result.status)
+      __io_println(contains(feedback, "TRUNCATED by the output limit"))
+      __io_println(!contains(feedback, "missing required parameter"))
+    },
+  )
+  // (b) Empty args + clean stop -> the feedback names the provider fault and
+  // coaches an identical re-issue.
+  with_llm_script(
+    [
+      {tool_calls: [{id: "t1", name: "write_note", arguments: {}}], stop_reason: "tool_calls"},
+      {
+        tool_calls: [{id: "t2", name: "write_note", arguments: {path: "a.txt"}}],
+        stop_reason: "tool_calls",
+      },
+      llm_text("##DONE##"),
+    ],
+    { ->
+      let result = agent_loop("Write a.txt.", nil, loop_opts())
+      let calls = llm_mock_calls()
+      let feedback = json_stringify(calls[1].messages)
+      __io_println(result.status)
+      __io_println(contains(feedback, "EMPTY arguments"))
+      __io_println(contains(feedback, "Re-issue the same call with its full arguments"))
+      __io_println(!contains(feedback, "missing required parameter"))
+    },
+  )
+  // (c) Non-empty but incomplete args -> the precise validator message stays;
+  // the empty-args cause-naming must not fire.
+  with_llm_script(
+    [
+      {tool_calls: [{id: "t1", name: "write_note", arguments: {body: "hello"}}], stop_reason: "length"},
+      {
+        tool_calls: [{id: "t2", name: "write_note", arguments: {path: "a.txt"}}],
+        stop_reason: "tool_calls",
+      },
+      llm_text("##DONE##"),
+    ],
+    { ->
+      let result = agent_loop("Write a.txt.", nil, loop_opts())
+      let calls = llm_mock_calls()
+      let feedback = json_stringify(calls[1].messages)
+      __io_println(result.status)
+      __io_println(contains(feedback, "missing required parameter(s): path"))
+      __io_println(!contains(feedback, "EMPTY arguments"))
+    },
+  )
+}

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -1176,6 +1176,11 @@ fn __dispatch_tool_calls(session_id, tool_calls, turn_opts) {
   agent_tool_search_emit_queries(session_id, tool_calls, turn_opts)
   let tools = turn_opts?.tools
   let cap = __resolve_max_concurrent_tools(turn_opts)
+  // `_stop_reason` is the turn's provider stop reason
+  // (`stop`/`length`/`tool_calls`/...). The dispatch host primitive uses it
+  // to cause-name empty-args tool calls: finish_reason=length means the
+  // arguments were TRUNCATED by the output cap, anything else means the
+  // provider dropped them (burin-code#2121).
   let dispatch_options = {
     session_id: session_id,
     tool_format: turn_opts.tool_format,
@@ -1188,6 +1193,7 @@ fn __dispatch_tool_calls(session_id, tool_calls, turn_opts) {
     _tool_caller: turn_opts?._tool_caller,
     _max_concurrent_tools: cap,
     _prefetch_next_turn: turn_opts?.prefetch_next_turn ?? false,
+    _stop_reason: turn_opts?._stop_reason ?? "",
   }
   let caller = turn_opts?._tool_caller
   let raw_dispatch = __dispatch_tool_calls_with_middleware(tool_calls, tools, dispatch_options, cap)
@@ -2788,7 +2794,12 @@ fn __agent_loop_run(message, session, initial_opts) {
       let dispatched = __dispatch_tool_calls(
         session.session_id,
         tool_calls,
-        turn_opts + {_iteration: iteration_index + 1, _tool_caller: opts?._tool_caller},
+        turn_opts
+          + {
+          _iteration: iteration_index + 1,
+          _tool_caller: opts?._tool_caller,
+          _stop_reason: llm_result?.stop_reason ?? "",
+        },
       )
       let dispatch = dispatched.dispatch
       stall_prev_dispatch = dispatch

--- a/crates/harn-vm/src/llm/agent_host_primitives.rs
+++ b/crates/harn-vm/src/llm/agent_host_primitives.rs
@@ -250,6 +250,64 @@ fn agent_primitive_denied_tool(
     })
 }
 
+/// Cause-named feedback for a tool call whose arguments arrived EMPTY
+/// (`{}` or null) and failed required-parameter validation.
+///
+/// Observed live on the OpenAI-compatible native tool-call route
+/// (burin-code#2121): 13/165 edit calls arrived with literally `{}` arguments
+/// while the model generated 549–5,056 output tokens those turns — the model
+/// authored content, but the provider boundary delivered an empty-args call.
+/// The generic "missing required parameter(s): path" message misdiagnoses
+/// that as a model slip and sends it into re-call loops. Name the actual
+/// cause instead, keyed off the turn's provider stop reason:
+///
+/// - length truncation (`length` / `max_tokens` / `MAX_TOKENS`): the
+///   arguments were cut off by the output-token limit — coach a smaller
+///   re-issue.
+/// - anything else: the provider/template dropped the arguments — coach an
+///   identical re-issue with the full arguments.
+///
+/// Returns `None` when the call's arguments were not empty, so ordinary
+/// validation failures keep the precise missing-parameter message. The
+/// `&'static str` is a machine-readable cause (`empty_arguments_truncated` /
+/// `empty_arguments_dropped`) exposed on the dispatch envelope so hosts can
+/// distinguish the class without string-matching the reason.
+fn empty_args_cause_named_feedback(
+    tool_name: &str,
+    raw_args: &serde_json::Value,
+    stop_reason: Option<&str>,
+) -> Option<(String, &'static str)> {
+    let args_empty = match raw_args {
+        serde_json::Value::Null => true,
+        serde_json::Value::Object(map) => map.is_empty(),
+        _ => false,
+    };
+    if !args_empty {
+        return None;
+    }
+    if agent_session_host::is_length_truncation(stop_reason) {
+        Some((
+            format!(
+                "Tool '{tool_name}' arrived with EMPTY arguments because the response hit \
+                 the output-token limit (finish_reason=length): your tool call's arguments \
+                 were TRUNCATED by the output limit. Re-issue the call with shorter \
+                 content, or split the change into several smaller calls."
+            ),
+            "empty_arguments_truncated",
+        ))
+    } else {
+        Some((
+            format!(
+                "Tool '{tool_name}' arrived with EMPTY arguments — a known \
+                 provider/template fault where the arguments you authored are dropped at \
+                 the provider boundary, not a formatting mistake on your part. Re-issue \
+                 the same call with its full arguments."
+            ),
+            "empty_arguments_dropped",
+        ))
+    }
+}
+
 /// Append a `PermissionDeny` transcript event that carries the structured
 /// [`crate::agent_events::ToolDenial`] alongside the human-readable reason.
 /// Silent no-op for sessions that were never opened.
@@ -1199,9 +1257,24 @@ async fn host_agent_dispatch_tool_call(
 
     let tool_schemas = tools::collect_tool_schemas(tools, None);
     if let Err(message) = tools::validate_tool_args(&tool_name, &tool_args, &tool_schemas) {
+        // Empty-args calls (`{}` / null arguments) are a provider-boundary
+        // fault class, not a model slip — replace the misdiagnosing
+        // missing-parameter message with cause-named feedback keyed off the
+        // turn's provider stop reason (threaded in by the agent loop as
+        // `_stop_reason`). See `empty_args_cause_named_feedback`.
+        let turn_stop_reason = agent_primitive_option_str(options, "_stop_reason");
+        let cause_named = empty_args_cause_named_feedback(
+            &tool_name,
+            &raw_args,
+            turn_stop_reason.as_deref().filter(|s| !s.is_empty()),
+        );
+        let (message, cause) = match cause_named {
+            Some((cause_message, cause)) => (cause_message, Some(cause)),
+            None => (message, None),
+        };
         // Schema validation is not a policy denial — the model can fix the
         // arguments and retry — so no structured `ToolDenial` is attached.
-        let denied = agent_primitive_denied_tool(
+        let mut denied = agent_primitive_denied_tool(
             &tool_name,
             &tool_id,
             &tool_args,
@@ -1209,6 +1282,15 @@ async fn host_agent_dispatch_tool_call(
             crate::agent_events::ToolCallErrorCategory::SchemaValidation,
             None,
         );
+        if let Some(cause) = cause {
+            // Machine-readable cause on both the envelope (for host harnesses
+            // reading the dispatch outcome) and the inner model-facing result
+            // (so it rides the transcript).
+            denied["cause"] = serde_json::json!(cause);
+            if let Some(result) = denied.get_mut("result") {
+                result["cause"] = serde_json::json!(cause);
+            }
+        }
         let denied = attach_hook_reminder_audit(denied, hook_reminder_reports);
         return Ok(json_to_vm_value(&denied));
     }
@@ -1938,6 +2020,64 @@ mod denied_tool_routing_tests {
         assert!(
             !next.contains("Do not retry"),
             "empty-name slip must be retry-positive: {next}"
+        );
+    }
+
+    use super::empty_args_cause_named_feedback;
+
+    #[test]
+    fn empty_args_with_length_truncation_names_the_truncation_cause() {
+        let (reason, cause) =
+            empty_args_cause_named_feedback("edit", &serde_json::json!({}), Some("length"))
+                .expect("empty args must be cause-named");
+        assert_eq!(cause, "empty_arguments_truncated");
+        assert!(
+            reason.contains("TRUNCATED") && reason.contains("output"),
+            "length-truncated empty args must name the output-limit cut: {reason}"
+        );
+        assert!(
+            reason.contains("shorter") || reason.contains("split"),
+            "truncation feedback must coach a smaller re-issue: {reason}"
+        );
+        assert!(
+            !reason.contains("missing required parameter"),
+            "must not misdiagnose as a missing-parameter slip: {reason}"
+        );
+        // Anthropic spelling and provider casing route to the same cause.
+        let (_, cause) =
+            empty_args_cause_named_feedback("edit", &serde_json::Value::Null, Some("MAX_TOKENS"))
+                .expect("null args must be cause-named");
+        assert_eq!(cause, "empty_arguments_truncated");
+    }
+
+    #[test]
+    fn empty_args_with_clean_stop_names_the_provider_fault_cause() {
+        for stop_reason in [Some("stop"), Some("tool_calls"), None] {
+            let (reason, cause) =
+                empty_args_cause_named_feedback("edit", &serde_json::json!({}), stop_reason)
+                    .expect("empty args must be cause-named");
+            assert_eq!(cause, "empty_arguments_dropped");
+            assert!(
+                reason.contains("EMPTY arguments") && reason.contains("provider"),
+                "clean-stop empty args must name the provider fault: {reason}"
+            );
+            assert!(
+                reason.contains("Re-issue the same call"),
+                "provider-fault feedback must coach an identical re-issue: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_empty_args_keep_the_precise_validator_message() {
+        assert!(
+            empty_args_cause_named_feedback(
+                "edit",
+                &serde_json::json!({ "content": "x" }),
+                Some("length")
+            )
+            .is_none(),
+            "a call that DID deliver arguments must keep the missing-parameter message"
         );
     }
 

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -794,6 +794,15 @@ pub(super) fn dump_llm_response(
         "cache_hit": result.cache_read_tokens > 0,
         "thinking": result.thinking,
         "thinking_summary": result.thinking_summary,
+        // Provider-reported finish/stop reason (`stop` / `length` /
+        // `tool_calls` for OpenAI-compatibles, `end_turn` / `max_tokens` /
+        // `tool_use` for Anthropic, `done_reason` for Ollama). The transport
+        // layer has always captured this onto `LlmResult.stop_reason`, but the
+        // observability record dropped it — so transcript mining saw
+        // stop_reason=None on every provider response and truncation analysis
+        // (burin-code#2121) was blind to output-cap cuts. `null` when the
+        // provider reported nothing.
+        "stop_reason": result.stop_reason,
         "response_ms": response_ms,
         // Server-side runtime telemetry (Ollama timings, llama.cpp prefill /
         // decode breakdown, etc.). Empty for providers that report nothing.
@@ -1542,6 +1551,10 @@ mod retry_tests {
             "the text-parsed call must surface in the sidecar, got: {parsed:?}"
         );
         assert_eq!(parsed[0]["name"], "run");
+        // The provider-reported stop reason must ride the observability record
+        // (burin-code#2121: it was dropped here, blinding transcript mining to
+        // length truncations on every provider route).
+        assert_eq!(event["stop_reason"], "stop");
 
         // 2. Request-construction / history path is UNCHANGED: the value that
         //    feeds the assistant history envelope is `native_tool_calls`, which

--- a/crates/harn-vm/src/llm/api/response.rs
+++ b/crates/harn-vm/src/llm/api/response.rs
@@ -1222,6 +1222,39 @@ mod tests {
     }
 
     #[test]
+    fn openai_parser_keeps_finish_reason_on_empty_args_tool_call() {
+        // burin-code#2121 evidence shape (non-streaming): the provider
+        // boundary delivers a named tool call with literally "{}" arguments.
+        // `finish_reason` must surface as `stop_reason` so downstream
+        // feedback can distinguish a length-truncated call from a clean-stop
+        // provider drop.
+        for finish_reason in ["length", "tool_calls"] {
+            let response = serde_json::json!({
+                "choices": [{
+                    "message": {
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "chatcmpl-tool-1",
+                                "type": "function",
+                                "function": {"name": "edit", "arguments": "{}"}
+                            }
+                        ]
+                    },
+                    "finish_reason": finish_reason
+                }],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 549}
+            });
+            let result = parse_llm_response(&response, "openrouter", "or-qwen", false)
+                .expect("parser succeeds");
+            assert_eq!(result.stop_reason.as_deref(), Some(finish_reason));
+            assert_eq!(result.tool_calls.len(), 1);
+            assert_eq!(result.tool_calls[0]["name"], "edit");
+            assert_eq!(result.tool_calls[0]["arguments"], serde_json::json!({}));
+        }
+    }
+
+    #[test]
     fn openai_parser_records_tool_search_call_as_query_event() {
         // OpenAI's Responses API (harn#71) surfaces the server-hosted
         // tool_search as a `tool_search_call` entry in the `tool_calls`

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -2018,6 +2018,35 @@ mod streaming_tool_call_tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn openai_stream_tool_call_cut_by_length_keeps_finish_reason() {
+        // burin-code#2121 evidence shape: the output-token cap cuts a native
+        // tool call mid-arguments. OpenRouter delivers the truncated args
+        // deltas and a final chunk that carries BOTH a `tool_calls` delta and
+        // `finish_reason:"length"`. The accumulated args fail to parse (-> the
+        // empty-object fallback the agent loop sees as an empty-args call),
+        // and `stop_reason` MUST still surface so the empty-args feedback can
+        // name the truncation cause.
+        let body = concat!(
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"chatcmpl-tool-1\",\"function\":{\"name\":\"edit\",\"arguments\":\"{\\\"pa\"}}]}}]}\n",
+            "data: {\"choices\":[{\"index\":0,\"finish_reason\":\"length\",\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"th\\\":\\\"src/ma\"}}]}}],\"usage\":{\"prompt_tokens\":4,\"completion_tokens\":9}}\n",
+            "data: [DONE]\n",
+        );
+        let session_id = fresh_session_id("oai-toolcall-length");
+        let (result, _events) = drive(body.as_bytes(), &session_id, false).await;
+
+        assert_eq!(result.stop_reason.as_deref(), Some("length"));
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0]["name"], "edit");
+        assert_eq!(
+            result.tool_calls[0]["arguments"],
+            serde_json::json!({}),
+            "truncated unparseable args fall back to the empty object"
+        );
+
+        clear_session_sinks(&session_id);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn openai_stream_announces_and_streams_partials() {
         // OpenAI Chat-Completions-style: tool name on the first delta,
         // arguments string concatenated across subsequent deltas.


### PR DESCRIPTION
Two halves of the same blind spot, observed live on the OpenRouter
native route (or-qwen3.6-35b, 2026-06-09 evals): 13/165 edit calls
arrived with literally `{}` arguments while the model authored
549-5,056 output tokens those turns, and stop_reason read as None on
all 806 provider responses mined from the transcripts.

1. stop_reason observability. The transport layer has always captured
   finish_reason onto `LlmResult.stop_reason` on BOTH OpenAI-compatible
   paths (streaming: transport.rs SSE accumulator; non-streaming:
   response.rs parse), but `dump_llm_response` dropped it from the
   `provider_call_response` record in llm_transcript.jsonl - so
   transcript mining saw stop_reason=None on every response and
   truncation analysis (#3016/#3179/#3147 class) was blind there. The
   record now carries `stop_reason` (null when the provider reported
   nothing). New tests pin the burin-code#2121 evidence shapes:
   a streamed tool call cut mid-arguments by finish_reason=length, and
   a non-streaming `{}`-args call with finish_reason length/tool_calls.

2. Cause-named empty-args feedback. A native call that arrives with
   empty (`{}`/null) arguments and fails required-parameter validation
   was misdiagnosed as "missing required parameter(s): path", sending
   models into re-call loops (two runs ended no_progress_streak with 0
   files written). The agent loop now threads the turn's provider stop
   reason into dispatch (`_stop_reason`), and the validation seam names
   the actual cause:
   - finish_reason=length -> "your tool call's arguments were TRUNCATED
     by the output limit" + coach a shorter/split re-issue
     (cause: empty_arguments_truncated)
   - clean stop -> "a known provider/template fault ... Re-issue the
     same call with its full arguments"
     (cause: empty_arguments_dropped)
   The machine-readable `cause` rides both the dispatch envelope and
   the inner tool result so host harnesses can classify without
   string-matching. Calls that DID deliver (incomplete) arguments keep
   the precise missing-parameter message.

Conformance spec edit: new tests/agents/agent_loop_empty_args_cause_feedback
covers all three branches end-to-end through agent_loop (native mock
calls with scripted stop_reason). No existing baseline changed.

Verification: cargo test -p harn-vm --lib llm::api (153),
llm::agent_host_primitives (14, +3 new), llm::agent_observe (31),
llm::agent_session_host (25); harn test conformance agents (208/208);
cargo fmt --check + clippy -D warnings on harn-vm/harn-stdlib;
harn fmt --check + harn check on the touched .harn (lint count at
baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
