### PR TITLE
harn: non-interactive git by default (prevent prompt-hangs)

### DIFF
--- a/changelog.d/git-noninteractive-default.fixed.md
+++ b/changelog.d/git-noninteractive-default.fixed.md
@@ -1,0 +1,15 @@
+- **Harn's git stdlib is now non-interactive by default, so a `.harn` git
+  operation can no longer hang on a credential or host-key prompt in a
+  TTY-less context (`harn serve`, `@job`, CI).** Every git subprocess the
+  stdlib spawns — the receipt builtins (`git.fetch`/`git.push`/`git.rebase`/
+  `git.worktree_create`/…) and the `std/worktree` helpers (`worktree_create`,
+  `worktree_status`, `worktree_diff`, `worktree_remove`, `worktree_shell`) —
+  now runs with `GIT_TERMINAL_PROMPT=0`, an empty `GIT_ASKPASS`/`SSH_ASKPASS`,
+  and an `ssh -oBatchMode=yes` transport so git fails fast instead of blocking
+  on an interactive prompt. The guard is merged (`env_mode: "merge"`), so
+  inherited `PATH`/`HOME` and credentials supplied via env, `.netrc`,
+  credential helpers, or a pre-loaded ssh-agent continue to authenticate
+  push/clone/fetch exactly as before — only *interactive prompting* is
+  disabled. `std/worktree` helpers take an optional trailing `options` dict, so
+  a caller that genuinely wants interactive git can re-enable it by passing its
+  own `env`/`env_mode`.

--- a/crates/harn-stdlib/src/stdlib/stdlib_git.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_git.harn
@@ -267,6 +267,29 @@ pub fn git_env_remove() -> list<string> {
   ]
 }
 
+/**
+ * git_noninteractive_env returns the prompt-guard env applied to every local
+ * git subprocess so a credential / host-key prompt fails fast instead of
+ * hanging a TTY-less runtime (`harn serve`, `@job`, CI).
+ *
+ * `GIT_TERMINAL_PROMPT=0` disables git's own prompting; an empty
+ * `GIT_ASKPASS`/`SSH_ASKPASS` refuses an external passphrase helper; and an
+ * `ssh -oBatchMode=yes` transport makes ssh non-interactive. This guard never
+ * removes credentials — auth via env, `.netrc`, credential helpers, or a
+ * loaded ssh-agent still works because those paths are non-interactive. It is
+ * merged (`env_mode: "merge"`) so inherited PATH/HOME/credentials survive, and
+ * a caller can re-enable prompting by passing its own `env`/`env_mode`.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: stable
+ * @example: git_noninteractive_env()
+ */
+pub fn git_noninteractive_env() -> dict {
+  return {GIT_TERMINAL_PROMPT: "0", GIT_ASKPASS: "", SSH_ASKPASS: "", GIT_SSH_COMMAND: "ssh -oBatchMode=yes"}
+}
+
 fn __git_non_empty_string(value, label) -> string {
   if type_of(value) != "string" || value == "" {
     throw "std/git: " + label + " must be a non-empty string"
@@ -338,11 +361,11 @@ fn __git_run_options(repo, options) -> dict {
     cwd: git_repo_path(opts?.repo ?? opts?.cwd ?? repo ?? "."),
     timeout_ms: opts?.timeout_ms ?? 120000,
     env_remove: opts?.env_remove ?? git_env_remove(),
+    env: git_noninteractive_env() + opts?.env ?? {},
+    env_mode: opts?.env_mode ?? "merge",
   }
   for key in [
     "stdin",
-    "env",
-    "env_mode",
     "capture",
     "background",
     "background_after_ms",
@@ -361,6 +384,11 @@ fn __git_run_options(repo, options) -> dict {
   return out
 }
 
+/**
+ * Non-interactive by default: a credential / host-key prompt fails
+ * fast instead of hanging a TTY-less runtime. Caller `env` keys win,
+ * and `env_mode: "merge"` keeps inherited PATH/HOME/credentials.
+ */
 fn __git_with_repo(repo, options) -> dict {
   let opts = options ?? {}
   return opts + {repo: repo}
@@ -419,7 +447,7 @@ fn __git_result(result, argv, cwd) -> GitCommandResult {
  */
 pub fn git_run(args: list<string>, options: GitRunOptions = {}) -> GitCommandResult {
   let argv = __git_argv(args)
-  let run_options = __git_run_options(options?.repo ?? ".", options)
+  let run_options = __git_run_options(options.repo ?? ".", options)
   return __git_result(process_run(argv, run_options), argv, run_options.cwd)
 }
 
@@ -600,7 +628,7 @@ pub fn git_log(repo = ".", options: GitLogOptions = {}) -> GitCommandResult {
   if opts.rev_range != nil {
     args = args + [__git_ref_arg(opts.rev_range, "rev_range")]
   }
-  let paths = __git_string_list(opts?.paths, "paths")
+  let paths = __git_string_list(opts.paths, "paths")
   if len(paths) > 0 {
     args = args + ["--"] + paths
   }
@@ -1080,7 +1108,7 @@ pub fn git_run_tool(
     return git_show(__git_non_empty_string(request.rev, "rev"), repo, request)
   }
   if op == "discover" {
-    return git_discover(request?.path ?? repo)
+    return git_discover(request.path ?? repo)
   }
   if op == "conflicts" {
     return git_conflicts(repo)
@@ -1093,13 +1121,13 @@ pub fn git_run_tool(
     )
   }
   if op == "fetch" {
-    return git_fetch(request?.remote ?? "origin", repo, request?.refspecs ?? [])
+    return git_fetch(request.remote ?? "origin", repo, request.refspecs ?? [])
   }
   if op == "switch" {
     return git_switch(__git_non_empty_string(request.branch, "branch"), repo, request)
   }
   if op == "pull_ff_only" {
-    return git_pull_ff_only(repo, request?.remote ?? "origin", request?.branch, request)
+    return git_pull_ff_only(repo, request.remote ?? "origin", request.branch, request)
   }
   if op == "rebase" {
     return git_rebase(__git_non_empty_string(request.base_ref, "base_ref"), repo)

--- a/crates/harn-stdlib/src/stdlib/stdlib_worktree.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_worktree.harn
@@ -1,6 +1,67 @@
-// std/worktree — isolated git worktree helpers built on exec_at/shell_at.
+// std/worktree — isolated git worktree helpers built on std/runtime process exec.
+//
+// Every git subprocess these helpers spawn runs non-interactive by
+// default: `GIT_TERMINAL_PROMPT=0` plus an empty askpass and an ssh
+// `BatchMode=yes` transport. Harn runs worktree git from TTY-less
+// contexts (`harn serve`, `@job`, CI); without this guard a clone/fetch
+// that needs a credential or host-key decision would block on an
+// interactive prompt and hang the runtime. The guard only disables
+// *prompting* — credentials supplied via env/helper/agent still work —
+// and is merged (`env_mode: "merge"`) so inherited PATH/HOME survive.
+// Callers that genuinely want interactive git can override by passing
+// their own `env` / `env_mode` in `options`.
 //
 // Import: import "std/worktree"
+import { git_env_remove, git_noninteractive_env } from "std/git"
+import { process_run, process_shell } from "std/runtime"
+
+/**
+ * worktree_noninteractive_env returns the default prompt guard env applied
+ * to git subprocesses so credential/host-key prompts fail fast. Alias of
+ * `git_noninteractive_env` — the single source of truth for the guard.
+ *
+ * @effects: []
+ * @allocation: heap
+ * @errors: []
+ * @api_stability: stable
+ * @example: worktree_noninteractive_env()
+ */
+pub fn worktree_noninteractive_env() -> dict {
+  return git_noninteractive_env()
+}
+
+/**
+ * __worktree_git_options builds process.exec options for a git command in
+ * `cwd`: non-interactive guard env merged with the inherited environment,
+ * the std/git ambient-env strip, and any caller overrides from `options`.
+ */
+fn __worktree_git_options(cwd, options) -> dict {
+  let opts = options ?? {}
+  // Caller `env` overrides individual guard keys; `env_mode` defaults to
+  // "merge" so inherited PATH/HOME/credentials survive.
+  let env = git_noninteractive_env() + opts?.env ?? {}
+  var out = {
+    cwd: cwd,
+    env: env,
+    env_mode: opts?.env_mode ?? "merge",
+    env_remove: opts?.env_remove ?? git_env_remove(),
+  }
+  for key in ["timeout_ms", "stdin", "capture", "max_inline_bytes", "policy_context"] {
+    if opts[key] != nil {
+      out = out + {[key]: opts[key]}
+    }
+  }
+  return out
+}
+
+/**
+ * __worktree_git runs one argv-mode git command in `cwd` with the
+ * non-interactive guard applied. `args` omits the leading "git".
+ */
+fn __worktree_git(cwd, args, options) {
+  return process_run(["git"] + args, __worktree_git_options(cwd, options))
+}
+
 /**
  * worktree_default_path.
  *
@@ -17,13 +78,13 @@ pub fn worktree_default_path(repo, name) {
 /**
  * worktree_create.
  *
- * @effects: []
+ * @effects: [host]
  * @allocation: heap
  * @errors: []
  * @api_stability: stable
  * @example: worktree_create(repo, name, base_ref, path)
  */
-pub fn worktree_create(repo, name, base_ref, path) {
+pub fn worktree_create(repo, name, base_ref, path, options = {}) {
   let target = if path == nil || path == "" {
     worktree_default_path(repo, name)
   } else {
@@ -31,64 +92,64 @@ pub fn worktree_create(repo, name, base_ref, path) {
   }
   harness.fs.mkdir(repo + "/.harn")
   harness.fs.mkdir(repo + "/.harn/worktrees")
-  let result = exec_at(repo, "git", "worktree", "add", "-B", name, target, base_ref)
+  let result = __worktree_git(repo, ["worktree", "add", "-B", name, target, base_ref], options)
   return {repo: repo, name: name, path: target, base_ref: base_ref, result: result, success: result?.success}
 }
 
 /**
  * worktree_remove.
  *
- * @effects: []
+ * @effects: [host]
  * @allocation: heap
  * @errors: []
  * @api_stability: stable
  * @example: worktree_remove(repo, path, force)
  */
-pub fn worktree_remove(repo, path, force) {
+pub fn worktree_remove(repo, path, force, options = {}) {
   if force {
-    return exec_at(repo, "git", "worktree", "remove", "--force", path)
+    return __worktree_git(repo, ["worktree", "remove", "--force", path], options)
   }
-  return exec_at(repo, "git", "worktree", "remove", path)
+  return __worktree_git(repo, ["worktree", "remove", path], options)
 }
 
 /**
  * worktree_status.
  *
- * @effects: []
+ * @effects: [host]
  * @allocation: heap
  * @errors: []
  * @api_stability: stable
  * @example: worktree_status(path)
  */
-pub fn worktree_status(path) {
-  return exec_at(path, "git", "status", "--short", "--branch")
+pub fn worktree_status(path, options = {}) {
+  return __worktree_git(path, ["status", "--short", "--branch"], options)
 }
 
 /**
  * worktree_diff.
  *
- * @effects: []
+ * @effects: [host]
  * @allocation: heap
  * @errors: []
  * @api_stability: stable
  * @example: worktree_diff(path, base_ref)
  */
-pub fn worktree_diff(path, base_ref) {
+pub fn worktree_diff(path, base_ref, options = {}) {
   if base_ref == nil || base_ref == "" {
-    return exec_at(path, "git", "diff", "--stat")
+    return __worktree_git(path, ["diff", "--stat"], options)
   }
-  return exec_at(path, "git", "diff", base_ref + "...HEAD")
+  return __worktree_git(path, ["diff", base_ref + "...HEAD"], options)
 }
 
 /**
  * worktree_shell.
  *
- * @effects: []
+ * @effects: [host]
  * @allocation: heap
  * @errors: []
  * @api_stability: stable
  * @example: worktree_shell(path, script)
  */
-pub fn worktree_shell(path, script) {
-  return shell_at(path, script)
+pub fn worktree_shell(path, script, options = {}) {
+  return process_shell(script, __worktree_git_options(path, options))
 }

--- a/crates/harn-vm/src/stdlib/git.rs
+++ b/crates/harn-vm/src/stdlib/git.rs
@@ -553,6 +553,33 @@ const GIT_ENV_OVERRIDES: &[&str] = &[
     "GIT_PREFIX",
 ];
 
+/// Non-interactive guard applied to every git subprocess Harn spawns.
+///
+/// Harn runs git from TTY-less contexts (`harn serve`, `@job`, CI). A
+/// fetch/push/clone that needs credentials or an SSH host-key decision
+/// would otherwise block on an interactive prompt and hang the runtime
+/// indefinitely. These variables tell git (and the ssh transport) to
+/// fail fast instead of prompting:
+///
+/// * `GIT_TERMINAL_PROMPT=0` — disable git's own terminal prompting
+///   (HTTPS username/password, missing-credential prompts).
+/// * `GIT_ASKPASS` / `SSH_ASKPASS` empty — refuse to shell out to a GUI
+///   or external askpass helper for a passphrase.
+/// * `GIT_SSH_COMMAND` with `BatchMode=yes` — make the ssh transport
+///   non-interactive (no passphrase / host-key prompts).
+///
+/// This is a *prompt* guard only: it never removes credentials. Auth via
+/// environment, `.netrc`, credential helpers, or pre-loaded ssh-agent
+/// keys continues to work because those paths are non-interactive. The
+/// env is merged (`env_mode: "merge"`) so inherited PATH/HOME and any
+/// caller-supplied credentials survive.
+const GIT_NONINTERACTIVE_ENV: &[(&str, &str)] = &[
+    ("GIT_TERMINAL_PROMPT", "0"),
+    ("GIT_ASKPASS", ""),
+    ("SSH_ASKPASS", ""),
+    ("GIT_SSH_COMMAND", "ssh -oBatchMode=yes"),
+];
+
 async fn exec_argv(command: &GitCommand) -> Result<VmValue, VmError> {
     let mut params = BTreeMap::new();
     params.insert(
@@ -582,6 +609,22 @@ async fn exec_argv(command: &GitCommand) -> Result<VmValue, VmError> {
                 .map(|name| VmValue::String(std::sync::Arc::from(*name)))
                 .collect(),
         )),
+    );
+    // Make every git subprocess non-interactive by default so a
+    // credential / host-key prompt fails fast instead of hanging a
+    // TTY-less runtime. `env_mode: "merge"` keeps inherited PATH/HOME
+    // and any credentials already present in the environment.
+    let mut env = BTreeMap::new();
+    for (key, value) in GIT_NONINTERACTIVE_ENV {
+        env.insert(
+            (*key).to_string(),
+            VmValue::String(std::sync::Arc::from(*value)),
+        );
+    }
+    params.insert("env".to_string(), VmValue::Dict(std::sync::Arc::new(env)));
+    params.insert(
+        "env_mode".to_string(),
+        VmValue::String(std::sync::Arc::from("merge")),
     );
     let caller = json!({
         "surface": "stdlib.git",
@@ -1297,6 +1340,51 @@ mod tests {
             );
         })
         .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn git_subprocess_carries_noninteractive_prompt_guard() {
+        // Every git subprocess Harn spawns must be non-interactive by
+        // default so a credential / host-key prompt fails fast instead
+        // of hanging a TTY-less runtime (`harn serve`, `@job`, CI). We
+        // run a probe through the same `exec_argv` path the receipt git
+        // builtins use and assert the guard env reached the child while
+        // an inherited env var survived the merge (proving `env_mode:
+        // "merge"`, not a clobbering replace). The inherited var uses a
+        // unique name so it can't race other tests in a shared process.
+        crate::stdlib::reset_stdlib_state();
+        std::env::set_var("HARN_GUARD_PROBE_INHERIT", "kept");
+        run_on_local(async {
+            let result = exec_argv(&GitCommand {
+                operation: "git.status",
+                action: "git.status",
+                cwd: std::env::temp_dir(),
+                argv: vec![
+                    "sh".to_string(),
+                    "-c".to_string(),
+                    "printf '%s|%s' \"$GIT_TERMINAL_PROMPT\" \"$HARN_GUARD_PROBE_INHERIT\""
+                        .to_string(),
+                ],
+                mutation: GitMutation::Read,
+                affected_paths: Vec::new(),
+                data_parser: GitDataParser::None,
+            })
+            .await
+            .expect("exec_argv probe");
+            let json = crate::llm::vm_value_to_json(&result);
+            let stdout = json["stdout"].as_str().unwrap_or_default();
+            let (prompt, inherited) = stdout.split_once('|').unwrap_or_default();
+            assert_eq!(
+                prompt, "0",
+                "git subprocess must inherit GIT_TERMINAL_PROMPT=0; stdout was {stdout:?}"
+            );
+            assert_eq!(
+                inherited, "kept",
+                "env_mode=merge must preserve inherited env; stdout was {stdout:?}"
+            );
+        })
+        .await;
+        std::env::remove_var("HARN_GUARD_PROBE_INHERIT");
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
Makes harn's git stdlib non-interactive by default so a .harn git op can't hang on a credential/host-key prompt in a TTY-less context (server/@job/CI — the class that hung CI ~64min). Guards all 3 git-subprocess spawn paths (native git.* receipt builtins, git_run wrappers, worktree helpers) with GIT_TERMINAL_PROMPT=0 + empty GIT_ASKPASS/SSH_ASKPASS + GIT_SSH_COMMAND='ssh -oBatchMode=yes', merge-mode (inherited PATH/HOME + credentials via env/.netrc/helper/ssh-agent unaffected), overridable per-call. Tested (merge-not-clobber proof); fmt/clippy/harn-check clean; changelog added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)