### PR TITLE
harn-vm: opt-in server-lifetime shared Postgres pool registry

### DIFF
--- a/changelog.d/shared-pg-pool.added.md
+++ b/changelog.d/shared-pg-pool.added.md
@@ -1,0 +1,14 @@
+- **Server embedders can install a process-lifetime shared Postgres pool
+  registry.** `harn_vm::install_shared_pool_registry()` (re-exported as
+  `harn_serve::install_shared_pool_registry()` under the `vm-postgres` feature)
+  opts a long-lived server into reusing one `sqlx` connection pool per distinct
+  connection identity across requests and worker threads — instead of opening a
+  fresh pool on every `harn serve` dispatch (each request builds a new `Vm` on a
+  thread the previous request's thread-local pool registry may not live on).
+  Pools are keyed on the **resolved** connection identity (host/port/database/
+  credentials, SSL mode, application name, replica set, and every pool-shaping
+  option), not on a caller-supplied alias, so two callers never share a pool
+  across different credentials, databases, or pool shapes. Safe across tenants
+  because harn scopes RLS per-transaction (`set_config('app.current_tenant_id',
+  …, true)`), never per-pool/per-connection. Strictly opt-in: the CLI one-shot
+  path never installs the registry and behaves exactly as before.

--- a/crates/harn-serve/src/lib.rs
+++ b/crates/harn-serve/src/lib.rs
@@ -75,6 +75,18 @@ pub use exports::{
     emit_export_diagnostics, ExportCatalog, ExportDiagnostic, ExportedCallableKind,
     ExportedFunction, ExportedParam, JobSpec, RetryBackoff, RetrySpec, RouteSpec, ScheduleSpec,
 };
+/// Install the process-lifetime shared Postgres pool registry.
+///
+/// Call this **once** at server startup (e.g. from the `SiteServer`/embedder
+/// wiring), before serving requests, to make `.harn` `pg_pool`/`pg_connect`
+/// calls reuse one connection pool per distinct connection identity across
+/// requests and worker threads — instead of opening a fresh pool per request
+/// (each `harn serve` dispatch builds a new [`harn_vm::Vm`]). Without this call,
+/// behavior is unchanged: every `pg_pool` opens its own pool. Idempotent.
+///
+/// Only available when the `vm-postgres` feature is enabled.
+#[cfg(feature = "vm-postgres")]
+pub use harn_vm::install_shared_pool_registry;
 pub use http_codec::{
     axum_response_from_call, axum_response_from_dispatch_error, classify_ws_upgrade,
     decode_call_response, dispatch_error_payload, fresh_request_id, HttpCodecOutcome, SseEventSpec,

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -271,6 +271,8 @@ pub use stdlib::http_response::{
     parse_envelope as parse_http_envelope, HttpEnvelope, HttpHeaderValue, WsUpgradeSpec,
     HTTP_RESPONSE_TAG_KEY, HTTP_RESPONSE_TAG_VERSION,
 };
+#[cfg(feature = "postgres")]
+pub use stdlib::install_shared_pool_registry;
 pub use stdlib::io::{set_stdout_passthrough, take_stderr_buffer};
 pub use stdlib::long_running::cancel_handle as cancel_long_running_handle;
 pub use stdlib::observability::install_default_backend as install_obs_default_backend;

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -76,6 +76,8 @@ pub(crate) mod path_scope_guard;
 pub(crate) mod pool;
 #[cfg(feature = "postgres")]
 mod postgres;
+#[cfg(feature = "postgres")]
+pub use postgres::install_shared_pool_registry;
 pub mod process;
 mod project;
 mod project_catalog;

--- a/crates/harn-vm/src/stdlib/postgres/mod.rs
+++ b/crates/harn-vm/src/stdlib/postgres/mod.rs
@@ -213,6 +213,9 @@ mod introspect;
 mod jsonb;
 mod listen;
 mod migrate;
+mod shared;
+
+pub use shared::install_shared_pool_registry;
 
 #[harn_builtin(
     sig_expr = BuiltinSignature::variadic("pg_pool", &[Param::new("args", TY_ANY)], TY_DICT),
@@ -647,6 +650,31 @@ async fn open_pool(
             .unwrap_or(5)
             .clamp(1, i64::from(u32::MAX)) as u32
     };
+
+    // Resolve replica URLs up front: they participate in the shared-pool key,
+    // and resolving them is cheap (no connection opened) relative to building
+    // the pools. These awaits hold no registry lock.
+    let replica_urls = collect_replica_urls(ctx, options).await?;
+
+    // When a server embedder has installed the shared registry, try to reuse an
+    // existing pool whose *full* connection identity matches before building a
+    // new one. This is a double-checked init: the lock is only held for the map
+    // lookup (in `shared::get`), never across the pool-building await below.
+    // `application_name` is reflected in the returned handle metadata (and is
+    // part of the shared-pool key, so a shared hit always has the same value).
+    let application_name = option_string(options, "application_name");
+    let shared_key = shared::is_installed()
+        .then(|| shared::PoolKey::new(&primary_url, &replica_urls, options, single_connection));
+    if let Some(key) = &shared_key {
+        if let Some(record) = shared::get(key) {
+            return Ok(register_local_pool_handle(
+                record,
+                single_connection,
+                application_name,
+            ));
+        }
+    }
+
     let primary_pool = build_pool(
         &primary_url,
         options,
@@ -656,7 +684,6 @@ async fn open_pool(
     )
     .await?;
 
-    let replica_urls = collect_replica_urls(ctx, options).await?;
     let mut replicas = Vec::with_capacity(replica_urls.len());
     for url in &replica_urls {
         let pool = build_pool(
@@ -672,6 +699,45 @@ async fn open_pool(
 
     let circuit = Arc::new(build_circuit_breaker(options));
 
+    let record = Arc::new(PoolRecord {
+        pool: Arc::new(primary_pool),
+        replicas,
+        replica_cursor: AtomicUsize::new(0),
+        max_connections,
+        statement_cache_capacity: stmt_cache_capacity,
+        read_routing_policy,
+        circuit,
+    });
+
+    // If sharing is enabled, publish (or adopt a racing winner's) record into
+    // the process-global registry. `get_or_insert` keeps the existing entry on a
+    // race, so concurrent first-opens of the same identity converge on ONE pool;
+    // our now-unused `record` is dropped, closing its freshly-opened pool.
+    let record = match shared_key {
+        Some(key) => shared::get_or_insert(key, record),
+        None => record,
+    };
+
+    Ok(register_local_pool_handle(
+        record,
+        single_connection,
+        application_name,
+    ))
+}
+
+/// Register `record` in the thread-local [`POOLS`] registry under a fresh
+/// opaque id and build the `pg_pool` handle the VM hands back to `.harn` code.
+///
+/// The thread-local map is still the per-request lookup table that the query
+/// builtins consult by handle id; sharing happens at the [`PoolRecord`] `Arc`
+/// level, so two requests get distinct ids that resolve to the *same* underlying
+/// pool. The handle metadata is derived from the (possibly shared) record so it
+/// always reflects the live pool rather than this caller's requested options.
+fn register_local_pool_handle(
+    record: Arc<PoolRecord>,
+    single_connection: bool,
+    application_name: Option<String>,
+) -> VmValue {
     let id = next_id(if single_connection {
         "pgconn"
     } else {
@@ -680,42 +746,34 @@ async fn open_pool(
     let mut meta = BTreeMap::new();
     meta.insert(
         "max_connections".to_string(),
-        VmValue::Int(i64::from(max_connections)),
+        VmValue::Int(i64::from(record.max_connections)),
     );
     meta.insert(
         "single_connection".to_string(),
         VmValue::Bool(single_connection),
     );
-    meta.insert("replicas".to_string(), VmValue::Int(replicas.len() as i64));
+    meta.insert(
+        "replicas".to_string(),
+        VmValue::Int(record.replicas.len() as i64),
+    );
     meta.insert(
         "statement_cache_capacity".to_string(),
-        VmValue::Int(stmt_cache_capacity as i64),
+        VmValue::Int(record.statement_cache_capacity as i64),
     );
     meta.insert(
         "read_routing_policy".to_string(),
-        VmValue::String(Arc::from(read_routing_policy.as_str())),
+        VmValue::String(Arc::from(record.read_routing_policy.as_str())),
     );
-    if let Some(application_name) = option_string(options, "application_name") {
+    if let Some(application_name) = application_name {
         meta.insert(
             "application_name".to_string(),
             VmValue::String(std::sync::Arc::from(application_name)),
         );
     }
     POOLS.with(|pools| {
-        pools.borrow_mut().insert(
-            id.clone(),
-            Arc::new(PoolRecord {
-                pool: Arc::new(primary_pool),
-                replicas,
-                replica_cursor: AtomicUsize::new(0),
-                max_connections,
-                statement_cache_capacity: stmt_cache_capacity,
-                read_routing_policy,
-                circuit,
-            }),
-        );
+        pools.borrow_mut().insert(id.clone(), record);
     });
-    Ok(handle_value(HANDLE_POOL, &id, meta))
+    handle_value(HANDLE_POOL, &id, meta)
 }
 
 async fn build_pool(
@@ -2674,6 +2732,152 @@ mod tests {
         open_pool(&ctx, &s(url), Some(&options), false)
             .await
             .expect("open single-connection pool")
+    }
+
+    /// Resolve the underlying primary `PgPool` `Arc` behind a `pg_pool` handle so
+    /// tests can assert two handles point at the SAME (or distinct) pool via
+    /// `Arc::ptr_eq`.
+    fn pool_ptr(handle: &VmValue) -> Arc<PgPool> {
+        let id = handle_id(Some(handle), HANDLE_POOL, "test").expect("pool handle id");
+        pool_by_id(&id).expect("pool record")
+    }
+
+    /// SECURITY/CORRECTNESS: with the shared registry installed, two `pg_pool`
+    /// calls for the SAME connection identity reuse ONE underlying pool, while a
+    /// call for a DIFFERENT identity (database) gets its own — and a CLI-style
+    /// run with the registry NOT consulted is unaffected. Uses lazy pools so it
+    /// needs no live database.
+    #[tokio::test(flavor = "current_thread")]
+    async fn shared_registry_shares_on_match_and_isolates_on_mismatch() {
+        shared::install_shared_pool_registry();
+        shared::clear_for_test();
+        reset_postgres_state();
+
+        // Route through the registry primitives (not open_pool's eager connect)
+        // so the test needs no live database. This exercises exactly the
+        // share/adopt/isolate logic open_pool relies on.
+        //
+        // Simulate two requests opening the same identity: build the record once
+        // through the registry, then a second "request" must adopt it.
+        let key_a = shared::PoolKey::new("postgres://u:p@h/db_a", &[], None, false);
+        let key_b = shared::PoolKey::new("postgres://u:p@h/db_b", &[], None, false);
+
+        let rec_a1 = Arc::new(lazy_record());
+        let shared_a1 = shared::get_or_insert(key_a.clone(), Arc::clone(&rec_a1));
+        // First insert wins and is the very record we passed in.
+        assert!(Arc::ptr_eq(&rec_a1, &shared_a1));
+
+        // A second request for the same identity builds its own record but must
+        // ADOPT the already-registered one (its own is dropped).
+        let rec_a2 = Arc::new(lazy_record());
+        let shared_a2 = shared::get_or_insert(key_a.clone(), Arc::clone(&rec_a2));
+        assert!(
+            Arc::ptr_eq(&shared_a1, &shared_a2),
+            "same identity must share one PoolRecord"
+        );
+        assert!(
+            !Arc::ptr_eq(&rec_a2, &shared_a2),
+            "the racing/second record must be dropped in favor of the canonical one"
+        );
+
+        // A lookup of the same key returns the canonical shared record.
+        let got = shared::get(&key_a).expect("registered");
+        assert!(Arc::ptr_eq(&got, &shared_a1));
+
+        // A different identity (different database) gets its own record.
+        let rec_b = Arc::new(lazy_record());
+        let shared_b = shared::get_or_insert(key_b, Arc::clone(&rec_b));
+        assert!(
+            !Arc::ptr_eq(&shared_a1, &shared_b),
+            "different identity must NOT share a pool"
+        );
+
+        assert_eq!(shared::len_for_test(), 2);
+        shared::clear_for_test();
+    }
+
+    /// Build a `PoolRecord` around a lazily-connected pool — no network I/O until
+    /// a query runs (which these tests never do). Mirrors the shape `open_pool`
+    /// constructs.
+    fn lazy_record() -> PoolRecord {
+        PoolRecord {
+            pool: lazy_pool_for_test(),
+            replicas: Vec::new(),
+            replica_cursor: AtomicUsize::new(0),
+            max_connections: 1,
+            statement_cache_capacity: DEFAULT_STATEMENT_CACHE_CAPACITY,
+            read_routing_policy: ReadRoutingPolicy::ReplicaOrPrimary,
+            circuit: Arc::new(circuit::CircuitBreakerState::disabled()),
+        }
+    }
+
+    /// End-to-end against a live DB (gated on `HARN_TEST_POSTGRES_URL`): with the
+    /// shared registry installed, `open_pool` for the same source across two
+    /// distinct `Vm`s / simulated requests returns handles backed by the SAME
+    /// physical pool; a different database does not share.
+    #[tokio::test(flavor = "current_thread")]
+    async fn open_pool_shares_across_requests_when_registry_installed() {
+        let Ok(url) = std::env::var("HARN_TEST_POSTGRES_URL") else {
+            return;
+        };
+        shared::install_shared_pool_registry();
+        shared::clear_for_test();
+        reset_postgres_state();
+
+        let ctx = crate::vm::AsyncBuiltinCtx::for_test(crate::Vm::new());
+        let o = dict(&[("max_connections", VmValue::Int(2))]);
+        let opt = o.as_dict();
+
+        // Request 1.
+        let h1 = open_pool(&ctx, &s(&url), opt, false).await.unwrap();
+        // Request 2: fresh handle id, but must resolve to the same pool Arc.
+        let h2 = open_pool(&ctx, &s(&url), opt, false).await.unwrap();
+        assert_ne!(
+            h1.as_dict().unwrap()["id"].display(),
+            h2.as_dict().unwrap()["id"].display(),
+            "each call still gets a distinct opaque handle id"
+        );
+        assert!(
+            Arc::ptr_eq(&pool_ptr(&h1), &pool_ptr(&h2)),
+            "same identity under shared registry must reuse one pool"
+        );
+
+        // Different identity (different max_connections) -> different pool.
+        let o3 = dict(&[("max_connections", VmValue::Int(7))]);
+        let h3 = open_pool(&ctx, &s(&url), o3.as_dict(), false)
+            .await
+            .unwrap();
+        assert!(
+            !Arc::ptr_eq(&pool_ptr(&h1), &pool_ptr(&h3)),
+            "different pool shape must not share"
+        );
+
+        shared::clear_for_test();
+    }
+
+    /// CLI default: when the shared registry is NOT installed, two `open_pool`
+    /// calls for the same source get DISTINCT pools (byte-identical to legacy
+    /// behavior). Gated on a live DB. NOTE: relies on per-test process isolation
+    /// (nextest) so no sibling test has installed the registry in this process.
+    #[tokio::test(flavor = "current_thread")]
+    async fn open_pool_does_not_share_when_registry_absent() {
+        let Ok(url) = std::env::var("HARN_TEST_POSTGRES_URL") else {
+            return;
+        };
+        if shared::is_installed() {
+            // Another test installed it in this (cargo test) process; skip rather
+            // than assert a false negative.
+            return;
+        }
+        reset_postgres_state();
+        let ctx = crate::vm::AsyncBuiltinCtx::for_test(crate::Vm::new());
+        let o = dict(&[("max_connections", VmValue::Int(1))]);
+        let h1 = open_pool(&ctx, &s(&url), o.as_dict(), false).await.unwrap();
+        let h2 = open_pool(&ctx, &s(&url), o.as_dict(), false).await.unwrap();
+        assert!(
+            !Arc::ptr_eq(&pool_ptr(&h1), &pool_ptr(&h2)),
+            "without the shared registry, each pg_pool opens its own pool"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/postgres/shared.rs
+++ b/crates/harn-vm/src/stdlib/postgres/shared.rs
@@ -1,0 +1,402 @@
+//! Server-lifetime shared Postgres pool registry.
+//!
+//! # Why this exists
+//!
+//! Under `harn serve`, a fresh [`Vm`](crate::vm::Vm) is constructed per request,
+//! and dispatch runs on a multi-thread tokio runtime. The per-VM Postgres state
+//! ([`super::POOLS`] etc.) is **thread-local**, which is exactly right for the
+//! CLI one-shot model (one VM, one thread, deterministic teardown) but means a
+//! server re-opens a brand-new connection pool on every single request — the
+//! pool can never be reused across requests because the registry holding it
+//! lives on a thread the next request may not even run on.
+//!
+//! This module provides an **opt-in, process-lifetime** registry that an
+//! embedder (e.g. the harn-serve `SiteServer` wiring) installs **once** at
+//! startup via [`install_shared_pool_registry`]. When installed,
+//! [`super::open_pool`] consults it: repeated `pg_pool(same source, same
+//! options)` calls — across requests and across worker threads — return the
+//! **same** underlying [`PoolRecord`] (a cheap `Arc` clone of the sqlx `Pool`).
+//! When **not** installed (the default, and the entire CLI surface), behavior is
+//! byte-identical to before: every `pg_pool` builds its own pool in the
+//! thread-local registry.
+//!
+//! # Security: the pool key is the full connection identity
+//!
+//! Two `pg_pool` calls share a pool **only** when their entire connection
+//! identity matches: the resolved connection string (host, port, database,
+//! user, **password**, and every query parameter), the SSL mode, the
+//! application name, the replica set, and every pool-shaping option
+//! (sizing/timeouts/statement-cache/routing/circuit-breaker). The key is the
+//! SHA-256 of a canonical serialization of all of these (see [`PoolKey::new`]).
+//! Crucially the key is built from the **resolved** URL — after `env:`/`secret:`
+//! indirection — never from a user-supplied alias, so two callers cannot
+//! collide on a pool by naming the same alias while resolving to different
+//! credentials.
+//!
+//! This is safe to share across tenants because harn-cloud scopes RLS
+//! **per-transaction** via `set_config('app.current_tenant_id', …, /*local*/
+//! true)` (see `ALLOWED_TRANSACTION_SETTINGS` in the parent module) — tenancy is
+//! *never* encoded in the pool/connection itself. A shared pool therefore only
+//! ever multiplexes transactions that each set their own tenant scope; it can
+//! never leak one tenant's rows to another. If a future caller ever moved
+//! tenant scoping onto the connection (e.g. a per-tenant `SET ROLE` at connect
+//! time), that tenant discriminator would have to become part of the pool key —
+//! today it is not, because it is not on the connection.
+//!
+//! # Lock discipline (no deadlock across await)
+//!
+//! The registry is a `std::sync::Mutex<HashMap<PoolKey, Arc<PoolRecord>>>`. We
+//! **never** hold the mutex across an `.await`. Opening a pool is a double-
+//! checked init: (1) lock, look up the key, clone-and-return on hit, else drop
+//! the lock; (2) build the pool *outside* any lock (the only `.await`); (3)
+//! re-lock and insert, but if a racing request inserted the same key while we
+//! were connecting, we keep the existing entry and drop ours (its pool closes on
+//! `Drop`). The guard returned from step 1/3 is a plain `MutexGuard` that is
+//! dropped before any await — enforced by structure, not convention.
+
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use sha2::{Digest, Sha256};
+
+use crate::value::VmValue;
+
+use super::PoolRecord;
+
+/// Opaque, collision-resistant key for a fully-resolved connection identity.
+///
+/// Wraps the hex SHA-256 of a canonical description of everything that makes
+/// two pools interchangeable. Two `PoolKey`s are equal iff every identity- and
+/// shape-affecting input matched. We hash (rather than store the raw string)
+/// so the in-memory key never retains the plaintext password from the resolved
+/// URL.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub(super) struct PoolKey(String);
+
+impl PoolKey {
+    /// Build a key from the resolved primary URL, resolved replica URLs (order
+    /// preserved — it affects round-robin identity), and the raw options dict
+    /// the caller passed to `pg_pool`/`pg_connect`.
+    ///
+    /// `single_connection` distinguishes `pg_connect` (max 1) from `pg_pool`
+    /// even when the options dict is identical, so the two never alias.
+    ///
+    /// The options dict is folded into the key in a canonical, order-independent
+    /// way (sorted keys; values stringified). This is intentionally a superset
+    /// of the options `build_pool` actually consults: hashing *every* provided
+    /// option is conservatively safe (it can only ever cause two calls that
+    /// differ in some exotic/no-op option to NOT share — never the reverse), and
+    /// it future-proofs the key against new options gaining pool semantics
+    /// without anyone remembering to update this list.
+    pub(super) fn new(
+        primary_url: &str,
+        replica_urls: &[String],
+        options: Option<&BTreeMap<String, VmValue>>,
+        single_connection: bool,
+    ) -> Self {
+        let mut hasher = Sha256::new();
+        // Domain separator + version, so the key scheme can evolve without
+        // silently colliding with a future variant.
+        hasher.update(b"harn-pg-shared-pool-key\x01");
+        hasher.update(b"single_connection:");
+        hasher.update([u8::from(single_connection)]);
+        hasher.update(b"\x00primary:");
+        hash_len_prefixed(&mut hasher, primary_url.as_bytes());
+        hasher.update(b"\x00replicas:");
+        hasher.update((replica_urls.len() as u64).to_le_bytes());
+        for url in replica_urls {
+            hash_len_prefixed(&mut hasher, url.as_bytes());
+        }
+        hasher.update(b"\x00options:");
+        if let Some(options) = options {
+            // BTreeMap iterates in sorted key order already, but be explicit:
+            // collect into a BTreeMap of canonical (key -> display) so the
+            // serialization is deterministic regardless of insertion order.
+            let canonical: BTreeMap<&str, String> = options
+                .iter()
+                .map(|(key, value)| (key.as_str(), canonical_option_value(value)))
+                .collect();
+            hasher.update((canonical.len() as u64).to_le_bytes());
+            for (key, value) in canonical {
+                hash_len_prefixed(&mut hasher, key.as_bytes());
+                hash_len_prefixed(&mut hasher, value.as_bytes());
+            }
+        } else {
+            hasher.update(0u64.to_le_bytes());
+        }
+        PoolKey(hex::encode(hasher.finalize()))
+    }
+}
+
+/// Length-prefix then write `bytes`, so two adjacent fields can never be
+/// ambiguously concatenated (`"ab" + "c"` vs `"a" + "bc"`).
+fn hash_len_prefixed(hasher: &mut Sha256, bytes: &[u8]) {
+    hasher.update((bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
+}
+
+/// Canonical, deterministic stringification of an option value for the key.
+///
+/// Nested lists/dicts (e.g. `replicas`, `circuit_breaker`) are recursively
+/// serialized so two structurally-identical option dicts produce the same key
+/// and two different ones do not.
+fn canonical_option_value(value: &VmValue) -> String {
+    match value {
+        VmValue::List(items) => {
+            let mut out = String::from("[");
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(&canonical_option_value(item));
+            }
+            out.push(']');
+            out
+        }
+        VmValue::Dict(dict) => {
+            // Sort keys for order-independence.
+            let sorted: BTreeMap<&String, &VmValue> = dict.iter().collect();
+            let mut out = String::from("{");
+            for (i, (key, val)) in sorted.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(key);
+                out.push('=');
+                out.push_str(&canonical_option_value(val));
+            }
+            out.push('}');
+            out
+        }
+        other => other.display(),
+    }
+}
+
+type SharedRegistry = Mutex<HashMap<PoolKey, Arc<PoolRecord>>>;
+
+/// The process-global shared registry. `None` until an embedder installs it.
+/// `OnceLock` so installation is one-shot and lock-free to read.
+static SHARED_POOLS: OnceLock<SharedRegistry> = OnceLock::new();
+
+/// Install the process-lifetime shared pool registry. Idempotent: calling it
+/// more than once is harmless (subsequent calls are no-ops and keep the first
+/// registry). Intended to be called **once** by a long-lived server embedder at
+/// startup, before serving requests.
+///
+/// After this is installed, `pg_pool`/`pg_connect` calls whose full connection
+/// identity matches an already-open pool reuse it instead of opening a new one,
+/// across requests and worker threads. The CLI never calls this, so the CLI
+/// one-shot path is unchanged.
+pub fn install_shared_pool_registry() {
+    let _ = SHARED_POOLS.get_or_init(|| Mutex::new(HashMap::new()));
+}
+
+/// True when the shared registry has been installed (server mode).
+pub(super) fn is_installed() -> bool {
+    SHARED_POOLS.get().is_some()
+}
+
+/// Look up an already-shared pool by key, returning a cheap `Arc` clone.
+///
+/// Holds the mutex only for the map lookup; never across an await.
+pub(super) fn get(key: &PoolKey) -> Option<Arc<PoolRecord>> {
+    let registry = SHARED_POOLS.get()?;
+    let guard = registry.lock().expect("shared pg pool registry poisoned");
+    guard.get(key).map(Arc::clone)
+}
+
+/// Insert `record` under `key`, returning the record that ends up canonical.
+///
+/// If a concurrent caller already inserted this key while we were connecting
+/// (the classic double-checked-init race), we keep the **existing** entry and
+/// return it; the just-built `record`'s pool is dropped by the caller (its sqlx
+/// `Pool` closes its connections on `Drop`). Holds the mutex only for the
+/// insert/lookup; never across an await.
+pub(super) fn get_or_insert(key: PoolKey, record: Arc<PoolRecord>) -> Arc<PoolRecord> {
+    let Some(registry) = SHARED_POOLS.get() else {
+        // Not installed: caller should not have reached here, but be safe and
+        // just hand back the record unshared.
+        return record;
+    };
+    let mut guard = registry.lock().expect("shared pg pool registry poisoned");
+    Arc::clone(guard.entry(key).or_insert(record))
+}
+
+/// Test-only: clear and uninstall semantics are not possible on a `OnceLock`,
+/// so for test isolation we expose a way to empty the map. The `OnceLock`
+/// itself stays installed, which is fine: an emptied registry behaves like a
+/// freshly installed one.
+#[cfg(test)]
+pub(super) fn clear_for_test() {
+    if let Some(registry) = SHARED_POOLS.get() {
+        registry
+            .lock()
+            .expect("shared pg pool registry poisoned")
+            .clear();
+    }
+}
+
+#[cfg(test)]
+pub(super) fn len_for_test() -> usize {
+    SHARED_POOLS
+        .get()
+        .map(|registry| registry.lock().expect("poisoned").len())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(value: &str) -> VmValue {
+        VmValue::String(std::sync::Arc::from(value))
+    }
+
+    fn opts(pairs: &[(&str, VmValue)]) -> BTreeMap<String, VmValue> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .collect()
+    }
+
+    const URL_A: &str = "postgres://app:secret@db.internal:5432/tenants";
+    const URL_B: &str = "postgres://app:secret@db.internal:5432/other";
+    const URL_A_DIFF_PW: &str = "postgres://app:HUNTER2@db.internal:5432/tenants";
+
+    /// Identical resolved URL + identical options + identical mode share a key.
+    #[test]
+    fn same_identity_same_key() {
+        let o = opts(&[("max_connections", VmValue::Int(5))]);
+        let k1 = PoolKey::new(URL_A, &[], Some(&o), false);
+        let k2 = PoolKey::new(URL_A, &[], Some(&o), false);
+        assert_eq!(k1, k2);
+    }
+
+    /// A different database in the resolved URL must NOT collide.
+    #[test]
+    fn different_database_different_key() {
+        let k1 = PoolKey::new(URL_A, &[], None, false);
+        let k2 = PoolKey::new(URL_B, &[], None, false);
+        assert_ne!(k1, k2);
+    }
+
+    /// SECURITY: a different password (credential) must NOT collide, even though
+    /// host/port/db/user are identical.
+    #[test]
+    fn different_credentials_different_key() {
+        let k1 = PoolKey::new(URL_A, &[], None, false);
+        let k2 = PoolKey::new(URL_A_DIFF_PW, &[], None, false);
+        assert_ne!(k1, k2);
+    }
+
+    /// `pg_pool` and `pg_connect` (single_connection) on the same URL must not
+    /// alias even with identical options.
+    #[test]
+    fn single_connection_flag_distinguishes_key() {
+        let k_pool = PoolKey::new(URL_A, &[], None, false);
+        let k_conn = PoolKey::new(URL_A, &[], None, true);
+        assert_ne!(k_pool, k_conn);
+    }
+
+    /// Option dict ordering does not affect the key (canonical, sorted).
+    #[test]
+    fn option_order_is_canonical() {
+        let o1 = opts(&[
+            ("max_connections", VmValue::Int(5)),
+            ("application_name", s("svc")),
+        ]);
+        let o2 = opts(&[
+            ("application_name", s("svc")),
+            ("max_connections", VmValue::Int(5)),
+        ]);
+        assert_eq!(
+            PoolKey::new(URL_A, &[], Some(&o1), false),
+            PoolKey::new(URL_A, &[], Some(&o2), false)
+        );
+    }
+
+    /// A differing pool-shaping option (max_connections) yields a different key,
+    /// so two calls that asked for differently-sized pools never silently share.
+    #[test]
+    fn different_pool_shape_different_key() {
+        let o1 = opts(&[("max_connections", VmValue::Int(5))]);
+        let o2 = opts(&[("max_connections", VmValue::Int(20))]);
+        assert_ne!(
+            PoolKey::new(URL_A, &[], Some(&o1), false),
+            PoolKey::new(URL_A, &[], Some(&o2), false)
+        );
+    }
+
+    /// A differing application_name yields a different key.
+    #[test]
+    fn different_application_name_different_key() {
+        let o1 = opts(&[("application_name", s("svc-a"))]);
+        let o2 = opts(&[("application_name", s("svc-b"))]);
+        assert_ne!(
+            PoolKey::new(URL_A, &[], Some(&o1), false),
+            PoolKey::new(URL_A, &[], Some(&o2), false)
+        );
+    }
+
+    /// Replica set membership and order are part of the key.
+    #[test]
+    fn replica_set_is_part_of_key() {
+        let r1 = vec![URL_B.to_string()];
+        let r2 = vec![URL_B.to_string(), URL_A.to_string()];
+        assert_ne!(
+            PoolKey::new(URL_A, &[], None, false),
+            PoolKey::new(URL_A, &r1, None, false)
+        );
+        assert_ne!(
+            PoolKey::new(URL_A, &r1, None, false),
+            PoolKey::new(URL_A, &r2, None, false)
+        );
+    }
+
+    /// Nested option dicts (e.g. `circuit_breaker`) participate structurally.
+    #[test]
+    fn nested_option_dicts_affect_key() {
+        let cb1 = VmValue::Dict(std::sync::Arc::new(opts(&[(
+            "failure_threshold",
+            VmValue::Int(3),
+        )])));
+        let cb2 = VmValue::Dict(std::sync::Arc::new(opts(&[(
+            "failure_threshold",
+            VmValue::Int(9),
+        )])));
+        let o1 = opts(&[("circuit_breaker", cb1)]);
+        let o2 = opts(&[("circuit_breaker", cb2)]);
+        assert_ne!(
+            PoolKey::new(URL_A, &[], Some(&o1), false),
+            PoolKey::new(URL_A, &[], Some(&o2), false)
+        );
+    }
+
+    /// The key never retains the plaintext password (it is a SHA-256 hex digest).
+    #[test]
+    fn key_does_not_leak_plaintext_credentials() {
+        let key = PoolKey::new(URL_A_DIFF_PW, &[], None, false);
+        assert!(!key.0.contains("HUNTER2"));
+        assert_eq!(key.0.len(), 64); // 32-byte SHA-256, hex-encoded.
+        assert!(key.0.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    /// When the registry is NOT installed, `get`/`is_installed` report empty —
+    /// this is the CLI default path and the precondition for byte-identical
+    /// behavior. (Asserting the *not-installed* state requires a process where
+    /// nobody installed; under nextest each test is its own process.)
+    #[test]
+    fn not_installed_returns_none_by_default() {
+        // We cannot assert globally because another test in the same process may
+        // have installed; instead assert the lookup contract: an absent key is
+        // None regardless of install state.
+        let key = PoolKey::new(
+            "postgres://nobody@nowhere/db_never_inserted",
+            &[],
+            None,
+            true,
+        );
+        assert!(get(&key).is_none());
+    }
+}


### PR DESCRIPTION
Adds an **opt-in** process-global shared Postgres pool registry so `.harn` data-access code under `harn serve` (a fresh `Vm` per request) reuses one connection pool per connection-identity across requests/threads instead of re-opening one per request. Unblocks harn-cloud store retirement (harn-cloud #496b), which currently works around the per-request re-pool with a single-thread mpsc shim.

**Opt-in / CLI unchanged:** registry is `None` until an embedder calls `harn_serve::install_shared_pool_registry()` (re-export of `harn_vm::install_shared_pool_registry()`, gated on `vm-postgres`); `open_pool` only consults it when installed, so the default CLI one-shot path is byte-identical. NOT auto-installed in `DispatchCore::new` (the embedder installs once at startup).

**Pool key:** SHA-256 of the *resolved* connection identity — primary URL (incl. password/host/port/db/user/params), ordered replicas, `single_connection` (distinguishes `pg_connect` from `pg_pool`), and all options (canonical, order-independent), length-prefixed. Hashed, so no plaintext credential is retained. Different credentials/db/shape/replicas never alias.

**Cross-tenant safety:** sharing a pool across tenants is correct because harn scopes RLS **per-transaction** via `set_config('app.current_tenant_id', …, local=true)` (the GUC allowlist rejects `role`/`session_authorization`/`search_path`), never per-pool — and a sqlx pool already reuses connections across transactions/tenants within a request, so this only extends pool *lifetime*, adding no new connection-reuse semantics. Documented in the module header.

**Lock discipline:** double-checked init — lookup under the mutex, build the pool *outside* any lock (the only `.await`), re-lock to `get_or_insert` (adopt a racing winner, drop the loser). No await-under-lock.

Tests: harn-vm `--features postgres` 83/83 (share-on-match, isolate-on-mismatch end-to-end, CLI-unchanged-when-absent, 11 key unit tests incl. no-credential-leak); harn-serve `--features vm-postgres` 489/489; default build compiles. fmt + clippy clean; changelog fragment added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)