### PR TITLE
harn-serve: @ws WebSocket-upgrade marker (SiteServer)

### DIFF
--- a/changelog.d/3215.added.md
+++ b/changelog.d/3215.added.md
@@ -1,0 +1,14 @@
+- **`@ws` WebSocket-upgrade marker for `harn serve site`.** A `pub fn`
+  carrying the bare `@ws` attribute alongside its HTTP route is answered
+  by the embedder's `SiteStreamProvider` instead of dispatching into the
+  VM — the WebSocket sibling of `@stream`. After the same admission (the
+  `SiteAuth` hook plus the route's `@scopes`, enforced *before* the
+  connection is handed off), the site adapter extracts the
+  `WebSocketUpgrade` and calls the new `SiteStreamProvider::upgrade`,
+  which completes the handshake and drives the socket; the `101` is
+  forwarded verbatim. The trait method has a default `426 Upgrade
+  Required` implementation, so existing providers keep compiling. A
+  non-WebSocket request to a `@ws` route is refused with the correct 4xx,
+  and a `@ws` route declared without a provider fails the router build
+  loudly. New diagnostics `HARN-SRV-014..016` cover a `@ws` marker with
+  arguments, without a route, or conflicting with `@stream`/`@raw`.

--- a/crates/harn-serve/src/adapters/site.rs
+++ b/crates/harn-serve/src/adapters/site.rs
@@ -96,6 +96,22 @@
 //! the function's return value is sent back (a string verbatim, any other
 //! value as JSON, `nil` sends nothing). This reuses the exact subprotocol
 //! negotiation and idle-keepalive machinery the other WS routes use.
+//!
+//! ## Embedder-driven WebSockets (`@ws`)
+//!
+//! The envelope path above runs the socket *in the VM* — each frame is a
+//! `.harn` dispatch. An embedder that owns the socket in Rust (a CLI
+//! proxy, a fan-out event hub) needs the raw upgrade handle instead. A
+//! route carrying the bare `@ws` attribute is that seam: like `@stream`
+//! it skips the VM and is answered by the same [`SiteStreamProvider`]
+//! after the same admission ([`SiteAuth`] hook + `@scopes`), but the
+//! adapter extracts the [`WebSocketUpgrade`] (auth gates it *before* the
+//! connection is handed off) and calls
+//! [`SiteStreamProvider::upgrade`], forwarding the `101` it returns. The
+//! provider drives the socket; the `.harn` function is a
+//! declaration-only stub that owns the route, its `@scopes`, and its
+//! docs. A non-WebSocket request to a `@ws` route is refused with the
+//! correct 4xx by axum's extractor — never a stray upgrade.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::{IpAddr, SocketAddr};
@@ -251,6 +267,56 @@ pub trait SiteStreamProvider: Send + Sync {
         request: Value,
         body: Option<Bytes>,
     ) -> Response;
+
+    /// Answer one admitted `@ws` request by completing the WebSocket
+    /// upgrade and driving the socket.
+    ///
+    /// This is the WebSocket sibling of [`open`](Self::open): a route
+    /// whose `.harn` export carries the bare `@ws` marker (see
+    /// [`crate::exports`]) never dispatches into the VM. After the same
+    /// admission — the [`SiteAuth`] hook plus the route's `@scopes` —
+    /// the adapter extracts the [`axum::extract::ws::WebSocketUpgrade`]
+    /// while the raw connection's `OnUpgrade` handle is still present,
+    /// then hands it here. The provider completes the handshake with
+    /// [`WebSocketUpgrade::on_upgrade`] (or harn-serve's own WS helpers)
+    /// and owns the socket for its lifetime; the `101 Switching
+    /// Protocols` response it returns is forwarded to the client
+    /// verbatim. Auth gates the upgrade *before* the connection is handed
+    /// off, exactly as it gates a `@stream` response.
+    ///
+    /// * `route` — the matched function's declared [`RouteSpec`].
+    /// * `auth` — the identity the [`SiteAuth`] hook resolved (tenant,
+    ///   scopes, opaque context); `None` when no hook is installed.
+    /// * `ws` — the extracted upgrade handle. Calling `on_upgrade`
+    ///   yields the live socket; the returned [`Response`] is the 101.
+    /// * `request` — the request head as the same JSON dict
+    ///   [`open`](Self::open) receives, minus any body (a WebSocket
+    ///   handshake carries none).
+    ///
+    /// The default implementation refuses with `426 Upgrade Required`,
+    /// so a provider that only serves `@stream`/`@raw` routes keeps
+    /// compiling and a misconfigured `@ws` route fails loudly rather
+    /// than 101-ing into a socket nobody drives.
+    async fn upgrade(
+        &self,
+        route: &RouteSpec,
+        _auth: Option<&SiteAuthContext>,
+        _ws: WebSocketUpgrade,
+        _request: Value,
+    ) -> Response {
+        (
+            StatusCode::UPGRADE_REQUIRED,
+            Json(json!({
+                "code": "ws_upgrade_unsupported",
+                "message": format!(
+                    "route {} {} is marked @ws but this stream provider does not implement \
+                     SiteStreamProvider::upgrade",
+                    route.method, route.path
+                ),
+            })),
+        )
+            .into_response()
+    }
 }
 
 /// Listener options for [`SiteServer::run_http`].
@@ -279,9 +345,10 @@ pub struct SiteServerConfig {
     /// (the default) keeps the historic behavior: no edge auth and
     /// tenant-less dispatch.
     pub auth: Option<Arc<dyn SiteAuth>>,
-    /// Embedder responder for `@stream` / `@raw` routes. Required when
-    /// the script declares any — building the router fails loudly
-    /// otherwise, since the route would have no body source.
+    /// Embedder responder for `@stream` / `@raw` / `@ws` routes.
+    /// Required when the script declares any — building the router fails
+    /// loudly otherwise, since the route would have no body source (or,
+    /// for `@ws`, no upgrade sink).
     pub stream_provider: Option<Arc<dyn SiteStreamProvider>>,
 }
 
@@ -396,6 +463,11 @@ struct SiteRoute {
     /// buffered (up to the configured limit) and handed to the provider
     /// as exact bytes.
     raw: bool,
+    /// `@ws` marker: after admission, perform the WebSocket upgrade and
+    /// hand the upgrade handle to [`SiteStreamProvider::upgrade`] instead
+    /// of dispatching into the VM. Mutually exclusive with
+    /// `stream`/`raw`.
+    ws: bool,
 }
 
 /// State shared by every site route handler: the dispatch executor plus
@@ -443,11 +515,17 @@ fn build_site_router(
         let Some(spec @ RouteSpec { method, path }) = function.route.as_ref() else {
             continue;
         };
-        // A `@stream` / `@raw` route has no body source without a
-        // provider; refusing to start beats serving a route that can
-        // only 500.
-        if (function.stream || function.raw) && stream_provider.is_none() {
-            let marker = if function.stream { "@stream" } else { "@raw" };
+        // A `@stream` / `@raw` / `@ws` route is answered by the provider,
+        // so it has no body source (or upgrade sink) without one;
+        // refusing to start beats serving a route that can only 500.
+        if (function.stream || function.raw || function.ws) && stream_provider.is_none() {
+            let marker = if function.stream {
+                "@stream"
+            } else if function.raw {
+                "@raw"
+            } else {
+                "@ws"
+            };
             return Err(format!(
                 "route {method} {path} (`{}`) is marked {marker} but no stream provider is \
                  configured; install one with SiteServerConfig::with_stream_provider(...)",
@@ -461,6 +539,7 @@ fn build_site_router(
             required_scopes: function.required_scopes.clone(),
             stream: function.stream,
             raw: function.raw,
+            ws: function.ws,
         };
         if let Some(existing) = by_method.insert(method.clone(), entry) {
             return Err(format!(
@@ -559,6 +638,61 @@ async fn site_dispatch(State(state): State<SiteState>, request: Request) -> Resp
             }
         },
     };
+
+    // `@ws` routes hand off to the embedder's provider after the *same*
+    // admission as `@stream`/`@raw` — auth gates the upgrade before the
+    // connection is handed off — but instead of producing a response
+    // body, the adapter extracts the WebSocket upgrade (while hyper's
+    // `OnUpgrade` extension is still on `parts`) and the provider drives
+    // the socket. The 101 it returns is forwarded verbatim.
+    if route.ws {
+        // Same admission back-stop as `@stream`/`@raw`: a `@ws` route
+        // never builds a `CallRequest`, so the dispatch-level scope
+        // check cannot cover it. With no hook there is no identity and
+        // no granted scopes, so any scope requirement refuses.
+        if auth_context.is_none() && !route.required_scopes.is_empty() {
+            return axum_response_from_dispatch_error(
+                DispatchError::Forbidden {
+                    required: route.required_scopes.clone(),
+                    granted: BTreeSet::new(),
+                },
+                &request_id,
+            );
+        }
+        let Some(provider) = state.stream_provider.as_ref() else {
+            // Unreachable: router construction refuses a @ws route
+            // without a provider. Shape a loud 500 rather than panic.
+            return axum_response_from_dispatch_error(
+                DispatchError::Execution(format!(
+                    "provider route {route_template} has no stream provider"
+                )),
+                &request_id,
+            );
+        };
+        // Extract the upgrade while the `OnUpgrade` extension is still
+        // present on `parts`. A non-WebSocket request (missing the
+        // upgrade headers / key) is refused here by axum's extractor
+        // with the correct 4xx — never a panic, never a stray 101.
+        let upgrade = match WebSocketUpgrade::from_request_parts(&mut parts, &()).await {
+            Ok(upgrade) => upgrade,
+            Err(rejection) => return rejection.into_response(),
+        };
+        // A WebSocket handshake carries no body, so none is built.
+        let request = build_request_value(
+            &method,
+            &parts.uri,
+            &route_template,
+            raw_params.as_ref(),
+            &query,
+            &parts.headers,
+            &[],
+            peer,
+            &state.trusted_proxies,
+        );
+        return provider
+            .upgrade(&route.spec, auth_context.as_ref(), upgrade, request)
+            .await;
+    }
 
     // `@stream` / `@raw` routes hand off to the embedder's provider
     // right after admission, with no VM dispatch — the provider's

--- a/crates/harn-serve/src/exports.rs
+++ b/crates/harn-serve/src/exports.rs
@@ -76,6 +76,18 @@ pub struct ExportedFunction {
     /// handling lives in embedder Rust. The `.harn` function body is a
     /// declaration-only stub, exactly as for `@stream`.
     pub raw: bool,
+    /// `true` when the function carries a `@ws` attribute alongside its
+    /// HTTP route. Like `@stream`, a `@ws` route never dispatches into
+    /// the VM: after the site adapter's admission checks (the embedder's
+    /// `SiteAuth` hook plus `@scopes`) it performs the WebSocket upgrade
+    /// and hands the upgrade handle to the embedder's
+    /// `SiteStreamProvider::upgrade`, which drives the socket. The marker
+    /// is the seam for embedder routes that need a real WebSocket
+    /// connection (mirroring how `@stream` is the seam for SSE). It
+    /// conflicts with `@stream`/`@raw` (they target different provider
+    /// entry points), so declaring both drops `@ws`. The `.harn`
+    /// function body is a declaration-only stub.
+    pub ws: bool,
 }
 
 /// A `.harn` worker/job entrypoint declared with `@job("name")`.
@@ -226,6 +238,17 @@ pub const RAW_WITHOUT_ROUTE: &str = "HARN-SRV-012";
 /// buffers it for the provider), so `@raw` is dropped and the route
 /// behaves as `@stream`.
 pub const RAW_CONFLICTS_WITH_STREAM: &str = "HARN-SRV-013";
+/// `@ws` carries arguments — it is a bare marker. The marker is dropped,
+/// so the route dispatches into the VM like any other handler.
+pub const WS_BAD_ARGS: &str = "HARN-SRV-014";
+/// `@ws` appears on a declaration without an HTTP route. A WebSocket
+/// upgrade only means something on a routed `pub fn`, so it is ignored.
+pub const WS_WITHOUT_ROUTE: &str = "HARN-SRV-015";
+/// `@ws` and `@stream`/`@raw` appear on the same declaration. They route
+/// to different provider entry points (a WebSocket upgrade vs. an
+/// SSE/raw response), so they contradict; `@ws` is dropped and the route
+/// behaves as `@stream`/`@raw`.
+pub const WS_CONFLICTS_WITH_STREAM_OR_RAW: &str = "HARN-SRV-016";
 
 impl std::fmt::Display for ExportDiagnostic {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -288,6 +311,8 @@ impl ExportCatalog {
             let route = route_from_attributes(attrs, name, &mut diagnostics);
             let stream = stream_from_attributes(attrs, name, route.as_ref(), &mut diagnostics);
             let raw = raw_from_attributes(attrs, name, route.as_ref(), stream, &mut diagnostics);
+            let ws =
+                ws_from_attributes(attrs, name, route.as_ref(), stream || raw, &mut diagnostics);
             functions.insert(
                 name.clone(),
                 ExportedFunction {
@@ -305,6 +330,7 @@ impl ExportCatalog {
                     route,
                     stream,
                     raw,
+                    ws,
                     job: job_from_attributes(attrs, name, &mut diagnostics),
                 },
             );
@@ -332,6 +358,7 @@ impl ExportCatalog {
             // one is inert — diagnose it the same way as on an unrouted fn.
             let stream = stream_from_attributes(attrs, name, None, &mut diagnostics);
             let raw = raw_from_attributes(attrs, name, None, stream, &mut diagnostics);
+            let ws = ws_from_attributes(attrs, name, None, stream || raw, &mut diagnostics);
             functions
                 .entry(name.clone())
                 .or_insert_with(|| ExportedFunction {
@@ -352,6 +379,7 @@ impl ExportCatalog {
                     route: None,
                     stream,
                     raw,
+                    ws,
                     job: job_from_attributes(attrs, name, &mut diagnostics),
                 });
         }
@@ -645,6 +673,52 @@ fn raw_from_attributes(
         return false;
     }
     raw
+}
+
+/// Resolve the `@ws` marker on a declaration.
+///
+/// `@ws` mirrors `@stream` (a bare, route-only marker that turns the
+/// route into a provider-answered route), except the provider is handed
+/// a WebSocket upgrade handle instead of producing a response body. It
+/// conflicts with `@stream`/`@raw`: those target the provider's response
+/// entry point (`open`), while `@ws` targets the upgrade entry point
+/// (`upgrade`). Declaring `@ws` alongside either is diagnosed
+/// (`HARN-SRV-016`) and `@ws` is dropped — the route behaves as
+/// `@stream`/`@raw`.
+fn ws_from_attributes(
+    attrs: &[Attribute],
+    fn_name: &str,
+    route: Option<&RouteSpec>,
+    stream_or_raw: bool,
+    diagnostics: &mut Vec<ExportDiagnostic>,
+) -> bool {
+    let ws = bare_route_marker_from_attributes(
+        attrs,
+        "ws",
+        fn_name,
+        route,
+        diagnostics,
+        WS_BAD_ARGS,
+        WS_WITHOUT_ROUTE,
+    );
+    if ws && stream_or_raw {
+        let line = attrs
+            .iter()
+            .find(|attr| attr.name == "ws")
+            .map(|attr| attr.span.line)
+            .unwrap_or(0);
+        diagnostics.push(ExportDiagnostic {
+            code: WS_CONFLICTS_WITH_STREAM_OR_RAW,
+            line,
+            message: format!(
+                "`@ws` on `{fn_name}` conflicts with `@stream`/`@raw` (a WebSocket upgrade and an \
+                 SSE/raw response are different provider entry points); dropping `@ws` — the route \
+                 behaves as `@stream`/`@raw`"
+            ),
+        });
+        return false;
+    }
+    ws
 }
 
 /// Shared resolution for the bare route markers (`@stream`, `@raw`):
@@ -1590,5 +1664,98 @@ pub fn both(req: dict) -> dict { return http_ok({}) }
         assert!(!function.raw);
         let codes: Vec<&str> = catalog.diagnostics().iter().map(|d| d.code).collect();
         assert_eq!(codes, vec![RAW_CONFLICTS_WITH_STREAM]);
+    }
+
+    #[test]
+    fn ws_attribute_marks_routed_functions_only() {
+        let catalog = catalog_from_source(
+            r#"
+@ws
+@route("GET", "/socket")
+pub fn socket(req: dict) -> dict { return http_ok({}) }
+
+@ws
+pub fn handler_live(req: dict) -> dict { return http_ok({}) }
+
+@route("GET", "/plain")
+pub fn plain(req: dict) -> dict { return http_ok({}) }
+"#,
+        );
+        assert!(
+            catalog.diagnostics().is_empty(),
+            "unexpected diagnostics: {:?}",
+            catalog.diagnostics()
+        );
+        // Works with an explicit @route and with the handler_* convention.
+        assert!(catalog.function("socket").expect("socket").ws);
+        assert!(catalog.function("handler_live").expect("live").ws);
+        // A routed fn without the marker is a plain dispatch route.
+        assert!(!catalog.function("plain").expect("plain").ws);
+        // `@ws` never implies `@stream` / `@raw`.
+        assert!(!catalog.function("socket").expect("socket").stream);
+        assert!(!catalog.function("socket").expect("socket").raw);
+    }
+
+    #[test]
+    fn ws_with_args_is_diagnosed_and_dropped() {
+        let catalog = catalog_from_source(
+            r#"
+@ws("chat")
+@route("GET", "/socket")
+pub fn socket(req: dict) -> dict { return http_ok({}) }
+"#,
+        );
+        assert!(!catalog.function("socket").expect("socket").ws);
+        let codes: Vec<&str> = catalog.diagnostics().iter().map(|d| d.code).collect();
+        assert_eq!(codes, vec![WS_BAD_ARGS]);
+    }
+
+    #[test]
+    fn ws_without_route_is_diagnosed_and_ignored() {
+        let catalog = catalog_from_source(
+            r"
+@ws
+pub fn helper(req: dict) -> dict { return req }
+",
+        );
+        assert!(!catalog.function("helper").expect("helper").ws);
+        let codes: Vec<&str> = catalog.diagnostics().iter().map(|d| d.code).collect();
+        assert_eq!(codes, vec![WS_WITHOUT_ROUTE]);
+    }
+
+    #[test]
+    fn ws_conflicting_with_stream_is_diagnosed_and_dropped() {
+        let catalog = catalog_from_source(
+            r#"
+@stream
+@ws
+@route("GET", "/both")
+pub fn both(req: dict) -> dict { return http_ok({}) }
+"#,
+        );
+        // `@stream` wins; `@ws` is dropped with a diagnostic.
+        let function = catalog.function("both").expect("both");
+        assert!(function.stream);
+        assert!(!function.ws);
+        let codes: Vec<&str> = catalog.diagnostics().iter().map(|d| d.code).collect();
+        assert_eq!(codes, vec![WS_CONFLICTS_WITH_STREAM_OR_RAW]);
+    }
+
+    #[test]
+    fn ws_conflicting_with_raw_is_diagnosed_and_dropped() {
+        let catalog = catalog_from_source(
+            r#"
+@raw
+@ws
+@route("POST", "/both")
+pub fn both(req: dict) -> dict { return http_ok({}) }
+"#,
+        );
+        // `@raw` wins; `@ws` is dropped with a diagnostic.
+        let function = catalog.function("both").expect("both");
+        assert!(function.raw);
+        assert!(!function.ws);
+        let codes: Vec<&str> = catalog.diagnostics().iter().map(|d| d.code).collect();
+        assert_eq!(codes, vec![WS_CONFLICTS_WITH_STREAM_OR_RAW]);
     }
 }

--- a/crates/harn-serve/tests/site_websocket.rs
+++ b/crates/harn-serve/tests/site_websocket.rs
@@ -1,0 +1,408 @@
+//! Embedder-driven WebSocket upgrades through `harn serve site` (the
+//! `@ws` route marker, #3215 family).
+//!
+//! Exercises the `@ws` marker + [`harn_serve::SiteStreamProvider::upgrade`]
+//! seam end-to-end: an admitted request on a `@ws` route reaches the
+//! embedder's provider with the matched route, the hook-resolved
+//! identity, and the request head; the provider completes the WebSocket
+//! upgrade and drives the socket (echoing inbound frames), and the live
+//! connection round-trips. Admission — the [`harn_serve::SiteAuth`] hook
+//! and the route's `@scopes` — still gates the route, refusing *before*
+//! the upgrade is performed (no creds → 401, wrong scope → 403). A
+//! non-WebSocket request to a `@ws` route is refused with the correct
+//! 4xx by axum's extractor rather than panicking. And a script that
+//! declares a `@ws` route refuses to build a router without a provider.
+//!
+//! The upgrade cases need a live socket, so they bind a loopback
+//! listener (mirroring `tests/site_hosting.rs`); the admission /
+//! not-a-socket / build cases drive the router through
+//! `tower::ServiceExt::oneshot` (mirroring `tests/site_streaming.rs`).
+
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::extract::ws::{Message, WebSocketUpgrade};
+use axum::http::request::Parts;
+use axum::http::{Request, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::{Json, Router};
+use futures_util::{SinkExt, StreamExt};
+use harn_serve::{
+    DispatchCore, DispatchCoreConfig, NoReplayCache, RouteSpec, SiteAuth, SiteAuthContext,
+    SiteAuthOutcome, SiteServer, SiteServerConfig, SiteStreamProvider,
+};
+use harn_vm::TenantId;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+/// One script backs every case: a `@scopes`-guarded `@ws` route and a
+/// plain dispatch route. The `@ws` route's body is a declaration-only
+/// stub — if it ever runs, the VM dispatched where the provider should
+/// have upgraded.
+const SITE_SCRIPT: &str = r#"
+@ws
+@scopes("live:read")
+@route("GET", "/topics/{topic}/live")
+pub fn topic_live(req: dict) -> dict {
+  return http_ok({ "buffered_stub": true })
+}
+
+@route("GET", "/plain")
+pub fn plain(req: dict) -> dict {
+  return http_ok({ "plain": true })
+}
+"#;
+
+/// Test provider: completes the upgrade and echoes each inbound text
+/// frame back as `echo:<text>`. Before echoing, it sends one priming
+/// frame carrying the route/tenant/path-param it was handed, so a single
+/// round-trip proves the whole admission + head-threading contract.
+struct EchoUpgradeProvider;
+
+#[async_trait::async_trait]
+impl SiteStreamProvider for EchoUpgradeProvider {
+    // `open` is never reached on a `@ws` route; a panic here would catch
+    // the adapter calling the wrong entry point.
+    async fn open(
+        &self,
+        _route: &RouteSpec,
+        _auth: Option<&SiteAuthContext>,
+        _request: Value,
+        _body: Option<axum::body::Bytes>,
+    ) -> Response {
+        panic!("a @ws route must call `upgrade`, never `open`");
+    }
+
+    async fn upgrade(
+        &self,
+        route: &RouteSpec,
+        auth: Option<&SiteAuthContext>,
+        ws: WebSocketUpgrade,
+        request: Value,
+    ) -> Response {
+        let opened = json!({
+            "route": { "method": route.method, "path": route.path },
+            "tenant": auth.and_then(|c| c.tenant_id.as_ref()).map(|t| t.0.clone()),
+            "topic": request["path_params"]["topic"],
+        })
+        .to_string();
+        ws.on_upgrade(move |mut socket| async move {
+            // Prime the client with the head dict so the test can assert
+            // the provider saw the matched route + identity.
+            if socket.send(Message::Text(opened.into())).await.is_err() {
+                return;
+            }
+            while let Some(Ok(message)) = socket.next().await {
+                match message {
+                    Message::Text(text) => {
+                        let reply = format!("echo:{text}");
+                        if socket.send(Message::Text(reply.into())).await.is_err() {
+                            break;
+                        }
+                    }
+                    Message::Close(_) => break,
+                    _ => {}
+                }
+            }
+        })
+    }
+}
+
+/// `SiteAuth` hook that always admits with a fixed identity.
+struct AllowAuth {
+    tenant: Option<&'static str>,
+    scopes: &'static [&'static str],
+}
+
+#[async_trait::async_trait]
+impl SiteAuth for AllowAuth {
+    async fn authenticate(&self, _parts: &Parts, _route: &RouteSpec) -> SiteAuthOutcome {
+        SiteAuthOutcome::Allow(SiteAuthContext {
+            tenant_id: self.tenant.map(TenantId::new),
+            scopes: self.scopes.iter().map(|s| s.to_string()).collect(),
+            context: None,
+        })
+    }
+}
+
+/// `SiteAuth` hook that always refuses with an embedder-shaped 401.
+struct DenyAuth;
+
+#[async_trait::async_trait]
+impl SiteAuth for DenyAuth {
+    async fn authenticate(&self, _parts: &Parts, _route: &RouteSpec) -> SiteAuthOutcome {
+        SiteAuthOutcome::deny(
+            (
+                StatusCode::UNAUTHORIZED,
+                [("x-embedder-deny", "1")],
+                Json(json!({ "error": "custom_embedder_denial" })),
+            )
+                .into_response(),
+        )
+    }
+}
+
+fn build_core(path: &Path) -> DispatchCore {
+    let mut config = DispatchCoreConfig::for_script(path);
+    config.replay_cache = Arc::new(NoReplayCache);
+    DispatchCore::new(config).expect("dispatch core")
+}
+
+/// Write the shared script to a temp dir and build a site router over it
+/// with the echo upgrade provider, optionally behind an auth hook. The
+/// temp dir is returned so it outlives the router.
+fn ws_router(auth: Option<Arc<dyn SiteAuth>>) -> (tempfile::TempDir, Router) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("site.harn");
+    std::fs::write(&path, SITE_SCRIPT).expect("write script");
+    let mut config = SiteServerConfig::new(build_core(&path))
+        .with_stream_provider(Arc::new(EchoUpgradeProvider));
+    if let Some(auth) = auth {
+        config = config.with_auth(auth);
+    }
+    let router = SiteServer::new(config).router().expect("site router");
+    (dir, router)
+}
+
+async fn read_body(response: Response) -> (StatusCode, String) {
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    (status, String::from_utf8_lossy(&bytes).into_owned())
+}
+
+/// The happy path: an admitted request on the `@ws` route upgrades, and
+/// the provider's socket echoes a message. The priming frame proves the
+/// provider saw the matched route, the hook's tenant, and the captured
+/// path param; the `.harn` stub body never runs.
+#[tokio::test]
+async fn ws_route_upgrades_and_echoes_through_provider() {
+    use tokio_tungstenite::tungstenite::protocol::Message as TungMessage;
+
+    let hook = Arc::new(AllowAuth {
+        tenant: Some("acme"),
+        scopes: &["live:read"],
+    });
+    let (_dir, router) = ws_router(Some(hook));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+
+    let url = format!("ws://{addr}/topics/deploys/live");
+    let (mut socket, _response) = tokio_tungstenite::connect_async(url).await.unwrap();
+
+    // First frame is the provider's priming head dict.
+    let primed = socket.next().await.unwrap().unwrap();
+    let TungMessage::Text(text) = primed else {
+        panic!("expected a text priming frame, got {primed:?}");
+    };
+    let opened: Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(opened["route"]["method"], "GET");
+    assert_eq!(opened["route"]["path"], "/topics/{topic}/live");
+    assert_eq!(opened["tenant"], "acme");
+    assert_eq!(opened["topic"], "deploys");
+
+    // Then the socket echoes inbound frames.
+    socket.send(TungMessage::Text("ping".into())).await.unwrap();
+    let echoed = socket.next().await.unwrap().unwrap();
+    assert_eq!(echoed, TungMessage::Text("echo:ping".into()));
+    socket.send(TungMessage::Close(None)).await.unwrap();
+}
+
+/// A `SiteAuth` `Deny` gates the `@ws` route before the upgrade: the
+/// embedder's 401 comes back verbatim and no socket is opened. Driven
+/// through `oneshot` with the real upgrade headers so the only reason it
+/// is refused is the auth hook, not a missing handshake.
+#[tokio::test]
+async fn auth_deny_refuses_ws_route_before_upgrade() {
+    let (_dir, router) = ws_router(Some(Arc::new(DenyAuth)));
+    let request = Request::builder()
+        .uri("/topics/deploys/live")
+        .header("connection", "upgrade")
+        .header("upgrade", "websocket")
+        .header("sec-websocket-version", "13")
+        .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    assert_eq!(response.headers()["x-embedder-deny"], "1");
+    let (status, body) = read_body(response).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert!(body.contains("custom_embedder_denial"));
+}
+
+/// An admitted identity whose scopes do not cover the route's `@scopes`
+/// is refused with the canonical `forbidden` envelope — again before the
+/// upgrade, even though the request carried a valid handshake.
+#[tokio::test]
+async fn scope_shortfall_yields_403_before_upgrade() {
+    let hook = Arc::new(AllowAuth {
+        tenant: Some("acme"),
+        scopes: &["live:write"],
+    });
+    let (_dir, router) = ws_router(Some(hook));
+    let request = Request::builder()
+        .uri("/topics/deploys/live")
+        .header("connection", "upgrade")
+        .header("upgrade", "websocket")
+        .header("sec-websocket-version", "13")
+        .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = read_body(router.oneshot(request).await.unwrap()).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    let envelope: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(envelope["code"], "forbidden");
+    assert_eq!(envelope["details"]["missing_scopes"][0], "live:read");
+}
+
+/// A scoped `@ws` route with no hook installed has no identity and no
+/// granted scopes, so it refuses with the canonical 403 before the
+/// upgrade — the same admission back-stop a scoped `@stream` route gets.
+#[tokio::test]
+async fn scoped_ws_route_without_hook_is_refused_at_admission() {
+    let (_dir, router) = ws_router(None);
+    let request = Request::builder()
+        .uri("/topics/deploys/live")
+        .header("connection", "upgrade")
+        .header("upgrade", "websocket")
+        .header("sec-websocket-version", "13")
+        .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = read_body(router.oneshot(request).await.unwrap()).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    let envelope: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(envelope["code"], "forbidden");
+}
+
+/// A plain (non-WebSocket) GET to a `@ws` route is admitted, then refused
+/// by axum's `WebSocketUpgrade` extractor with the correct 4xx — not a
+/// panic, and not a stray 101.
+#[tokio::test]
+async fn non_websocket_request_to_ws_route_is_refused_with_4xx() {
+    let hook = Arc::new(AllowAuth {
+        tenant: Some("acme"),
+        scopes: &["live:read"],
+    });
+    let (_dir, router) = ws_router(Some(hook));
+    // No upgrade headers at all — a plain GET.
+    let request = Request::builder()
+        .uri("/topics/deploys/live")
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let status = response.status();
+    assert!(
+        status.is_client_error(),
+        "a non-WebSocket request to a @ws route must be a 4xx, got {status}"
+    );
+    // axum's extractor returns 426 / 400 for a non-upgrade request.
+    assert_ne!(status, StatusCode::SWITCHING_PROTOCOLS);
+    assert_ne!(status, StatusCode::OK);
+}
+
+/// A non-`@ws` route on the same script is untouched: it dispatches into
+/// the VM and renders its buffered JSON reply.
+#[tokio::test]
+async fn non_ws_route_still_dispatches_into_the_vm() {
+    let hook = Arc::new(AllowAuth {
+        tenant: None,
+        scopes: &[],
+    });
+    let (_dir, router) = ws_router(Some(hook));
+    let request = Request::builder()
+        .uri("/plain")
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = read_body(router.oneshot(request).await.unwrap()).await;
+    assert_eq!(status, StatusCode::OK);
+    let value: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(value["plain"], true);
+}
+
+/// Declaring a `@ws` route without installing a provider is a
+/// configuration error surfaced at router-build time, not a 500 at
+/// request time.
+#[tokio::test]
+async fn ws_route_without_provider_refuses_to_build() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("site.harn");
+    std::fs::write(&path, SITE_SCRIPT).expect("write script");
+    let config = SiteServerConfig::new(build_core(&path));
+    let error = SiteServer::new(config).router().expect_err("must refuse");
+    assert!(
+        error.contains("@ws") && error.contains("with_stream_provider"),
+        "unhelpful error: {error}"
+    );
+}
+
+/// The default `SiteStreamProvider::upgrade` (a provider that only
+/// implements `open`) refuses a `@ws` route with `426 Upgrade Required`
+/// rather than 101-ing into a socket nobody drives. Drives a real
+/// handshake so the request reaches the default method.
+#[tokio::test]
+async fn default_upgrade_impl_returns_426() {
+    // A provider that implements only `open` (the default `upgrade`
+    // applies). `open` must never be reached for a `@ws` route.
+    struct OpenOnlyProvider;
+    #[async_trait::async_trait]
+    impl SiteStreamProvider for OpenOnlyProvider {
+        async fn open(
+            &self,
+            _route: &RouteSpec,
+            _auth: Option<&SiteAuthContext>,
+            _request: Value,
+            _body: Option<axum::body::Bytes>,
+        ) -> Response {
+            unreachable!("@ws must use the upgrade entry point");
+        }
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("site.harn");
+    // No @scopes so admission is unconditional and the request reaches
+    // the provider's default `upgrade`.
+    std::fs::write(
+        &path,
+        r#"
+@ws
+@route("GET", "/socket")
+pub fn socket(req: dict) -> dict { return http_ok({}) }
+"#,
+    )
+    .expect("write script");
+    let config =
+        SiteServerConfig::new(build_core(&path)).with_stream_provider(Arc::new(OpenOnlyProvider));
+    let router = SiteServer::new(config).router().expect("site router");
+
+    // A live socket is required: the `WebSocketUpgrade` extractor needs
+    // the real `OnUpgrade` connection state to succeed and reach the
+    // provider's default `upgrade`, which then refuses with 426.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+
+    let url = format!("ws://{addr}/socket");
+    let error = tokio_tungstenite::connect_async(url)
+        .await
+        .expect_err("the default upgrade impl must refuse the handshake");
+    let tokio_tungstenite::tungstenite::Error::Http(response) = error else {
+        panic!("expected an HTTP rejection, got {error:?}");
+    };
+    assert_eq!(response.status(), StatusCode::UPGRADE_REQUIRED);
+    let body = response
+        .body()
+        .as_ref()
+        .map(|bytes| String::from_utf8_lossy(bytes).into_owned())
+        .unwrap_or_default();
+    assert!(
+        body.contains("ws_upgrade_unsupported"),
+        "unexpected body: {body}"
+    );
+}


### PR DESCRIPTION
Adds a bare `@ws` route marker mirroring `@stream`, so embedder routes that need a WebSocket upgrade can run on `SiteServer` (the last harn-core enabler for migrating harn-cloud's gateway WS routes — /acp, task WS).

- `@ws` parsed beside `@stream`/`@raw` (diagnostics HARN-SRV-014/015/016: no-args, needs-route, conflicts-with-stream/raw); `ws: bool` on ExportedFunction + SiteRoute.
- New **default** trait method `SiteStreamProvider::upgrade(route, auth, ws: WebSocketUpgrade, request) -> Response` (default = 426), so existing impls compile unchanged.
- Dispatch: runs SiteAuth admission + `@scopes` FIRST (auth gates the upgrade — 401/403 before the extractor), then extracts `WebSocketUpgrade::from_request_parts` while OnUpgrade is still on parts, calls the provider, forwards the 101 verbatim. Non-WS request → correct 4xx, no panic.
- 8 integration tests (site_websocket.rs) + 5 catalog tests; 505 harn-serve tests pass; fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)