### PR TITLE
fix: cross-cutting bug sweep — 10 root-cause fixes (compiler, typechecker, stdlib, fmt, lint, spec, MCP fixtures, release tooling)

### DIFF
--- a/changelog.d/bug-sweep-2026-06-11.fixed.md
+++ b/changelog.d/bug-sweep-2026-06-11.fixed.md
@@ -1,0 +1,37 @@
+- **Cross-cutting bug sweep (10+ root-cause fixes).**
+  - *Compiler:* a function or program body whose bytecode exceeded 64 KiB
+    silently truncated its `u16` jump operands and jumped somewhere wild at
+    runtime; every finalized chunk is now guarded and oversized bodies fail
+    compilation with a clear "split it into smaller functions" error.
+  - *Typechecker:* optional subscript access on a shape (`x?["k"]`) dropped
+    the optional flag, so an unknown key inferred gradual instead of `nil`
+    and mismatched assignments passed silently.
+  - *Stdlib:* the regex builtins (`regex_match`, `regex_replace`,
+    `regex_captures`, `regex_split`) stringified an explicit `nil`
+    pattern/text/replacement to the literal string `"nil"` and compiled —
+    and matched — it as a real regex; `nil` now takes the same fallback as a
+    missing argument (mirroring the existing flags guard).
+  - *Formatter:* `harn fmt` relocated comments to the end of the file from
+    three positions — trailing comments on inline match arms
+    (`1 -> { x } // c`), trailing comments on dict/struct-literal entries,
+    and full-line comments inside multiline dict/list literals. All three now
+    stay anchored, and a literal with interior comments keeps its multiline
+    shape.
+  - *Linter:* `comparison-to-bool` flagged optional-chained presence tests
+    (`d?.enabled == false`) as "redundant" and its autofix rewrote them to
+    `!d?.enabled`, which flips the branch when the chain is nil; the rule now
+    skips operands that can be nil via optional chaining. Also,
+    `prefer-optional-shorthand` diagnostics reported byte-based columns,
+    overshooting on lines with multibyte characters; columns are now
+    character-based.
+  - *Spec:* `spec/HARN_SPEC.md` claimed `if`/`else` and `match` execute
+    without creating a child scope, contradicting both the docs and actual
+    behavior (branch/arm bodies are block-scoped); the scope-creation section
+    now matches the implementation.
+  - *MCP test fixtures:* `FakeServerBehavior::HeaderMismatch` was declared
+    but never implemented; the fake RC server now validates `Mcp-Method` /
+    `Mcp-Name` headers via the production negotiation helper and answers
+    `-32600` with the spec error shape.
+  - *Docs/release:* `docs/src/embedding-rust.md` pinned `tag = "v0.8.57"`
+    (~46 releases stale); the pins are refreshed and
+    `release_gate.sh prepare` now bumps them automatically each release.

--- a/crates/harn-fmt/src/formatter/decls.rs
+++ b/crates/harn-fmt/src/formatter/decls.rs
@@ -596,6 +596,9 @@ impl Formatter<'_> {
         if arm.body.len() == 1 && crate::helpers::is_simple_expr(&arm.body[0]) {
             let expr = self.format_expr(&arm.body[0], self.indent);
             self.writeln(&format!("{pattern}{guard} -> {{ {expr} }}"));
+            // Keep a same-line comment on the arm (`1 -> { x } // c`)
+            // attached; unclaimed it would be flushed to the end of file.
+            self.attach_trailing_comment(arm.body[0].span.end_line);
         } else {
             self.writeln(&format!("{pattern}{guard} -> {{"));
             self.indent();

--- a/crates/harn-fmt/src/formatter/expressions.rs
+++ b/crates/harn-fmt/src/formatter/expressions.rs
@@ -244,14 +244,34 @@ impl Formatter<'_> {
             Node::ListLiteral(elems) => {
                 // Children land at `indent + 1` if the list wraps; render them
                 // there so their own internal wrapping is at the right depth.
-                let rendered = elems
+                let mut from_line = node.span.line + 1;
+                let items = elems
                     .iter()
-                    .map(|e| self.format_expr(e, indent + 1))
+                    .map(|e| {
+                        let body = self.format_expr(e, indent + 1);
+                        let item = self.commented_item(
+                            body,
+                            from_line,
+                            e.span.line,
+                            e.span.end_line,
+                            node.span.end_line,
+                        );
+                        from_line = e.span.end_line + 1;
+                        item
+                    })
                     .collect::<Vec<_>>();
-                let items = self.format_comma_sequence(rendered, 1, indent);
+                let items = self.format_comma_sequence_commented(items, 1, indent);
                 format!("[{items}]")
             }
-            Node::DictLiteral(entries) => self.format_dict_entries(entries, indent),
+            Node::DictLiteral(entries) => {
+                let items = self.format_dict_entry_list(
+                    entries,
+                    1,
+                    indent,
+                    (node.span.line, node.span.end_line),
+                );
+                format!("{{{items}}}")
+            }
             Node::RangeExpr {
                 start,
                 end,
@@ -293,7 +313,12 @@ impl Formatter<'_> {
                 struct_name,
                 fields,
             } => {
-                let items = self.format_dict_entry_list(fields, struct_name.len() + 2, indent);
+                let items = self.format_dict_entry_list(
+                    fields,
+                    struct_name.len() + 2,
+                    indent,
+                    (node.span.line, node.span.end_line),
+                );
                 format!("{struct_name} {{{items}}}")
             }
             Node::DeferStmt { body } => self.format_block_expr("defer {", body, indent),
@@ -337,7 +362,16 @@ impl Formatter<'_> {
                     if arm.body.len() == 1 && is_simple_expr(&arm.body[0]) {
                         let expr = self.format_expr(&arm.body[0], arm_indent);
                         result.push_str(&indent_str);
-                        result.push_str(&format!("{pattern}{guard_str} -> {{ {expr} }}\n"));
+                        result.push_str(&format!("{pattern}{guard_str} -> {{ {expr} }}"));
+                        // Keep a same-line comment on the arm (`1 -> { x } // c`)
+                        // attached; unclaimed it would be flushed to EOF.
+                        if let Some(trail) =
+                            self.take_trailing_comment_for_line(arm.body[0].span.end_line)
+                        {
+                            result.push_str("  ");
+                            result.push_str(&trail);
+                        }
+                        result.push('\n');
                     } else {
                         result.push_str(&indent_str);
                         result.push_str(&format!("{pattern}{guard_str} -> {{\n"));
@@ -737,30 +771,37 @@ impl Formatter<'_> {
         }
     }
 
-    fn format_dict_entries(&self, entries: &[harn_parser::DictEntry], indent: usize) -> String {
-        let items = self.format_dict_entry_list(entries, 1, indent);
-        format!("{{{items}}}")
-    }
-
     pub(super) fn format_dict_entry_list(
         &self,
         entries: &[harn_parser::DictEntry],
         prefix_len: usize,
         indent: usize,
+        (open_line, close_line): (usize, usize),
     ) -> String {
         // Each entry value (and computed key) may itself wrap; if it does, it
         // lands at `indent + 1`, so render children at that depth.
-        let rendered = entries
+        let mut from_line = open_line + 1;
+        let items = entries
             .iter()
             .map(|e| {
-                if let Node::Spread(inner) = &e.value.node {
-                    return format!("...{}", self.format_expr(inner, indent + 1));
-                }
-                let k = self.format_dict_key(&e.key, indent + 1);
-                let v = self.format_expr(&e.value, indent + 1);
-                format!("{k}: {v}")
+                let body = if let Node::Spread(inner) = &e.value.node {
+                    format!("...{}", self.format_expr(inner, indent + 1))
+                } else {
+                    let k = self.format_dict_key(&e.key, indent + 1);
+                    let v = self.format_expr(&e.value, indent + 1);
+                    format!("{k}: {v}")
+                };
+                let item = self.commented_item(
+                    body,
+                    from_line,
+                    e.key.span.line.min(e.value.span.line),
+                    e.value.span.end_line,
+                    close_line,
+                );
+                from_line = e.value.span.end_line + 1;
+                item
             })
             .collect::<Vec<_>>();
-        self.format_comma_sequence(rendered, prefix_len, indent)
+        self.format_comma_sequence_commented(items, prefix_len, indent)
     }
 }

--- a/crates/harn-fmt/src/formatter/mod.rs
+++ b/crates/harn-fmt/src/formatter/mod.rs
@@ -18,6 +18,14 @@ pub(crate) struct Comment {
     pub(crate) is_doc: bool,
 }
 
+/// One item of a comma sequence (list element, dict/struct entry) together
+/// with the comments anchored to it in the source.
+pub(super) struct CommentedItem {
+    pub(super) leading: Vec<String>,
+    pub(super) body: String,
+    pub(super) trailing: Option<String>,
+}
+
 pub(crate) struct Formatter<'a> {
     pub(crate) source: &'a str,
     pub(crate) output: String,
@@ -134,6 +142,77 @@ impl<'a> Formatter<'a> {
         }
         out.push_str(&close_indent);
         out
+    }
+
+    /// Render a comma sequence whose items may carry source comments:
+    /// full-line comments that sat above the item inside the literal and a
+    /// trailing same-line comment. Any present comment forces the sequence
+    /// multiline so the comments are emitted in place — previously they
+    /// were left unclaimed and flushed to the end of the file.
+    pub(super) fn format_comma_sequence_commented(
+        &self,
+        items: Vec<CommentedItem>,
+        prefix_len: usize,
+        indent: usize,
+    ) -> String {
+        let has_comments = items
+            .iter()
+            .any(|item| !item.leading.is_empty() || item.trailing.is_some());
+        if !has_comments {
+            let rendered = items.into_iter().map(|item| item.body).collect();
+            return self.format_comma_sequence(rendered, prefix_len, indent);
+        }
+        let item_indent = "  ".repeat(indent + 1);
+        let close_indent = "  ".repeat(indent);
+        let mut out = String::new();
+        out.push('\n');
+        for item in items {
+            for comment in &item.leading {
+                out.push_str(&item_indent);
+                out.push_str(comment);
+                out.push('\n');
+            }
+            out.push_str(&item_indent);
+            out.push_str(&item.body);
+            out.push(',');
+            if let Some(trail) = item.trailing {
+                out.push_str("  ");
+                out.push_str(&trail);
+            }
+            out.push('\n');
+        }
+        out.push_str(&close_indent);
+        out
+    }
+
+    /// Claim the comments that belong to one sequence item: full-line
+    /// comments on the lines `[from_line, item_line)` (inside the literal,
+    /// above the item) and the trailing comment on `item_end_line`. The
+    /// trailing comment is left alone when the item ends on the literal's
+    /// closing line — that comment belongs to the enclosing statement and
+    /// is attached by `attach_trailing_comment`/`format_body_string`.
+    pub(super) fn commented_item(
+        &self,
+        body: String,
+        from_line: usize,
+        item_line: usize,
+        item_end_line: usize,
+        literal_end_line: usize,
+    ) -> CommentedItem {
+        let mut leading = Vec::new();
+        for line in from_line..item_line {
+            if let Some(comment) = self.take_trailing_comment_for_line(line) {
+                leading.push(comment);
+            }
+        }
+        let trailing = (item_end_line < literal_end_line)
+            .then(|| self.take_trailing_comment_for_line(item_end_line))
+            .flatten();
+        CommentedItem {
+            leading,
+            body,
+            trailing,
+        }
     }
 
     pub(super) fn format_typed_params_wrapped(

--- a/crates/harn-fmt/src/tests.rs
+++ b/crates/harn-fmt/src/tests.rs
@@ -1325,6 +1325,58 @@ fn test_doc_comment_existing_block_is_canonicalized() {
 }
 
 #[test]
+fn test_inline_match_arm_trailing_comment_stays_on_arm() {
+    let source =
+        "fn pick(x: int) -> int {\n  match x {\n    1 -> { 10 } // ten\n    _ -> { 0 }\n  }\n}\n";
+    let result = format_source(source).unwrap();
+    assert!(
+        result.contains("1 -> { 10 }  // ten"),
+        "arm comment must stay on the arm line (was flushed to EOF), got:\n{result}"
+    );
+    assert_roundtrip(source);
+}
+
+#[test]
+fn test_dict_entry_comments_stay_in_literal() {
+    let source =
+        "fn f() -> dict {\n  let d = {\n    // section\n    x: 1,\n    y: 2, // why\n  }\n  d\n}\n";
+    let result = format_source(source).unwrap();
+    assert!(
+        result.contains("    // section\n    x: 1,"),
+        "full-line comment must stay above its entry, got:\n{result}"
+    );
+    assert!(
+        result.contains("y: 2,  // why"),
+        "trailing entry comment must stay on the entry, got:\n{result}"
+    );
+    assert_roundtrip(source);
+}
+
+#[test]
+fn test_list_item_trailing_comment_stays_in_literal() {
+    let source = "fn f() -> list {\n  let l = [\n    1, // one\n    2,\n  ]\n  l\n}\n";
+    let result = format_source(source).unwrap();
+    assert!(
+        result.contains("1,  // one"),
+        "list item comment must stay on the item, got:\n{result}"
+    );
+    assert_roundtrip(source);
+}
+
+#[test]
+fn test_statement_comment_after_inline_dict_stays_on_statement() {
+    // The dict ends on the statement line, so the comment belongs to the
+    // statement and the literal must not absorb it (or force-wrap).
+    let source = "fn f() -> dict {\n  let d = {x: 1} // note\n  d\n}\n";
+    let result = format_source(source).unwrap();
+    assert!(
+        result.contains("let d = {x: 1}  // note"),
+        "statement-level comment must stay on the statement, got:\n{result}"
+    );
+    assert_roundtrip(source);
+}
+
+#[test]
 fn test_plain_double_slash_comment_preserved_verbatim() {
     let source = "// plain comment\npub fn exposed() -> string {\n  return \"x\"\n}\n";
     let result = format_source(source).unwrap();

--- a/crates/harn-lint/src/fixes.rs
+++ b/crates/harn-lint/src/fixes.rs
@@ -252,6 +252,26 @@ pub(crate) fn is_pure_expression(node: &Node) -> bool {
     }
 }
 
+/// True when the expression has an optional-chaining link (`?.`, `?.()`,
+/// `?[]`) anywhere along its receiver chain, i.e. it can evaluate to `nil`
+/// because some receiver was nil. For such expressions `expr == false` /
+/// `expr != true` are presence-sensitive tests, not redundant boolean
+/// noise: `nil == false` is `false`, while the "simplified" `!expr` is
+/// `true` for nil. Only the receiver chain propagates nil, so call/index
+/// arguments are not inspected.
+pub(crate) fn contains_optional_chaining(node: &Node) -> bool {
+    match node {
+        Node::OptionalPropertyAccess { .. }
+        | Node::OptionalMethodCall { .. }
+        | Node::OptionalSubscriptAccess { .. } => true,
+        Node::PropertyAccess { object, .. }
+        | Node::MethodCall { object, .. }
+        | Node::SubscriptAccess { object, .. }
+        | Node::SliceAccess { object, .. } => contains_optional_chaining(&object.node),
+        _ => false,
+    }
+}
+
 /// Conservative NaN analysis for the self-comparison autofix. Returns true
 /// only when the expression provably cannot evaluate to a NaN float, nor to a
 /// list/dict transitively containing one.

--- a/crates/harn-lint/src/linter/walk.rs
+++ b/crates/harn-lint/src/linter/walk.rs
@@ -9,8 +9,8 @@ use super::Linter;
 use crate::decls::{FnDeclaration, ImportInfo, TypeDeclaration};
 use crate::diagnostic::{LintDiagnostic, LintSeverity};
 use crate::fixes::{
-    empty_statement_removal_fix, is_nan_free, is_pure_expression, nil_fallback_ternary_parts,
-    unnecessary_cast_fix,
+    contains_optional_chaining, empty_statement_removal_fix, is_nan_free, is_pure_expression,
+    nil_fallback_ternary_parts, unnecessary_cast_fix,
 };
 use crate::harndoc::extract_harndoc;
 use crate::naming::simplify_bool_comparison;
@@ -551,7 +551,17 @@ impl<'a> Linter<'a> {
                 if (op == "==" || op == "!=") && !is_self_comparison {
                     let is_bool_left = matches!(left.node, Node::BoolLiteral(_));
                     let is_bool_right = matches!(right.node, Node::BoolLiteral(_));
-                    if is_bool_left || is_bool_right {
+                    // `x?.y == false` is a presence test, not redundancy:
+                    // a nil receiver makes the comparison `false` while the
+                    // "simplified" `!x?.y` would be `true`. Skip the lint
+                    // (and its behavior-changing autofix) for operands that
+                    // can be nil via optional chaining.
+                    let other_can_be_nil = if is_bool_left {
+                        contains_optional_chaining(&right.node)
+                    } else {
+                        contains_optional_chaining(&left.node)
+                    };
+                    if (is_bool_left || is_bool_right) && !other_can_be_nil {
                         let (suggestion, msg) = if op == "==" {
                             if matches!(right.node, Node::BoolLiteral(true))
                                 || matches!(left.node, Node::BoolLiteral(true))

--- a/crates/harn-lint/src/rules/optional_shorthand.rs
+++ b/crates/harn-lint/src/rules/optional_shorthand.rs
@@ -611,8 +611,33 @@ fn line_for(source: &str, offset: usize) -> usize {
 }
 
 fn column_for(source: &str, offset: usize) -> usize {
+    // 1-based *character* column: byte arithmetic would overshoot on any
+    // line containing multibyte characters before the offset.
     let upto = &source[..offset.min(source.len())];
-    upto.rfind('\n')
-        .map(|idx| offset - idx)
-        .unwrap_or(offset + 1)
+    let line_start = upto.rfind('\n').map(|idx| idx + 1).unwrap_or(0);
+    upto[line_start..].chars().count() + 1
+}
+
+#[cfg(test)]
+mod position_tests {
+    use super::column_for;
+
+    #[test]
+    fn column_counts_chars_not_bytes() {
+        // 'é' is 2 bytes / 1 char: 'b' sits at byte 4 but char column 4.
+        let first = "aé b";
+        let off = first.find('b').unwrap();
+        assert_eq!(column_for(first, off), 4);
+
+        // Same shape on a later line: line-relative, still char-based.
+        let multi = "x\naé b";
+        let off = multi.rfind('b').unwrap();
+        assert_eq!(column_for(multi, off), 4);
+    }
+
+    #[test]
+    fn column_is_one_based_at_line_start() {
+        assert_eq!(column_for("abc", 0), 1);
+        assert_eq!(column_for("a\nbc", 2), 1);
+    }
 }

--- a/crates/harn-lint/src/tests/boolean_patterns.rs
+++ b/crates/harn-lint/src/tests/boolean_patterns.rs
@@ -53,6 +53,28 @@ if x == 1 { log("one") }
 }
 
 #[test]
+fn test_no_comparison_to_bool_for_optional_chaining() {
+    // `d?.enabled == false` is a presence test: it is `false` when the
+    // chain is nil, while the rewrite `!d?.enabled` would be `true`.
+    // The rule (and its autofix) must not fire on optional-chained
+    // operands, including chains continuing past the `?.` link.
+    for expr in [
+        "d?.enabled == false",
+        "false == d?.enabled",
+        "d?.flags.strict != true",
+        "d?[\"enabled\"] == false",
+    ] {
+        let diags = lint_source(&format!(
+            "pipeline default(task) {{\n  let d = {{}}\n  if {expr} {{ log(\"x\") }}\n}}"
+        ));
+        assert!(
+            !has_rule(&diags, "comparison-to-bool"),
+            "should not trigger for `{expr}`: {diags:?}"
+        );
+    }
+}
+
+#[test]
 fn test_constant_logical_operand_autofix() {
     let source = "pipeline default(task) {\n  let x = true\n  let a = x || true\n  let b = x && false\n  log(a)\n  log(b)\n}";
     let diags = lint_source(source);

--- a/crates/harn-mcp-rc-compat/src/fake_server.rs
+++ b/crates/harn-mcp-rc-compat/src/fake_server.rs
@@ -176,6 +176,26 @@ async fn post_mcp(
         .and_then(JsonValue::as_str)
         .unwrap_or_default()
         .to_string();
+    if behavior == FakeServerBehavior::HeaderMismatch {
+        // Strict-server slice: validate the RC `Mcp-Method` / `Mcp-Name`
+        // headers against the body exactly like a real RC server and
+        // answer `-32600` on disagreement. Reuses the production
+        // negotiation helper so the fake can't drift from the spec.
+        let header_lookup = |name: &str| headers.get(name).and_then(|value| value.to_str().ok());
+        let body_name = body
+            .pointer("/params/name")
+            .and_then(JsonValue::as_str)
+            .filter(|name| !name.is_empty());
+        if let Err(error_body) = mcp_protocol::negotiate_rc_http_request(
+            header_lookup,
+            body.get("method").and_then(JsonValue::as_str),
+            body_name,
+            &id,
+        ) {
+            drop(guard);
+            return json_response_with_protocol(error_body, DRAFT_PROTOCOL_VERSION);
+        }
+    }
     let response = handle_request(&mut guard, behavior, &id, &method, &body);
     drop(guard);
     match response {

--- a/crates/harn-mcp-rc-compat/tests/client.rs
+++ b/crates/harn-mcp-rc-compat/tests/client.rs
@@ -58,6 +58,46 @@ async fn modern_success_fake_server_emits_envelope_and_cache_hint() {
 }
 
 #[tokio::test]
+async fn header_mismatch_fake_server_validates_mcp_method_header() {
+    let server = spawn_fake_http_server(FakeServerBehavior::HeaderMismatch).await;
+    let url = format!("{}/mcp", server.base_url);
+
+    // Agreeing header and body sail through to the normal handler.
+    let list = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {"_meta": rc_meta("client.rs")},
+    });
+    let ok = post_rc(&url, &list, &rc_headers("tools/list", &list["params"])).await;
+    assert!(
+        ok.body.get("result").is_some(),
+        "matching headers must succeed; got {}",
+        ok.body
+    );
+
+    // A spoofed `Mcp-Method` header is rejected with the RC `-32600`
+    // shape, mirroring the strict generic server.
+    let call = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {
+            "name": "echo",
+            "arguments": {"message": "spoofed"},
+            "_meta": rc_meta("client.rs"),
+        },
+    });
+    let bad = post_rc(&url, &call, &rc_headers("tools/list", &call["params"])).await;
+    assert_eq!(bad.body["error"]["code"], json!(-32600));
+    assert_eq!(
+        bad.body["error"]["data"]["headerValue"],
+        json!("tools/list")
+    );
+    assert_eq!(bad.body["error"]["data"]["bodyMethod"], json!("tools/call"));
+}
+
+#[tokio::test]
 async fn unsupported_version_fake_server_returns_minus_32004_then_succeeds() {
     let server = spawn_fake_http_server(FakeServerBehavior::UnsupportedVersionRetry).await;
     let url = format!("{}/mcp", server.base_url);

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -1289,7 +1289,7 @@ impl TypeChecker {
             TypeExpr::DictType(_, value) => Some(*value.clone()),
             TypeExpr::Shape(fields) => {
                 if let Node::StringLiteral(key) = &index.node {
-                    Self::shape_property_type(fields, key, false)
+                    Self::shape_property_type(fields, key, optional)
                 } else {
                     None
                 }

--- a/crates/harn-parser/src/typechecker/tests/nil_safety.rs
+++ b/crates/harn-parser/src/typechecker/tests/nil_safety.rs
@@ -59,6 +59,16 @@ fn optional_subscript_on_nil_is_allowed() {
 }
 
 #[test]
+fn optional_subscript_unknown_shape_key_infers_nil() {
+    // `x?["b"]` on a shape without a `b` field is statically nil, so
+    // assigning it to `int` must be a mismatch — same standard as
+    // `x?.b` property access. (The Shape subscript arm used to drop the
+    // optional flag and infer gradual, silently accepting this.)
+    let errs = errors("pipeline t(task) { let x: {a: int} = {a: 1}\nlet y: int = x?[\"b\"] }");
+    assert!(has(&errs, "expected int"), "got: {errs:?}");
+}
+
+#[test]
 fn subscript_on_concrete_list_is_silent() {
     let errs = errors("pipeline t(task) { let xs: list = []\nlog(xs[0]) }");
     let warns = warnings("pipeline t(task) { let xs: list = []\nlog(xs[0]) }");

--- a/crates/harn-vm/src/compiler/closures.rs
+++ b/crates/harn-vm/src/compiler/closures.rs
@@ -39,6 +39,7 @@ impl Compiler {
         let param_slots = crate::chunk::ParamSlot::vec_from_typed(params);
         let has_runtime_type_checks =
             CompiledFunction::has_runtime_type_checks_for_params(&param_slots);
+        super::ensure_chunk_addressable(&fn_compiler.chunk, &format!("fn `{name}`"), self.line)?;
         let func = CompiledFunction {
             name: name.to_string(),
             type_params: type_params.iter().map(|param| param.name.clone()).collect(),
@@ -85,6 +86,7 @@ impl Compiler {
         let param_slots = crate::chunk::ParamSlot::vec_from_typed(params);
         let has_runtime_type_checks =
             CompiledFunction::has_runtime_type_checks_for_params(&param_slots);
+        super::ensure_chunk_addressable(&fn_compiler.chunk, &format!("fn `{name}`"), self.line)?;
         let func = CompiledFunction {
             name: name.to_string(),
             type_params: Vec::new(),
@@ -345,6 +347,7 @@ impl Compiler {
         let param_slots = crate::chunk::ParamSlot::vec_from_typed(params);
         let has_runtime_type_checks =
             CompiledFunction::has_runtime_type_checks_for_params(&param_slots);
+        super::ensure_chunk_addressable(&fn_compiler.chunk, "closure", self.line)?;
         let func = CompiledFunction {
             name: "<closure>".to_string(),
             type_params: Vec::new(),

--- a/crates/harn-vm/src/compiler/concurrency.rs
+++ b/crates/harn-vm/src/compiler/concurrency.rs
@@ -67,6 +67,7 @@ impl Compiler {
         let param_slots = crate::chunk::ParamSlot::vec_from_typed(&typed_params);
         let has_runtime_type_checks =
             CompiledFunction::has_runtime_type_checks_for_params(&param_slots);
+        super::ensure_chunk_addressable(&fn_compiler.chunk, &format!("`{fn_name}`"), self.line)?;
         let func = CompiledFunction {
             name: fn_name.to_string(),
             type_params: Vec::new(),
@@ -100,6 +101,7 @@ impl Compiler {
         fn_compiler.struct_layouts = self.struct_layouts.clone();
         fn_compiler.compile_block(body)?;
         fn_compiler.chunk.emit(Op::Return, self.line);
+        super::ensure_chunk_addressable(&fn_compiler.chunk, "spawn body", self.line)?;
         let func = CompiledFunction {
             name: "<spawn>".to_string(),
             type_params: Vec::new(),

--- a/crates/harn-vm/src/compiler/decls.rs
+++ b/crates/harn-vm/src/compiler/decls.rs
@@ -103,6 +103,11 @@ impl Compiler {
                 let param_slots = crate::chunk::ParamSlot::vec_from_typed(params);
                 let has_runtime_type_checks =
                     CompiledFunction::has_runtime_type_checks_for_params(&param_slots);
+                super::ensure_chunk_addressable(
+                    &fn_compiler.chunk,
+                    &format!("method `{type_name}.{name}`"),
+                    self.line,
+                )?;
                 let func = CompiledFunction {
                     name: format!("{type_name}.{name}"),
                     type_params: type_params.iter().map(|param| param.name.clone()).collect(),
@@ -163,6 +168,7 @@ impl Compiler {
         let param_slots = crate::chunk::ParamSlot::vec_from_typed(&params);
         let has_runtime_type_checks =
             CompiledFunction::has_runtime_type_checks_for_params(&param_slots);
+        super::ensure_chunk_addressable(&fn_compiler.chunk, &format!("fn `{name}`"), self.line)?;
         let func = CompiledFunction {
             name: name.to_string(),
             type_params: Vec::new(),

--- a/crates/harn-vm/src/compiler/mod.rs
+++ b/crates/harn-vm/src/compiler/mod.rs
@@ -21,6 +21,30 @@ pub use error::CompileError;
 
 use crate::chunk::{Chunk, Constant, Op};
 
+/// Jump operands are 16-bit chunk offsets (`emit_jump`, `patch_jump`,
+/// backward loop jumps), so a chunk whose code grows past `u16::MAX`
+/// bytes would silently truncate jump targets and land somewhere wild at
+/// runtime. Every finalized chunk (the program chunk and each compiled
+/// function's chunk) must pass through this guard so oversized bodies
+/// fail compilation instead of miscompiling.
+pub(crate) fn ensure_chunk_addressable(
+    chunk: &Chunk,
+    what: &str,
+    line: u32,
+) -> Result<(), CompileError> {
+    if chunk.code.len() > u16::MAX as usize {
+        return Err(CompileError {
+            message: format!(
+                "{what} compiled to {} bytes of bytecode, more than the 64 KiB a jump \
+                 operand can address; split it into smaller functions",
+                chunk.code.len()
+            ),
+            line,
+        });
+    }
+    Ok(())
+}
+
 /// Environment variable that disables optional compiler optimizations.
 ///
 /// The VM still emits structurally required bytecode, such as parameter

--- a/crates/harn-vm/src/compiler/state.rs
+++ b/crates/harn-vm/src/compiler/state.rs
@@ -282,6 +282,7 @@ impl Compiler {
             self.chunk.emit(Op::Nil, self.line);
         }
         self.chunk.emit(Op::Return, self.line);
+        super::ensure_chunk_addressable(&self.chunk, "the program body", self.line)?;
         Ok(self.chunk)
     }
 
@@ -333,6 +334,7 @@ impl Compiler {
         self.drain_finallys_to_floor(0)?;
         self.chunk.emit(Op::Nil, self.line);
         self.chunk.emit(Op::Return, self.line);
+        super::ensure_chunk_addressable(&self.chunk, "the pipeline body", self.line)?;
         Ok(self.chunk)
     }
 
@@ -1384,6 +1386,7 @@ impl Compiler {
         let param_slots = crate::chunk::ParamSlot::vec_from_typed(params);
         let has_runtime_type_checks =
             CompiledFunction::has_runtime_type_checks_for_params(&param_slots);
+        super::ensure_chunk_addressable(&fn_compiler.chunk, "function body", self.line)?;
         Ok(CompiledFunction {
             name: String::new(),
             type_params: type_params.iter().map(|param| param.name.clone()).collect(),

--- a/crates/harn-vm/src/compiler/tests.rs
+++ b/crates/harn-vm/src/compiler/tests.rs
@@ -24,6 +24,27 @@ fn try_compile(source: &str) -> Result<Chunk, CompileError> {
 }
 
 #[test]
+fn oversized_function_chunk_is_a_compile_error_not_a_miscompile() {
+    // Jump operands are u16 chunk offsets; a body that compiles past
+    // 64 KiB used to silently truncate jump targets (`loop_start as
+    // u16`, `patch_jump`'s `code.len() as u16`) and jump somewhere
+    // wild at runtime. It must be a compile error instead.
+    let mut body = String::new();
+    for i in 0..6000 {
+        // Each iteration emits a conditional, so the chunk accumulates
+        // patched jumps on both sides of the 64 KiB boundary.
+        body.push_str(&format!("  if task == {i} {{ log({i}) }}\n"));
+    }
+    let source = format!("fn huge(task: int) {{\n{body}}}\npipeline t(task) {{ huge(1) }}");
+    let err = try_compile(&source).unwrap_err();
+    assert!(
+        err.message.contains("64 KiB") && err.message.contains("huge"),
+        "{}",
+        err.message
+    );
+}
+
+#[test]
 fn match_list_pattern_rest_must_be_last() {
     let err = try_compile(
         r"pipeline t(task) { match [1, 2, 3] { [...rest, last] -> { log(last) } _ -> {} } }",

--- a/crates/harn-vm/src/stdlib/regex.rs
+++ b/crates/harn-vm/src/stdlib/regex.rs
@@ -69,6 +69,19 @@ fn optional_flags(args: &[VmValue], idx: usize) -> std::borrow::Cow<'_, str> {
     }
 }
 
+/// Read a required string argument (pattern/text/replacement). Returns
+/// `None` when the slot is absent *or* explicitly `nil`, so each builtin
+/// can take its missing-argument fallback. Without this guard
+/// `Nil.as_str_cow()` stringifies to `"nil"`, and a forwarded unset
+/// optional would silently be compiled — and matched — as the literal
+/// pattern/text `nil`.
+fn required_str(args: &[VmValue], idx: usize) -> Option<std::borrow::Cow<'_, str>> {
+    match args.get(idx) {
+        None | Some(VmValue::Nil) => None,
+        Some(v) => Some(v.as_str_cow()),
+    }
+}
+
 fn build_regex(pattern: &str, flags: &str) -> Result<regex::Regex, String> {
     let mut builder = regex::RegexBuilder::new(pattern);
     for flag in flags.chars() {
@@ -105,21 +118,19 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
     category = "regex"
 )]
 fn regex_match_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    if args.len() >= 2 {
-        let pattern = args[0].as_str_cow();
-        let text = args[1].as_str_cow();
-        let flags = optional_flags(args, 2);
-        let re = get_cached_regex(&pattern, &flags)?;
-        let matches: Vec<VmValue> = re
-            .find_iter(&text)
-            .map(|m| VmValue::String(std::sync::Arc::from(m.as_str())))
-            .collect();
-        if matches.is_empty() {
-            return Ok(VmValue::Nil);
-        }
-        return Ok(VmValue::List(std::sync::Arc::new(matches)));
+    let (Some(pattern), Some(text)) = (required_str(args, 0), required_str(args, 1)) else {
+        return Ok(VmValue::Nil);
+    };
+    let flags = optional_flags(args, 2);
+    let re = get_cached_regex(&pattern, &flags)?;
+    let matches: Vec<VmValue> = re
+        .find_iter(&text)
+        .map(|m| VmValue::String(std::sync::Arc::from(m.as_str())))
+        .collect();
+    if matches.is_empty() {
+        return Ok(VmValue::Nil);
     }
-    Ok(VmValue::Nil)
+    Ok(VmValue::List(std::sync::Arc::new(matches)))
 }
 
 // Both `regex_replace` and `regex_replace_all` replace every match via the
@@ -131,17 +142,18 @@ fn regex_match_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
     category = "regex"
 )]
 fn regex_replace_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    if args.len() >= 3 {
-        let pattern = args[0].as_str_cow();
-        let replacement = args[1].as_str_cow();
-        let text = args[2].as_str_cow();
-        let flags = optional_flags(args, 3);
-        let re = get_cached_regex(&pattern, &flags)?;
-        return Ok(VmValue::String(std::sync::Arc::from(
-            re.replace_all(&text, replacement.as_ref()).into_owned(),
-        )));
-    }
-    Ok(VmValue::Nil)
+    let (Some(pattern), Some(replacement), Some(text)) = (
+        required_str(args, 0),
+        required_str(args, 1),
+        required_str(args, 2),
+    ) else {
+        return Ok(VmValue::Nil);
+    };
+    let flags = optional_flags(args, 3);
+    let re = get_cached_regex(&pattern, &flags)?;
+    Ok(VmValue::String(std::sync::Arc::from(
+        re.replace_all(&text, replacement.as_ref()).into_owned(),
+    )))
 }
 
 #[harn_builtin(
@@ -149,11 +161,9 @@ fn regex_replace_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
     category = "regex"
 )]
 fn regex_captures_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    if args.len() < 2 {
+    let (Some(pattern), Some(text)) = (required_str(args, 0), required_str(args, 1)) else {
         return Ok(VmValue::List(std::sync::Arc::new(Vec::new())));
-    }
-    let pattern = args[0].as_str_cow();
-    let text = args[1].as_str_cow();
+    };
     let flags = optional_flags(args, 2);
     let re = get_cached_regex(&pattern, &flags)?;
 
@@ -234,11 +244,9 @@ fn regex_captures_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
     category = "regex"
 )]
 fn regex_split_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    if args.len() < 2 {
+    let (Some(text), Some(pattern)) = (required_str(args, 0), required_str(args, 1)) else {
         return Ok(VmValue::Nil);
-    }
-    let text = args[0].as_str_cow();
-    let pattern = args[1].as_str_cow();
+    };
     let flags = optional_flags(args, 2);
     let re = get_cached_regex(&pattern, &flags)?;
     Ok(VmValue::List(std::sync::Arc::new(
@@ -530,6 +538,39 @@ mod tests {
         )
         .unwrap();
         assert_eq!(replaced.display(), "a#b#");
+    }
+
+    #[test]
+    fn nil_required_args_take_missing_arg_fallback() {
+        // A nil pattern/text must NOT stringify to the literal "nil"
+        // (which would compile — and match — as a real regex). Each
+        // builtin takes the same fallback as a missing argument.
+        let mut vm = vm();
+
+        // Would previously compile pattern "nil" and find it in the text.
+        let m = call(&mut vm, "regex_match", vec![VmValue::Nil, s("a nil value")]).unwrap();
+        assert!(matches!(m, VmValue::Nil), "got {:?}", m.display());
+        let m = call(&mut vm, "regex_match", vec![s("nil"), VmValue::Nil]).unwrap();
+        assert!(matches!(m, VmValue::Nil), "got {:?}", m.display());
+
+        let c = call(
+            &mut vm,
+            "regex_captures",
+            vec![VmValue::Nil, s("a nil value")],
+        )
+        .unwrap();
+        assert!(unwrap_list(&c).is_empty());
+
+        let r = call(
+            &mut vm,
+            "regex_replace",
+            vec![VmValue::Nil, s("#"), s("a1b2")],
+        )
+        .unwrap();
+        assert!(matches!(r, VmValue::Nil), "got {:?}", r.display());
+
+        let sp = call(&mut vm, "regex_split", vec![VmValue::Nil, s(",")]).unwrap();
+        assert!(matches!(sp, VmValue::Nil), "got {:?}", sp.display());
     }
 
     #[test]

--- a/docs/src/embedding-rust.md
+++ b/docs/src/embedding-rust.md
@@ -11,7 +11,7 @@ against:
 
 ```toml
 [dependencies]
-harn-serve = { git = "https://github.com/burin-labs/harn", tag = "v0.8.57" }
+harn-serve = { git = "https://github.com/burin-labs/harn", tag = "v0.8.103" }
 serde_json = "1"
 tokio = { version = "1", features = ["rt", "sync"] }
 ```
@@ -56,10 +56,10 @@ start.
 
 ```toml
 # Parity-critical eval harness
-harn-serve = { git = "...", tag = "v0.8.57", features = ["full"] }
+harn-serve = { git = "...", tag = "v0.8.103", features = ["full"] }
 
 # Lean smoke-test harness
-harn-serve = { git = "...", tag = "v0.8.57", features = ["hostlib"] }
+harn-serve = { git = "...", tag = "v0.8.103", features = ["hostlib"] }
 ```
 
 Finer control is available one layer down: `harn-hostlib` exposes per-family

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -823,11 +823,14 @@ New child scopes are created for:
 - `for` loop bodies (loop variable is mutable)
 - `while` loop iterations
 - `parallel`, `parallel each`, and `parallel settle` task bodies (isolated interpreter per task)
+- `if`/`else` branch bodies and `match` arm bodies
 - `try`/`catch` blocks (catch body gets its own child scope with optional error variable)
 - Closure invocations (child of the *captured* environment, not the call site)
 - `block` nodes
 
-Control flow statements (`if`/`else`, `match`) execute in the current scope without creating a new child scope.
+Control flow *headers* (`if` conditions, `match` scrutinees) evaluate in the current
+scope, but each branch or arm body is its own child scope: bindings declared inside
+shadow outer names and do not leak past the body.
 
 ## Destructuring patterns
 

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -317,6 +317,22 @@ cmd_prepare() {
   next="$(next_version "$bump")"
   bump_version "$next"
   cargo run --quiet --bin harn -- run scripts/sync_protocol_fixture_runtime_versions.harn -- --from "$current" --to "$next"
+  # Keep the embedding guide's `tag = "vX.Y.Z"` pins on the released version
+  # line. Nothing owned these before and they silently drifted ~46 versions
+  # behind; match any prior version rather than `$current` so a stale doc
+  # still converges.
+  python3 - "$next" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+next_version = sys.argv[1]
+doc = Path("docs/src/embedding-rust.md")
+text = doc.read_text()
+updated = re.sub(r'tag = "v\d+\.\d+\.\d+"', f'tag = "v{next_version}"', text)
+if updated != text:
+    doc.write_text(updated)
+PY
   # The audit lanes that ran before prepare populate `target/debug/incremental/`
   # with object-file references keyed to the *old* version's crate hashes.
   # Once `bump_version` rewrites Cargo.toml the workspace crates rebuild with

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -821,11 +821,14 @@ New child scopes are created for:
 - `for` loop bodies (loop variable is mutable)
 - `while` loop iterations
 - `parallel`, `parallel each`, and `parallel settle` task bodies (isolated interpreter per task)
+- `if`/`else` branch bodies and `match` arm bodies
 - `try`/`catch` blocks (catch body gets its own child scope with optional error variable)
 - Closure invocations (child of the *captured* environment, not the call site)
 - `block` nodes
 
-Control flow statements (`if`/`else`, `match`) execute in the current scope without creating a new child scope.
+Control flow *headers* (`if` conditions, `match` scrutinees) evaluate in the current
+scope, but each branch or arm body is its own child scope: bindings declared inside
+shadow outer names and do not leak past the body.
 
 ## Destructuring patterns
 


### PR DESCRIPTION
## Summary

Autonomous sweep for high-priority, unambiguous bugs across the codebase. Eight parallel search agents surveyed the parser, typechecker, compiler/VM, stdlib, CLI/scripts, serve/protocol surfaces, fmt/lint, and docs/spec; every candidate was then adversarially verified by hand (several agent findings were disproven and discarded — e.g. the `+`/`-` multiline-continuation asymmetry is spec-mandated, `JumpIfFalse` peeks so `retry` lowering is balanced, `filter_nil` dropping `"null"` strings is documented behavior). The 10 findings below survived verification, each with a root-cause fix and a regression test.

## Fixes

1. **Compiler — silent miscompile past 64 KiB** (`harn-vm`): jump operands are `u16` chunk offsets, and `patch_jump`/backward loop jumps cast `usize` offsets with `as u16`. A function or program body compiling to >65535 bytes silently truncated targets and jumped wild at runtime. Every finalized chunk (program + each function/closure/spawn/method chunk) now passes a guard that turns this into a clear compile error.
2. **Typechecker — `x?["k"]` dropped the optional flag** (`harn-parser`): the Shape arm of subscript inference hardcoded `optional: false`, so an unknown key inferred gradual instead of `nil` and mismatched assignments type-checked silently. Now consistent with `x?.k` property inference.
3. **Stdlib — regex builtins matched the literal pattern `"nil"`** (`harn-vm`): an explicit `nil` pattern/text/replacement was stringified via `as_str_cow()` to `"nil"` and compiled as a real regex (`regex_match(nil, "a nil value")` returned `["nil"]`). `nil` now takes the same fallback as a missing argument, mirroring the existing `optional_flags` guard and its rationale comment.
4. **fmt — comments relocated to EOF** (`harn-fmt`, 3 distinct positions): trailing comments on inline match arms (`1 -> { x } // c`, both the expression and statement rendering paths), trailing comments on dict/struct-literal entries, and full-line comments inside multiline dict/list literals were never claimed at their position and got flushed to the end of the file. They now stay anchored; a literal with interior comments keeps its multiline shape; a statement-level comment after an inline literal (`let d = {x: 1} // note`) is still attributed to the statement. Verified idempotent; repo stdlib stays fmt-clean.
5. **lint — behavior-changing `comparison-to-bool` autofix** (`harn-lint`): `d?.enabled == false` was flagged "redundant" and autofixed to `!d?.enabled`, which flips the branch when the chain is nil (proven with a runtime repro: `nil == false` → else-branch, `!nil` → then-branch). The rule now skips operands that can be nil via optional chaining along the receiver chain.
6. **lint — byte-based diagnostic columns** (`harn-lint`): `prefer-optional-shorthand` computed columns by byte arithmetic, overshooting on any line with multibyte characters before the span. Columns are now 1-based character counts.
7. **Spec — scope-creation section contradicted reality** (`spec/HARN_SPEC.md`): the spec claimed `if`/`else` and `match` "execute in the current scope without creating a new child scope," but branch/arm bodies are block-scoped (verified: inner `let` shadows and does not leak; docs already said so). Spec source fixed + generated mirror resynced.
8. **MCP fixtures — declared-but-hollow `FakeServerBehavior::HeaderMismatch`** (`harn-mcp-rc-compat`): the variant's docstring promised `-32600` on `Mcp-Method`/body disagreement, but `post_mcp` never inspected headers and nothing constructed the variant. It now validates via the production `negotiate_rc_http_request` helper (so the fake can't drift from the spec) with a test covering both the agree and spoofed-header paths.
9. **Docs — embedding guide pinned `v0.8.57`** (~46 releases stale): pins refreshed to the current version line.
10. **Release tooling — nothing owned those pins**: `release_gate.sh prepare` now rewrites the `tag = "vX.Y.Z"` pins in `docs/src/embedding-rust.md` on every version bump (matching any prior version so a stale doc converges), next to the existing protocol-fixture version sync.

## Tests

- New regression tests in `harn-parser` (typechecker nil-safety), `harn-vm` (compiler oversize guard, regex nil args), `harn-lint` (optional-chaining gate ×4 shapes, char-column unit tests), `harn-fmt` (4 comment-anchoring tests incl. idempotency round-trips), `harn-mcp-rc-compat` (HeaderMismatch wire test).
- Full crate suites run locally for the touched crates: harn-fmt (160 passed), harn-lint, harn-parser, harn-vm targeted suites, harn-mcp-rc-compat client tests; `make fmt-harn` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)