### PR TITLE
fix(parser): unify @job(retry:) and @retry(...) validation (post-#3233)

### DIFF
--- a/changelog.d/retry-validator-parity.changed.md
+++ b/changelog.d/retry-validator-parity.changed.md
@@ -1,0 +1,5 @@
+- **`@retry(...)` and `@job(retry: {...})` now share one validator.** The
+  standalone job modifier and its compact dict alias are documented as
+  equivalent, so their recognized keys and backoff strategies
+  (`svix`/`linear`/`exponential`) are now a single source of truth — the two
+  surfaces can no longer drift apart in what they accept or reject.

--- a/crates/harn-parser/src/typechecker/inference/statements/attributes.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements/attributes.rs
@@ -1,5 +1,12 @@
 use super::*;
 
+/// Recognized retry fields, shared by the compact `@job(retry: {...})` dict
+/// and the standalone `@retry(...)` attribute (documented aliases — keep them
+/// in lockstep).
+const RETRY_KNOWN_KEYS: &[&str] = &["max", "max_attempts", "backoff", "policy"];
+/// Recognized backoff strategies for both retry surfaces (case-insensitive).
+const RETRY_BACKOFFS: &[&str] = &["svix", "linear", "exponential"];
+
 impl TypeChecker {
     /// Validate attribute usage and emit warnings for unknown attributes.
     /// Recognized attribute names are the runtime/tooling attributes plus
@@ -670,6 +677,53 @@ impl TypeChecker {
         }
     }
 
+    /// Validate one recognized retry field (`max`/`max_attempts`/`backoff`/
+    /// `policy`) for either retry surface. The compact `@job(retry: {...})`
+    /// dict and the standalone `@retry(...)` attribute are documented as
+    /// aliases, so they MUST validate identically — sharing this helper (and
+    /// [`RETRY_KNOWN_KEYS`]/[`RETRY_BACKOFFS`]) is what keeps them from
+    /// drifting. `key_span` points at the field name (unknown-key warning),
+    /// `value_span` at its value (type warnings). `label` is the surface name
+    /// woven into messages (`@job(retry: {{ ... }})` or `@retry(...)`).
+    fn validate_retry_field(
+        &mut self,
+        key: &str,
+        value: &Node,
+        key_span: Span,
+        value_span: Span,
+        label: &str,
+    ) {
+        if !RETRY_KNOWN_KEYS.contains(&key) {
+            self.warning_at(
+                Code::InvalidAttributeArgument,
+                format!("unknown `{label}` field `{key}`; expected one of {RETRY_KNOWN_KEYS:?}"),
+                key_span,
+            );
+            return;
+        }
+        match (key, value) {
+            ("max" | "max_attempts", Node::IntLiteral(i)) if *i >= 0 => {}
+            ("max" | "max_attempts", _) => self.warning_at(
+                Code::InvalidAttributeArgument,
+                format!("`{label}` `max` must be a non-negative integer"),
+                value_span,
+            ),
+            ("backoff" | "policy", value) => {
+                let ok = symbol_like_value(value)
+                    .map(|v| RETRY_BACKOFFS.contains(&v.to_ascii_lowercase().as_str()))
+                    .unwrap_or(false);
+                if !ok {
+                    self.warning_at(
+                        Code::InvalidAttributeArgument,
+                        format!("`{label}` `backoff` must be one of {RETRY_BACKOFFS:?}"),
+                        value_span,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
     /// Validate `@job("name", retry: { max:, backoff: })`. The positional
     /// name (optional) must be a string; the compact named `retry` dict is
     /// accepted as an alias for the standalone `@retry(...)` job modifier.
@@ -710,8 +764,6 @@ impl TypeChecker {
     }
 
     pub(super) fn expect_job_retry_dict(&mut self, value: &SNode, span: Span) {
-        const KNOWN_KEYS: &[&str] = &["max", "max_attempts", "backoff", "policy"];
-        const BACKOFFS: &[&str] = &["svix", "linear", "exponential"];
         let Node::DictLiteral(entries) = &value.node else {
             self.warning_at(
                 Code::InvalidAttributeArgument,
@@ -730,46 +782,20 @@ impl TypeChecker {
                 );
                 continue;
             };
-            if !KNOWN_KEYS.contains(&field_name) {
-                self.warning_at(
-                    Code::InvalidAttributeArgument,
-                    format!(
-                        "unknown `@job(retry: ...)` field `{field_name}`; expected one of {KNOWN_KEYS:?}"
-                    ),
-                    entry.key.span,
-                );
-                continue;
-            }
-            match (field_name, &entry.value.node) {
-                ("max" | "max_attempts", Node::IntLiteral(i)) if *i >= 0 => {}
-                ("max" | "max_attempts", _) => self.warning_at(
-                    Code::InvalidAttributeArgument,
-                    "`@job(retry: { max: ... })` must be a non-negative integer".to_string(),
-                    entry.value.span,
-                ),
-                ("backoff" | "policy", value) => {
-                    let ok = symbol_like_value(value)
-                        .map(|v| BACKOFFS.contains(&v.to_ascii_lowercase().as_str()))
-                        .unwrap_or(false);
-                    if !ok {
-                        self.warning_at(
-                            Code::InvalidAttributeArgument,
-                            format!(
-                                "`@job(retry: {{ backoff: ... }})` must be one of {BACKOFFS:?}"
-                            ),
-                            entry.value.span,
-                        );
-                    }
-                }
-                _ => {}
-            }
+            self.validate_retry_field(
+                field_name,
+                &entry.value.node,
+                entry.key.span,
+                entry.value.span,
+                "@job(retry: { ... })",
+            );
         }
     }
 
-    /// Validate `@retry(max: N, backoff: "strategy")`.
+    /// Validate `@retry(max: N, backoff: "strategy")`. Documented as an alias
+    /// for the compact `@job(retry: {...})` dict, so it shares
+    /// [`TypeChecker::validate_retry_field`] to stay in lockstep.
     pub(super) fn validate_retry_args(&mut self, attr: &Attribute) {
-        const KNOWN_KEYS: &[&str] = &["max", "max_attempts", "backoff", "policy"];
-        const BACKOFFS: &[&str] = &["svix", "linear", "exponential"];
         for arg in &attr.args {
             let Some(name) = arg.name.as_deref() else {
                 self.warning_at(
@@ -780,35 +806,13 @@ impl TypeChecker {
                 );
                 continue;
             };
-            if !KNOWN_KEYS.contains(&name) {
-                self.warning_at(
-                    Code::InvalidAttributeArgument,
-                    format!("unknown `@retry` argument `{name}`; expected one of {KNOWN_KEYS:?}"),
-                    arg.span,
-                );
-                continue;
-            }
-            match (name, &arg.value.node) {
-                ("max" | "max_attempts", Node::IntLiteral(i)) if *i >= 0 => {}
-                ("max" | "max_attempts", _) => self.warning_at(
-                    Code::InvalidAttributeArgument,
-                    "`@retry(max: ...)` must be a non-negative integer".to_string(),
-                    arg.value.span,
-                ),
-                ("backoff" | "policy", value) => {
-                    let ok = symbol_like_value(value)
-                        .map(|v| BACKOFFS.contains(&v.to_ascii_lowercase().as_str()))
-                        .unwrap_or(false);
-                    if !ok {
-                        self.warning_at(
-                            Code::InvalidAttributeArgument,
-                            format!("`@retry(backoff: ...)` must be one of {BACKOFFS:?}"),
-                            arg.value.span,
-                        );
-                    }
-                }
-                _ => {}
-            }
+            self.validate_retry_field(
+                name,
+                &arg.value.node,
+                arg.span,
+                arg.value.span,
+                "@retry(...)",
+            );
         }
     }
 

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -396,6 +396,39 @@ pipeline test_bare_serial(task) {}
 }
 
 #[test]
+fn test_job_retry_dict_and_standalone_retry_validate_identically() {
+    // The compact `@job(retry: {...})` dict and the standalone `@retry(...)`
+    // attribute are documented aliases and now share one validator, so they
+    // MUST accept/reject the same backoff strategies. A valid strategy warns
+    // on neither; an invalid one warns on both. Guards against the two
+    // surfaces drifting (e.g. one list keeping a `"exp"` the other dropped).
+    let valid = warnings(
+        r#"
+@job("nightly", retry: {max: 3, backoff: "exponential"})
+@retry(max: 3, backoff: "linear")
+fn nightly() -> string { return "ok" }
+"#,
+    );
+    assert!(
+        valid.iter().all(|w| !w.contains("backoff")),
+        "recognized backoff strategies must warn on neither retry surface: {valid:?}"
+    );
+
+    let invalid = warnings(
+        r#"
+@job("nightly", retry: {max: 3, backoff: "exp"})
+@retry(max: 3, backoff: "exp")
+fn nightly() -> string { return "ok" }
+"#,
+    );
+    let backoff_warns = invalid.iter().filter(|w| w.contains("backoff")).count();
+    assert_eq!(
+        backoff_warns, 2,
+        "an unrecognized backoff must warn on BOTH retry surfaces (compact + standalone): {invalid:?}"
+    );
+}
+
+#[test]
 fn test_heavy_attribute_requires_positive_int_threads() {
     let warns = warnings(
         r#"


### PR DESCRIPTION
## Summary

Review pass over the last ~10 merged PRs (#3224, #3226, #3228, #3229, #3230, #3231, #3232, #3233) surfaced one genuine, generalizable defect introduced by #3233 (Complete Harn job worker surface).

#3233 added a standalone `@retry(...)` job modifier next to the compact `@job(..., retry: {...})` dict and documents them as **aliases**, but shipped two independent validators that duplicate:
- the recognized keys (`max`/`max_attempts`/`backoff`/`policy`),
- the backoff-strategy allowlist (`svix`/`linear`/`exponential`), and
- the whole `(key, value)` match arm.

They had **already drifted once inside that PR**: `expect_job_retry_dict` dropped `"exp"` from its backoff list while the new `validate_retry_args` never carried it. Two documented-equivalent surfaces that validate from two copies of the same allowlist are a latent correctness hazard — a future edit to one and not the other makes the alias and the standalone form accept/reject different values.

## Fix

- Hoist `RETRY_KNOWN_KEYS` / `RETRY_BACKOFFS` to module-level consts (single source of truth).
- Extract one `validate_retry_field(key, value, key_span, value_span, label)` helper; both `expect_job_retry_dict` (compact dict) and `validate_retry_args` (standalone attr) call it.
- Behavior is unchanged — lint-only warnings, exactly the key/backoff sets `main` already enforced (message wording is now uniform across both surfaces).
- New parser unit test pins the parity invariant: a recognized backoff warns on **neither** surface; an unrecognized one warns on **both**.

## What else was reviewed (no fix needed)

- **#3230 / #3232 provider catalog** — cross-checked the OpenRouter caching/tool capabilities against live provider docs. All confirmed correct: DeepSeek = automatic caching (no breakpoint emitted), Gemini 2.5 = explicit `cache_control` on the last block (OpenRouter announced "set cache_control on a message… uses only the last breakpoint"), Anthropic = top-level, Qwen/Alibaba explicit list matches the catalog exactly. DeepSeek tool-capable alias rows order-correctly (v3.1 before chat\*; exact r1 before distill). No mismatch found.
- **#3226** warn-once sampling-param dedup — correct, thread_local registered in the audit toml, well tested.
- **#3224** empty-args cause-naming + stop_reason observability — correct; `is_length_truncation` is case-insensitive and `_stop_reason` is threaded from the loop.
- **#3228** mise/asdf PATH normalizer — sound (declaration-gated, no phantom paths). Minor Windows note: `apply_to_env` looks up the PATH key case-sensitively; a non-`PATH`-cased caller key on Windows could double-set — not worth churn for a gated, default-off feature.
- **#3229** binary site bodies, **#3231** fenced-json near-miss recovery — both correct; no false-positive paths found.

## Verification

- `cargo test -p harn-parser` — 471 passed
- `cargo clippy -p harn-parser --all-targets` — clean
- `cargo fmt -p harn-parser -- --check`
- `harn test conformance --filter attributes_step` (1/1), `--filter trigger` (75/75)

🤖 Generated with [Claude Code](https://claude.com/claude-code)