### PR TITLE
fix(agent-loop): drop provider empty-name tool calls instead of terminating silently

### DIFF
--- a/changelog.d/2120.fixed.md
+++ b/changelog.d/2120.fixed.md
@@ -1,0 +1,9 @@
+- **Agent loop no longer terminates silently on provider empty-name tool calls
+  (burin-code#2120).** When a provider returns a malformed tool call with an
+  empty / whitespace-only name alongside valid sibling calls in the same turn
+  (observed live as a turn carrying `[look, "", look]`), the loop now drops only
+  the nameless call, keeps and dispatches the valid siblings, and injects
+  parse-guidance so the model re-emits a named call next turn — instead of
+  passing the empty-name call through unguarded and ending the loop, which read
+  as a model give-up (`result=INCOMPLETE, outcome_kind=null`) but was a pure
+  harness dispatch failure that corrupted eval-meter accounting.

--- a/conformance/tests/agents/agent_loop_blank_name_tool_call_filter.expected
+++ b/conformance/tests/agents/agent_loop_blank_name_tool_call_filter.expected
@@ -1,0 +1,9 @@
+done
+look
+2
+true
+true
+true
+done
+true
+true

--- a/conformance/tests/agents/agent_loop_blank_name_tool_call_filter.harn
+++ b/conformance/tests/agents/agent_loop_blank_name_tool_call_filter.harn
@@ -1,0 +1,95 @@
+// A provider can emit a malformed tool call with an EMPTY/whitespace name
+// alongside valid sibling calls in the same turn (observed live on go/rust
+// eval runs: a turn carrying `[look, "", look]`). Dispatching the nameless
+// call resolves no tool and used to terminate the agent loop SILENTLY — a pure
+// harness failure that read as a model give-up (result=INCOMPLETE,
+// outcome_kind=null). The loop must instead drop ONLY the empty-name call,
+// keep the valid siblings (they dispatch), inject parse-guidance so the model
+// re-emits a named call, and KEEP RUNNING.
+import { llm_text, with_llm_script } from "std/testing"
+
+fn look_tools() {
+  var registry = tool_registry()
+  registry = tool_define(
+    registry,
+    "look",
+    "Read a file window.",
+    {
+      handler: { _args -> "looked" },
+      parameters: {file: {type: "string", description: "File to read"}},
+      returns: {type: "string"},
+      annotations: {kind: "read"},
+    },
+  )
+  return registry
+}
+
+pipeline main() {
+  // Sibling-survival: [look, "", look] -> both look calls dispatch, the
+  // empty-name call is dropped with parse_guidance, and the loop continues to
+  // the terminal done turn rather than stopping on the malformed sibling.
+  with_llm_script(
+    [
+      {
+        text: "",
+        tool_calls: [
+          {id: "look_a", name: "look", arguments: {file: "a.go"}},
+          {id: "blank", name: "", arguments: {}},
+          {id: "look_b", name: "look", arguments: {file: "b.go"}},
+        ],
+      },
+      llm_text("##DONE##"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Read the files, then finish.",
+        nil,
+        {
+          provider: "mock",
+          tools: look_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          done_judge: nil,
+          max_iterations: 5,
+          max_nudges: 3,
+        },
+      )
+      __io_println(result.status)
+      __io_println(result.tools.successful[0])
+      __io_println(len(result.tools.successful))
+      let calls = llm_mock_calls()
+      let retry_messages = json_stringify(calls[1].messages)
+      __io_println(contains(retry_messages, "parse_guidance"))
+      __io_println(contains(retry_messages, "empty/blank name"))
+      __io_println(result.llm.iterations >= 2)
+    },
+  )
+  // All-blank: a turn whose ONLY tool call has an empty name. Nothing
+  // dispatches, but the loop still injects parse-guidance and keeps running
+  // (does not silently terminate as INCOMPLETE).
+  with_llm_script(
+    [{text: "", tool_calls: [{id: "blank_only", name: "  ", arguments: {}}]}, llm_text("##DONE##")],
+    { ->
+      let result = agent_loop(
+        "Do the task, then finish.",
+        nil,
+        {
+          provider: "mock",
+          tools: look_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          done_sentinel: "##DONE##",
+          done_judge: nil,
+          max_iterations: 5,
+          max_nudges: 3,
+        },
+      )
+      __io_println(result.status)
+      let calls = llm_mock_calls()
+      let retry_messages = json_stringify(calls[1].messages)
+      __io_println(contains(retry_messages, "parse_guidance"))
+      __io_println(result.llm.iterations >= 2)
+    },
+  )
+}

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -783,12 +783,44 @@ fn __visible_text(parsed, raw_text) {
   return raw_text
 }
 
+/**
+ * A tool call with an empty / whitespace-only name is provider JSON
+ * malformation, not a dispatchable call. Some providers emit a stray
+ * `{name: "", arguments: {}}` block alongside valid sibling calls (observed
+ * live on go/rust eval runs: a turn carrying `[look, "", look]`). Dispatching
+ * the nameless call resolves no tool and used to terminate the agent loop
+ * silently — a pure harness failure that read as a model give-up
+ * (result=INCOMPLETE, outcome_kind=null). Detect it here so callers can drop
+ * the malformed call, keep the valid siblings, and inject parse-guidance.
+ */
+fn __tool_call_name_is_blank(call) -> bool {
+  return __tool_call_name(call).trim() == ""
+}
+
+/**
+ * Partition tool calls into the dispatchable ones (named) and a count of the
+ * malformed empty-name calls that were dropped. Source order of the kept calls
+ * is preserved so order-sensitive parsers/parallel dispatch stay correct.
+ */
+fn __filter_blank_name_tool_calls(calls) {
+  var kept = []
+  var dropped = 0
+  for call in calls ?? [] {
+    if __tool_call_name_is_blank(call) {
+      dropped = dropped + 1
+    } else {
+      kept = kept.push(call)
+    }
+  }
+  return {calls: kept, dropped: dropped}
+}
+
 fn __resolve_tool_calls(llm_result, parsed) {
   let native_calls = llm_result?.native_tool_calls ?? llm_result?.tool_calls ?? []
   if len(native_calls) > 0 {
-    return native_calls
+    return __filter_blank_name_tool_calls(native_calls).calls
   }
-  return parsed?.calls ?? []
+  return __filter_blank_name_tool_calls(parsed?.calls ?? []).calls
 }
 
 fn __agent_await_resumption_call(tool_calls) {
@@ -1018,6 +1050,60 @@ fn __maybe_inject_parse_error_feedback(session_id, parsed, tool_calls, turn_opts
   // stall path; a partial-success turn made real progress and stays subject to
   // normal stall accounting.
   return !has_partial_success
+}
+
+/**
+ * Count empty-name tool calls in the raw turn (native, else text-parsed) that
+ * `__resolve_tool_calls` will drop. Used by the dispatch site to inject
+ * parse-guidance so the model re-emits a valid call next turn instead of the
+ * loop terminating on the malformed sibling.
+ */
+fn __blank_name_dropped_count(llm_result, parsed) -> int {
+  let native_calls = llm_result?.native_tool_calls ?? llm_result?.tool_calls ?? []
+  let source = if len(native_calls) > 0 {
+    native_calls
+  } else {
+    parsed?.calls ?? []
+  }
+  return __filter_blank_name_tool_calls(source).dropped
+}
+
+/**
+ * Drop-only guidance for provider-malformed empty-name tool calls. The
+ * filtered valid siblings have already dispatched; this tells the model the
+ * nameless call was discarded and to re-emit a named call. Returns true when a
+ * note was injected (so the caller flags turn-level tool-call feedback and the
+ * stall accounting stays consistent with the parse-error path).
+ */
+fn __maybe_inject_blank_name_feedback(session_id, llm_result, parsed, dispatched_count, turn_opts) -> bool {
+  let dropped = __blank_name_dropped_count(llm_result, parsed)
+  if dropped == 0 {
+    return false
+  }
+  let has_partial_success = dispatched_count > 0
+  let feedback = parse_guidance_prompt(
+    {
+      error_summary: "Dropped "
+        + to_string(dropped)
+        + " tool call(s) with an empty/blank name — every tool call must name a tool.",
+      has_partial_success: has_partial_success,
+      parsed_call_count: dispatched_count,
+      body_hint: agent_tool_call_paradigm(turn_opts).body_hint,
+      is_json_format: agent_tool_format(turn_opts) == "json",
+    },
+    turn_opts,
+  )
+  agent_session_inject_feedback(session_id, "parse_guidance", feedback)
+  agent_emit_event(
+    session_id,
+    "tool_call_blank_name_dropped",
+    {
+      dropped_count: dropped,
+      dispatched_count: dispatched_count,
+      has_partial_success: has_partial_success,
+    },
+  )
+  return true
 }
 
 fn __detect_native_fallback(
@@ -2439,7 +2525,19 @@ fn __agent_loop_run(message, session, initial_opts) {
         normalized
       }
       agent_session_record_assistant(session.session_id, recorded_assistant)
-      let had_parse_errors = __maybe_inject_parse_error_feedback(session.session_id, parsed, tool_calls, turn_opts)
+      let had_parse_errors_base = __maybe_inject_parse_error_feedback(session.session_id, parsed, tool_calls, turn_opts)
+      let had_blank_name_drop = if fallback_outcome.triggered {
+        false
+      } else {
+        __maybe_inject_blank_name_feedback(
+          session.session_id,
+          llm_result,
+          parsed,
+          len(tool_calls),
+          turn_opts,
+        )
+      }
+      let had_parse_errors = had_parse_errors_base || had_blank_name_drop
       let await_call = __agent_await_resumption_call(tool_calls)
       if await_call != nil {
         let await_result = try {
@@ -3146,6 +3244,10 @@ fn __agent_loop_run(message, session, initial_opts) {
   return unwrap(run)
 }
 
+// Provider-malformed empty-name calls were filtered out of `tool_calls`
+// by `__resolve_tool_calls`; inject parse-guidance for the drop so the
+// model re-emits a named call instead of the loop terminating silently
+// on the nameless sibling.
 // #3220: this turn attempted a tool call that did not dispatch — the
 // native-fallback contract rejected text-emitted calls (corrective
 // feedback queued), or the parser dropped every call and parse

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -2318,6 +2318,18 @@ fn build_agent_event(
             kind: "tool_parse_error_feedback".to_string(),
             content: get_string("error_summary"),
         }),
+        // `tool_call_blank_name_dropped` fires when a provider emits one or more
+        // tool calls with an empty/whitespace name (JSON malformation). The
+        // engine drops ONLY the nameless calls, keeps valid siblings, and
+        // injects parse-guidance so the loop self-corrects instead of
+        // terminating silently on the malformed call. Surfaced on the
+        // FeedbackInjected stream like the sibling corrections above; `content`
+        // carries the dropped-call count.
+        "tool_call_blank_name_dropped" => Ok(AgentEvent::FeedbackInjected {
+            session_id: session_id.to_string(),
+            kind: "tool_call_blank_name_dropped".to_string(),
+            content: get_usize("dropped_count").to_string(),
+        }),
         // `llm_auto_continue` fires when a length-truncated turn with an
         // incomplete tool call is re-issued with a raised output cap instead of
         // burning the turn on parse-guidance. Engine-emitted (not user


### PR DESCRIPTION
## The bug (KEYSTONE harness defect, verified across 8+ eval runs)

When a provider returns a native tool call with an **empty / whitespace-only name** (JSON malformation) alongside valid sibling calls in the same turn, the agent loop passed the nameless call through `__resolve_tool_calls` (`std/agent/loop.harn`) **unguarded**. The empty-name call resolved no tool and the loop **terminated silently**: `summary.json result=INCOMPLETE, outcome_kind=null`. This read as a model give-up but was a pure harness dispatch failure that corrupted eval-meter accounting.

Reproduced live (Burin eval transcripts), e.g. `eval-go-engine-20260608-235300-t5` — final assistant turn carried three native tool_calls `[look, {name:""}, look]` and the loop ended right there. Also seen in `rust-test-235327-t2` (6 empty-name calls), `rust-parser-194108/195244`, `go-engine-234515-t4`, `rust-test-235333-t3`.

## Layer

Burin's runtime loop (`lib/runtime/loop.harn`) explicitly delegates tool-call dispatch to harn-vm's `agent_loop` ("there is no burin-pipeline-side dispatch"). `__resolve_tool_calls` lives in **Harn core** (`crates/harn-stdlib/src/stdlib/agent/loop.harn`), so the fix belongs here per the Harn-owns-tool-call-parsing boundary. **A Harn release (v0.8.104) + a Burin repin will be needed for Burin to consume it.**

## The fix

- Filter empty / whitespace-name calls out of `__resolve_tool_calls` **before** dispatch, on both the native and text-parsed paths, preserving source order of the kept calls.
- At the dispatch site, inject the existing `parse_guidance` feedback for the drop (`has_partial_success` when valid siblings dispatched) and emit a new `tool_call_blank_name_dropped` `FeedbackInjected` event. The loop continues; the model self-corrects next turn.
- Registered the new event type in `agent_session_host.rs`, mirroring `tool_parse_error_feedback`.

## #2121

Distinct seam — burin-code#2121 is valid-**name** + empty-**ARGS** native edit calls, already handled in the dispatch host via `empty_args_cause_named_feedback`. This PR covers empty-**name** calls (which never reach a dispatchable executor). No additional #2121 work needed.

## Tests

- New conformance test `agent_loop_blank_name_tool_call_filter`: a `[look, "", look]` turn dispatches both valid calls, drops the empty-name one with parse-guidance, and keeps running; an all-blank turn still injects guidance and continues.
- Full `agents/` conformance suite: **211 passed, 0 failed**.
- `cargo test -p harn-vm --lib agent_session_host`: 25 passed; `empty_args` (#2121): 5 passed.
- `harn fmt --check` clean on changed `.harn` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)