### PR TITLE
feat(scanner): fingerprint scala/kotlin/+7 as primary_language (was dormant; unblocks Burin per-language authoring grounding)

### DIFF
--- a/changelog.d/3259.added.md
+++ b/changelog.d/3259.added.md
@@ -1,0 +1,5 @@
+- **Project scanner fingerprints more languages as `primary_language`.** Scala,
+  Kotlin, Swift, Elixir, Zig and friends are now recognized by extension and
+  build-tool signals instead of being dropped as `unknown`, so downstream
+  consumers (e.g. per-language authoring grounding) can key off an accurate
+  `primary_language`.

--- a/crates/harn-vm/src/stdlib/project.rs
+++ b/crates/harn-vm/src/stdlib/project.rs
@@ -41,7 +41,23 @@ const FINGERPRINT_SKIP_DIRS: &[&str] = &[
     "venv",
 ];
 const PROJECT_FINGERPRINT_MAX_DEPTH: usize = RuntimeLimits::DEFAULT.max_project_fingerprint_depth;
-const PROJECT_LANGUAGE_ORDER: &[&str] = &["rust", "typescript", "python", "go", "swift", "ruby"];
+const PROJECT_LANGUAGE_ORDER: &[&str] = &[
+    "rust",
+    "typescript",
+    "python",
+    "go",
+    "swift",
+    "ruby",
+    "scala",
+    "kotlin",
+    "java",
+    "elixir",
+    "zig",
+    "php",
+    "csharp",
+    "c",
+    "cpp",
+];
 const PROJECT_FRAMEWORK_ORDER: &[&str] = &["axum", "next", "react", "django", "fastapi", "rails"];
 const PROJECT_PACKAGE_MANAGER_ORDER: &[&str] = &[
     "cargo", "spm", "pnpm", "npm", "yarn", "uv", "poetry", "pip", "go-mod", "bundler",
@@ -1830,6 +1846,32 @@ fn inspect_fingerprint_file(path: &Path, rel: &str, name: &str, signals: &mut Fi
             signals.test_runners.insert("xctest".to_string());
         }
         "Gemfile" => inspect_gemfile(path, signals),
+        "build.sbt" => {
+            signals.languages.insert("scala".to_string());
+            signals.build_tools.insert("sbt".to_string());
+        }
+        "build.gradle.kts" => {
+            signals.languages.insert("kotlin".to_string());
+            signals.build_tools.insert("gradle".to_string());
+        }
+        "mix.exs" => {
+            signals.languages.insert("elixir".to_string());
+            signals.package_managers.insert("mix".to_string());
+            signals.build_tools.insert("mix".to_string());
+        }
+        "pom.xml" => {
+            signals.languages.insert("java".to_string());
+            signals.build_tools.insert("maven".to_string());
+        }
+        "composer.json" => {
+            signals.languages.insert("php".to_string());
+            signals.package_managers.insert("composer".to_string());
+            signals.build_tools.insert("composer".to_string());
+        }
+        "build.zig" | "build.zig.zon" => {
+            signals.languages.insert("zig".to_string());
+            signals.build_tools.insert("zig".to_string());
+        }
         _ => {}
     }
 
@@ -1884,6 +1926,34 @@ fn inspect_fingerprint_file(path: &Path, rel: &str, name: &str, signals: &mut Fi
         Some("rb") => {
             signals.languages.insert("ruby".to_string());
             signals.ruby_project = true;
+        }
+        Some("scala") | Some("sc") => {
+            signals.languages.insert("scala".to_string());
+        }
+        Some("kt") | Some("kts") => {
+            signals.languages.insert("kotlin".to_string());
+        }
+        Some("java") => {
+            signals.languages.insert("java".to_string());
+        }
+        Some("ex") | Some("exs") => {
+            signals.languages.insert("elixir".to_string());
+        }
+        Some("zig") | Some("zon") => {
+            signals.languages.insert("zig".to_string());
+        }
+        Some("php") => {
+            signals.languages.insert("php".to_string());
+        }
+        Some("cs") => {
+            signals.languages.insert("csharp".to_string());
+        }
+        Some("c") | Some("h") => {
+            signals.languages.insert("c".to_string());
+        }
+        Some("cpp") | Some("cc") | Some("cxx") | Some("hpp") | Some("hh") | Some("hxx")
+        | Some("mm") => {
+            signals.languages.insert("cpp".to_string());
         }
         _ => {}
     }
@@ -3424,6 +3494,146 @@ mod tests {
         assert_eq!(fingerprint.test_runner.as_deref(), Some("nextest"));
         assert_eq!(fingerprint.build_tool.as_deref(), Some("cargo"));
         assert_eq!(fingerprint.vcs.as_deref(), Some("git"));
+    }
+
+    #[test]
+    fn project_fingerprint_detects_scala_sbt_profile() {
+        let dir = temp_dir("fingerprint-scala");
+        std::fs::create_dir_all(dir.path().join("src/main/scala")).unwrap();
+        std::fs::write(
+            dir.path().join("build.sbt"),
+            "name := \"app\"\nscalaVersion := \"3.3.1\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("src/main/scala/Main.scala"),
+            "object Main { def main(args: Array[String]): Unit = () }\n",
+        )
+        .unwrap();
+
+        let fingerprint = detect_project_fingerprint(dir.path());
+        assert_eq!(fingerprint.primary_language, "scala");
+        assert!(fingerprint.languages.contains(&"scala".to_string()));
+        assert!(fingerprint.build_tool.as_deref() == Some("sbt"));
+    }
+
+    #[test]
+    fn project_fingerprint_detects_kotlin_gradle_kts_profile() {
+        let dir = temp_dir("fingerprint-kotlin");
+        std::fs::create_dir_all(dir.path().join("src/main/kotlin")).unwrap();
+        std::fs::write(
+            dir.path().join("build.gradle.kts"),
+            "plugins { kotlin(\"jvm\") version \"2.0.0\" }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("src/main/kotlin/Main.kt"),
+            "fun main() {}\n",
+        )
+        .unwrap();
+
+        let fingerprint = detect_project_fingerprint(dir.path());
+        assert_eq!(fingerprint.primary_language, "kotlin");
+        assert!(fingerprint.languages.contains(&"kotlin".to_string()));
+        assert!(fingerprint.build_tool.as_deref() == Some("gradle"));
+    }
+
+    #[test]
+    fn project_fingerprint_detects_elixir_mix_profile() {
+        let dir = temp_dir("fingerprint-elixir");
+        std::fs::create_dir_all(dir.path().join("lib")).unwrap();
+        std::fs::write(
+            dir.path().join("mix.exs"),
+            "defmodule App.MixProject do\n  use Mix.Project\nend\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("lib/app.ex"), "defmodule App do\nend\n").unwrap();
+
+        let fingerprint = detect_project_fingerprint(dir.path());
+        assert_eq!(fingerprint.primary_language, "elixir");
+        assert_eq!(fingerprint.package_manager.as_deref(), Some("mix"));
+        assert_eq!(fingerprint.build_tool.as_deref(), Some("mix"));
+    }
+
+    #[test]
+    fn project_fingerprint_detects_zig_profile() {
+        let dir = temp_dir("fingerprint-zig");
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(
+            dir.path().join("build.zig"),
+            "const std = @import(\"std\");\npub fn build(b: *std.Build) void { _ = b; }\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("src/main.zig"), "pub fn main() void {}\n").unwrap();
+
+        let fingerprint = detect_project_fingerprint(dir.path());
+        assert_eq!(fingerprint.primary_language, "zig");
+        assert_eq!(fingerprint.build_tool.as_deref(), Some("zig"));
+    }
+
+    #[test]
+    fn project_fingerprint_detects_java_maven_profile() {
+        let dir = temp_dir("fingerprint-java");
+        std::fs::create_dir_all(dir.path().join("src/main/java/app")).unwrap();
+        std::fs::write(
+            dir.path().join("pom.xml"),
+            "<project><modelVersion>4.0.0</modelVersion></project>\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("src/main/java/app/App.java"),
+            "package app;\npublic class App {}\n",
+        )
+        .unwrap();
+
+        let fingerprint = detect_project_fingerprint(dir.path());
+        assert_eq!(fingerprint.primary_language, "java");
+        assert_eq!(fingerprint.build_tool.as_deref(), Some("maven"));
+    }
+
+    #[test]
+    fn project_fingerprint_detects_php_composer_profile() {
+        let dir = temp_dir("fingerprint-php");
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(
+            dir.path().join("composer.json"),
+            "{\n  \"name\": \"acme/app\"\n}\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("src/index.php"), "<?php\necho \"hi\";\n").unwrap();
+
+        let fingerprint = detect_project_fingerprint(dir.path());
+        assert_eq!(fingerprint.primary_language, "php");
+        assert_eq!(fingerprint.package_manager.as_deref(), Some("composer"));
+    }
+
+    #[test]
+    fn project_fingerprint_detects_csharp_profile() {
+        let dir = temp_dir("fingerprint-csharp");
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(
+            dir.path().join("src/Program.cs"),
+            "class Program { static void Main() {} }\n",
+        )
+        .unwrap();
+
+        let fingerprint = detect_project_fingerprint(dir.path());
+        assert_eq!(fingerprint.primary_language, "csharp");
+    }
+
+    #[test]
+    fn project_fingerprint_detects_cpp_profile() {
+        let dir = temp_dir("fingerprint-cpp");
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(
+            dir.path().join("src/main.cpp"),
+            "int main() { return 0; }\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("src/util.hpp"), "#pragma once\n").unwrap();
+
+        let fingerprint = detect_project_fingerprint(dir.path());
+        assert_eq!(fingerprint.primary_language, "cpp");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Burin's per-language authoring grounding + skill cards (burin-code PR #2193) activate **only** when the Harn scanner reports a project's `primary_language`. But the scanner's fingerprint (`crates/harn-vm/src/stdlib/project.rs`) only detected 6 languages — `rust, typescript, python, go, swift, ruby` — so the grounding was **dormant for exactly the languages it targets** (scala, kotlin, and others).

## Audit

Burin's supported language set (eval matrix): swift, scala, kotlin, rust, go, python, typescript, c, cpp, csharp, php, ruby, java, zig, elixir.

Detected before this PR: rust, typescript, python, go, swift, ruby.

**Missing (9): scala, kotlin, java, elixir, zig, php, csharp, c, cpp.**

## Fix

`detect_project_fingerprint` selects `primary_language` from the set of detected `languages` (empty → `unknown`, exactly one → that language, more than one → `mixed`). Languages are gathered from a source-extension `match` block plus exact-name manifest handlers. This PR mirrors that exact mechanism for the missing languages:

- **Extension map**: `.scala`/`.sc`→scala, `.kt`/`.kts`→kotlin, `.java`→java, `.ex`/`.exs`→elixir, `.zig`/`.zon`→zig, `.php`→php, `.cs`→csharp, `.c`/`.h`→c, `.cpp`/`.cc`/`.cxx`/`.hpp`/`.hh`/`.hxx`/`.mm`→cpp.
- **Manifest handlers** (mirroring `Cargo.toml`/`go.mod`/`Package.swift`): `build.sbt`→scala (+sbt build tool), `build.gradle.kts`→kotlin (+gradle), `mix.exs`→elixir (+mix pm/build), `pom.xml`→java (+maven), `composer.json`→php (+composer), `build.zig`/`build.zig.zon`→zig.
- `build.gradle` (no `.kts`) is **deliberately not** an exact-name manifest match since it is shared by Kotlin and Java; those projects disambiguate via `.kt`/`.java` source extensions.
- Added all 9 languages to `PROJECT_LANGUAGE_ORDER` for deterministic precedence (the `ordered_values` fallback already appended unknown values, but explicit ordering is cleaner and matches existing langs).

The extension/manifest names mirror Burin's own language catalog (`lib/lang/catalog.harn`) so the fingerprint names line up with the grounding's expectations.

## Tests

8 new Rust unit tests in the existing fingerprint test module (scala/sbt, kotlin/gradle.kts, elixir/mix, zig, java/maven, php/composer, csharp, cpp), each asserting `primary_language == <lang>`. `cargo test -p harn-vm` green (37 passed), `clippy -D warnings` clean, `fmt` clean.

## Follow-up

Once Harn is released and burin-code repins, #2193's per-language authoring grounding activates for these languages.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)