### PR TITLE
Fix Linux Landlock EINVAL when a sandbox read-root is a regular file

### DIFF
--- a/changelog.d/linux-landlock-file-roots.fixed.md
+++ b/changelog.d/linux-landlock-file-roots.fixed.md
@@ -1,0 +1,11 @@
+- **Linux process sandbox no longer fails to spawn when a read-root resolves
+  to a regular file.** `process.exec` under the `worktree`/`os_hardened`
+  profiles built a Landlock `PATH_BENEATH` rule with directory-only access
+  rights (`READ_DIR`, the `MAKE_*`/`REMOVE_*` family, `REFER`) even when the
+  root was a *file* — e.g. the package-manager-config preset's `~/.gitconfig`,
+  `~/.cargo/config.toml`, or `~/.npmrc`. On a kernel with Landlock support the
+  kernel rejects such a rule with `EINVAL`, surfacing as
+  `host_call process.exec: Invalid argument (os error 22)`. The directory-only
+  bits are now stripped for non-directory rule targets, so the remaining
+  file-applicable rights (`READ_FILE`/`EXECUTE`/…) are still enforced and the
+  spawn succeeds.

--- a/crates/harn-vm/src/stdlib/sandbox/linux.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/linux.rs
@@ -241,6 +241,22 @@ fn push_rule(
             )));
         }
     };
+    // Landlock rejects (EINVAL) a PATH_BENEATH rule whose `parent_fd`
+    // points at a non-directory file but whose `allowed_access` carries
+    // directory-only rights (READ_DIR, the MAKE_*/REMOVE_* family,
+    // REFER). Read-root presets routinely resolve to *files* (e.g.
+    // `~/.gitconfig`, `~/.cargo/config.toml`), so mask the directory-only
+    // bits off when the handle is not a directory. The remaining
+    // file-applicable rights (READ_FILE/EXECUTE/WRITE_FILE/…) still apply.
+    let is_dir = file
+        .metadata()
+        .map(|metadata| metadata.is_dir())
+        .unwrap_or(false);
+    let allowed_access = if is_dir {
+        allowed_access
+    } else {
+        allowed_access & !DIRECTORY_ONLY_ACCESS_FS
+    };
     profile.rules.push(LandlockRule {
         file,
         allowed_access: allowed_access & profile.handled_access_fs,
@@ -496,6 +512,24 @@ const LANDLOCK_ACCESS_FS_REFER: u64 = 1 << 13;
 const LANDLOCK_ACCESS_FS_TRUNCATE: u64 = 1 << 14;
 const LANDLOCK_ACCESS_FS_IOCTL_DEV: u64 = 1 << 15;
 
+/// Access rights that Landlock only permits on a *directory* handle. A
+/// PATH_BENEATH rule that pairs any of these with a non-directory
+/// `parent_fd` is rejected with EINVAL, so [`push_rule`] strips them when
+/// the resolved path is a regular file. (`READ_FILE`, `WRITE_FILE`,
+/// `EXECUTE`, `TRUNCATE`, and `IOCTL_DEV` are valid on file handles and
+/// are intentionally absent here.)
+const DIRECTORY_ONLY_ACCESS_FS: u64 = LANDLOCK_ACCESS_FS_READ_DIR
+    | LANDLOCK_ACCESS_FS_REMOVE_DIR
+    | LANDLOCK_ACCESS_FS_REMOVE_FILE
+    | LANDLOCK_ACCESS_FS_MAKE_CHAR
+    | LANDLOCK_ACCESS_FS_MAKE_DIR
+    | LANDLOCK_ACCESS_FS_MAKE_REG
+    | LANDLOCK_ACCESS_FS_MAKE_SOCK
+    | LANDLOCK_ACCESS_FS_MAKE_FIFO
+    | LANDLOCK_ACCESS_FS_MAKE_BLOCK
+    | LANDLOCK_ACCESS_FS_MAKE_SYM
+    | LANDLOCK_ACCESS_FS_REFER;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -649,6 +683,56 @@ mod tests {
                 "{device} must not receive device ioctl access"
             );
         }
+    }
+
+    #[test]
+    fn directory_only_access_excludes_file_applicable_rights() {
+        // The file-applicable rights must never be classified as
+        // directory-only, otherwise `push_rule` would strip a read/exec
+        // grant from a regular-file rule and silently under-scope it.
+        for right in [
+            LANDLOCK_ACCESS_FS_READ_FILE,
+            LANDLOCK_ACCESS_FS_WRITE_FILE,
+            LANDLOCK_ACCESS_FS_EXECUTE,
+            LANDLOCK_ACCESS_FS_TRUNCATE,
+            LANDLOCK_ACCESS_FS_IOCTL_DEV,
+        ] {
+            assert_eq!(
+                DIRECTORY_ONLY_ACCESS_FS & right,
+                0,
+                "file-applicable right {right:#x} must not be directory-only",
+            );
+        }
+        // READ_DIR is the right that triggers the EINVAL on regular files.
+        assert_ne!(
+            DIRECTORY_ONLY_ACCESS_FS & LANDLOCK_ACCESS_FS_READ_DIR,
+            0,
+            "READ_DIR must be classified as directory-only",
+        );
+    }
+
+    #[test]
+    fn read_only_access_on_a_regular_file_drops_directory_only_bits() {
+        // A read-only preset root that resolves to a *file* (e.g.
+        // `~/.gitconfig`) must end up with only file-applicable rights;
+        // the `READ_DIR` bit in `read_only_access()` would otherwise make
+        // `landlock_add_rule` return EINVAL.
+        let masked = read_only_access() & !DIRECTORY_ONLY_ACCESS_FS;
+        assert_eq!(
+            masked & LANDLOCK_ACCESS_FS_READ_DIR,
+            0,
+            "READ_DIR must be stripped for non-directory rules",
+        );
+        assert_ne!(
+            masked & LANDLOCK_ACCESS_FS_READ_FILE,
+            0,
+            "READ_FILE must survive for non-directory rules",
+        );
+        assert_ne!(
+            masked & LANDLOCK_ACCESS_FS_EXECUTE,
+            0,
+            "EXECUTE must survive for non-directory rules",
+        );
     }
 
     #[test]


### PR DESCRIPTION
Root-cause of a Linux-only `host_call process.exec` spawn EINVAL (os error 22): harn's Landlock backend adds a `PATH_BENEATH` rule with directory-only access rights (`READ_DIR`, etc.) even when the read-root is a **regular file**. Landlock rejects file+dir-only-rights with EINVAL. The default package-manager-config preset resolves to regular files (`~/.gitconfig`, `~/.cargo/config.toml`, `~/.npmrc`); when one exists the spawn fails. macOS uses `sandbox-exec` (no Landlock) so it passes locally — a nasty local-green/CI-red divergence that bit factory C2 (harn-cloud #745).

**Fix:** in `linux.rs` `push_rule`, stat the opened handle and mask off directory-only access bits for non-directory roots before building the rule (mirrors the kernel contract + upstream `landlock` crate). **Security preserved** — directory roots unchanged; file roots never needed dir-only rights, so nothing is weakened; enforcement stays fully on (not a degrade-to-off). Verified on a Linux runner (ABI 8): the exact `add_rule(~/.gitconfig, 0xd)` EINVAL now passes; +2 unit tests; 3725 harn-vm tests pass; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)