### PR TITLE
harn-serve: combined @ws + @stream route (single SSE+WS route)

### DIFF
--- a/changelog.d/ws-stream-combined.added.md
+++ b/changelog.d/ws-stream-combined.added.md
@@ -1,0 +1,15 @@
+- **One `harn serve site` route can now be both a WebSocket upgrade and an
+  SSE/stream route.** A routed `pub fn` may carry `@ws` *and* `@stream`
+  together: after the route runs auth + `@scopes` admission once, the site
+  adapter sniffs the request head's `Upgrade: websocket` / `Connection:
+  upgrade` headers (before any extractor or the body is consumed) — a genuine
+  handshake takes the `SiteStreamProvider::upgrade` path, while every other
+  request falls through to the `SiteStreamProvider::open` (SSE/stream) path
+  instead of being refused with a 4xx. This is the seam the harn-cloud gateway
+  `/acp` carve-out needs (one route, two transports, one admission). The
+  previous `@ws`∧`@stream` conflict diagnostic (`HARN-SRV-016`) now fires only
+  for `@ws`∧`@raw` (a handshake carries no request body, but `@raw` exists to
+  buffer one). `@ws`-only and `@stream`-only routes are unchanged: a non-upgrade
+  request to a `@ws`-only route is still refused with the correct 4xx by axum's
+  extractor, and the `SiteStreamProvider::upgrade` default impl still returns
+  `426 Upgrade Required` so embedders that implement only `open` keep compiling.

--- a/crates/harn-serve/src/adapters/site.rs
+++ b/crates/harn-serve/src/adapters/site.rs
@@ -110,8 +110,24 @@
 //! [`SiteStreamProvider::upgrade`], forwarding the `101` it returns. The
 //! provider drives the socket; the `.harn` function is a
 //! declaration-only stub that owns the route, its `@scopes`, and its
-//! docs. A non-WebSocket request to a `@ws` route is refused with the
-//! correct 4xx by axum's extractor — never a stray upgrade.
+//! docs. A non-WebSocket request to a `@ws`-only route is refused with
+//! the correct 4xx by axum's extractor — never a stray upgrade.
+//!
+//! ## One route, two transports (`@ws` + `@stream`)
+//!
+//! A single route may carry **both** `@ws` and `@stream` — the seam the
+//! gateway `/acp` carve-out needs: one route that runs auth + `@scopes`
+//! once, then serves a genuine WebSocket handshake *and* an SSE/stream
+//! response from the same admission. After admission the adapter sniffs
+//! the request head's `Upgrade: websocket` / `Connection: upgrade`
+//! headers (before any extractor or the body is consumed): a genuine
+//! handshake takes the `@ws` [`SiteStreamProvider::upgrade`] path, while
+//! every other request falls through to the `@stream`
+//! [`SiteStreamProvider::open`] path — never a 4xx for the non-upgrade
+//! caller. Auth gates both branches identically; the same provider
+//! implements both `open` and `upgrade`. (`@ws` + `@raw` stays a
+//! conflict: a handshake carries no body, but `@raw` exists to buffer
+//! one.)
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::{IpAddr, SocketAddr};
@@ -465,8 +481,12 @@ struct SiteRoute {
     raw: bool,
     /// `@ws` marker: after admission, perform the WebSocket upgrade and
     /// hand the upgrade handle to [`SiteStreamProvider::upgrade`] instead
-    /// of dispatching into the VM. Mutually exclusive with
-    /// `stream`/`raw`.
+    /// of dispatching into the VM. May be combined with `stream` (one
+    /// route, two transports): when both are set the adapter sniffs the
+    /// request's upgrade headers — a genuine handshake takes the
+    /// [`SiteStreamProvider::upgrade`] path, every other request falls
+    /// through to the [`SiteStreamProvider::open`] (`stream`) path. Still
+    /// mutually exclusive with `raw` (a handshake carries no body).
     ws: bool,
 }
 
@@ -645,7 +665,18 @@ async fn site_dispatch(State(state): State<SiteState>, request: Request) -> Resp
     // body, the adapter extracts the WebSocket upgrade (while hyper's
     // `OnUpgrade` extension is still on `parts`) and the provider drives
     // the socket. The 101 it returns is forwarded verbatim.
-    if route.ws {
+    //
+    // A route may carry `@ws` *and* `@stream` together — one route, two
+    // transports (the gateway `/acp` carve-out): a genuine WebSocket
+    // handshake upgrades through `provider.upgrade(...)`, while every
+    // other request falls through to the `@stream` `provider.open(...)`
+    // path below. The branch is picked by sniffing the request's
+    // `Upgrade`/`Connection` headers on the head we already hold — before
+    // any extractor or the body is consumed — so neither branch races the
+    // other for the request. A `@ws`-only route keeps the historic
+    // behavior: a non-upgrade request is refused by axum's extractor with
+    // the correct 4xx (there is no stream path to fall through to).
+    if route.ws && (is_websocket_upgrade(&parts.headers) || !route.stream) {
         // Same admission back-stop as `@stream`/`@raw`: a `@ws` route
         // never builds a `CallRequest`, so the dispatch-level scope
         // check cannot cover it. With no hook there is no identity and
@@ -670,9 +701,11 @@ async fn site_dispatch(State(state): State<SiteState>, request: Request) -> Resp
             );
         };
         // Extract the upgrade while the `OnUpgrade` extension is still
-        // present on `parts`. A non-WebSocket request (missing the
-        // upgrade headers / key) is refused here by axum's extractor
-        // with the correct 4xx — never a panic, never a stray 101.
+        // present on `parts`. On a `@ws`-only route a non-WebSocket
+        // request (missing the upgrade headers / key) is refused here by
+        // axum's extractor with the correct 4xx — never a panic, never a
+        // stray 101. On a combined `@ws @stream` route we only reach this
+        // when the header sniff already saw a genuine handshake.
         let upgrade = match WebSocketUpgrade::from_request_parts(&mut parts, &()).await {
             Ok(upgrade) => upgrade,
             Err(rejection) => return rejection.into_response(),

--- a/crates/harn-serve/src/exports.rs
+++ b/crates/harn-serve/src/exports.rs
@@ -83,10 +83,17 @@ pub struct ExportedFunction {
     /// and hands the upgrade handle to the embedder's
     /// `SiteStreamProvider::upgrade`, which drives the socket. The marker
     /// is the seam for embedder routes that need a real WebSocket
-    /// connection (mirroring how `@stream` is the seam for SSE). It
-    /// conflicts with `@stream`/`@raw` (they target different provider
-    /// entry points), so declaring both drops `@ws`. The `.harn`
-    /// function body is a declaration-only stub.
+    /// connection (mirroring how `@stream` is the seam for SSE).
+    ///
+    /// `@ws` may be combined with `@stream` on one route: the adapter
+    /// sniffs the request's `Upgrade`/`Connection` headers and routes a
+    /// genuine WebSocket handshake to `SiteStreamProvider::upgrade` while
+    /// every other request falls through to `SiteStreamProvider::open`
+    /// (the SSE/stream path) — one route serving both transports (the
+    /// gateway `/acp` carve-out). `@ws` still conflicts with `@raw` (a
+    /// handshake carries no body, but `@raw` buffers one), so declaring
+    /// that pair drops `@ws`. The `.harn` function body is a
+    /// declaration-only stub.
     pub ws: bool,
 }
 
@@ -244,10 +251,11 @@ pub const WS_BAD_ARGS: &str = "HARN-SRV-014";
 /// `@ws` appears on a declaration without an HTTP route. A WebSocket
 /// upgrade only means something on a routed `pub fn`, so it is ignored.
 pub const WS_WITHOUT_ROUTE: &str = "HARN-SRV-015";
-/// `@ws` and `@stream`/`@raw` appear on the same declaration. They route
-/// to different provider entry points (a WebSocket upgrade vs. an
-/// SSE/raw response), so they contradict; `@ws` is dropped and the route
-/// behaves as `@stream`/`@raw`.
+/// `@ws` and `@raw` appear on the same declaration. A WebSocket
+/// handshake carries no request body, but `@raw` exists to buffer one, so
+/// they contradict; `@ws` is dropped and the route behaves as `@raw`.
+/// (`@ws` + `@stream` is *not* a conflict — it is the combined route that
+/// upgrades a genuine handshake and falls through to the stream otherwise.)
 pub const WS_CONFLICTS_WITH_STREAM_OR_RAW: &str = "HARN-SRV-016";
 
 impl std::fmt::Display for ExportDiagnostic {
@@ -311,8 +319,7 @@ impl ExportCatalog {
             let route = route_from_attributes(attrs, name, &mut diagnostics);
             let stream = stream_from_attributes(attrs, name, route.as_ref(), &mut diagnostics);
             let raw = raw_from_attributes(attrs, name, route.as_ref(), stream, &mut diagnostics);
-            let ws =
-                ws_from_attributes(attrs, name, route.as_ref(), stream || raw, &mut diagnostics);
+            let ws = ws_from_attributes(attrs, name, route.as_ref(), raw, &mut diagnostics);
             functions.insert(
                 name.clone(),
                 ExportedFunction {
@@ -358,7 +365,7 @@ impl ExportCatalog {
             // one is inert — diagnose it the same way as on an unrouted fn.
             let stream = stream_from_attributes(attrs, name, None, &mut diagnostics);
             let raw = raw_from_attributes(attrs, name, None, stream, &mut diagnostics);
-            let ws = ws_from_attributes(attrs, name, None, stream || raw, &mut diagnostics);
+            let ws = ws_from_attributes(attrs, name, None, raw, &mut diagnostics);
             functions
                 .entry(name.clone())
                 .or_insert_with(|| ExportedFunction {
@@ -679,17 +686,23 @@ fn raw_from_attributes(
 ///
 /// `@ws` mirrors `@stream` (a bare, route-only marker that turns the
 /// route into a provider-answered route), except the provider is handed
-/// a WebSocket upgrade handle instead of producing a response body. It
-/// conflicts with `@stream`/`@raw`: those target the provider's response
-/// entry point (`open`), while `@ws` targets the upgrade entry point
-/// (`upgrade`). Declaring `@ws` alongside either is diagnosed
-/// (`HARN-SRV-016`) and `@ws` is dropped — the route behaves as
-/// `@stream`/`@raw`.
+/// a WebSocket upgrade handle instead of producing a response body.
+///
+/// `@ws` *combines* with `@stream` on one route: the site adapter sniffs
+/// the request's upgrade headers and routes a genuine WebSocket handshake
+/// to the provider's `upgrade` entry point while every other request
+/// falls through to the `open` (SSE/stream) entry point — one route, two
+/// transports (the gateway `/acp` carve-out). Both flags are carried.
+///
+/// `@ws` still conflicts with `@raw`, though: a WebSocket handshake
+/// carries no request body, while `@raw` exists precisely to buffer one,
+/// so the pair contradicts. Declaring `@ws` alongside `@raw` is diagnosed
+/// (`HARN-SRV-016`) and `@ws` is dropped — the route behaves as `@raw`.
 fn ws_from_attributes(
     attrs: &[Attribute],
     fn_name: &str,
     route: Option<&RouteSpec>,
-    stream_or_raw: bool,
+    raw: bool,
     diagnostics: &mut Vec<ExportDiagnostic>,
 ) -> bool {
     let ws = bare_route_marker_from_attributes(
@@ -701,7 +714,7 @@ fn ws_from_attributes(
         WS_BAD_ARGS,
         WS_WITHOUT_ROUTE,
     );
-    if ws && stream_or_raw {
+    if ws && raw {
         let line = attrs
             .iter()
             .find(|attr| attr.name == "ws")
@@ -711,9 +724,10 @@ fn ws_from_attributes(
             code: WS_CONFLICTS_WITH_STREAM_OR_RAW,
             line,
             message: format!(
-                "`@ws` on `{fn_name}` conflicts with `@stream`/`@raw` (a WebSocket upgrade and an \
-                 SSE/raw response are different provider entry points); dropping `@ws` — the route \
-                 behaves as `@stream`/`@raw`"
+                "`@ws` on `{fn_name}` conflicts with `@raw` (a WebSocket handshake carries no \
+                 request body, but `@raw` buffers one); dropping `@ws` — the route behaves as \
+                 `@raw`. (Pair `@ws` with `@stream` instead for a route that is both a WebSocket \
+                 upgrade and an SSE/stream fallback.)"
             ),
         });
         return false;
@@ -1724,7 +1738,10 @@ pub fn helper(req: dict) -> dict { return req }
     }
 
     #[test]
-    fn ws_conflicting_with_stream_is_diagnosed_and_dropped() {
+    fn ws_combined_with_stream_carries_both_flags_without_diagnostic() {
+        // `@ws` + `@stream` is the *combined* route (one route that both
+        // upgrades a genuine WebSocket handshake and falls through to the
+        // SSE/stream path otherwise): both flags survive, no diagnostic.
         let catalog = catalog_from_source(
             r#"
 @stream
@@ -1733,12 +1750,15 @@ pub fn helper(req: dict) -> dict { return req }
 pub fn both(req: dict) -> dict { return http_ok({}) }
 "#,
         );
-        // `@stream` wins; `@ws` is dropped with a diagnostic.
         let function = catalog.function("both").expect("both");
         assert!(function.stream);
-        assert!(!function.ws);
+        assert!(function.ws);
+        assert!(!function.raw);
         let codes: Vec<&str> = catalog.diagnostics().iter().map(|d| d.code).collect();
-        assert_eq!(codes, vec![WS_CONFLICTS_WITH_STREAM_OR_RAW]);
+        assert!(
+            codes.is_empty(),
+            "combined @ws @stream must not be diagnosed, got {codes:?}"
+        );
     }
 
     #[test]

--- a/crates/harn-serve/tests/site_websocket.rs
+++ b/crates/harn-serve/tests/site_websocket.rs
@@ -109,6 +109,93 @@ impl SiteStreamProvider for EchoUpgradeProvider {
     }
 }
 
+/// Script for the combined `@ws @stream` route — one route that is both a
+/// WebSocket upgrade and an SSE/stream fallback (the gateway `/acp`
+/// carve-out). The body is a declaration-only stub; if it ever runs the
+/// VM dispatched where the provider should have answered either branch.
+const COMBINED_SCRIPT: &str = r#"
+@ws
+@stream
+@scopes("acp:read")
+@route("GET", "/acp/{session}")
+pub fn acp(req: dict) -> dict {
+  return http_ok({ "buffered_stub": true })
+}
+"#;
+
+/// Provider for the combined route: a genuine handshake upgrades and
+/// echoes (`upgrade`); every other request gets a plain `200` carrying
+/// the head dict (`open`), proving the non-upgrade branch falls through
+/// to the stream path instead of a 4xx.
+struct DualProvider;
+
+#[async_trait::async_trait]
+impl SiteStreamProvider for DualProvider {
+    async fn open(
+        &self,
+        route: &RouteSpec,
+        auth: Option<&SiteAuthContext>,
+        request: Value,
+        _body: Option<axum::body::Bytes>,
+    ) -> Response {
+        // Non-upgrade requests land here on the combined route. Shape a
+        // marker response that echoes the head so the test proves the
+        // stream branch saw the matched route + identity.
+        Json(json!({
+            "via": "open",
+            "route": { "method": route.method, "path": route.path },
+            "tenant": auth.and_then(|c| c.tenant_id.as_ref()).map(|t| t.0.clone()),
+            "session": request["path_params"]["session"],
+        }))
+        .into_response()
+    }
+
+    async fn upgrade(
+        &self,
+        _route: &RouteSpec,
+        _auth: Option<&SiteAuthContext>,
+        ws: WebSocketUpgrade,
+        _request: Value,
+    ) -> Response {
+        ws.on_upgrade(move |mut socket| async move {
+            if socket
+                .send(Message::Text("via:upgrade".into()))
+                .await
+                .is_err()
+            {
+                return;
+            }
+            while let Some(Ok(message)) = socket.next().await {
+                match message {
+                    Message::Text(text) => {
+                        let reply = format!("echo:{text}");
+                        if socket.send(Message::Text(reply.into())).await.is_err() {
+                            break;
+                        }
+                    }
+                    Message::Close(_) => break,
+                    _ => {}
+                }
+            }
+        })
+    }
+}
+
+/// Build a site router over [`COMBINED_SCRIPT`] with [`DualProvider`],
+/// optionally behind an auth hook.
+fn combined_router(auth: Option<Arc<dyn SiteAuth>>) -> (tempfile::TempDir, Router) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("site.harn");
+    std::fs::write(&path, COMBINED_SCRIPT).expect("write script");
+    let mut config =
+        SiteServerConfig::new(build_core(&path)).with_stream_provider(Arc::new(DualProvider));
+    if let Some(auth) = auth {
+        config = config.with_auth(auth);
+    }
+    let router = SiteServer::new(config).router().expect("site router");
+    (dir, router)
+}
+
 /// `SiteAuth` hook that always admits with a fixed identity.
 struct AllowAuth {
     tenant: Option<&'static str>,
@@ -404,5 +491,160 @@ pub fn socket(req: dict) -> dict { return http_ok({}) }
     assert!(
         body.contains("ws_upgrade_unsupported"),
         "unexpected body: {body}"
+    );
+}
+
+/// Combined `@ws @stream` route, WebSocket branch: a genuine handshake on
+/// the route upgrades through `provider.upgrade(...)` and the socket
+/// echoes, exactly as a `@ws`-only route would — the `@stream` flag does
+/// not steal a real upgrade.
+#[tokio::test]
+async fn combined_route_upgrades_a_genuine_handshake() {
+    use tokio_tungstenite::tungstenite::protocol::Message as TungMessage;
+
+    let hook = Arc::new(AllowAuth {
+        tenant: Some("acme"),
+        scopes: &["acp:read"],
+    });
+    let (_dir, router) = combined_router(Some(hook));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+
+    let url = format!("ws://{addr}/acp/s-1");
+    let (mut socket, _response) = tokio_tungstenite::connect_async(url).await.unwrap();
+
+    let primed = socket.next().await.unwrap().unwrap();
+    assert_eq!(primed, TungMessage::Text("via:upgrade".into()));
+    socket.send(TungMessage::Text("ping".into())).await.unwrap();
+    let echoed = socket.next().await.unwrap().unwrap();
+    assert_eq!(echoed, TungMessage::Text("echo:ping".into()));
+    socket.send(TungMessage::Close(None)).await.unwrap();
+}
+
+/// Combined `@ws @stream` route, stream branch: a plain GET to the *same*
+/// route is not refused with a 4xx (as a `@ws`-only route would be) — it
+/// falls through to `provider.open(...)` and gets the SSE/stream-path
+/// response, carrying the matched route + hook identity.
+#[tokio::test]
+async fn combined_route_falls_through_to_stream_for_plain_get() {
+    let hook = Arc::new(AllowAuth {
+        tenant: Some("acme"),
+        scopes: &["acp:read"],
+    });
+    let (_dir, router) = combined_router(Some(hook));
+    let request = Request::builder()
+        .uri("/acp/s-7")
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = read_body(router.oneshot(request).await.unwrap()).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a plain GET to a combined @ws @stream route must hit the stream path, not a 4xx"
+    );
+    let value: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(value["via"], "open");
+    assert_eq!(value["route"]["path"], "/acp/{session}");
+    assert_eq!(value["tenant"], "acme");
+    assert_eq!(value["session"], "s-7");
+}
+
+/// A request carrying a half-upgrade header set that is *not* a genuine
+/// handshake (no `Sec-WebSocket-Key`) is not treated as an upgrade on a
+/// combined route: it falls through to the stream path rather than being
+/// handed to the `WebSocketUpgrade` extractor (which would 400 it).
+#[tokio::test]
+async fn combined_route_partial_upgrade_headers_fall_through_to_stream() {
+    let hook = Arc::new(AllowAuth {
+        tenant: Some("acme"),
+        scopes: &["acp:read"],
+    });
+    let (_dir, router) = combined_router(Some(hook));
+    let request = Request::builder()
+        .uri("/acp/s-9")
+        // `Upgrade: websocket` but no `Sec-WebSocket-Key`: not a genuine
+        // handshake by `is_websocket_upgrade`'s contract.
+        .header("upgrade", "websocket")
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = read_body(router.oneshot(request).await.unwrap()).await;
+    assert_eq!(status, StatusCode::OK);
+    let value: Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(value["via"], "open");
+}
+
+/// Auth gates *both* branches of a combined route identically: a denied
+/// request never reaches `upgrade` (handshake) or `open` (plain GET).
+#[tokio::test]
+async fn combined_route_auth_gates_both_branches() {
+    // Handshake request with a denying hook → embedder 401, no upgrade.
+    let (_dir, router) = combined_router(Some(Arc::new(DenyAuth)));
+    let ws_request = Request::builder()
+        .uri("/acp/s-1")
+        .header("connection", "upgrade")
+        .header("upgrade", "websocket")
+        .header("sec-websocket-version", "13")
+        .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(ws_request).await.unwrap();
+    assert_eq!(response.headers()["x-embedder-deny"], "1");
+    let (status, body) = read_body(response).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert!(body.contains("custom_embedder_denial"));
+
+    // Plain GET with a denying hook → same embedder 401, no `open`.
+    let (_dir, router) = combined_router(Some(Arc::new(DenyAuth)));
+    let plain_request = Request::builder()
+        .uri("/acp/s-1")
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = read_body(router.oneshot(plain_request).await.unwrap()).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert!(body.contains("custom_embedder_denial"));
+}
+
+/// Scope shortfall gates both branches of a combined route before either
+/// provider entry point: a handshake *and* a plain GET get the canonical
+/// 403, even with a valid identity that lacks the route's `@scopes`.
+#[tokio::test]
+async fn combined_route_scope_shortfall_gates_both_branches() {
+    let hook = || {
+        Arc::new(AllowAuth {
+            tenant: Some("acme"),
+            scopes: &["acp:write"], // not acp:read
+        })
+    };
+
+    let (_dir, router) = combined_router(Some(hook()));
+    let ws_request = Request::builder()
+        .uri("/acp/s-1")
+        .header("connection", "upgrade")
+        .header("upgrade", "websocket")
+        .header("sec-websocket-version", "13")
+        .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = read_body(router.oneshot(ws_request).await.unwrap()).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        serde_json::from_str::<Value>(&body).unwrap()["code"],
+        "forbidden"
+    );
+
+    let (_dir, router) = combined_router(Some(hook()));
+    let plain_request = Request::builder()
+        .uri("/acp/s-1")
+        .body(Body::empty())
+        .unwrap();
+    let (status, body) = read_body(router.oneshot(plain_request).await.unwrap()).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        serde_json::from_str::<Value>(&body).unwrap()["code"],
+        "forbidden"
     );
 }


### PR DESCRIPTION
Lets a single SiteServer route be BOTH a WebSocket upgrade AND an SSE/stream route — the last harn-core enabler for harn-cloud's /acp gateway carve-out (`acp_get` branches WS-or-SSE on one path). The 0.8.101 `@ws` marker was mutually exclusive with `@stream` and unconditionally extracted the upgrade.

`@ws`+`@stream` now carry both flags (no diagnostic; `@ws`+`@raw` still conflicts). Dispatch runs auth+`@scopes` admission FIRST (unchanged), then header-sniffs `Upgrade: websocket`+`Sec-WebSocket-Key` off the request head BEFORE extraction: genuine handshake → `provider.upgrade()`; non-upgrade on a combined route → falls through to `provider.open()` (SSE). `@ws`-only / `@stream`-only routes unchanged (backward-compat; `SiteStreamProvider::upgrade` default untouched, so CloudStreamProvider still compiles). +5 tests; 510 harn-serve tests pass; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)