### PR TITLE
harn-serve: per-method route scopes (@scopes "PUT write:x")

### DIFF
--- a/crates/harn-serve/src/adapters/site.rs
+++ b/crates/harn-serve/src/adapters/site.rs
@@ -129,6 +129,7 @@
 //! conflict: a handshake carries no body, but `@raw` exists to buffer
 //! one.)
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
@@ -467,9 +468,14 @@ struct SiteRoute {
     /// The function's declared [`RouteSpec`] (method may be `*`),
     /// handed to the embedder's [`SiteAuth`] hook.
     spec: RouteSpec,
-    /// `@scopes(...)` declared on the function; empty means no scope
-    /// requirement (public, as far as scopes are concerned).
+    /// Method-agnostic `@scopes(...)` baseline declared on the function;
+    /// empty means no scope requirement (public, as far as scopes are
+    /// concerned). Required of every method; see [`SiteRoute::scopes_for`].
     required_scopes: BTreeSet<String>,
+    /// Per-method `@scopes("GET read:x", ...)` extras, keyed by uppercased
+    /// HTTP method. Unioned onto `required_scopes` for the matching method;
+    /// empty for the common uniform route. See [`SiteRoute::scopes_for`].
+    method_scopes: BTreeMap<String, BTreeSet<String>>,
     /// `@stream` marker: after admission, hand the request head to the
     /// [`SiteStreamProvider`] instead of dispatching into the VM. The
     /// request body is never read.
@@ -488,6 +494,27 @@ struct SiteRoute {
     /// through to the [`SiteStreamProvider::open`] (`stream`) path. Still
     /// mutually exclusive with `raw` (a handshake carries no body).
     ws: bool,
+}
+
+impl SiteRoute {
+    /// The scopes this route requires of `method`: the method-agnostic
+    /// `required_scopes` baseline, unioned with any per-method extras
+    /// declared for that method. A method with no extras (the uniform
+    /// case) resolves to the baseline alone — so a route that never used
+    /// the per-method `@scopes` form behaves exactly as before. The method
+    /// is matched on its uppercased name, the same key the parser stores.
+    ///
+    /// Returns a borrowed `Cow` to keep the uniform path allocation-free:
+    /// only a genuinely per-method route (a non-empty `method_scopes`
+    /// entry on top of a non-empty baseline) builds an owned union.
+    fn scopes_for(&self, method: &Method) -> Cow<'_, BTreeSet<String>> {
+        match self.method_scopes.get(method.as_str()) {
+            None => Cow::Borrowed(&self.required_scopes),
+            Some(extra) if extra.is_empty() => Cow::Borrowed(&self.required_scopes),
+            Some(extra) if self.required_scopes.is_empty() => Cow::Borrowed(extra),
+            Some(extra) => Cow::Owned(self.required_scopes.union(extra).cloned().collect()),
+        }
+    }
 }
 
 /// State shared by every site route handler: the dispatch executor plus
@@ -557,6 +584,7 @@ fn build_site_router(
             function: function.name.clone(),
             spec: spec.clone(),
             required_scopes: function.required_scopes.clone(),
+            method_scopes: function.method_scopes.clone(),
             stream: function.stream,
             raw: function.raw,
             ws: function.ws,
@@ -594,6 +622,33 @@ fn build_site_router(
         .layer(DefaultBodyLimit::max(DEFAULT_HTTP_BODY_LIMIT_BYTES))
         .with_state(state);
     Ok(crate::apply_transport_layers(router, transport))
+}
+
+/// Scope back-stop for provider routes (`@ws` / `@stream` / `@raw`).
+///
+/// These routes never build a `CallRequest`, so the dispatch-level
+/// `AuthPolicy` scope check that back-stops a plain route cannot cover
+/// them. With a `SiteAuth` hook installed, the admission check at the top
+/// of [`site_dispatch`] already compared the method-resolved requirement
+/// against the hook-granted scopes; this helper is the *no-hook* case —
+/// no identity means no granted scopes, so any non-empty requirement
+/// refuses, matching the allow-all default a plain route would hit at
+/// dispatch. Returns `Some(403)` to short-circuit, or `None` to admit.
+fn provider_scope_backstop(
+    auth_context: Option<&SiteAuthContext>,
+    required_scopes: &BTreeSet<String>,
+    request_id: &str,
+) -> Option<Response> {
+    if auth_context.is_none() && !required_scopes.is_empty() {
+        return Some(axum_response_from_dispatch_error(
+            DispatchError::Forbidden {
+                required: required_scopes.clone(),
+                granted: BTreeSet::new(),
+            },
+            request_id,
+        ));
+    }
+    None
 }
 
 /// Single entry point for every site route. Resolves the handler,
@@ -640,15 +695,19 @@ async fn site_dispatch(State(state): State<SiteState>, request: Request) -> Resp
     // dispatch. `Deny` short-circuits with the embedder's response
     // verbatim; `Allow` is then checked against the route's `@scopes`
     // (a route without `@scopes` has no scope requirement).
+    // The scopes this route requires of *this* request's method: the
+    // method-agnostic baseline unioned with any per-method `@scopes`
+    // extras (uniform routes resolve to the baseline, allocation-free).
+    let required_scopes = route.scopes_for(&method);
     let auth_context = match state.auth.as_ref() {
         None => None,
         Some(hook) => match hook.authenticate(&parts, &route.spec).await {
             SiteAuthOutcome::Deny(response) => return *response,
             SiteAuthOutcome::Allow(context) => {
-                if !route.required_scopes.is_subset(&context.scopes) {
+                if !required_scopes.is_subset(&context.scopes) {
                     return axum_response_from_dispatch_error(
                         DispatchError::Forbidden {
-                            required: route.required_scopes.clone(),
+                            required: required_scopes.into_owned(),
                             granted: context.scopes,
                         },
                         &request_id,
@@ -677,18 +736,12 @@ async fn site_dispatch(State(state): State<SiteState>, request: Request) -> Resp
     // behavior: a non-upgrade request is refused by axum's extractor with
     // the correct 4xx (there is no stream path to fall through to).
     if route.ws && (is_websocket_upgrade(&parts.headers) || !route.stream) {
-        // Same admission back-stop as `@stream`/`@raw`: a `@ws` route
-        // never builds a `CallRequest`, so the dispatch-level scope
-        // check cannot cover it. With no hook there is no identity and
-        // no granted scopes, so any scope requirement refuses.
-        if auth_context.is_none() && !route.required_scopes.is_empty() {
-            return axum_response_from_dispatch_error(
-                DispatchError::Forbidden {
-                    required: route.required_scopes.clone(),
-                    granted: BTreeSet::new(),
-                },
-                &request_id,
-            );
+        // Same admission back-stop as `@stream`/`@raw`, resolved per
+        // method (see `provider_scope_backstop`).
+        if let Some(response) =
+            provider_scope_backstop(auth_context.as_ref(), &required_scopes, &request_id)
+        {
+            return response;
         }
         let Some(provider) = state.stream_provider.as_ref() else {
             // Unreachable: router construction refuses a @ws route
@@ -735,20 +788,12 @@ async fn site_dispatch(State(state): State<SiteState>, request: Request) -> Resp
     // never reads one, `@raw` buffers it and hands the exact bytes over.
     if route.stream || route.raw {
         // A provider route never builds a `CallRequest`, so the
-        // dispatch-level `AuthPolicy` scope check cannot back-stop it
-        // the way it does for plain routes. With a hook installed the
-        // admission above already compared `@scopes` against the
-        // hook-granted set; without one, no identity means no granted
-        // scopes, and any scope requirement refuses — matching the
-        // allow-all default a plain route would hit at dispatch.
-        if auth_context.is_none() && !route.required_scopes.is_empty() {
-            return axum_response_from_dispatch_error(
-                DispatchError::Forbidden {
-                    required: route.required_scopes.clone(),
-                    granted: BTreeSet::new(),
-                },
-                &request_id,
-            );
+        // dispatch-level `AuthPolicy` scope check cannot back-stop it the
+        // way it does for plain routes (see `provider_scope_backstop`).
+        if let Some(response) =
+            provider_scope_backstop(auth_context.as_ref(), &required_scopes, &request_id)
+        {
+            return response;
         }
         let Some(provider) = state.stream_provider.as_ref() else {
             // Unreachable: router construction refuses a @stream/@raw

--- a/crates/harn-serve/src/exports.rs
+++ b/crates/harn-serve/src/exports.rs
@@ -30,12 +30,27 @@ pub struct ExportedFunction {
     pub return_type: Option<TypeExpr>,
     pub input_schema: serde_json::Value,
     pub output_schema: Option<serde_json::Value>,
-    /// Scopes the caller's credential must carry to invoke this function.
-    /// Populated from `@scopes("...", "...")` attribute literals on the
-    /// declaration; empty when no attribute is present, meaning the route
-    /// is unrestricted beyond whatever scopes the auth method enforces
-    /// globally.
+    /// Scopes the caller's credential must carry to invoke this function,
+    /// for *every* HTTP method (the method-agnostic baseline). Populated
+    /// from un-prefixed `@scopes("...", "...")` literals on the
+    /// declaration; empty when no such literal is present, meaning the
+    /// route is unrestricted beyond whatever scopes the auth method
+    /// enforces globally. The dispatch-level scope check (API / A2A / MCP
+    /// and the site VM backstop) reads this baseline set, so it stays the
+    /// strict-subset floor of whatever a per-method route additionally
+    /// requires.
     pub required_scopes: BTreeSet<String>,
+    /// Additional scopes required only for specific HTTP methods, declared
+    /// with a method-prefixed `@scopes("GET read:x", "PUT write:x")`
+    /// literal (see [`scopes_from_attributes`] for the grammar). The site
+    /// adapter unions a request's resolved requirement as
+    /// `required_scopes ∪ method_scopes[method]`; methods absent from the
+    /// map fall back to the `required_scopes` baseline. Only the
+    /// `harn serve site` HTTP admission layer consults this map — the
+    /// dispatch-level adapters (API / A2A / MCP) have no per-method HTTP
+    /// surface and use `required_scopes` alone. Empty for the common
+    /// uniform case, keeping the per-method path zero-cost.
+    pub method_scopes: BTreeMap<String, BTreeSet<String>>,
     /// Rate / backpressure ceilings declared via `@limits(...)`. `None`
     /// when the route is unbounded — the dispatch path short-circuits
     /// cheaply when both `limits` and `budget` are absent.
@@ -315,6 +330,7 @@ impl ExportCatalog {
                 continue;
             }
 
+            let scopes = scopes_from_attributes(attrs, name, &mut diagnostics);
             let (limits, budget) = limits_and_budget_from_attributes(attrs);
             let route = route_from_attributes(attrs, name, &mut diagnostics);
             let stream = stream_from_attributes(attrs, name, route.as_ref(), &mut diagnostics);
@@ -331,7 +347,8 @@ impl ExportCatalog {
                     output_schema: return_type
                         .as_ref()
                         .and_then(harn_vm::json_schema_for_type_expr),
-                    required_scopes: scopes_from_attributes(attrs, name, &mut diagnostics),
+                    required_scopes: scopes.baseline,
+                    method_scopes: scopes.per_method,
                     limits,
                     budget,
                     route,
@@ -359,7 +376,7 @@ impl ExportCatalog {
             if has_public_exports && !*is_pub {
                 continue;
             }
-            let required_scopes = scopes_from_attributes(attrs, name, &mut diagnostics);
+            let scopes = scopes_from_attributes(attrs, name, &mut diagnostics);
             let (limits, budget) = limits_and_budget_from_attributes(attrs);
             // Pipelines never carry a route, so a `@stream` / `@raw` on
             // one is inert — diagnose it the same way as on an unrouted fn.
@@ -377,7 +394,8 @@ impl ExportCatalog {
                     output_schema: return_type
                         .as_ref()
                         .and_then(harn_vm::json_schema_for_type_expr),
-                    required_scopes,
+                    required_scopes: scopes.baseline,
+                    method_scopes: scopes.per_method,
                     limits,
                     budget,
                     // Pipelines are dispatch-only; they never carry an
@@ -439,18 +457,58 @@ fn pipeline_exported_params(params: &[String]) -> Vec<ExportedParam> {
         .collect()
 }
 
+/// The two scope buckets a `@scopes(...)` attribute set resolves into: a
+/// method-agnostic `baseline` required of every method, plus optional
+/// `per_method` extras keyed by uppercased HTTP method. The site adapter
+/// resolves a request's requirement as `baseline ∪ per_method[method]`;
+/// every other adapter reads `baseline` alone.
+#[derive(Default)]
+struct ParsedScopes {
+    baseline: BTreeSet<String>,
+    per_method: BTreeMap<String, BTreeSet<String>>,
+}
+
+/// HTTP methods recognized as a `@scopes` literal prefix. A first
+/// whitespace-delimited word matching one of these (case-insensitively)
+/// switches the literal from the uniform form to the per-method form;
+/// anything else is treated as a plain (baseline) scope, so an unusual
+/// scope string that happens to contain a space is never misread as a
+/// method prefix.
+const SCOPE_METHOD_PREFIXES: [&str; 7] =
+    ["GET", "PUT", "POST", "DELETE", "PATCH", "HEAD", "OPTIONS"];
+
 /// Collect scope literals from any `@scopes(...)` attributes on a
 /// declaration. Both positional and named arguments are accepted (named
 /// args are useful for ergonomics like `@scopes(read: "personas:read")`
 /// in callers that prefer key-value form); only string literals
 /// contribute. Multiple `@scopes` attributes on the same declaration
-/// union into one set.
+/// union together.
+///
+/// ## Grammar
+///
+/// Each string literal is one of:
+///
+/// * **Uniform** — `"read:x"`: a bare scope required of every HTTP method.
+///   This is the historic form and the default; it lands in the
+///   `baseline` set unchanged.
+/// * **Per-method** — `"GET read:x"`: an HTTP method (one of
+///   [`SCOPE_METHOD_PREFIXES`], case-insensitive), a single run of
+///   whitespace, then the scope. The scope is required *only* for that
+///   method, in addition to the baseline. The whitespace separator can
+///   never collide with a scope token (scopes use `:`-delimited words,
+///   never spaces), so the uniform form is unambiguous and untouched.
+///
+/// So `@scopes("read:x", "PUT write:x")` requires `read:x` of every
+/// method and additionally `write:x` of `PUT`. A method named in a
+/// per-method literal but never given its own baseline still inherits the
+/// baseline; a method *not* named anywhere falls back to the baseline
+/// alone (resolution lives in the site adapter).
 fn scopes_from_attributes(
     attrs: &[Attribute],
     fn_name: &str,
     diagnostics: &mut Vec<ExportDiagnostic>,
-) -> BTreeSet<String> {
-    let mut set = BTreeSet::new();
+) -> ParsedScopes {
+    let mut parsed = ParsedScopes::default();
     for attr in attrs {
         if attr.name != "scopes" {
             continue;
@@ -458,7 +516,14 @@ fn scopes_from_attributes(
         for arg in &attr.args {
             match &arg.value.node {
                 Node::StringLiteral(value) | Node::RawStringLiteral(value) => {
-                    set.insert(value.clone());
+                    match parse_scope_literal(value) {
+                        Some((method, scope)) => {
+                            parsed.per_method.entry(method).or_default().insert(scope);
+                        }
+                        None => {
+                            parsed.baseline.insert(value.clone());
+                        }
+                    }
                 }
                 // A non-string scope is silently dropped by the
                 // collector, which would leave the route *less*
@@ -474,7 +539,27 @@ fn scopes_from_attributes(
             }
         }
     }
-    set
+    parsed
+}
+
+/// Split a `@scopes` literal into an optional `(METHOD, scope)` pair.
+///
+/// Returns `Some((uppercased_method, scope))` when the literal begins with
+/// a recognized HTTP method ([`SCOPE_METHOD_PREFIXES`], case-insensitive)
+/// followed by whitespace and a non-empty scope; `None` for the uniform
+/// form (no method prefix, or a leading word that is not a method), which
+/// the caller files under the method-agnostic baseline verbatim.
+fn parse_scope_literal(literal: &str) -> Option<(String, String)> {
+    let (first, rest) = literal.split_once(char::is_whitespace)?;
+    let method = first.to_ascii_uppercase();
+    if !SCOPE_METHOD_PREFIXES.contains(&method.as_str()) {
+        return None;
+    }
+    let scope = rest.trim();
+    if scope.is_empty() {
+        return None;
+    }
+    Some((method, scope.to_string()))
 }
 
 /// Resolve the HTTP route a `pub fn` answers under `harn serve site`.
@@ -1166,6 +1251,61 @@ pub fn ping() -> string {
         );
         let ping = catalog.function("ping").expect("ping");
         assert!(ping.required_scopes.is_empty());
+    }
+
+    #[test]
+    fn export_catalog_splits_method_prefixed_scopes_from_the_baseline() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("server.harn");
+        std::fs::write(
+            &path,
+            r#"
+@scopes("base:read", "GET extra:get", "put extra:put")
+@route("*", "/r")
+pub fn r() -> string { return "ok" }
+"#,
+        )
+        .expect("write script");
+
+        let catalog = ExportCatalog::from_path(&path).expect("catalog");
+        let r = catalog.function("r").expect("r export");
+        // An un-prefixed literal stays in the method-agnostic baseline.
+        assert_eq!(r.required_scopes, BTreeSet::from(["base:read".to_string()]));
+        // A method prefix (case-insensitive) routes the scope into the
+        // per-method bucket under the uppercased method key.
+        assert_eq!(
+            r.method_scopes.get("GET"),
+            Some(&BTreeSet::from(["extra:get".to_string()]))
+        );
+        assert_eq!(
+            r.method_scopes.get("PUT"),
+            Some(&BTreeSet::from(["extra:put".to_string()]))
+        );
+    }
+
+    #[test]
+    fn export_catalog_keeps_colon_scopes_uniform_without_a_method_prefix() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("server.harn");
+        // A leading word that is *not* an HTTP method (here a normal
+        // `scope:verb` token) is never misread as a per-method prefix —
+        // the historic uniform form is untouched.
+        std::fs::write(
+            &path,
+            r#"
+@scopes("personas:read")
+pub fn r() -> string { return "ok" }
+"#,
+        )
+        .expect("write script");
+
+        let catalog = ExportCatalog::from_path(&path).expect("catalog");
+        let r = catalog.function("r").expect("r export");
+        assert_eq!(
+            r.required_scopes,
+            BTreeSet::from(["personas:read".to_string()])
+        );
+        assert!(r.method_scopes.is_empty());
     }
 
     #[test]

--- a/crates/harn-serve/tests/site_auth.rs
+++ b/crates/harn-serve/tests/site_auth.rs
@@ -48,6 +48,12 @@ pub fn scoped_route(harness: Harness, req: dict) -> dict {
 pub fn ctx_route(req: dict) -> dict {
   return http_ok({ "ctx": host_call("embedder.auth_context", {}) })
 }
+
+@scopes("base:read", "PUT personas:write")
+@route("*", "/per_method")
+pub fn per_method_route(req: dict) -> dict {
+  return http_ok({ "ok": true })
+}
 "#;
 
 /// `SiteAuth` hook that always admits with a fixed identity.
@@ -172,8 +178,18 @@ fn site_router(
 }
 
 async fn get(router: Router, uri: &str) -> Response {
+    request(router, "GET", uri).await
+}
+
+async fn request(router: Router, method: &str, uri: &str) -> Response {
     router
-        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .method(method)
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap()
 }
@@ -328,4 +344,72 @@ async fn hook_sees_request_head_and_matched_route() {
     let echoed: Value =
         serde_json::from_str(body["ctx"].as_str().expect("bridge echoes a string")).unwrap();
     assert_eq!(echoed, json!({ "route": "/ctx", "method": "GET" }));
+}
+
+/// Per-method `@scopes`: `/per_method` declares the baseline `base:read`
+/// for every method plus `personas:write` only for `PUT`. A `GET` needs
+/// just the baseline — an `Allow` carrying `base:read` admits it even
+/// without `personas:write`, proving the per-method extra is scoped to
+/// `PUT` and `GET` falls back to the baseline alone.
+#[tokio::test]
+async fn per_method_get_requires_only_the_baseline_scope() {
+    let hook = Arc::new(AllowAuth {
+        tenant: None,
+        scopes: &["base:read"],
+        context: None,
+    });
+    let (_dir, router) = site_router(Some(hook), None);
+    let (status, body) = read_json(request(router, "GET", "/per_method").await).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ok"], true);
+}
+
+/// The same baseline-only credential is *insufficient* for `PUT`, which
+/// unions `personas:write` onto the baseline: admission refuses with the
+/// canonical envelope, and the missing scope is exactly the per-method
+/// extra (not the already-granted baseline).
+#[tokio::test]
+async fn per_method_put_demands_the_method_scoped_extra() {
+    let hook = Arc::new(AllowAuth {
+        tenant: None,
+        scopes: &["base:read"],
+        context: None,
+    });
+    let (_dir, router) = site_router(Some(hook), None);
+    let (status, body) = read_json(request(router, "PUT", "/per_method").await).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(body["code"], "forbidden");
+    assert_eq!(body["details"]["missing_scopes"][0], "personas:write");
+    assert_eq!(body["details"]["required_scopes"][0], "base:read");
+    assert_eq!(body["details"]["required_scopes"][1], "personas:write");
+}
+
+/// A credential carrying both the baseline and the per-method extra
+/// admits `PUT` — the union is satisfied.
+#[tokio::test]
+async fn per_method_put_admits_with_baseline_plus_extra() {
+    let hook = Arc::new(AllowAuth {
+        tenant: None,
+        scopes: &["base:read", "personas:write"],
+        context: None,
+    });
+    let (_dir, router) = site_router(Some(hook), None);
+    let (status, body) = read_json(request(router, "PUT", "/per_method").await).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ok"], true);
+}
+
+/// A method with no per-method extra (here `DELETE`) falls back to the
+/// baseline requirement — `base:read` alone admits it, same as `GET`.
+#[tokio::test]
+async fn per_method_unlisted_method_falls_back_to_baseline() {
+    let hook = Arc::new(AllowAuth {
+        tenant: None,
+        scopes: &["base:read"],
+        context: None,
+    });
+    let (_dir, router) = site_router(Some(hook), None);
+    let (status, body) = read_json(request(router, "DELETE", "/per_method").await).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ok"], true);
 }


### PR DESCRIPTION
## What

Extends harn-serve `SiteServer` route scopes from a single flat set to support **per-method** scopes, so a route can require different scopes per HTTP method (e.g. `GET` needs `read:x`, `PUT` needs `write:x`). Backward-compatible: existing uniform `@scopes("read:x")` markers are unchanged.

Unblocks harn-cloud moving routes like MCP `POST` (and other mixed-method endpoints) fully onto harn-serve, where a uniform route-level scope would otherwise over- or under-gate.

## Grammar

Each `@scopes(...)` literal is one of:
- **Uniform** (default, unchanged): `@scopes("read:x")` — required of every method.
- **Per-method**: `@scopes("PUT write:x")` — leading whitespace-delimited word, if a recognized HTTP method (`GET/PUT/POST/DELETE/PATCH/HEAD/OPTIONS`, case-insensitive), is stripped; the rest is required *only* for that method. The historic `scope:verb` colon form (no space) is never misread — it stays a uniform baseline scope.

`@scopes("read:x", "PUT write:x")` ⇒ baseline `read:x` for all methods + `write:x` only on `PUT`.

## Model

- `ExportedFunction.required_scopes` stays the method-agnostic **baseline** (read unchanged by core dispatch + API/A2A/MCP adapters).
- New `method_scopes: BTreeMap<String, BTreeSet<String>>` on `ExportedFunction` + `SiteRoute`; only the site adapter consults it.
- `SiteRoute::scopes_for(method)` returns `baseline ∪ method_scopes[method]` as a `Cow` (uniform routes stay borrow-only). All three site enforcement sites (auth-hook admission + the two no-hook `@ws` / `@stream`·`@raw` backstops) resolve by method. The duplicated backstop is factored into one `provider_scope_backstop(...)` helper.

## Tests
- `cargo test -p harn-serve`: lib 443 passed; `site_auth` 12 (incl. 4 new `per_method_*`: GET baseline-only admits, PUT 403 without extra, PUT 200 with baseline+extra, unlisted DELETE falls back to baseline); streaming/websocket/raw/hosting/conformance all green. 0 failures.
- `cargo clippy -p harn-serve --all-targets` clean; `cargo fmt --all --check` clean.

Body-dependent scope (e.g. MCP POST scope from the JSON-RPC body method) is intentionally out of scope — noted as the next seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)