### PR TITLE
docs: document SSRF egress policy controls

### DIFF
--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1009,7 +1009,7 @@ pipeline summarize() {
 | `http_delete(url, options?)` | url: string, options: dict | dict | DELETE request |
 | `http_request(method, url, options?)` | method: string, url: string, options: dict | dict | Generic HTTP request |
 | `http_download(url, dst_path, options?)` | url: string, dst_path: string, options: dict | dict | Stream a response body to a file |
-| `egress_policy(config)` | config: dict | dict | Install the process egress policy used by HTTP, SSE, WebSocket, and connector outbound calls |
+| `egress_policy(config)` | config: dict | dict | Install the process egress policy used by HTTP, SSE, WebSocket, and connector outbound calls, including DNS-resolved private-address blocking |
 | `security_policy(config)` | config: dict | dict | Install the prompt-injection defense policy (spotlighting of untrusted output + lethal-trifecta gate + MCP schema pinning + `local-ml` injection detection). See `std/security`. |
 | `http_server_tls_plain()` | none | dict | Build HTTP-server TLS config for intentional cleartext/local listener mode |
 | `http_server_tls_edge(options?)` | options: dict | dict | Build HTTP-server TLS config for edge-terminated HTTPS; local listener stays plain and HSTS is enabled by default |
@@ -1086,17 +1086,26 @@ routes through an existing session when one is provided. `http_post`,
 `http_put`, and `http_patch` accept an options dict as the second argument
 when you want to send multipart without a separate string body.
 
-`egress_policy({allow, deny, default})` installs a process-scoped outbound
-network policy before user code opens real connections. Rules accept exact
-hosts (`api.example.com`), suffix wildcards (`*.example.com`), IP literals or
-CIDR ranges (`127.0.0.0/8`), and optional port restrictions
-(`api.example.com:443`). Deny rules override allow rules; `default: "deny"`
-turns the policy into an allowlist. Operators can seed the same policy without
-editing scripts via comma-separated `HARN_EGRESS_ALLOW`, `HARN_EGRESS_DENY`,
-and `HARN_EGRESS_DEFAULT=deny`. Under default `harn run`, the worktree
-sandbox denies network side effects before destination policy is consulted;
-use `egress_policy(...)` for network-enabled host policies or explicit
-`--no-sandbox` runs.
+`egress_policy({allow, deny, default, block_private, allow_loopback})` installs
+a process-scoped outbound network policy before user code opens real
+connections. Rules accept exact hosts (`api.example.com`), suffix wildcards
+(`*.example.com`), IP literals or CIDR ranges (`127.0.0.0/8`), and optional
+port restrictions (`api.example.com:443`). Deny rules override allow rules;
+`default: "deny"` turns the policy into an allowlist.
+
+`block_private: "private"` blocks loopback, RFC 1918, link-local and cloud
+metadata addresses, multicast, documentation, CGNAT, benchmark, and equivalent
+IPv6 ranges after DNS resolution and again at connect time. Under default
+`harn run`, this private-address guard is on unless the policy explicitly sets
+`block_private: "off"`. `allow_loopback: true` opens only loopback addresses;
+metadata and other private ranges remain blocked.
+
+Operators can seed the same policy without editing scripts via comma-separated
+`HARN_EGRESS_ALLOW`, `HARN_EGRESS_DENY`, `HARN_EGRESS_DEFAULT=deny`,
+`HARN_EGRESS_BLOCK_PRIVATE=private|off`, and `HARN_EGRESS_ALLOW_LOOPBACK=1`.
+Under default `harn run`, the worktree sandbox denies network side effects
+before destination policy is consulted; use `egress_policy(...)` for
+network-enabled host policies or explicit `--no-sandbox` runs.
 
 ```harn
 pipeline main(task) {

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -5130,7 +5130,7 @@ provider integrations.
 | Function | Description |
 |---|---|
 | `connector_call(provider, method, params?)` | Invoke the active outbound connector client for `provider` and return JSON-like result data |
-| `egress_policy(config)` | Install a process egress policy for HTTP, SSE, WebSocket, and Rust-backed connector outbound calls. Rules support exact hosts, `*.suffix` hosts, IP literals/CIDR, optional `:port`, and `default: "deny"` allowlist mode. Blocked calls throw `{type: "EgressBlocked", category: "egress_blocked", host, port, reason, url}` |
+| `egress_policy(config)` | Install a process egress policy for HTTP, SSE, WebSocket, and Rust-backed connector outbound calls. Rules support exact hosts, `*.suffix` hosts, IP literals/CIDR, optional `:port`, and `default: "deny"` allowlist mode. `block_private: "private"` blocks DNS-resolved loopback, private, link-local, metadata, multicast, documentation, CGNAT, benchmark, and equivalent IPv6 ranges; `block_private: "off"` opts out, and `allow_loopback: true` opens only loopback. The same axes can be seeded with `HARN_EGRESS_BLOCK_PRIVATE` and `HARN_EGRESS_ALLOW_LOOPBACK`. Blocked calls throw `{type: "EgressBlocked", category: "egress_blocked", host, port, reason, url}` |
 | `secret_get(secret_id)` | Read a secret from the active connector context. Only available while executing a Harn-backed connector export such as `normalize_inbound` or `call` |
 | `event_log_emit(topic, kind, payload, headers?)` | Append an event to the active event log from a Harn-backed connector export |
 | `metrics_inc(name, amount?)` | Increment a connector-owned Prometheus counter from a Harn-backed connector export |

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -5128,7 +5128,7 @@ provider integrations.
 | Function | Description |
 |---|---|
 | `connector_call(provider, method, params?)` | Invoke the active outbound connector client for `provider` and return JSON-like result data |
-| `egress_policy(config)` | Install a process egress policy for HTTP, SSE, WebSocket, and Rust-backed connector outbound calls. Rules support exact hosts, `*.suffix` hosts, IP literals/CIDR, optional `:port`, and `default: "deny"` allowlist mode. Blocked calls throw `{type: "EgressBlocked", category: "egress_blocked", host, port, reason, url}` |
+| `egress_policy(config)` | Install a process egress policy for HTTP, SSE, WebSocket, and Rust-backed connector outbound calls. Rules support exact hosts, `*.suffix` hosts, IP literals/CIDR, optional `:port`, and `default: "deny"` allowlist mode. `block_private: "private"` blocks DNS-resolved loopback, private, link-local, metadata, multicast, documentation, CGNAT, benchmark, and equivalent IPv6 ranges; `block_private: "off"` opts out, and `allow_loopback: true` opens only loopback. The same axes can be seeded with `HARN_EGRESS_BLOCK_PRIVATE` and `HARN_EGRESS_ALLOW_LOOPBACK`. Blocked calls throw `{type: "EgressBlocked", category: "egress_blocked", host, port, reason, url}` |
 | `secret_get(secret_id)` | Read a secret from the active connector context. Only available while executing a Harn-backed connector export such as `normalize_inbound` or `call` |
 | `event_log_emit(topic, kind, payload, headers?)` | Append an event to the active event log from a Harn-backed connector export |
 | `metrics_inc(name, amount?)` | Increment a connector-owned Prometheus counter from a Harn-backed connector export |


### PR DESCRIPTION
## Summary
- document the SSRF/private-address `egress_policy` controls in the HTTP builtin reference
- update the canonical language spec and regenerated docs mirror with `block_private`, `allow_loopback`, and their env hatches

## Context
The runtime work for #3172 already landed in #3182, with resolved-IP NetPolicy follow-up in #3198. This closes the remaining user-facing docs/spec gap for the public policy axes.

Closes #3172.

## Verification
- `make check-language-spec`
- `make lint-md`
- `git diff --check`
- pre-commit hook
- pre-push hook

Note: attempted `cargo test -p harn-vm ssrf --lib`, but stopped it after it spent over an hour in the `harn-vm` test compile/link step on this busy machine. No runtime files changed in this branch.
