### PR TITLE
fix(sandbox): honor embedder sandbox config in code/ActAuto mode (was loaded-then-ignored) + complete JVM/iOS toolchain cache presets + SSRF guard on the agent path; no change to the no-config default

### DIFF
--- a/changelog.d/sandbox-honor-config.security.md
+++ b/changelog.d/sandbox-honor-config.security.md
@@ -1,0 +1,32 @@
+- **The ACP `code` (ActAuto) coding mode now honors an embedder-supplied
+  sandbox config instead of discarding it.** Previously, an embedder's
+  `AcpSandboxConfig` (e.g. from `sandbox.json` / `BURIN_SANDBOX_CONFIG`) was
+  loaded and validated but silently dropped in `code` mode, because the ActAuto
+  tier short-circuited to "no per-turn policy" before the config was applied —
+  so the default coding agent ran with no filesystem scoping, no OS
+  confinement, and no egress guard even when the embedder asked for them.
+  ActAuto's *approval* semantics (no human approval gate) are now decoupled
+  from *OS confinement*: when the embedder provides a non-default sandbox
+  config, `code` mode applies it as a `Worktree`-level OS sandbox (seatbelt on
+  macOS, Landlock on Linux) seeded from the config's read-only roots and
+  process presets, while keeping ActAuto's `network` side-effect ceiling. **No
+  change to the no-config default** — a session with no sandbox config behaves
+  exactly as before (ambient policy, no per-turn ceiling).
+- **The SSRF private-address egress guard is now installed on the ACP
+  agent/serve path** (not just `harn run`) whenever the embedder opts into
+  sandboxing. While active it blocks outbound requests to private / loopback /
+  link-local / cloud-metadata addresses (e.g. `169.254.169.254`, `127.0.0.1`,
+  `10.x`, `192.168.x`) while leaving legitimate public traffic — model API
+  calls, `web_search` / `web_fetch` to public hosts — fully allowed. The
+  metadata endpoint stays blocked even with the loopback escape hatch. Local
+  model servers on loopback are reached via the documented
+  `HARN_EGRESS_ALLOW_LOOPBACK=1` / `egress_policy({block_private:"off"})` opt
+  out. With no sandbox config the guard is not installed, so default egress is
+  unchanged.
+- **The `DeveloperToolchains` sandbox preset now covers JVM/iOS toolchain
+  caches** so a `Worktree`-confined build does not break Gradle, Maven,
+  CocoaPods, Xcode, or Kotlin/Native. Read+write access is granted to
+  `~/.gradle`, `~/.m2`, `~/.konan`, `~/Library/Caches/CocoaPods`, and
+  `~/Library/Developer/Xcode/DerivedData` when the policy allows workspace
+  writes (read-only otherwise), mirroring the existing `UserTemp` cache-write
+  pattern.

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -716,6 +716,20 @@ impl AcpServerConfig {
 }
 
 impl AcpSandboxConfig {
+    /// Whether the embedder actually contributed any sandbox configuration.
+    ///
+    /// A default (empty) config means "embedder said nothing" — the no-config
+    /// path that must behave exactly as before. A non-default config (any
+    /// read-only root, or any process preset/read/write root) is the signal
+    /// that the embedder opted into confinement, which the ActAuto `code` mode
+    /// now honors as a `Worktree`-level OS sandbox.
+    pub fn is_configured(&self) -> bool {
+        !self.read_only_roots.is_empty()
+            || self.process.presets.is_some()
+            || !self.process.read_roots.is_empty()
+            || !self.process.write_roots.is_empty()
+    }
+
     pub fn with_read_only_roots(roots: Vec<String>) -> Self {
         Self {
             read_only_roots: canonicalize_sandbox_roots(roots),

--- a/crates/harn-serve/src/adapters/acp/modes.rs
+++ b/crates/harn-serve/src/adapters/acp/modes.rs
@@ -402,10 +402,25 @@ pub(super) fn policy_for_mode(
 ) -> Option<CapabilityPolicy> {
     let mode = definition(mode_id)?;
     if mode.autonomy_tier == AutonomyTier::ActAuto {
-        // Full-access mode leaves the ambient host/runtime policy as the
-        // authority. Installing a no-op ceiling would still make legacy bridge
-        // fallbacks look policy-governed and block them.
-        return None;
+        // ActAuto is the "no human approval gate" tier — but that is an
+        // *approval* decision, decoupled from *OS confinement*. When the
+        // embedder said nothing about sandboxing, preserve the historical
+        // behavior exactly: no per-turn policy, ambient host/runtime policy
+        // remains the authority (installing a no-op ceiling would make legacy
+        // bridge fallbacks look policy-governed and block them).
+        if !sandbox.is_configured() {
+            return None;
+        }
+        // The embedder opted into confinement (sandbox.json /
+        // BURIN_SANDBOX_CONFIG). Honor it as a `Worktree`-level OS sandbox
+        // seeded from the config's roots/presets, while keeping ActAuto's
+        // approval semantics (no approval gate -> `side_effect_level: network`,
+        // no recursion clamp). This is the seam that stops the "config loaded
+        // then ignored" theater for the default coding mode.
+        let mut policy = harn_vm::policy_for_autonomy_tier(AutonomyTier::ActAuto);
+        policy.sandbox_profile = harn_vm::orchestration::SandboxProfile::Worktree;
+        apply_sandbox_config(&mut policy, sandbox);
+        return Some(policy);
     }
     let mut policy = harn_vm::policy_for_autonomy_tier(mode.autonomy_tier);
     apply_sandbox_config(&mut policy, sandbox);
@@ -428,19 +443,48 @@ fn apply_sandbox_config(policy: &mut CapabilityPolicy, sandbox: &AcpSandboxConfi
 }
 
 /// RAII guard that pushes a CapabilityPolicy on construction and pops it on
-/// drop. Full-access `code` mode has no extra policy to push.
+/// drop, and (when the embedder opted into sandboxing) installs the SSRF
+/// private-address egress guard for the turn. The no-config `code` mode has no
+/// extra policy to push and no SSRF guard, leaving egress exactly as before.
+///
+/// The serve adapter runs the whole prompt turn — including the agent's model
+/// HTTP calls — on a single current-thread `LocalSet` runtime (see
+/// `crates/harn-serve/src/adapter.rs`), so a thread-local egress guard held for
+/// the turn's lifetime covers every outbound request made during that turn,
+/// the same way the thread-local execution-policy stack already does.
 pub(super) struct ModePolicyGuard {
     pushed: bool,
+    // Held for the turn so the SSRF private-address backstop stays installed
+    // until the guard drops. `None` when the embedder supplied no sandbox
+    // config (the no-config default path).
+    _ssrf_guard: Option<harn_vm::egress::SsrfGuardScope>,
 }
 
 impl ModePolicyGuard {
     pub(super) fn enter(mode_id: &str, sandbox: &AcpSandboxConfig) -> Self {
+        // Install the SSRF guard only when the embedder opted into sandboxing.
+        // It blocks PRIVATE/loopback/link-local/metadata egress while leaving
+        // public traffic (model APIs, web_search/web_fetch to public hosts)
+        // ALLOWED. Local model servers on loopback are reached via the
+        // documented `HARN_EGRESS_ALLOW_LOOPBACK=1` /
+        // `egress_policy({block_private:"off"})` hatch; the metadata endpoint
+        // stays blocked regardless. With no sandbox config we install nothing,
+        // so egress is byte-identical to today's default.
+        let ssrf_guard = sandbox
+            .is_configured()
+            .then(harn_vm::egress::require_ssrf_guard_for_host);
         match policy_for_mode(mode_id, sandbox) {
             Some(policy) => {
                 harn_vm::orchestration::push_execution_policy(policy);
-                Self { pushed: true }
+                Self {
+                    pushed: true,
+                    _ssrf_guard: ssrf_guard,
+                }
             }
-            None => Self { pushed: false },
+            None => Self {
+                pushed: false,
+                _ssrf_guard: ssrf_guard,
+            },
         }
     }
 }
@@ -637,8 +681,59 @@ mod tests {
     }
 
     #[test]
-    fn policy_for_code_is_none() {
+    fn policy_for_code_with_no_config_is_none() {
+        // No-config default MUST be byte-identical to historical behavior:
+        // ActAuto `code` mode installs no per-turn policy, leaving the ambient
+        // (unrestricted) host/runtime policy as the authority.
         assert!(policy_for_mode("code", &AcpSandboxConfig::default()).is_none());
+        // The default config is, by definition, not "configured".
+        assert!(!AcpSandboxConfig::default().is_configured());
+    }
+
+    #[test]
+    fn policy_for_code_with_config_applies_worktree_confinement() {
+        // When the embedder opts into sandboxing, ActAuto `code` mode now
+        // honors it as a Worktree-level OS sandbox instead of discarding it.
+        let roots = vec!["/work/project".to_string()];
+        let sandbox = AcpSandboxConfig::with_read_only_roots(roots.clone());
+        assert!(sandbox.is_configured());
+        let policy = policy_for_mode("code", &sandbox)
+            .expect("configured code mode must install a confinement policy");
+        // Worktree-level OS confinement is engaged...
+        assert_eq!(
+            policy.sandbox_profile,
+            harn_vm::orchestration::SandboxProfile::Worktree
+        );
+        // ...the embedder roots are carried through...
+        assert_eq!(policy.read_only_roots, roots);
+        // ...and ActAuto approval semantics are preserved (no approval gate ->
+        // network side effects allowed, no recursion clamp).
+        assert_eq!(policy.side_effect_level.as_deref(), Some("network"));
+        assert_eq!(policy.recursion_limit, None);
+    }
+
+    #[test]
+    fn policy_for_code_with_process_config_applies_confinement() {
+        let process = harn_vm::orchestration::ProcessSandboxPolicy {
+            presets: Some(vec![
+                harn_vm::orchestration::ProcessSandboxPreset::DeveloperToolchains,
+            ]),
+            read_roots: vec!["/opt/sdk".to_string()],
+            write_roots: Vec::new(),
+        };
+        let sandbox = AcpSandboxConfig::with_process(process);
+        assert!(sandbox.is_configured());
+        let policy = policy_for_mode("code", &sandbox)
+            .expect("process-config code mode must install a confinement policy");
+        assert_eq!(
+            policy.sandbox_profile,
+            harn_vm::orchestration::SandboxProfile::Worktree
+        );
+        assert_eq!(
+            policy.process_sandbox.read_roots,
+            vec!["/opt/sdk".to_string()]
+        );
+        assert_eq!(policy.side_effect_level.as_deref(), Some("network"));
     }
 
     #[test]
@@ -727,12 +822,20 @@ mod tests {
     }
 
     #[test]
-    fn code_mode_ignores_embedder_read_only_roots() {
-        // Full-access mode pushes no per-turn policy; the ambient sandbox is
-        // already unrestricted so there is nothing to union into.
+    fn code_mode_honors_embedder_read_only_roots() {
+        // Previously full-access mode discarded embedder roots entirely. Now a
+        // configured embedder gets Worktree confinement with its roots applied.
         let sandbox =
             AcpSandboxConfig::with_read_only_roots(vec!["/opt/burin/pipelines".to_string()]);
-        assert!(policy_for_mode("code", &sandbox).is_none());
+        let policy = policy_for_mode("code", &sandbox).expect("configured code mode has policy");
+        assert_eq!(
+            policy.read_only_roots,
+            vec!["/opt/burin/pipelines".to_string()]
+        );
+        assert_eq!(
+            policy.sandbox_profile,
+            harn_vm::orchestration::SandboxProfile::Worktree
+        );
     }
 
     #[test]
@@ -740,5 +843,50 @@ mod tests {
         assert!(is_known("ask"));
         assert!(!is_known(""));
         assert!(!is_known("plan"));
+    }
+
+    #[test]
+    fn no_config_code_mode_installs_no_ssrf_guard() {
+        // The default (no-config) path must not change egress behavior at all:
+        // the SSRF private-address guard is NOT installed, so the agent's
+        // egress (including loopback to a local model server) is unchanged.
+        assert_eq!(
+            harn_vm::egress::current_ssrf_client_settings(),
+            (false, false),
+            "precondition: no guard active outside a turn"
+        );
+        {
+            let _guard = ModePolicyGuard::enter("code", &AcpSandboxConfig::default());
+            assert_eq!(
+                harn_vm::egress::current_ssrf_client_settings(),
+                (false, false),
+                "no-config code mode must leave egress unguarded (public + private allowed)"
+            );
+        }
+    }
+
+    #[test]
+    fn configured_code_mode_installs_ssrf_guard() {
+        // A configured embedder gets the SSRF private-address backstop for the
+        // turn: block_private becomes active. Public hosts stay reachable (the
+        // guard only blocks private/loopback/link-local/metadata addresses).
+        assert_eq!(
+            harn_vm::egress::current_ssrf_client_settings(),
+            (false, false)
+        );
+        {
+            let sandbox = AcpSandboxConfig::with_read_only_roots(vec!["/work/project".to_string()]);
+            let _guard = ModePolicyGuard::enter("code", &sandbox);
+            assert!(
+                harn_vm::egress::current_ssrf_client_settings().0,
+                "configured code mode must arm the SSRF private-address guard"
+            );
+        }
+        // The guard is released when the turn's ModePolicyGuard drops.
+        assert_eq!(
+            harn_vm::egress::current_ssrf_client_settings(),
+            (false, false),
+            "SSRF guard must release on turn end"
+        );
     }
 }

--- a/crates/harn-vm/src/stdlib/sandbox/linux.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/linux.rs
@@ -186,6 +186,19 @@ fn landlock_profile(
     for root in process_sandbox_package_manager_config_read_roots(policy) {
         push_rule(&mut profile, root, read_only_access(), true)?;
     }
+    // JVM/iOS toolchain caches (Gradle/Maven/Kotlin-Native/Xcode/CocoaPods).
+    // Grant write when the policy allows workspace writes so a sandboxed build
+    // can populate its caches; otherwise read-only so dependency resolution
+    // still works. These roots are optional — they are skipped when absent.
+    let toolchain_cache_roots = super::process_sandbox_developer_toolchain_cache_roots(policy);
+    let toolchain_cache_access = if policy_allows_workspace_write(policy) {
+        workspace_access
+    } else {
+        read_only_access()
+    };
+    for root in toolchain_cache_roots {
+        push_rule(&mut profile, root, toolchain_cache_access, true)?;
+    }
     if policy_allows_workspace_write(policy) {
         for root in process_sandbox_policy_write_roots(policy) {
             push_rule(&mut profile, root, workspace_access, false)?;

--- a/crates/harn-vm/src/stdlib/sandbox/macos.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/macos.rs
@@ -138,10 +138,13 @@ fn has_swiftpm_option(args: &[String], option: &str) -> bool {
 fn render_profile(policy: &CapabilityPolicy) -> String {
     let developer_toolchain_read_roots = process_sandbox_developer_toolchain_read_roots(policy);
     let package_manager_read_roots = process_sandbox_package_manager_config_read_roots(policy);
+    let developer_toolchain_cache_roots =
+        super::process_sandbox_developer_toolchain_cache_roots(policy);
     render_profile_with_extra_read_roots(
         policy,
         &developer_toolchain_read_roots,
         &package_manager_read_roots,
+        &developer_toolchain_cache_roots,
     )
 }
 
@@ -149,6 +152,7 @@ fn render_profile_with_extra_read_roots(
     policy: &CapabilityPolicy,
     developer_toolchain_read_roots: &[std::path::PathBuf],
     package_manager_read_roots: &[std::path::PathBuf],
+    developer_toolchain_cache_roots: &[std::path::PathBuf],
 ) -> String {
     let roots = process_sandbox_roots(policy);
     let read_only_roots = process_sandbox_readonly_roots(policy);
@@ -170,7 +174,10 @@ fn render_profile_with_extra_read_roots(
             sandbox_profile_escape(root)
         ));
     }
-    for root in developer_toolchain_read_roots {
+    for root in developer_toolchain_read_roots
+        .iter()
+        .chain(developer_toolchain_cache_roots.iter())
+    {
         profile.push_str(&format!(
             "(allow file-read* (subpath \"{}\"))\n",
             sandbox_profile_escape(&root.display().to_string())
@@ -206,7 +213,10 @@ fn render_profile_with_extra_read_roots(
         for root in preset_write_roots(policy) {
             profile.push_str(&format!(" (subpath \"{}\")", sandbox_profile_escape(root)));
         }
-        for root in &policy_write_roots {
+        for root in policy_write_roots
+            .iter()
+            .chain(developer_toolchain_cache_roots.iter())
+        {
             profile.push_str(&format!(
                 " (subpath \"{}\")",
                 sandbox_profile_escape(&root.display().to_string())
@@ -411,6 +421,7 @@ mod tests {
             &macos_policy_with_workspace_ops(&["read_text", "write_text", "delete"]),
             &[],
             &package_roots,
+            &[],
         );
         let npmrc_path = super::super::package_manager_config_read_roots_for_home(temp_home.path())
             .into_iter()
@@ -455,6 +466,7 @@ mod tests {
             &macos_policy_with_workspace_ops(&["read_text", "write_text", "delete"]),
             &toolchain_roots,
             &[],
+            &[],
         );
 
         for path in [uv_path, rustup_path] {
@@ -468,6 +480,74 @@ mod tests {
                 "home toolchain root must stay read-only: {profile}"
             );
         }
+    }
+
+    #[test]
+    fn sandbox_profile_allows_jvm_ios_toolchain_caches_read_write() {
+        let temp_home = tempfile::tempdir().expect("temp home");
+        let cache_roots =
+            super::super::developer_toolchain_cache_write_roots_for_home(temp_home.path());
+        let gradle_path = cache_roots
+            .iter()
+            .find(|path| path.ends_with(std::path::Path::new(".gradle")))
+            .expect("gradle cache root")
+            .display()
+            .to_string();
+        let derived_data_path = cache_roots
+            .iter()
+            .find(|path| {
+                path.ends_with(std::path::Path::new("Library/Developer/Xcode/DerivedData"))
+            })
+            .expect("DerivedData cache root")
+            .display()
+            .to_string();
+
+        // Writable policy: the build can read AND write its toolchain caches.
+        // The writable roots all land on the single `(allow file-write* ...)`
+        // line, so isolate that line and assert each cache subpath is on it.
+        let writable = render_profile_with_extra_read_roots(
+            &macos_policy_with_workspace_ops(&["read_text", "write_text", "delete"]),
+            &[],
+            &[],
+            &cache_roots,
+        );
+        let write_line = writable
+            .lines()
+            .find(|line| line.starts_with("(allow file-write* (subpath"))
+            .expect("a multi-subpath file-write* allow line");
+        for path in [&gradle_path, &derived_data_path] {
+            let escaped = sandbox_profile_escape(path);
+            assert!(
+                writable.contains(&format!("(allow file-read* (subpath \"{escaped}\"))")),
+                "JVM/iOS toolchain cache should be readable: {writable}"
+            );
+            assert!(
+                write_line.contains(&format!("(subpath \"{escaped}\")")),
+                "JVM/iOS toolchain cache should be writable under a writable policy: {writable}"
+            );
+        }
+
+        // Read-only policy: caches are readable (dependency resolution) but
+        // never writable — the whole workspace-write block is skipped.
+        let read_only = render_profile_with_extra_read_roots(
+            &macos_policy_with_workspace_ops(&["read_text"]),
+            &[],
+            &[],
+            &cache_roots,
+        );
+        let gradle_escaped = sandbox_profile_escape(&gradle_path);
+        assert!(
+            read_only.contains(&format!(
+                "(allow file-read* (subpath \"{gradle_escaped}\"))"
+            )),
+            "toolchain cache should still be readable under a read-only policy: {read_only}"
+        );
+        assert!(
+            !read_only
+                .lines()
+                .any(|line| line.starts_with("(allow file-write* (subpath")),
+            "read-only policy must not emit a workspace file-write allow: {read_only}"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/sandbox/mod.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/mod.rs
@@ -842,6 +842,28 @@ pub(crate) fn process_sandbox_package_manager_config_read_roots(
     package_manager_config_read_roots_for_home(&home)
 }
 
+/// Per-user toolchain *cache* roots that JVM/iOS build tools read **and write**
+/// while a sandboxed build runs (Gradle, Maven, CocoaPods, Xcode, Kotlin
+/// Native). Unlike [`developer_toolchain_read_roots_for_home`] these are not
+/// read-only: a build legitimately populates `~/.gradle/caches`,
+/// `~/.m2/repository`, `~/Library/Developer/Xcode/DerivedData`, etc. They are
+/// gated on the `DeveloperToolchains` preset and granted *write* only when the
+/// active policy already permits workspace writes (mirroring `UserTemp`); under
+/// a read-only policy they fall back to read access so dependency resolution
+/// still works.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+pub(crate) fn process_sandbox_developer_toolchain_cache_roots(
+    policy: &CapabilityPolicy,
+) -> Vec<PathBuf> {
+    if !process_sandbox_presets(policy).contains(&ProcessSandboxPreset::DeveloperToolchains) {
+        return Vec::new();
+    }
+    let Some(home) = sandbox_user_home_dir() else {
+        return Vec::new();
+    };
+    developer_toolchain_cache_write_roots_for_home(&home)
+}
+
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 fn sandbox_user_home_dir() -> Option<PathBuf> {
     // Only an absolute home grounds the user-scope read-roots below; a
@@ -883,6 +905,27 @@ pub(crate) fn developer_toolchain_read_roots_for_home(home: &Path) -> Vec<PathBu
         .into_iter()
         .map(|entry| normalize_for_policy(&home.join(entry))),
     );
+    roots.sort_unstable();
+    roots.dedup();
+    roots
+}
+
+/// Per-user JVM/iOS toolchain cache roots (read+write). Kept platform-shared so
+/// the macOS seatbelt and Linux Landlock backends render the same set; the
+/// macOS-only `~/Library/...` entries are simply absent on Linux disk and the
+/// `optional`/NotFound handling in each backend skips roots that do not exist.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+pub(crate) fn developer_toolchain_cache_write_roots_for_home(home: &Path) -> Vec<PathBuf> {
+    let mut roots: Vec<_> = [
+        ".gradle",                             // Gradle (JVM/Android/Kotlin)
+        ".m2",                                 // Maven (JVM)
+        ".konan",                              // Kotlin/Native
+        "Library/Caches/CocoaPods",            // CocoaPods (iOS/macOS)
+        "Library/Developer/Xcode/DerivedData", // Xcode build products
+    ]
+    .into_iter()
+    .map(|entry| normalize_for_policy(&home.join(entry)))
+    .collect();
     roots.sort_unstable();
     roots.dedup();
     roots
@@ -1469,6 +1512,55 @@ mod tests {
         assert!(
             roots.iter().all(|path| path.starts_with(&normalized_home)),
             "developer-toolchain roots must stay under HOME"
+        );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    #[test]
+    fn developer_toolchain_cache_roots_cover_jvm_and_ios_toolchains() {
+        let temp_home = tempfile::tempdir().expect("temp home");
+        let roots = developer_toolchain_cache_write_roots_for_home(temp_home.path());
+        let normalized_home = normalize_for_policy(temp_home.path());
+
+        for suffix in [
+            Path::new(".gradle"),
+            Path::new(".m2"),
+            Path::new(".konan"),
+            Path::new("Library/Caches/CocoaPods"),
+            Path::new("Library/Developer/Xcode/DerivedData"),
+        ] {
+            assert!(
+                roots.iter().any(|path| path.ends_with(suffix)),
+                "expected a JVM/iOS toolchain cache grant for {}",
+                suffix.display()
+            );
+        }
+        assert!(
+            roots.iter().all(|path| path.starts_with(&normalized_home)),
+            "toolchain cache roots must stay under HOME"
+        );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    #[test]
+    fn developer_toolchain_cache_roots_require_developer_toolchains_preset() {
+        let mut policy = CapabilityPolicy {
+            workspace_roots: vec!["/tmp/harn-workspace".to_string()],
+            ..CapabilityPolicy::default()
+        };
+        // Default presets include DeveloperToolchains -> cache roots present
+        // (only when an absolute HOME is resolvable on this host).
+        if sandbox_user_home_dir().is_some() {
+            assert!(
+                !process_sandbox_developer_toolchain_cache_roots(&policy).is_empty(),
+                "default presets should render JVM/iOS cache roots"
+            );
+        }
+        // Explicitly dropping DeveloperToolchains removes them.
+        policy.process_sandbox.presets = Some(vec![ProcessSandboxPreset::SystemRuntime]);
+        assert!(
+            process_sandbox_developer_toolchain_cache_roots(&policy).is_empty(),
+            "cache roots must be gated on the DeveloperToolchains preset"
         );
     }
 


### PR DESCRIPTION
Security-foundation fix to the Harn sandbox / ACP serve path. Three coherent changes, all gated so the **no-config default is byte-identical to today** (a user with no sandbox config behaves exactly as before).

## Vet summary (file:line confirmed before editing)

The default coding-agent ACP mode (`code`) is the `ActAuto` tier. `policy_for_mode` (`crates/harn-serve/src/adapters/acp/modes.rs`) returned `None` for `ActAuto`, short-circuiting **before** `apply_sandbox_config` ran — so the embedder's `AcpSandboxConfig` (from `sandbox.json` / `BURIN_SANDBOX_CONFIG`) was loaded + validated then **discarded**. Result: the default coding agent ran with no fs scoping, no OS confinement (seatbelt/Landlock), and no egress/SSRF guard *even when the embedder configured one*. Separately, the `DeveloperToolchains` preset covered Swift/Rust/Python/Node but not JVM/iOS cache roots, and the SSRF private-address guard was installed on `harn run` but not on the ACP serve/agent path.

## R1 — Honor embedder sandbox config in `code`/ActAuto mode

`crates/harn-serve/src/adapters/acp/modes.rs` `policy_for_mode`: decouple the **approval tier** from **OS confinement**. ActAuto still means "no human approval gate", but when the embedder provides a non-default `AcpSandboxConfig` (`AcpSandboxConfig::is_configured()` — any read-only root or process preset/root), `code` mode now builds a `Worktree`-level OS-confinement policy seeded from the config's roots/presets, while preserving ActAuto approval semantics (`side_effect_level: network`, no recursion clamp). **No config → `None` (ambient), unchanged.**

## R4 — JVM/iOS toolchain cache completeness

`crates/harn-vm/src/stdlib/sandbox/{mod,macos,linux}.rs`: new `developer_toolchain_cache_write_roots_for_home` (gated on the existing `DeveloperToolchains` preset) adds `~/.gradle`, `~/.m2`, `~/.konan`, `~/Library/Caches/CocoaPods`, `~/Library/Developer/Xcode/DerivedData`. Granted **read+write** under a writable policy (read-only otherwise), mirroring the `UserTemp` cache pattern, wired through both the macOS seatbelt and Linux Landlock backends. A `Worktree`-confined Gradle/Maven/CocoaPods build can now read/write its caches.

## R5 — SSRF/egress guard on the agent path

`crates/harn-serve/src/adapters/acp/modes.rs` `ModePolicyGuard`: install `harn_vm::egress::require_ssrf_guard_for_host()` for the turn **when the embedder opted into sandboxing** (same `is_configured()` signal as R1). The serve adapter runs the whole turn — including the agent's model HTTP — on one current-thread `LocalSet` runtime (`crates/harn-serve/src/adapter.rs`), so a thread-local guard held for the turn covers all egress, exactly like the existing thread-local execution-policy stack.

- **Egress stays ALLOWED for legitimate public traffic** (model API calls, `web_search`/`web_fetch` to public hosts). This is **not** default-deny egress.
- **Only PRIVATE/loopback/link-local/metadata addresses are guarded** (`169.254.169.254`, `127.0.0.1`, `10.x`, `192.168.x`).
- **Scoped conservatively**: gated on `is_configured()` so the no-config default installs nothing → local model servers on loopback keep working by default. Configured sessions reach loopback model servers via the documented `HARN_EGRESS_ALLOW_LOOPBACK=1` / `egress_policy({block_private:"off"})` hatch; the metadata endpoint stays blocked even then.

## Proof / test evidence

New tests:
- `policy_for_code_with_no_config_is_none` — no-config code mode = `None` (unchanged); `AcpSandboxConfig::default().is_configured()` is false.
- `policy_for_code_with_config_applies_worktree_confinement` / `policy_for_code_with_process_config_applies_confinement` / `code_mode_honors_embedder_read_only_roots` — configured code mode → `Worktree` profile, roots applied, ActAuto semantics (`network`, no recursion clamp) preserved.
- `no_config_code_mode_installs_no_ssrf_guard` / `configured_code_mode_installs_ssrf_guard` — SSRF guard absent with no config, armed (and released on drop) with config.
- `developer_toolchain_cache_roots_cover_jvm_and_ios_toolchains` / `..._require_developer_toolchains_preset` / `sandbox_profile_allows_jvm_ios_toolchain_caches_read_write` — the new roots render read-only and read+write as expected, gated on the preset.
- Existing `acp_code_mode_allows_writes_in_prompt` still passes (no-config code mode still writes).
- SSRF public-allowed / private-blocked is proven by the existing `egress::tests::default_on_blocks_loopback_under_run_scope` (`8.8.8.8` allowed, `127.0.0.1` + `169.254.169.254` blocked under the guard scope).

Results (isolated `CARGO_TARGET_DIR`):
- `cargo test -p harn-serve` — **445 + suites pass, 0 fail**.
- `cargo test -p harn-vm --lib sandbox` — **43 pass**; `--lib egress` — **56 pass** (single-threaded).
- `cargo clippy -p harn-vm -p harn-serve --all-targets -- -D warnings` — **clean**; `cargo fmt --check` — **clean**.

Note: `egress::tests::current_resolved_ip_rules_reflects_installed_policy` flakes under parallel test execution (global egress-policy state); **confirmed pre-existing on untouched `origin/main`** (1/4 runs fail identically) and unrelated to this change — no egress-module code was touched. Passes single-threaded.

Changelog fragment: `changelog.d/sandbox-honor-config.security.md`.

This unblocks the Burin `/yolo` toggle + safe-default (staged for after this releases + repins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)