### PR TITLE
std/postgres/query: raw_sql / named_raw_sql no-scan helpers

### DIFF
--- a/changelog.d/named-raw-sql.added.md
+++ b/changelog.d/named-raw-sql.added.md
@@ -1,0 +1,8 @@
+- **`std/postgres/query` gains `raw_sql(template, params?)` and
+  `named_raw_sql(name, mode, template, params?)`.** These build query records
+  from literal SQL with **no** `{name}` scanning, so brace-heavy SQL — JSON
+  paths (`#>>'{}'`), array literals (`'{a,b}'::text[]`), and
+  `jsonb_set(.., '{path}', ..)` — no longer needs `{{`/`}}` doubling.
+  Parameters are positional (`$1`, `$2`, ...). The existing `sql(...)` /
+  `named_sql(...)` named-placeholder behavior, including `{{`/`}}` escaping and
+  `unsafe_sql(...)` fragments, is unchanged.

--- a/conformance/tests/stdlib/postgres_query_helpers.expected
+++ b/conformance/tests/stdlib/postgres_query_helpers.expected
@@ -29,3 +29,14 @@ true
 true
 vaults.id::text AS id, to_json(vaults.created_at)#>>'{}' AS created_at, CASE WHEN items.expires_at IS NULL THEN NULL ELSE to_json(items.expires_at)#>>'{}' END AS expires_at
 true
+SELECT data#>>'{}' AS data FROM events WHERE tags && '{a,b}'::text[] AND tenant_id = $1::uuid
+tenant-a
+1
+UPDATE t SET d = jsonb_set(d, '{path}', $1)
+42
+SELECT '{}'::jsonb AS empty
+scan_events
+many
+true
+true
+true

--- a/conformance/tests/stdlib/postgres_query_helpers.harn
+++ b/conformance/tests/stdlib/postgres_query_helpers.harn
@@ -6,10 +6,12 @@ import {
   ident_path,
   many,
   named,
+  named_raw_sql,
   named_sql,
   nullable_timestamptz_json,
   one,
   quote_identifier,
+  raw_sql,
   run,
   select_clause,
   sql,
@@ -157,4 +159,30 @@ LIMIT {limit}
     timestamptz_json("vaults.bad;drop")
   }
   __io_println(is_err(bad_qualified))
+  // raw_sql: braces are literal, no {name} scanning, positional params.
+  let raw_query = raw_sql(
+    "SELECT data#>>'{}' AS data FROM events WHERE tags && '{a,b}'::text[] AND tenant_id = $1::uuid",
+    ["tenant-a"],
+  )
+  __io_println(raw_query.sql)
+  __io_println(raw_query.params?[0])
+  __io_println(len(raw_query.params ?? []))
+  // A bare {path} that would be a placeholder in sql(...) is left untouched.
+  let raw_jsonb = raw_sql("UPDATE t SET d = jsonb_set(d, '{path}', $1)", [42])
+  __io_println(raw_jsonb.sql)
+  __io_println(raw_jsonb.params?[0])
+  // named_raw_sql carries name + mode and renders verbatim.
+  let raw_named = named_raw_sql("scan_events", "many", "SELECT '{}'::jsonb AS empty", [])
+  __io_println(raw_named.sql)
+  __io_println(raw_named.name)
+  __io_println(raw_named.mode)
+  let raw_empty = try {
+    raw_sql("   ", [])
+  }
+  __io_println(is_err(raw_empty))
+  let raw_named_empty = try {
+    named_raw_sql("nope", "one", "", [])
+  }
+  __io_println(is_err(raw_named_empty))
+  __io_println(regex_match("nope", to_string(unwrap_err(raw_named_empty))) != nil)
 }

--- a/crates/harn-stdlib/src/stdlib/postgres/query.harn
+++ b/crates/harn-stdlib/src/stdlib/postgres/query.harn
@@ -244,6 +244,57 @@ pub fn named_sql(
 }
 
 /**
+ * Build a parameterized query record from literal SQL, with NO `{name}`
+ * scanning.
+ *
+ * Unlike [`sql`], the template is used byte-for-byte: `{` and `}` are ordinary
+ * characters, so brace-heavy SQL — JSON paths (`#>>'{}'`), array literals
+ * (`'{a,b}'::text[]`), and `jsonb_set(.., '{path}', ..)` — needs no `{{`/`}}`
+ * doubling. Parameters are positional: write `$1`, `$2`, ... directly and pass
+ * the matching `params` list. This is the literal-SQL companion to [`sql`]; use
+ * [`sql`] when you want named placeholders and `{{`/`}}` escaping.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: raw_sql("SELECT data#>>'{}' FROM events WHERE tenant_id = $1::uuid", [tenant_id])
+ */
+pub fn raw_sql(template: string, params: list<any> = [], options = nil) -> PgQuery {
+  if type_of(template) != "string" || trim(template) == "" {
+    throw "std/postgres/query: SQL template must be a non-empty string"
+  }
+  return __normalize_query({sql: template, params: params, options: options})
+}
+
+/**
+ * Build a named parameterized query record from literal SQL, with NO `{name}`
+ * scanning.
+ *
+ * The named, mode-carrying companion to [`raw_sql`]: the template is used
+ * byte-for-byte (no `{{`/`}}` doubling) and parameters are positional `$1`,
+ * `$2`, ... matching the `params` list.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: named_raw_sql("list_events", "many", "SELECT data#>>'{}' FROM events WHERE tags && '{a,b}'::text[]", [])
+ */
+pub fn named_raw_sql(
+  name: string,
+  mode: PgQueryMode,
+  template: string,
+  params: list<any> = [],
+  options = nil,
+) -> PgNamedQuery {
+  if type_of(template) != "string" || trim(template) == "" {
+    throw __query_error_prefix({name: name}) + "sql must be a non-empty string"
+  }
+  return __normalize_query({name: name, mode: mode, sql: template, params: params, options: options})
+}
+
+/**
  * Run a query that returns zero or one row.
  *
  * @effects: [postgres]

--- a/docs/src/postgres.md
+++ b/docs/src/postgres.md
@@ -152,6 +152,26 @@ let q = sql(
 // q.params == [tenant_id]
 ```
 
+For brace-heavy literal SQL — JSON paths (`#>>'{}'`), array literals
+(`'{a,b}'::text[]`), `jsonb_set(.., '{path}', ..)` — doubling every brace is
+noisy and error-prone. `raw_sql(template, params?)` and
+`named_raw_sql(name, mode, template, params?)` take the SQL byte-for-byte with
+**no** `{name}` scanning, so braces need no `{{`/`}}` escaping. Parameters are
+positional — write `$1`, `$2`, ... yourself and pass the matching list:
+
+```harn,ignore
+let q = raw_sql(
+  "SELECT data#>>'{}' AS data FROM events WHERE tags && '{a,b}'::text[] AND tenant_id = $1::uuid",
+  [tenant_id],
+)
+// q.sql    == "SELECT data#>>'{}' AS data FROM events WHERE tags && '{a,b}'::text[] AND tenant_id = $1::uuid"
+// q.params == [tenant_id]
+```
+
+Use `sql(...)` / `named_sql(...)` when you want named placeholders and
+`{{`/`}}` escaping; reach for `raw_sql(...)` / `named_raw_sql(...)` when the SQL
+is literal and the braces are the SQL's own.
+
 Postgres cannot bind identifiers as parameters. Use `ident(...)` or
 `ident_path(...)` when SQL structure must be dynamic, and reserve
 `unsafe_sql(...)` for the rare source-controlled fragment that no typed helper


### PR DESCRIPTION
Additive literal-SQL helpers (no {name} scanning; positional $1/$2) to drop {{}} brace-doubling — companion to sql/named_sql. Surfaced converting 33 harn-cloud store families; also documents the jsonb_set('{path}',…) placeholder trap. No change to sql/named_sql/unsafe_sql (render byte-identical); conformance + docs + changelog included; zero Rust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)