### PR TITLE
fix(llm): OpenRouter per-(provider,model) upstream denylist + billed-no-op contract guard

### DIFF
--- a/changelog.d/openrouter-route-denylist.fixed.md
+++ b/changelog.d/openrouter-route-denylist.fixed.md
@@ -1,0 +1,17 @@
+- **OpenRouter route-around for broken upstreams plus a billed-no-op contract
+  guard.** Capability rows gained a data-driven `provider_route_denylist`
+  (`Vec<String>`) that the OpenAI-compatible request builder materializes into
+  the OpenRouter request body's `provider.ignore` array (merged and deduped,
+  preserving existing entries). The `qwen/qwen3.6*` openrouter row denies the
+  `Ambient` upstream, which billed reasoning tokens and then finished with
+  `finish_reason: "stop"` and empty `tool_calls` — narrating the intended tool
+  call on the reasoning channel and serializing it to no wire field — while
+  `Parasail` / `AtlasCloud` / `AkashML` serve the identical request natively.
+  Native tools stay on; only the broken upstream is routed around (the
+  `require_parameters` knob does not help). As a deterministic backstop across
+  every OpenAI-compatible route (streaming and non-streaming), a clean-finish
+  turn that billed output, offered tools, captured no tool call or tool-search
+  block, and produced fewer than 24 committed answer characters now fails loudly
+  as an "upstream contract violation" instead of returning a silent empty
+  success. A `length`/truncation finish, a normal tool call, a substantive text
+  answer, and a tool-less prompt are all left untouched.

--- a/crates/harn-vm/src/llm/api/response.rs
+++ b/crates/harn-vm/src/llm/api/response.rs
@@ -497,12 +497,90 @@ pub(crate) fn parse_openai_responses_response(
     })
 }
 
+/// Minimum number of non-whitespace characters a clean, tool-less completion
+/// must carry to count as a committed answer rather than a billed no-op. The
+/// canonical violation is OpenRouter's `Ambient` upstream for
+/// `qwen/qwen3.6-35b-a3b`: it narrates the intended tool call on the reasoning
+/// channel, emits a tiny `content` preamble (e.g. `"creating files\n\n"`), then
+/// finishes with `finish_reason: "stop"` and EMPTY `tool_calls` — billing
+/// thousands of reasoning tokens while dispatching nothing. A short preamble
+/// defeats a bare `text.is_empty()` guard, so we require a structural floor of
+/// committed visible characters before accepting a clean, tool-offered turn
+/// that produced no tool call. This is a fixed structural threshold, not a
+/// token ratio.
+pub(crate) const MIN_COMMITTED_ANSWER_CHARS: usize = 24;
+
+/// Structural signals describing a finished LLM turn, used by
+/// [`is_billed_noncommittal_completion`]. All fields are derived from the
+/// parsed response plus the outbound request; none involve model-name or
+/// provider-name branching.
+pub(crate) struct CompletionContractSignals<'a> {
+    /// The provider-reported finish/stop reason, if any.
+    pub stop_reason: Option<&'a str>,
+    /// Billed completion/output tokens for this turn.
+    pub output_tokens: i64,
+    /// Whether the outbound request offered any tools to the model.
+    pub tools_offered: bool,
+    /// Number of dispatchable tool calls captured from the response.
+    pub tool_call_count: usize,
+    /// Whether the response carried a server-side tool-search block (which
+    /// counts as the model "doing something" even with no committed text).
+    pub has_tool_search_block: bool,
+    /// The committed visible answer text.
+    pub text: &'a str,
+}
+
+/// Deterministic detector for a finished-clean LLM turn that billed output
+/// but delivered neither a dispatchable tool call nor a committed answer — an
+/// upstream contract violation (the model serialized its action only onto the
+/// reasoning channel, or onto no wire field at all).
+///
+/// Returns `true` only when ALL hold:
+/// - the turn finished cleanly (stop reason is `stop` / `tool_calls` /
+///   `end_turn` / absent — NOT `length`, so genuine truncation never misfires),
+/// - the provider billed output tokens (`output_tokens > 0`),
+/// - tools were offered in the request (so a deliberate terse text answer to a
+///   tool-less prompt is never flagged),
+/// - no dispatchable tool call was captured,
+/// - no server-side tool-search block was present, and
+/// - the committed visible text is below [`MIN_COMMITTED_ANSWER_CHARS`]
+///   non-whitespace characters.
+pub(crate) fn is_billed_noncommittal_completion(signals: &CompletionContractSignals) -> bool {
+    let finished_clean = !matches!(signals.stop_reason, Some("length"));
+    finished_clean
+        && signals.output_tokens > 0
+        && signals.tools_offered
+        && signals.tool_call_count == 0
+        && !signals.has_tool_search_block
+        && signals.text.trim().chars().count() < MIN_COMMITTED_ANSWER_CHARS
+}
+
+/// Build the loud, actionable error returned when
+/// [`is_billed_noncommittal_completion`] fires. Names the provider/model and
+/// the structural facts so eval dashboards and operators can route around the
+/// broken upstream instead of silently absorbing a billed no-op.
+pub(crate) fn billed_noncommittal_completion_error(
+    provider: &str,
+    model: &str,
+    output_tokens: i64,
+) -> VmError {
+    VmError::Thrown(VmValue::String(std::sync::Arc::from(format!(
+        "provider {provider} model {model} returned billed output \
+         (completion_tokens={output_tokens}) with no dispatchable tool call or answer \
+         (upstream contract violation): the model finished cleanly but committed neither a \
+         tool call nor a substantive text answer. This usually means a broken OpenRouter \
+         upstream serialized the tool call onto the reasoning channel only; consider a \
+         provider_route_denylist for the offending upstream."
+    ))))
+}
+
 /// Parse a complete (non-streaming) LLM JSON response into an `LlmResult`.
 pub(crate) fn parse_llm_response(
     json: &serde_json::Value,
     provider: &str,
     model: &str,
     is_anthropic_style: bool,
+    tools_offered: bool,
 ) -> Result<LlmResult, VmError> {
     if provider == "openai"
         && json
@@ -796,6 +874,26 @@ pub(crate) fn parse_llm_response(
             ),
             ))));
         }
+        // Deterministic upstream contract-violation backstop. A short, clean,
+        // tool-offered completion that billed output but dispatched no tool
+        // call (and carried no tool-search block) is a billed no-op — the
+        // structured action went only to the reasoning channel or nowhere.
+        // This catches the case the `text.is_empty()` guard above misses
+        // because the upstream emitted a tiny content preamble.
+        if is_billed_noncommittal_completion(&CompletionContractSignals {
+            stop_reason: stop_reason.as_deref(),
+            output_tokens,
+            tools_offered,
+            tool_call_count: tool_calls.len(),
+            has_tool_search_block,
+            text: &text,
+        }) {
+            return Err(billed_noncommittal_completion_error(
+                provider,
+                model,
+                output_tokens,
+            ));
+        }
 
         Ok(LlmResult {
             text,
@@ -935,8 +1033,142 @@ pub(super) fn extract_cache_write_tokens(usage: &serde_json::Value) -> i64 {
 mod tests {
     use super::{
         extract_cache_read_tokens, extract_cache_write_tokens, extract_openai_choice_logprobs,
-        parse_llm_response, parse_openai_responses_response,
+        is_billed_noncommittal_completion, parse_llm_response, parse_openai_responses_response,
+        CompletionContractSignals,
     };
+
+    #[test]
+    fn contract_violation_fires_on_billed_noop_tool_turn() {
+        // Ambient shape: clean `stop`, billed tokens, tools offered, no tool
+        // call, no tool-search, tiny content preamble below the floor.
+        let signals = CompletionContractSignals {
+            stop_reason: Some("stop"),
+            output_tokens: 342,
+            tools_offered: true,
+            tool_call_count: 0,
+            has_tool_search_block: false,
+            text: "creating files\n\n",
+        };
+        assert!(is_billed_noncommittal_completion(&signals));
+    }
+
+    #[test]
+    fn contract_violation_silent_on_normal_tool_call() {
+        let signals = CompletionContractSignals {
+            stop_reason: Some("tool_calls"),
+            output_tokens: 800,
+            tools_offered: true,
+            tool_call_count: 2,
+            has_tool_search_block: false,
+            text: "",
+        };
+        assert!(!is_billed_noncommittal_completion(&signals));
+    }
+
+    #[test]
+    fn contract_violation_silent_on_substantive_text_answer() {
+        let signals = CompletionContractSignals {
+            stop_reason: Some("stop"),
+            output_tokens: 120,
+            tools_offered: true,
+            tool_call_count: 0,
+            has_tool_search_block: false,
+            text: "Here is the full explanation you asked for, in detail.",
+        };
+        assert!(!is_billed_noncommittal_completion(&signals));
+    }
+
+    #[test]
+    fn contract_violation_silent_on_truncation() {
+        // A `length`/truncation finish must never misfire even when short.
+        let signals = CompletionContractSignals {
+            stop_reason: Some("length"),
+            output_tokens: 4096,
+            tools_offered: true,
+            tool_call_count: 0,
+            has_tool_search_block: false,
+            text: "creating files\n\n",
+        };
+        assert!(!is_billed_noncommittal_completion(&signals));
+    }
+
+    #[test]
+    fn contract_violation_silent_when_no_tools_offered() {
+        // A deliberately terse text reply to a tool-less prompt is fine.
+        let signals = CompletionContractSignals {
+            stop_reason: Some("stop"),
+            output_tokens: 6,
+            tools_offered: false,
+            tool_call_count: 0,
+            has_tool_search_block: false,
+            text: "Yes.",
+        };
+        assert!(!is_billed_noncommittal_completion(&signals));
+    }
+
+    #[test]
+    fn contract_violation_silent_on_tool_search_block() {
+        let signals = CompletionContractSignals {
+            stop_reason: Some("stop"),
+            output_tokens: 200,
+            tools_offered: true,
+            tool_call_count: 0,
+            has_tool_search_block: true,
+            text: "",
+        };
+        assert!(!is_billed_noncommittal_completion(&signals));
+    }
+
+    #[test]
+    fn parse_llm_response_rejects_ambient_billed_noop() {
+        // End-to-end through the openai-compat parser: the Ambient response
+        // shape (clean stop, billed reasoning tokens, tiny content preamble,
+        // empty tool_calls) must surface a loud contract-violation error
+        // rather than a silent empty success.
+        let response = serde_json::json!({
+            "id": "gen-ambient",
+            "model": "qwen/qwen3.6-35b-a3b",
+            "provider": "Ambient",
+            "choices": [{
+                "index": 0,
+                "finish_reason": "stop",
+                "message": { "role": "assistant", "content": "creating files\n\n" }
+            }],
+            "usage": { "prompt_tokens": 321, "completion_tokens": 342 }
+        });
+        let err = parse_llm_response(&response, "openrouter", "qwen/qwen3.6-35b-a3b", false, true)
+            .expect_err("billed no-op tool turn must be rejected");
+        let message = err.to_string();
+        assert!(
+            message.contains("upstream contract violation"),
+            "error must name the contract violation: {message}"
+        );
+    }
+
+    #[test]
+    fn parse_llm_response_allows_short_answer_when_no_tools_offered() {
+        // Same short content, but no tools were offered: this is a legitimate
+        // terse answer and must parse cleanly.
+        let response = serde_json::json!({
+            "id": "gen-terse",
+            "model": "qwen/qwen3.6-35b-a3b",
+            "choices": [{
+                "index": 0,
+                "finish_reason": "stop",
+                "message": { "role": "assistant", "content": "creating files\n\n" }
+            }],
+            "usage": { "prompt_tokens": 321, "completion_tokens": 6 }
+        });
+        let result = parse_llm_response(
+            &response,
+            "openrouter",
+            "qwen/qwen3.6-35b-a3b",
+            false,
+            false,
+        )
+        .expect("short answer with no tools offered parses cleanly");
+        assert_eq!(result.text.trim(), "creating files");
+    }
 
     #[test]
     fn cache_write_tokens_supports_openrouter_prompt_details_shape() {
@@ -1149,7 +1381,7 @@ mod tests {
             "usage": {"input_tokens": 1, "output_tokens": 0}
         });
 
-        let error = parse_llm_response(&response, "anthropic", "claude-opus-4-7", true)
+        let error = parse_llm_response(&response, "anthropic", "claude-opus-4-7", true, false)
             .expect_err("missing content must be rejected");
 
         assert!(error.to_string().contains("missing content array"));
@@ -1162,7 +1394,7 @@ mod tests {
             "usage": {"prompt_tokens": 1, "completion_tokens": 0}
         });
 
-        let error = parse_llm_response(&response, "openai", "gpt-5.4-preview", false)
+        let error = parse_llm_response(&response, "openai", "gpt-5.4-preview", false, false)
             .expect_err("missing choices must be rejected");
 
         assert!(error
@@ -1180,7 +1412,7 @@ mod tests {
             "usage": {"prompt_tokens": 1, "completion_tokens": 0}
         });
 
-        let error = parse_llm_response(&response, "openai", "gpt-5.4-preview", false)
+        let error = parse_llm_response(&response, "openai", "gpt-5.4-preview", false, false)
             .expect_err("empty provider message must be rejected");
 
         assert!(error.to_string().contains("delivered no content"));
@@ -1202,7 +1434,7 @@ mod tests {
             ],
             "usage": {"input_tokens": 10, "output_tokens": 5}
         });
-        let result = parse_llm_response(&response, "anthropic", "claude-opus-4-7", true)
+        let result = parse_llm_response(&response, "anthropic", "claude-opus-4-7", true, false)
             .expect("parser succeeds");
 
         // tool_calls is for *dispatchable* user tools — server-side tools
@@ -1245,7 +1477,7 @@ mod tests {
                 }],
                 "usage": {"prompt_tokens": 10, "completion_tokens": 549}
             });
-            let result = parse_llm_response(&response, "openrouter", "or-qwen", false)
+            let result = parse_llm_response(&response, "openrouter", "or-qwen", false, false)
                 .expect("parser succeeds");
             assert_eq!(result.stop_reason.as_deref(), Some(finish_reason));
             assert_eq!(result.tool_calls.len(), 1);
@@ -1278,7 +1510,7 @@ mod tests {
             }],
             "usage": {"prompt_tokens": 10, "completion_tokens": 5}
         });
-        let result = parse_llm_response(&response, "openai", "gpt-5.4-preview", false)
+        let result = parse_llm_response(&response, "openai", "gpt-5.4-preview", false, false)
             .expect("parser succeeds");
 
         assert!(
@@ -1315,7 +1547,7 @@ mod tests {
             }],
             "usage": {"prompt_tokens": 3, "completion_tokens": 1}
         });
-        let result = parse_llm_response(&response, "openai", "gpt-5.4-preview", false)
+        let result = parse_llm_response(&response, "openai", "gpt-5.4-preview", false, false)
             .expect("parser succeeds");
 
         assert!(result.tool_calls.is_empty());
@@ -1348,7 +1580,8 @@ mod tests {
             "usage": {"prompt_tokens": 5, "completion_tokens": 7}
         });
 
-        let result = parse_llm_response(&response, "openai", "o3", false).expect("parser succeeds");
+        let result =
+            parse_llm_response(&response, "openai", "o3", false, false).expect("parser succeeds");
 
         assert_eq!(result.text, "Final answer.");
         assert_eq!(
@@ -1381,7 +1614,7 @@ mod tests {
             ],
             "usage": {"input_tokens": 3, "output_tokens": 1}
         });
-        let result = parse_llm_response(&response, "anthropic", "claude-opus-4-7", true)
+        let result = parse_llm_response(&response, "anthropic", "claude-opus-4-7", true, false)
             .expect("parser succeeds");
 
         let result_block = result
@@ -1417,8 +1650,8 @@ mod tests {
             "usage": {"prompt_tokens": 314, "completion_tokens": 27}
         });
 
-        let result =
-            parse_llm_response(&response, "vllm", "qwen3.6", false).expect("parser succeeds");
+        let result = parse_llm_response(&response, "vllm", "qwen3.6", false, false)
+            .expect("parser succeeds");
 
         assert_eq!(
             result.telemetry.source,
@@ -1453,8 +1686,8 @@ mod tests {
             }
         });
 
-        let result =
-            parse_llm_response(&response, "llamacpp", "qwen-7b", false).expect("parser succeeds");
+        let result = parse_llm_response(&response, "llamacpp", "qwen-7b", false, false)
+            .expect("parser succeeds");
 
         assert_eq!(
             result.telemetry.source,
@@ -1473,7 +1706,7 @@ mod tests {
             "usage": {"input_tokens": 5, "output_tokens": 2},
             "stop_reason": "end_turn"
         });
-        let result = parse_llm_response(&response, "anthropic", "claude-opus-4-7", true)
+        let result = parse_llm_response(&response, "anthropic", "claude-opus-4-7", true, false)
             .expect("parser succeeds");
         assert_eq!(
             result.telemetry.source,

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -13,7 +13,10 @@ use super::openai_normalize::{
 };
 use super::options::{DeltaSender, LlmRequestPayload};
 use super::partial_tool_args::{project_partial, DeltaCoalescer, PartialToolArgs};
-use super::response::{extract_cache_read_tokens, extract_cache_write_tokens, parse_llm_response};
+use super::response::{
+    billed_noncommittal_completion_error, extract_cache_read_tokens, extract_cache_write_tokens,
+    is_billed_noncommittal_completion, parse_llm_response, CompletionContractSignals,
+};
 use super::result::LlmResult;
 use super::telemetry::{elapsed_ms, source as telemetry_source, ProviderTelemetry};
 use super::thinking::ThinkingStreamSplitter;
@@ -318,6 +321,14 @@ async fn vm_call_llm_api_with_body_inner(
     let provider = &opts.provider;
     let model = &opts.model;
     let wants_streaming = delta_tx.is_some() && opts.stream;
+    // Whether this request offered any tools to the model. Used by the
+    // billed-no-op contract guard so a deliberately terse text answer to a
+    // tool-less prompt is never misclassified as a missing tool call.
+    let tools_offered = body
+        .get("tools")
+        .and_then(|tools| tools.as_array())
+        .map(|tools| !tools.is_empty())
+        .unwrap_or(false);
 
     let resolved = crate::llm::helpers::ResolvedProvider::resolve(provider);
     let use_stream_transport = if is_ollama && !opts.stream {
@@ -444,6 +455,7 @@ async fn vm_call_llm_api_with_body_inner(
                     tx,
                     opts.session_id.as_deref(),
                     schema_watch,
+                    tools_offered,
                 )
                 .await;
             }
@@ -519,13 +531,14 @@ async fn vm_call_llm_api_with_body_inner(
 
     let is_anthropic_style =
         crate::llm::provider::provider_uses_anthropic_messages(provider, model);
-    parse_llm_response(&json, provider, model, is_anthropic_style)
+    parse_llm_response(&json, provider, model, is_anthropic_style, tools_offered)
 }
 
 /// Consume an SSE streaming response from an already-sent request.
 /// Parses `data: {...}` lines from the response body, then defers to
 /// [`consume_sse_lines`] for the parsing and event-emission logic so
 /// tests can drive the same code path against an in-memory `AsyncBufRead`.
+#[allow(clippy::too_many_arguments)]
 async fn vm_call_llm_api_sse_from_response(
     response: reqwest::Response,
     provider: &str,
@@ -534,6 +547,7 @@ async fn vm_call_llm_api_sse_from_response(
     delta_tx: DeltaSender,
     session_id: Option<&str>,
     schema_watch: Option<super::schema_stream::StreamSchemaWatch>,
+    tools_offered: bool,
 ) -> Result<LlmResult, VmError> {
     use tokio_stream::StreamExt;
 
@@ -549,6 +563,7 @@ async fn vm_call_llm_api_sse_from_response(
         delta_tx,
         session_id,
         schema_watch,
+        tools_offered,
     )
     .await
 }
@@ -659,6 +674,7 @@ fn streaming_tool_call_id(provider_id: &str, fallback_index: usize) -> String {
 /// behavior can be tested against canned byte streams without standing
 /// up a full `reqwest::Response`. The Anthropic / OpenAI branches and
 /// the trailing accumulator drain that finalize the call live here.
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
     reader: R,
     provider: &str,
@@ -667,6 +683,7 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
     delta_tx: DeltaSender,
     session_id: Option<&str>,
     mut schema_watch: Option<super::schema_stream::StreamSchemaWatch>,
+    tools_offered: bool,
 ) -> Result<LlmResult, VmError> {
     use tokio::io::AsyncBufReadExt;
     let mut lines = reader.lines();
@@ -1203,6 +1220,26 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
         return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(format!(
             "openai-compatible model {model} reported completion_tokens={output_tokens} but delivered no content, reasoning, or tool calls"
         )))));
+    }
+    // Deterministic upstream contract-violation backstop (streaming path).
+    // Mirrors the non-streaming detector in `response::parse_llm_response`: a
+    // short, clean, tool-offered turn that billed output but dispatched no tool
+    // call is a billed no-op (the action went only to the reasoning channel).
+    // The bare `text.is_empty()` guard above misses it because the upstream
+    // emitted a tiny content preamble.
+    if is_billed_noncommittal_completion(&CompletionContractSignals {
+        stop_reason: stop_reason.as_deref(),
+        output_tokens,
+        tools_offered,
+        tool_call_count: tool_calls.len(),
+        has_tool_search_block,
+        text: &text,
+    }) {
+        return Err(billed_noncommittal_completion_error(
+            provider,
+            model,
+            output_tokens,
+        ));
     }
 
     // Use the caller-supplied provider id rather than collapsing every
@@ -1797,6 +1834,7 @@ mod streaming_tool_call_tests {
             delta_tx,
             Some(session_id),
             None,
+            false,
         )
         .await
         .expect("sse parse should succeed");
@@ -2134,6 +2172,7 @@ mod streaming_tool_call_tests {
             delta_tx,
             None,
             None,
+            false,
         )
         .await
         .expect("parse");
@@ -2228,6 +2267,7 @@ mod sse_read_error_tests {
             delta_tx,
             None,
             None,
+            false,
         )
         .await
         .expect_err("mid-stream read failure must not return a truncated success");
@@ -2260,6 +2300,7 @@ mod sse_read_error_tests {
             delta_tx,
             None,
             None,
+            false,
         )
         .await
         .expect_err("mid-stream reset must surface as an error");
@@ -2281,9 +2322,18 @@ mod sse_read_error_tests {
         .as_bytes();
         let (delta_tx, _delta_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
         let reader = tokio::io::BufReader::new(body);
-        let result = consume_sse_lines(reader, "openai", "test-model", false, delta_tx, None, None)
-            .await
-            .expect("clean EOF without [DONE] parses");
+        let result = consume_sse_lines(
+            reader,
+            "openai",
+            "test-model",
+            false,
+            delta_tx,
+            None,
+            None,
+            false,
+        )
+        .await
+        .expect("clean EOF without [DONE] parses");
         assert_eq!(result.text, "hello");
         assert_eq!(result.stop_reason.as_deref(), Some("stop"));
     }
@@ -2353,6 +2403,7 @@ mod schema_stream_abort_tests {
             delta_tx,
             None,
             Some(watch),
+            false,
         )
         .await
         .expect_err("schema abort must surface as error");

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -404,6 +404,18 @@ pub struct ProviderRule {
     /// matching Qwen's own published guidance.
     #[serde(default)]
     pub auto_reasoning_overrides: Option<BTreeMap<String, String>>,
+    /// OpenRouter upstream provider names that must be excluded from routing
+    /// for this `(provider, model)` row. Materialized into the request body's
+    /// `provider.ignore` array (see
+    /// [`crate::llm::providers::openai_compat::apply_openrouter_route_denylist`]).
+    /// This is a data-driven route-around for upstreams that serve a route
+    /// incorrectly while still advertising the model — the canonical case is
+    /// OpenRouter's `Ambient` upstream billing reasoning tokens for
+    /// `qwen/qwen3.6-35b-a3b` and then finishing with empty `tool_calls`,
+    /// while Parasail / AtlasCloud / AkashML serve the identical request
+    /// natively. Only consulted for the `openrouter` provider.
+    #[serde(default)]
+    pub provider_route_denylist: Option<Vec<String>>,
 }
 
 /// Resolved capabilities for a `(provider, model)` pair. Unset rule
@@ -470,6 +482,10 @@ pub struct Capabilities {
     /// Per-task auto-policy reasoning-level overrides for this route.
     /// See [`ProviderRule::auto_reasoning_overrides`].
     pub auto_reasoning_overrides: BTreeMap<String, String>,
+    /// OpenRouter upstream provider names to exclude from routing for this
+    /// row. See [`ProviderRule::provider_route_denylist`]. Empty means "no
+    /// route restriction".
+    pub provider_route_denylist: Vec<String>,
 }
 
 impl Default for Capabilities {
@@ -530,6 +546,7 @@ impl Default for Capabilities {
             tool_mode_parity_notes: None,
             thinking_disable_directive: None,
             auto_reasoning_overrides: BTreeMap::new(),
+            provider_route_denylist: Vec::new(),
         }
     }
 }
@@ -1160,6 +1177,7 @@ fn defaults_to_caps(defaults: &ProviderDefaults) -> Capabilities {
         tool_mode_parity_notes: None,
         thinking_disable_directive: None,
         auto_reasoning_overrides: None,
+        provider_route_denylist: None,
     };
     let mut caps = rule_to_caps(&empty, defaults);
     caps.preferred_tool_format = None;
@@ -1263,6 +1281,7 @@ fn rule_to_caps(rule: &ProviderRule, defaults: &ProviderDefaults) -> Capabilitie
         tool_mode_parity_notes: rule.tool_mode_parity_notes.clone(),
         thinking_disable_directive: rule.thinking_disable_directive.clone(),
         auto_reasoning_overrides: rule.auto_reasoning_overrides.clone().unwrap_or_default(),
+        provider_route_denylist: rule.provider_route_denylist.clone().unwrap_or_default(),
     }
 }
 
@@ -1513,6 +1532,24 @@ preferred_tool_format = "native"
         assert!(report.render_human().contains(
             "acme:acme-good-1 (provider.acme model_match=\"acme-good-*\") missing native_tools; suggest native_tools = true, preferred_tool_format = \"native\""
         ));
+    }
+
+    #[test]
+    fn openrouter_qwen36_keeps_native_and_denies_ambient_upstream() {
+        reset();
+        let caps = lookup("openrouter", "qwen/qwen3.6-35b-a3b");
+        // The route-around must NOT downgrade the tool format: native stays on.
+        assert!(caps.native_tools);
+        assert_eq!(caps.preferred_tool_format.as_deref(), Some("native"));
+        // The broken Ambient upstream is denied via the data-driven denylist.
+        assert_eq!(caps.provider_route_denylist, vec!["Ambient".to_string()]);
+    }
+
+    #[test]
+    fn provider_route_denylist_defaults_empty_for_unmarked_rows() {
+        reset();
+        let caps = lookup("anthropic", "claude-opus-4-7");
+        assert!(caps.provider_route_denylist.is_empty());
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -1668,6 +1668,20 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
+# Route around OpenRouter's `Ambient` upstream for this row. With raw SSE
+# captures (evidence: /tmp/qwen36_*), Ambient narrates the tool call on the
+# `reasoning` channel, emits a tiny `content` preamble, then finishes with
+# `finish_reason: "stop"` and EMPTY `tool_calls` — billing ~2800 reasoning
+# tokens while the structured call is never serialized to any wire field. The
+# `Parasail` / `AtlasCloud` / `AkashML` upstreams serve the IDENTICAL request
+# natively (`finish: tool_calls`, valid calls), so native WORKS — only Ambient
+# is broken. This denies the broken upstream rather than downgrading the tool
+# format (KEEP native_tools / preferred_tool_format = "native" above): the
+# proven workaround is the OpenRouter `provider.ignore` body knob (the
+# `require_parameters` knob does NOT help — Ambient advertises tools, stays
+# selected). Materialized into `provider.ignore` by
+# `apply_openrouter_route_denylist`.
+provider_route_denylist = ["Ambient"]
 
 [[provider.openrouter]]
 model_match = "qwen/qwen3-coder-plus"

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/30-qwen-routed.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/30-qwen-routed.toml
@@ -245,6 +245,20 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
+# Route around OpenRouter's `Ambient` upstream for this row. With raw SSE
+# captures (evidence: /tmp/qwen36_*), Ambient narrates the tool call on the
+# `reasoning` channel, emits a tiny `content` preamble, then finishes with
+# `finish_reason: "stop"` and EMPTY `tool_calls` — billing ~2800 reasoning
+# tokens while the structured call is never serialized to any wire field. The
+# `Parasail` / `AtlasCloud` / `AkashML` upstreams serve the IDENTICAL request
+# natively (`finish: tool_calls`, valid calls), so native WORKS — only Ambient
+# is broken. This denies the broken upstream rather than downgrading the tool
+# format (KEEP native_tools / preferred_tool_format = "native" above): the
+# proven workaround is the OpenRouter `provider.ignore` body knob (the
+# `require_parameters` knob does NOT help — Ambient advertises tools, stays
+# selected). Materialized into `provider.ignore` by
+# `apply_openrouter_route_denylist`.
+provider_route_denylist = ["Ambient"]
 
 [[provider.openrouter]]
 model_match = "qwen/qwen3-coder-plus"

--- a/crates/harn-vm/src/llm/providers/azure_openai.rs
+++ b/crates/harn-vm/src/llm/providers/azure_openai.rs
@@ -118,11 +118,17 @@ impl AzureOpenAiProvider {
             .json()
             .await
             .map_err(|error| vm_err(format!("azure_openai response parse error: {error}")))?;
+        let tools_offered = body
+            .get("tools")
+            .and_then(|tools| tools.as_array())
+            .map(|tools| !tools.is_empty())
+            .unwrap_or(false);
         let result = crate::llm::api::parse_llm_response_for_provider(
             &json,
             "azure_openai",
             &request.model,
             false,
+            tools_offered,
         )?;
         maybe_emit_delta(delta_tx, &result.text);
         Ok(result)

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -250,6 +250,15 @@ impl OpenAiCompatibleProvider {
         {
             ensure_openrouter_require_parameters(&mut body);
         }
+        // Data-driven OpenRouter upstream route-around. The capability row may
+        // deny specific upstream providers that serve this (provider, model)
+        // route incorrectly (e.g. billing reasoning tokens then finishing with
+        // empty tool_calls) while still advertising the model. We merge those
+        // names into the request body's `provider.ignore` so OpenRouter reroutes
+        // to a healthy upstream. Pure capability lookup — no model-name branch.
+        if opts.provider == "openrouter" && !caps.provider_route_denylist.is_empty() {
+            apply_openrouter_route_denylist(&mut body, &caps.provider_route_denylist);
+        }
         if let Some(ref tools) = opts.native_tools {
             if !tools.is_empty() {
                 body["tools"] = serde_json::Value::Array(provider_request_tools(
@@ -442,6 +451,43 @@ pub(crate) fn ensure_openrouter_require_parameters(body: &mut serde_json::Value)
         Some(_) => {}
         None => {
             body["provider"] = serde_json::json!({"require_parameters": true});
+        }
+    }
+}
+
+/// Merge `deny` into the OpenRouter request body's `provider.ignore` array,
+/// preserving any entries already present and de-duplicating. Creates the
+/// `provider` object and/or `ignore` array when absent. This is the wire
+/// materialization of the capability-row `provider_route_denylist`; it is
+/// provider-agnostic data plumbing with no model-specific logic — the caller
+/// decides whether a denylist applies by consulting the capability matrix.
+pub(crate) fn apply_openrouter_route_denylist(body: &mut serde_json::Value, deny: &[String]) {
+    if deny.is_empty() {
+        return;
+    }
+    if !body.is_object() {
+        return;
+    }
+    let provider = body
+        .as_object_mut()
+        .expect("body is an object")
+        .entry("provider".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    let Some(provider_obj) = provider.as_object_mut() else {
+        return;
+    };
+    let ignore = provider_obj
+        .entry("ignore".to_string())
+        .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+    let Some(ignore_arr) = ignore.as_array_mut() else {
+        return;
+    };
+    for name in deny {
+        let already_present = ignore_arr
+            .iter()
+            .any(|existing| existing.as_str() == Some(name.as_str()));
+        if !already_present {
+            ignore_arr.push(serde_json::Value::String(name.clone()));
         }
     }
 }
@@ -1618,5 +1664,61 @@ thinking_modes = ["enabled"]
             "non-reserved model keeps canonical delimiter: {serialized}"
         );
         assert!(!serialized.contains("[[CALL]]"));
+    }
+
+    #[test]
+    fn route_denylist_seeds_provider_ignore_on_empty_body() {
+        let mut body = json!({"model": "qwen/qwen3.6-35b-a3b"});
+        apply_openrouter_route_denylist(&mut body, &["Ambient".to_string()]);
+        assert_eq!(body["provider"]["ignore"], json!(["Ambient"]));
+    }
+
+    #[test]
+    fn route_denylist_merges_and_dedupes_existing_ignore() {
+        let mut body = json!({
+            "model": "qwen/qwen3.6-35b-a3b",
+            "provider": { "ignore": ["X"], "require_parameters": true }
+        });
+        apply_openrouter_route_denylist(&mut body, &["Ambient".to_string(), "X".to_string()]);
+        // Existing entry preserved, new entry appended, duplicate not re-added.
+        assert_eq!(body["provider"]["ignore"], json!(["X", "Ambient"]));
+        // Unrelated provider keys are left untouched.
+        assert_eq!(body["provider"]["require_parameters"], json!(true));
+    }
+
+    #[test]
+    fn route_denylist_noop_for_empty_deny() {
+        let mut body = json!({"model": "qwen/qwen3.6-35b-a3b"});
+        apply_openrouter_route_denylist(&mut body, &[]);
+        assert!(body.get("provider").is_none());
+    }
+
+    #[test]
+    fn build_request_body_applies_qwen36_ambient_denylist_for_openrouter_only() {
+        // The qwen3.6 openrouter capability row carries
+        // provider_route_denylist = ["Ambient"]; build_request_body must
+        // materialize it into provider.ignore for the openrouter provider.
+        let mut payload = base_request_payload();
+        payload.provider = "openrouter".to_string();
+        payload.model = "qwen/qwen3.6-35b-a3b".to_string();
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        let ignore = body["provider"]["ignore"]
+            .as_array()
+            .expect("provider.ignore array present for qwen3.6 openrouter route");
+        assert!(
+            ignore.iter().any(|v| v.as_str() == Some("Ambient")),
+            "qwen3.6 openrouter body must deny the Ambient upstream: {body}"
+        );
+
+        // A non-openrouter provider serving the same model id must NOT get a
+        // provider.ignore block — the denylist is openrouter-scoped.
+        let mut other = base_request_payload();
+        other.provider = "vllm".to_string();
+        other.model = "qwen/qwen3.6-35b-a3b".to_string();
+        let other_body = OpenAiCompatibleProvider::build_request_body(&other, false);
+        assert!(
+            other_body.get("provider").is_none(),
+            "non-openrouter provider must not receive provider.ignore: {other_body}"
+        );
     }
 }


### PR DESCRIPTION
Two deterministic, data-driven, Harn-layer fixes for an OpenRouter upstream-routing defect, verified from raw SSE captures.

## Root cause (raw evidence)

`qwen/qwen3.6-35b-a3b` via OpenRouter, native tool calls:

- On OpenRouter's **Ambient** upstream the model narrates the intended tool call on the `reasoning` channel, emits a tiny `content` preamble (e.g. `"creating files\n\n"`), then finishes `finish_reason:"stop"` with **EMPTY** `tool_calls` — ~2800 billed reasoning tokens, zero dispatchable calls. The structured call is never serialized to any wire field. Recurs (13 calls / 10 scenarios). The non-streaming path is affected identically.
- **Parasail / AtlasCloud / AkashML** serve the IDENTICAL request correctly (`finish:tool_calls`, valid native calls). Native WORKS — only Ambient is broken.
- Proven workaround: request body `"provider":{"ignore":["Ambient"]}` reroutes to a healthy upstream → valid `tool_calls`. The `require_parameters` knob does NOT help (Ambient advertises tools, stays selected).

## Part 1 — per-(provider,model) upstream denylist (primary)

A reusable, data-driven `provider_route_denylist: Vec<String>` capability field (added to `ProviderRule`, the resolved `Capabilities`, `rule_to_caps`, and the empty-rule default). When non-empty for the `openrouter` provider, `build_request_body` merges the names into the request body's `provider.ignore` via a new generic helper `apply_openrouter_route_denylist` (creates `provider`/`ignore` if absent, preserves + dedupes existing entries). The `qwen/qwen3.6*` openrouter capability row denies `Ambient` while **keeping** `native_tools` / `preferred_tool_format="native"`. Pure capability lookup — **zero `if model == "qwen"` branches**. Route around the bad upstream; do not downgrade the format.

## Part 2 — deterministic billed-no-op contract guard (backstop)

Replaces the defeated `text.is_empty()` empty-output guard (a short content preamble slips past it) with a shared predicate `is_billed_noncommittal_completion`, applied in BOTH the streaming (`transport.rs`) and non-streaming (`response.rs`) tails. It fires only when ALL hold: the turn finished cleanly (`stop`/`tool_calls`/`end_turn`/None — **not** `length`/truncation) AND `output_tokens > 0` AND tools were offered AND no tool call was captured AND no tool-search block AND committed text `< 24` non-whitespace chars (a fixed structural floor, **not** a token ratio). On violation it returns a loud, actionable "provider returned billed output with no dispatchable tool call or answer (upstream contract violation)" error instead of a silent empty success. `tools_offered` is derived from the outbound request body and threaded to both parsers.

## Tests

- `apply_openrouter_route_denylist`: empty body → `provider.ignore=["Ambient"]`; existing `ignore=["X"]` → merged+deduped (other provider keys preserved); empty deny → no-op.
- `build_request_body`: qwen3.6 openrouter row materializes `provider.ignore` containing `Ambient`; a non-openrouter provider serving the same model id gets **no** `provider` block.
- Contract predicate: Ambient violation shape → true; normal tool_calls → false; substantive text (≥floor) → false; `length` truncation → false; no-tools-offered short answer → false; tool-search block → false.
- End-to-end: the Ambient JSON shape is rejected through the openai-compat parser with the contract-violation message; the same short content with no tools offered parses cleanly.
- Capabilities-load: qwen3.6 row parses with `provider_route_denylist=["Ambient"]` and still `native_tools` / `preferred_tool_format="native"`; unmarked rows default to empty.

`cargo nextest run -p harn-vm`: **3746 passed, 0 failed**. `cargo clippy -p harn-vm --all-targets -- -D warnings` clean. `cargo fmt -p harn-vm --check` clean.

## Framing

Deterministic, Harn-layer, and generalizable: the denylist is a reusable per-(provider,model) data framework (not a qwen-specific branch), and the contract detector is a structural floor shared by both transport paths. This **supersedes burin #2172** (the Burin-side workaround) and **replaces the harn #3249 ratio-guard idea** with a deterministic structural detector. Closes the silent billed-work-loss on the broken upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)