### PR TITLE
fix(harn-serve): preserve binary site bodies

### DIFF
--- a/changelog.d/3214.fixed.md
+++ b/changelog.d/3214.fixed.md
@@ -1,0 +1,5 @@
+- **harn-serve hosted site handlers now preserve binary HTTP bodies through
+  dispatch (#3214).** Request `body` is no longer UTF-8-lossy for binary
+  payloads; handlers use `body_base64` when `body_kind` is `base64`, and
+  `http_reply(..., bytes, headers)` now returns byte-exact responses with
+  caller-controlled headers.

--- a/crates/harn-serve/src/adapters/site.rs
+++ b/crates/harn-serve/src/adapters/site.rs
@@ -28,14 +28,15 @@
 //!
 //! ```text
 //! { method, path, route, path_params, params, query, headers,
-//!   body, body_base64, content_length, client_ip, remote_addr }
+//!   body, body_kind, body_base64, content_length, client_ip, remote_addr }
 //! ```
 //!
-//! `body` is the UTF-8-lossy view (convenient for JSON/text handlers);
-//! `body_base64` is the standard-base64 encoding of the *raw* bytes, so a
-//! binary handler recovers the exact payload with `bytes_from_base64(...)`
-//! — multipart uploads survive losslessly through the JSON dispatch
-//! boundary this way.
+//! `body` is present only when the payload is valid UTF-8 (convenient for
+//! JSON/text handlers); binary payloads set `body` to `nil`, `body_kind` to
+//! `base64`, and `body_base64` to the standard-base64 encoding of the raw
+//! bytes. A binary handler recovers the exact payload with
+//! `bytes_from_base64(...)` — multipart uploads survive losslessly through
+//! the JSON dispatch boundary this way.
 //!
 //! `remote_addr` is the real transport peer (`ip:port`) wired through from
 //! the listener. `client_ip` is the *originating* client IP: by default it
@@ -902,8 +903,8 @@ async fn send_ws_reply(session: &WsSession, value: Value) -> bool {
 
 /// Assemble the `req` dict handed to a `.harn` handler. Mirrors the
 /// in-process `http_server` shape so handlers are portable between the
-/// embedded server and a hosted site, with `body_base64` added as the
-/// binary-safe channel through the JSON dispatch boundary.
+/// embedded server and a hosted site, with strict text-or-base64 body
+/// fields so binary payloads never pass through UTF-8 replacement.
 #[allow(clippy::too_many_arguments)]
 fn build_request_value(
     method: &Method,
@@ -951,10 +952,16 @@ fn build_request_value(
     request.insert("path_params".into(), path_params);
     request.insert("query".into(), Value::Object(query));
     request.insert("headers".into(), Value::Object(header_map));
-    request.insert(
-        "body".into(),
-        Value::String(String::from_utf8_lossy(body).into_owned()),
-    );
+    match std::str::from_utf8(body) {
+        Ok(text) => {
+            request.insert("body".into(), Value::String(text.to_string()));
+            request.insert("body_kind".into(), Value::String("text".to_string()));
+        }
+        Err(_) => {
+            request.insert("body".into(), Value::Null);
+            request.insert("body_kind".into(), Value::String("base64".to_string()));
+        }
+    }
     request.insert(
         "body_base64".into(),
         Value::String(base64::engine::general_purpose::STANDARD.encode(body)),

--- a/crates/harn-serve/src/http_codec.rs
+++ b/crates/harn-serve/src/http_codec.rs
@@ -231,6 +231,19 @@ fn envelope_to_outcome(envelope: HttpEnvelope, request_id: &str) -> HttpCodecOut
                 chunks,
             }
         }
+        "bytes" => {
+            let chunks = envelope
+                .body
+                .as_ref()
+                .and_then(value_to_bytes)
+                .into_iter()
+                .collect();
+            HttpCodecOutcome::Stream {
+                status,
+                headers,
+                chunks,
+            }
+        }
         "sse" => {
             let events = body_to_sse(envelope.body.as_ref());
             HttpCodecOutcome::Sse {
@@ -604,6 +617,10 @@ mod tests {
         String::from_utf8(bytes.to_vec()).unwrap()
     }
 
+    async fn body_bytes(response: Response) -> Bytes {
+        to_bytes(response.into_body(), usize::MAX).await.unwrap()
+    }
+
     #[test]
     fn auth_request_from_http_lowercases_headers_and_drops_invalid_utf8() {
         let mut headers = HeaderMap::new();
@@ -780,6 +797,34 @@ mod tests {
         });
         let response = make_response(envelope);
         assert_eq!(body_text(response).await, "hello");
+    }
+
+    #[tokio::test]
+    async fn bytes_envelope_renders_raw_body_and_headers() {
+        let envelope = json!({
+            "__http_response__": "v1",
+            "status": 200,
+            "body_kind": "bytes",
+            "headers": {
+                "Content-Type": "application/vnd.harn.harnpack",
+                "Content-Disposition": "attachment; filename=\"demo.harnpack\"",
+            },
+            "body": {"$bytes_b64": "AP/+gA=="},
+        });
+        let response = make_response(envelope);
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/vnd.harn.harnpack"
+        );
+        assert_eq!(
+            response.headers().get(header::CONTENT_DISPOSITION).unwrap(),
+            "attachment; filename=\"demo.harnpack\""
+        );
+        assert_eq!(
+            body_bytes(response).await.as_ref(),
+            &[0x00, 0xff, 0xfe, 0x80]
+        );
     }
 
     // --- End-to-end: .harn handler -> DispatchCore -> codec ----------

--- a/crates/harn-serve/tests/site_hosting.rs
+++ b/crates/harn-serve/tests/site_hosting.rs
@@ -48,7 +48,7 @@ pub fn conditional(req: dict) -> dict {
   if inm == etag {
     return http_not_modified(etag, {})
   }
-  return http_response(200, json_parse(body), { "ETag": etag })
+  return http_reply(200, json_parse(body), { "ETag": etag })
 }
 
 // Binary-safe multipart: the raw bytes survive the JSON dispatch boundary
@@ -57,7 +57,25 @@ pub fn conditional(req: dict) -> dict {
 pub fn upload(req: dict) -> dict {
   let raw = bytes_from_base64(req.body_base64)
   let parsed = multipart_parse(raw, req.headers["content-type"])
-  return http_ok({ "parts": parsed.field_count })
+  return http_ok({
+    "parts": parsed.field_count,
+    "body_is_nil": req.body == nil,
+    "body_kind": req.body_kind,
+    "body_base64_matches": bytes_to_base64(raw) == req.body_base64,
+    "content_length": req.content_length,
+  })
+}
+
+@route("GET", "/download")
+pub fn download(req: dict) -> dict {
+  return http_reply(
+    200,
+    bytes_from_base64("AP/+gA=="),
+    {
+      "Content-Type": "application/vnd.harn.harnpack",
+      "Content-Disposition": "attachment; filename=\"demo.harnpack\"",
+    },
+  )
 }
 
 // Zero-config: the handler_* convention mounts this at /ping.
@@ -306,13 +324,20 @@ async fn conditional_get_returns_304_via_http_not_modified() {
 async fn multipart_upload_is_observed_by_harn_handler() {
     let (_dir, router) = site_router();
     let boundary = "----site-host-boundary";
-    // Two fields, the second binary (a NUL byte) — proof the bytes survive
-    // the base64 round-trip into the handler intact.
-    let body = format!(
-        "--{boundary}\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\nhello\r\n\
-         --{boundary}\r\nContent-Disposition: form-data; name=\"blob\"; filename=\"a.bin\"\r\n\
-         Content-Type: application/octet-stream\r\n\r\n\x00\x01\x02\r\n--{boundary}--\r\n"
+    // Two fields, the second deliberately invalid UTF-8, so the hosted
+    // request must expose the base64 body path instead of a lossy text view.
+    let mut body = Vec::new();
+    body.extend_from_slice(
+        format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\nhello\r\n\
+             --{boundary}\r\nContent-Disposition: form-data; name=\"blob\"; filename=\"a.bin\"\r\n\
+             Content-Type: application/octet-stream\r\n\r\n"
+        )
+        .as_bytes(),
     );
+    body.extend_from_slice(&[0x00, 0xff, 0xfe, 0x80]);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+    let body_len = body.len();
     let response = router
         .oneshot(
             Request::builder()
@@ -322,7 +347,7 @@ async fn multipart_upload_is_observed_by_harn_handler() {
                     header::CONTENT_TYPE,
                     format!("multipart/form-data; boundary={boundary}"),
                 )
-                .body(Body::from(body.into_bytes()))
+                .body(Body::from(body))
                 .unwrap(),
         )
         .await
@@ -330,6 +355,36 @@ async fn multipart_upload_is_observed_by_harn_handler() {
     let (status, parsed) = read_json(response).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(parsed["parts"], 2);
+    assert_eq!(parsed["body_is_nil"], true);
+    assert_eq!(parsed["body_kind"], "base64");
+    assert_eq!(parsed["body_base64_matches"], true);
+    assert_eq!(parsed["content_length"].as_u64().unwrap(), body_len as u64);
+}
+
+#[tokio::test]
+async fn binary_response_from_harn_handler_round_trips_byte_exact() {
+    let (_dir, router) = site_router();
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/download")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers()[header::CONTENT_TYPE],
+        "application/vnd.harn.harnpack"
+    );
+    assert_eq!(
+        response.headers()[header::CONTENT_DISPOSITION],
+        "attachment; filename=\"demo.harnpack\""
+    );
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(body.as_ref(), &[0x00, 0xff, 0xfe, 0x80]);
 }
 
 #[tokio::test]

--- a/crates/harn-vm/src/stdlib/http_response.rs
+++ b/crates/harn-vm/src/stdlib/http_response.rs
@@ -33,6 +33,7 @@ pub const HTTP_RESPONSE_TAG_VERSION: &str = "v1";
 
 const BODY_KIND_JSON: &str = "json";
 const BODY_KIND_NONE: &str = "none";
+const BODY_KIND_BYTES: &str = "bytes";
 const BODY_KIND_STREAM: &str = "stream";
 const BODY_KIND_SSE: &str = "sse";
 
@@ -116,6 +117,8 @@ fn http_reply_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
     let headers = parse_headers(args.get(2), "http_reply")?;
     let body_kind = if status == 204 || status == 304 || matches!(body, VmValue::Nil) {
         BODY_KIND_NONE
+    } else if matches!(body, VmValue::Bytes(_)) {
+        BODY_KIND_BYTES
     } else {
         BODY_KIND_JSON
     };
@@ -1098,6 +1101,26 @@ mod tests {
             }
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    #[test]
+    fn http_reply_bytes_uses_bytes_body_kind() {
+        let bytes = VmValue::Bytes(std::sync::Arc::new(vec![0x00, 0xff, 0xfe, 0x80]));
+        let headers = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            "Content-Type".to_string(),
+            VmValue::String(std::sync::Arc::from("application/octet-stream")),
+        )])));
+        let response =
+            http_reply_impl(&[VmValue::Int(200), bytes, headers], &mut String::new()).unwrap();
+        let map = dict(&response);
+        assert_eq!(
+            map.get("body_kind").and_then(|v| match v {
+                VmValue::String(s) => Some(s.as_ref()),
+                _ => None,
+            }),
+            Some(BODY_KIND_BYTES)
+        );
+        assert!(matches!(map.get("body"), Some(VmValue::Bytes(_))));
     }
 
     #[test]

--- a/docs/src/harn-serve.md
+++ b/docs/src/harn-serve.md
@@ -53,7 +53,7 @@ adapter renders it into a real `axum::Response`:
 | `http_error(status, code, message, details?)`    | error envelope: `{ code, message, request_id, details? }` |
 | `http_stream(source, content_type?)`             | streamed body, `source` is a list or channel of chunks  |
 | `http_sse(source, retry_ms?)`                    | Server-Sent Events, `source` is a list or channel       |
-| `http_reply(status, body?, headers?)`            | low-level escape hatch for arbitrary 1xx-5xx codes      |
+| `http_reply(status, body?, headers?)`            | low-level escape hatch for arbitrary 1xx-5xx codes; a `bytes` body is rendered byte-exact |
 
 Plain values returned from a handler still work — they degrade to
 `200 OK` with `Content-Type: application/json`. Untagged dicts that
@@ -186,18 +186,19 @@ Mapping:
 
 - the request dict mirrors the in-process `http_server` shape:
   `{ method, path, route, path_params, params, query, headers, body,
-  body_base64, content_length, client_ip, remote_addr }`
-- `body` is the UTF-8-lossy view; `body_base64` is the standard-base64
-  encoding of the raw bytes, so binary payloads (e.g. a multipart upload)
-  round-trip losslessly — recover them with
-  `bytes_from_base64(req.body_base64)` and hand the result to
-  `multipart_parse`
+  body_kind, body_base64, content_length, client_ip, remote_addr }`
+- `body` is set only when the payload is valid UTF-8; binary payloads set
+  `body` to `nil`, `body_kind` to `base64`, and `body_base64` to the
+  standard-base64 encoding of the raw bytes. Recover binary uploads with
+  `bytes_from_base64(req.body_base64)` and hand the result to `multipart_parse`
 - header keys are lower-cased; `client_ip` is read from
   `X-Forwarded-For` / `X-Real-IP` when present
 - responses go through the same codec as every other surface, so
   `http_ok` / `http_created` / `http_not_modified` / `http_error` /
-  `http_stream` / `http_sse` plus content negotiation, ETag, and
-  compression all behave identically
+  `http_stream` / `http_sse` / `http_reply` plus content negotiation, ETag,
+  and compression all behave identically. `http_reply(200, bytes, headers)`
+  returns the raw bytes with caller-supplied `Content-Type` /
+  `Content-Disposition` preserved.
 - WebSocket handlers return
   `http_upgrade_ws(req, { on_message: "fn_name" })`; the named function
   runs per inbound frame with a `{type, data}` / `{type, data_base64}`


### PR DESCRIPTION
## Summary
- preserve non-UTF-8 hosted-site request bodies by exposing `body_kind` and keeping `body_base64` byte-exact instead of using UTF-8 replacement
- teach `http_reply(..., bytes, headers)` to tag byte bodies and have the serve codec render them as raw bytes with caller headers preserved
- add unit/integration coverage and update harn-serve docs/changelog

Fixes #3214.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `make lint-test-patterns`
- `/Users/ksinder/projects/harn/target/debug/harn run scripts/check_rust_prompt_prose.harn -- --self-test`
- `/Users/ksinder/projects/harn/target/debug/harn run scripts/check_rust_prompt_prose.harn`
- `CARGO_BUILD_JOBS=4 cargo test -p harn-vm http_reply_bytes_uses_bytes_body_kind -- --nocapture`
- `CARGO_BUILD_JOBS=4 cargo test -p harn-serve`
- pre-push hook: markdownlint, targeted local Rust checks, generated highlight keyword check