### PR TITLE
fix(hostlib): platform-correct PATH fixtures in toolchain_path tests (Windows CI red, #3239 follow-up)

### DIFF
--- a/changelog.d/3239-toolchain-path-windows-tests.fixed.md
+++ b/changelog.d/3239-toolchain-path-windows-tests.fixed.md
@@ -1,0 +1,6 @@
+The Windows CI red in the toolchain-PATH normalizer is fixed: the unit tests
+now build their PATH fixtures and expectations with `std::env::join_paths`
+(platform separator) instead of hardcoding a unix `:`, so the
+prepended-toolchain assertions pass on Windows (`;`) as well as unix (`:`).
+Implementation behavior was already correct on Windows; only the test fixtures
+were unix-specific.

--- a/crates/harn-hostlib/src/tools/proc/toolchain_path.rs
+++ b/crates/harn-hostlib/src/tools/proc/toolchain_path.rs
@@ -559,6 +559,17 @@ mod tests {
         assert!(env.resolve_calls.borrow().is_empty());
     }
 
+    /// Join PATH components with the platform separator (`;` on Windows, `:` on
+    /// unix) via the same `std::env::join_paths` that `apply_to_env` uses, so
+    /// fixtures and expectations match the child PATH on every OS instead of
+    /// hardcoding a unix `:` that Windows treats as part of a single entry.
+    fn join_path_str(parts: &[&str]) -> String {
+        std::env::join_paths(parts.iter().map(std::ffi::OsStr::new))
+            .expect("clean ASCII path components join")
+            .into_string()
+            .expect("ASCII path joins to valid UTF-8")
+    }
+
     #[test]
     fn declared_and_installed_prepends_resolved_bin_dir() {
         let env = FakeEnv::with_gate_on()
@@ -577,15 +588,22 @@ mod tests {
         assert!(norm.unresolved.is_empty());
 
         let mut env_map = BTreeMap::new();
+        let base = join_path_str(&["/usr/bin", "/bin"]);
         apply_to_env(
             &mut env_map,
             EnvMode::InheritClean,
-            Some("/usr/bin:/bin"),
+            Some(base.as_str()),
             &norm,
         );
+        let expected = join_path_str(&[
+            "/opt/mise/installs/ruby/3.2.2",
+            "/opt/mise/installs/node/20.11.0",
+            "/usr/bin",
+            "/bin",
+        ]);
         assert_eq!(
             env_map.get("PATH").map(String::as_str),
-            Some("/opt/mise/installs/ruby/3.2.2:/opt/mise/installs/node/20.11.0:/usr/bin:/bin")
+            Some(expected.as_str())
         );
     }
 
@@ -692,9 +710,10 @@ mod tests {
             &norm,
         );
         // Replace mode ignores the parent PATH; prepends to the caller's.
+        let expected = join_path_str(&["/opt/ruby/bin", "/sbin"]);
         assert_eq!(
             env_map.get("PATH").map(String::as_str),
-            Some("/opt/ruby/bin:/sbin")
+            Some(expected.as_str())
         );
     }
 
@@ -726,9 +745,10 @@ mod tests {
         let mut env_map = BTreeMap::new();
         env_map.insert("PATH".to_string(), "/caller/path".to_string());
         apply_to_env(&mut env_map, EnvMode::Patch, Some("/parent/path"), &norm);
+        let expected = join_path_str(&["/opt/ruby/bin", "/caller/path"]);
         assert_eq!(
             env_map.get("PATH").map(String::as_str),
-            Some("/opt/ruby/bin:/caller/path")
+            Some(expected.as_str())
         );
     }
 


### PR DESCRIPTION
## Problem

After #3239, the three `toolchain_path::tests` `apply_to_env` cases (`declared_and_installed_prepends_resolved_bin_dir`, `caller_path_override_wins_over_parent_in_inherit_mode`, `replace_mode_with_caller_path_prepends`) **still failed on the Windows CI job** — turning harn `main` red (e.g. run 27289855095).

## Root cause

The implementation (`apply_to_env`) is already Windows-correct — it splits/joins PATH via `std::env::split_paths`/`join_paths`, which use the platform separator. The **tests** were the problem: they passed a unix `:`-joined base PATH (`Some("/usr/bin:/bin")`) and asserted against `:`-joined expected strings. On Windows, `split_paths` treats a `:`-string as a single entry, so the actual child PATH came out as `ruby;node;/usr/bin:/bin` (prepended dirs `;`-joined, base left as the unix literal) and never matched the all-`:` expectation.

```
left:  "…/ruby/3.2.2;…/node/20.11.0;/usr/bin:/bin"   (actual on Windows)
right: "…/ruby/3.2.2:…/node/20.11.0:/usr/bin:/bin"   (hardcoded unix expectation)
```

## Fix

Test-only. A `join_path_str` helper builds the base input and all expected strings via the same `std::env::join_paths`, so fixtures use `;` on Windows and `:` on unix uniformly. No implementation change (it was already correct).

## Verification

- `cargo test -p harn-hostlib toolchain_path`: **12/12 pass** on macOS (incl. the 3 formerly-failing).
- `cargo clippy -p harn-hostlib --tests`: clean. `cargo fmt --check`: clean.
- Reasoned through the Windows path: base `/usr/bin;/bin` → split → `[/usr/bin, /bin]` → prepend ruby/node → join → `ruby;node;/usr/bin;/bin`, matching the helper-built expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)