### PR TITLE
refactor(glob): unify seven divergent glob matchers into one harn-glob crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,6 +2350,7 @@ dependencies = [
  "futures",
  "harn-dap",
  "harn-fmt",
+ "harn-glob",
  "harn-guard",
  "harn-hostlib",
  "harn-ir",
@@ -2454,6 +2455,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "harn-glob"
+version = "0.8.103"
+dependencies = [
+ "globset",
+]
+
+[[package]]
 name = "harn-guard"
 version = "0.8.103"
 dependencies = [
@@ -2534,6 +2542,7 @@ dependencies = [
 name = "harn-ir"
 version = "0.8.103"
 dependencies = [
+ "harn-glob",
  "harn-lexer",
  "harn-parser",
 ]
@@ -2767,6 +2776,7 @@ dependencies = [
  "harn-builtin-meta",
  "harn-builtin-registry",
  "harn-clock",
+ "harn-glob",
  "harn-ir",
  "harn-lexer",
  "harn-modules",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/harn-builtin-macros",
     "crates/harn-opcode-macros",
     "crates/harn-clock",
+    "crates/harn-glob",
     "crates/harn-lexer",
     "crates/harn-parser",
     "crates/harn-ir",

--- a/changelog.d/3265.changed.md
+++ b/changelog.d/3265.changed.md
@@ -1,0 +1,7 @@
+- **One glob matcher for the whole workspace (#3265).** Seven divergent
+  `glob_match` implementations (invariant globs, metadata scan, model
+  config/capability patterns, hook routing, mock prompt patterns, skills
+  triggers) consolidated into the new `harn-glob` crate with three explicit
+  contracts (`match_path`, `match_name`, `match_prose`). Model and hook
+  patterns now share full glob syntax (`*`, `?`, `[..]`), and path globs
+  uniformly treat `**/` as matching zero directories.

--- a/changelog.d/3265.fixed.md
+++ b/changelog.d/3265.fixed.md
@@ -1,0 +1,5 @@
+- **`metadata` directory-scan `**` patterns match again (#3265).** The
+  scanner's hand-rolled matcher compared the second `*` in `**/*.rs`
+  literally, so recursive `**` scan patterns never matched; scan patterns now
+  go through the shared glob matcher (bare substring patterns keep their
+  historical behavior).

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -33,6 +33,7 @@ name = "harn"
 path = "src/main.rs"
 
 [dependencies]
+harn-glob = { path = "../harn-glob", version = "0.8", default-features = false }
 harn-lexer = { path = "../harn-lexer", version = "0.8" }
 harn-parser = { path = "../harn-parser", version = "0.8" }
 harn-ir = { path = "../harn-ir", version = "0.8" }

--- a/crates/harn-cli/src/commands/skills.rs
+++ b/crates/harn-cli/src/commands/skills.rs
@@ -1165,55 +1165,7 @@ fn count_path_hits(patterns: &[String], files: &[String]) -> usize {
     hits
 }
 
-fn glob_match(pattern: &str, path: &str) -> bool {
-    glob_match_inner(pattern.as_bytes(), 0, path.as_bytes(), 0)
-}
-
-fn glob_match_inner(pat: &[u8], mut pi: usize, path: &[u8], mut si: usize) -> bool {
-    while pi < pat.len() {
-        match pat[pi] {
-            b'*' => {
-                let double = pi + 1 < pat.len() && pat[pi + 1] == b'*';
-                let next_pi = if double { pi + 2 } else { pi + 1 };
-                let next_pi = if double && next_pi < pat.len() && pat[next_pi] == b'/' {
-                    next_pi + 1
-                } else {
-                    next_pi
-                };
-                if next_pi >= pat.len() {
-                    if double {
-                        return true;
-                    }
-                    return !path[si..].contains(&b'/');
-                }
-                for try_si in si..=path.len() {
-                    if !double && path[si..try_si].contains(&b'/') {
-                        break;
-                    }
-                    if glob_match_inner(pat, next_pi, path, try_si) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-            b'?' => {
-                if si >= path.len() || path[si] == b'/' {
-                    return false;
-                }
-                pi += 1;
-                si += 1;
-            }
-            c => {
-                if si >= path.len() || path[si] != c {
-                    return false;
-                }
-                pi += 1;
-                si += 1;
-            }
-        }
-    }
-    si == path.len()
-}
+use harn_glob::match_path as glob_match;
 
 fn truncate(value: &str, max: usize) -> String {
     if value.chars().count() <= max {

--- a/crates/harn-glob/Cargo.toml
+++ b/crates/harn-glob/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "harn-glob"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Glob pattern matching primitives for the Harn programming language"
+
+[features]
+default = ["name"]
+# `match_name` (full glob syntax over flat names) pulls in globset; path and
+# prose matching are dependency-free so low layers can opt out.
+name = ["dep:globset"]
+
+[dependencies]
+globset = { version = "0.4", optional = true }
+
+[lints]
+workspace = true

--- a/crates/harn-glob/src/lib.rs
+++ b/crates/harn-glob/src/lib.rs
@@ -1,0 +1,323 @@
+//! The single glob-matching implementation for the Harn workspace.
+//!
+//! Before this crate existed, seven near-identical `glob_match` functions
+//! lived in `harn-ir`, `harn-vm` (metadata scan, llm config, capabilities,
+//! merge-captain audit, runtime hooks, llm mock), and `harn-cli` (skills) —
+//! each with subtly different wildcard semantics. A pattern that matched in
+//! one subsystem silently behaved differently in another (hook routing
+//! honored `?`/`[...]`, model-override matching did not; the metadata scanner
+//! matched the `*` in `**/*.rs` literally). This crate is the one place those
+//! semantics are defined.
+//!
+//! Three contracts, chosen per call site:
+//!
+//! - [`match_path`] — slash-aware file-path globs: `*`/`?` never cross `/`,
+//!   `**` crosses directories. Use for path-shaped inputs (invariant globs,
+//!   skill manifests, workspace paths).
+//! - [`match_name`] — full glob syntax (`*`, `?`, `[...]`, `{a,b}`) over flat
+//!   identifiers where `/` has no special meaning (`*` crosses it). Use for
+//!   tool names, model ids, hook patterns, event names.
+//! - [`match_prose`] — `*`-only ordered-segment matching where every other
+//!   character is literal. Use when patterns target free text that routinely
+//!   contains `?`, `[`, or `{` as ordinary prose (e.g. llm-mock prompt
+//!   matchers).
+
+/// Slash-aware glob matching for file paths.
+///
+/// Semantics:
+/// - `*` matches any run of characters except `/`
+/// - `?` matches exactly one character except `/`
+/// - `**` matches any run of characters including `/` (a leading `**/` also
+///   matches zero directories, so `src/**/*.rs` matches `src/main.rs`)
+/// - every other character matches itself; the whole path must be consumed
+#[must_use]
+pub fn match_path(pattern: &str, path: &str) -> bool {
+    match_path_bytes(pattern.as_bytes(), 0, path.as_bytes(), 0)
+}
+
+fn match_path_bytes(pat: &[u8], mut pi: usize, path: &[u8], mut si: usize) -> bool {
+    while pi < pat.len() {
+        match pat[pi] {
+            b'*' => {
+                let double = pat.get(pi + 1) == Some(&b'*');
+                let mut next_pi = if double { pi + 2 } else { pi + 1 };
+                if double && pat.get(next_pi) == Some(&b'/') {
+                    // `**/` also matches zero directories.
+                    next_pi += 1;
+                }
+                if next_pi >= pat.len() {
+                    if double {
+                        return true;
+                    }
+                    return !path[si..].contains(&b'/');
+                }
+                for try_si in si..=path.len() {
+                    if !double && path[si..try_si].contains(&b'/') {
+                        break;
+                    }
+                    if match_path_bytes(pat, next_pi, path, try_si) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            b'?' => {
+                if si >= path.len() || path[si] == b'/' {
+                    return false;
+                }
+                pi += 1;
+                si += 1;
+            }
+            expected => {
+                if si >= path.len() || path[si] != expected {
+                    return false;
+                }
+                pi += 1;
+                si += 1;
+            }
+        }
+    }
+    si == path.len()
+}
+
+/// Full glob matching for flat names (tool names, model ids, hook patterns).
+///
+/// `/` has no special meaning: `*` and `?` match across it. Beyond `*` and
+/// `?`, character classes (`[abc]`) and alternates (`{a,b}`) are supported
+/// via [`globset`]. Patterns that fail to parse as globs fall back to the
+/// historical prefix/suffix/equality behavior shared by the pre-consolidation
+/// call sites, so an unclosed `[` never panics or silently rejects.
+///
+/// Compiled matchers are cached per thread; patterns come from configuration
+/// and hook registration, so the cache stays small.
+#[cfg(feature = "name")]
+#[must_use]
+pub fn match_name(pattern: &str, name: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    if !has_name_meta(pattern) {
+        return pattern == name;
+    }
+    // Fast paths for the dominant shapes: `prefix*`, `*suffix`, `*infix*`.
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        if !has_name_meta(prefix) {
+            return name.starts_with(prefix);
+        }
+        if let Some(infix) = prefix.strip_prefix('*') {
+            if !has_name_meta(infix) {
+                return name.contains(infix);
+            }
+        }
+    }
+    if let Some(suffix) = pattern.strip_prefix('*') {
+        if !has_name_meta(suffix) {
+            return name.ends_with(suffix);
+        }
+    }
+    compiled_name_match(pattern, name)
+}
+
+#[cfg(feature = "name")]
+fn has_name_meta(pattern: &str) -> bool {
+    pattern
+        .bytes()
+        .any(|byte| matches!(byte, b'*' | b'?' | b'['))
+}
+
+#[cfg(feature = "name")]
+fn compiled_name_match(pattern: &str, name: &str) -> bool {
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    thread_local! {
+        static COMPILED: RefCell<HashMap<Box<str>, Option<globset::GlobMatcher>>> =
+            RefCell::new(HashMap::new());
+    }
+
+    COMPILED.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        // Patterns are config/registration-driven and bounded in practice;
+        // the cap only guards against pathological dynamic pattern churn.
+        if cache.len() > 512 {
+            cache.clear();
+        }
+        let matcher = cache.entry(Box::from(pattern)).or_insert_with(|| {
+            globset::Glob::new(pattern)
+                .ok()
+                .map(|glob| glob.compile_matcher())
+        });
+        match matcher {
+            Some(matcher) => matcher.is_match(name),
+            // Unparsable glob: match the way pre-consolidation call sites did.
+            None => {
+                if let Some(prefix) = pattern.strip_suffix('*') {
+                    return name.starts_with(prefix);
+                }
+                if let Some(suffix) = pattern.strip_prefix('*') {
+                    return name.ends_with(suffix);
+                }
+                pattern == name
+            }
+        }
+    })
+}
+
+/// `*`-only ordered-segment matching over free text.
+///
+/// Splits the pattern on `*` and requires the literal segments to appear in
+/// order, anchored at the start/end unless the pattern begins/ends with `*`.
+/// Every character other than `*` is literal — including `?`, `[`, and `{` —
+/// because prose targets (prompts, transcript text) routinely contain them.
+#[must_use]
+pub fn match_prose(pattern: &str, text: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    if !pattern.contains('*') {
+        return pattern == text;
+    }
+    let segments: Vec<&str> = pattern.split('*').collect();
+    let last = segments.len() - 1;
+    let mut remaining = text;
+    for (index, segment) in segments.iter().enumerate() {
+        if segment.is_empty() {
+            continue;
+        }
+        if index == 0 {
+            match remaining.strip_prefix(segment) {
+                Some(rest) => remaining = rest,
+                None => return false,
+            }
+        } else if index == last {
+            return remaining.ends_with(segment);
+        } else {
+            match remaining.find(segment) {
+                Some(at) => remaining = &remaining[at + segment.len()..],
+                None => return false,
+            }
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- match_path: ported from harn-ir and harn-cli (skills) test suites ---
+
+    #[test]
+    fn path_single_star_stays_within_a_directory() {
+        assert!(match_path("src/*.rs", "src/main.rs"));
+        assert!(!match_path("src/*.rs", "src/nested/main.rs"));
+        assert!(!match_path("src/*.rs", "other/main.rs"));
+    }
+
+    #[test]
+    fn path_double_star_crosses_directories() {
+        assert!(match_path("src/**/*.rs", "src/nested/main.rs"));
+        assert!(match_path("src/**/*.rs", "src/main.rs"));
+        assert!(match_path("infra/**", "infra/terraform/main.tf"));
+        assert!(match_path("**", "anything/at/all"));
+        assert!(match_path("**/*.rs", "main.rs"));
+        assert!(match_path("**/*.rs", "deep/tree/main.rs"));
+    }
+
+    #[test]
+    fn path_question_mark_matches_one_non_separator() {
+        assert!(match_path("src/ma?n.rs", "src/main.rs"));
+        assert!(!match_path("src/ma?n.rs", "src/man.rs"));
+        assert!(!match_path("a?b", "a/b"));
+    }
+
+    #[test]
+    fn path_literal_and_edge_cases() {
+        assert!(match_path("exact.rs", "exact.rs"));
+        assert!(!match_path("exact.rs", "exact.rs.bak"));
+        assert!(!match_path("src/**", "src"));
+        assert!(match_path("src/**", "src/anything"));
+        assert!(match_path("", ""));
+        assert!(!match_path("", "x"));
+    }
+
+    // --- match_name: ported from hooks, llm_config, capabilities,
+    //     merge_captain_audit test suites ---
+
+    #[test]
+    fn name_star_matches_everything() {
+        assert!(match_name("*", "anything"));
+        assert!(match_name("*", ""));
+    }
+
+    #[test]
+    fn name_prefix_suffix_and_exact() {
+        assert!(match_name("claude-*", "claude-sonnet-4-20250514"));
+        assert!(match_name("gpt-*", "gpt-4o"));
+        assert!(!match_name("claude-*", "gpt-4o"));
+        assert!(match_name("*-latest", "llama3.2-latest"));
+        assert!(!match_name("*-latest", "llama3.2"));
+        assert!(match_name("gpt-4o", "gpt-4o"));
+        assert!(!match_name("gpt-4o", "gpt-4o-mini"));
+    }
+
+    #[test]
+    fn name_substring_and_middle_star() {
+        assert!(match_name("*gpt*", "openai/gpt-5.4"));
+        assert!(match_name("*claude*", "anthropic/claude-opus-4-7"));
+        assert!(!match_name("*xyz*", "openai/gpt-5.4"));
+        assert!(match_name("claude-*-latest", "claude-sonnet-latest"));
+        assert!(!match_name("claude-*-latest", "claude-sonnet-beta"));
+    }
+
+    #[test]
+    fn name_star_crosses_separators() {
+        assert!(match_name("tool/*", "tool/a/b"));
+        assert!(match_name("*svc", "a/b/svc"));
+    }
+
+    #[test]
+    fn name_multi_star_segments_in_order() {
+        assert!(match_name("a*b*c", "a-x-b-y-c"));
+        assert!(!match_name("a*b*c", "a-x-c-y-b"));
+        assert!(match_name("pre*mid*", "pre-anything-mid-tail"));
+    }
+
+    #[test]
+    fn name_question_mark_and_classes() {
+        assert!(match_name("gpt-?o", "gpt-4o"));
+        assert!(!match_name("gpt-?o", "gpt-44o"));
+        assert!(match_name("file[12]", "file1"));
+        assert!(!match_name("file[12]", "file3"));
+    }
+
+    #[test]
+    fn name_unparsable_glob_falls_back_to_legacy_affix_matching() {
+        // Unclosed `[` fails glob compilation; legacy behavior treated the
+        // pattern as a literal prefix when it ends in `*`.
+        assert!(match_name("f[oo*", "f[oo-bar"));
+        assert!(!match_name("f[oo*", "g[oo-bar"));
+        assert!(match_name("f[oo", "f[oo"));
+    }
+
+    // --- match_prose: ported from the llm mock matcher tests ---
+
+    #[test]
+    fn prose_segments_in_order_with_literal_punctuation() {
+        assert!(match_prose("*", "anything"));
+        assert!(match_prose("hello", "hello"));
+        assert!(!match_prose("hello", "hello world"));
+        assert!(match_prose("hello*", "hello world"));
+        assert!(match_prose("*world", "hello world"));
+        assert!(match_prose("*llo wo*", "hello world"));
+        assert!(match_prose("he*wo*ld", "hello world"));
+        assert!(!match_prose("he*xx*ld", "hello world"));
+    }
+
+    #[test]
+    fn prose_treats_glob_metacharacters_as_literals() {
+        assert!(match_prose("what is [x]?*", "what is [x]? tell me"));
+        assert!(!match_prose("what is [x]?*", "what is x? tell me"));
+        assert!(match_prose("*{json}*", "respond with {json} only"));
+    }
+}

--- a/crates/harn-ir/Cargo.toml
+++ b/crates/harn-ir/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 description = "CFG and invariant analysis for the Harn programming language"
 
 [dependencies]
+harn-glob = { path = "../harn-glob", version = "0.8", default-features = false }
 harn-lexer = { path = "../harn-lexer", version = "0.8" }
 harn-parser = { path = "../harn-parser", version = "0.8" }
 

--- a/crates/harn-ir/src/lib.rs
+++ b/crates/harn-ir/src/lib.rs
@@ -2431,48 +2431,7 @@ fn pattern_label(node: &SNode) -> String {
     }
 }
 
-fn glob_match(pattern: &str, path: &str) -> bool {
-    fn helper(pattern: &[u8], pi: usize, path: &[u8], si: usize) -> bool {
-        if pi == pattern.len() {
-            return si == path.len();
-        }
-
-        if pattern[pi] == b'*' {
-            if pattern.get(pi + 1) == Some(&b'*') {
-                let next = pi + 2;
-                if next == pattern.len() {
-                    return true;
-                }
-                for index in si..=path.len() {
-                    if helper(pattern, next, path, index) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-
-            let next = pi + 1;
-            let mut index = si;
-            while index <= path.len() {
-                if helper(pattern, next, path, index) {
-                    return true;
-                }
-                if index == path.len() || path[index] == b'/' {
-                    break;
-                }
-                index += 1;
-            }
-            return false;
-        }
-
-        if si == path.len() || pattern[pi] != path[si] {
-            return false;
-        }
-        helper(pattern, pi + 1, path, si + 1)
-    }
-
-    helper(pattern.as_bytes(), 0, path.as_bytes(), 0)
-}
+use harn_glob::match_path as glob_match;
 
 #[cfg(test)]
 mod tests {
@@ -3017,5 +2976,7 @@ fn handler() {
         assert!(glob_match("src/*.rs", "src/main.rs"));
         assert!(!glob_match("src/*.rs", "src/nested/main.rs"));
         assert!(glob_match("src/**/*.rs", "src/nested/main.rs"));
+        // `**/` also matches zero directories (git/globset convention).
+        assert!(glob_match("src/**/*.rs", "src/main.rs"));
     }
 }

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -45,6 +45,7 @@ harn-opcode-macros = { path = "../harn-opcode-macros", version = "0.8" }
 linkme = "0.3"
 parking_lot = "0.12"
 harn-clock = { path = "../harn-clock", version = "0.8" }
+harn-glob = { path = "../harn-glob", version = "0.8" }
 harn-ir = { path = "../harn-ir", version = "0.8" }
 harn-lexer = { path = "../harn-lexer", version = "0.8" }
 harn-modules = { path = "../harn-modules", version = "0.8" }

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -1376,29 +1376,10 @@ fn extract_version(model: &str) -> Option<(u32, u32)> {
     claude_generation(model).or_else(|| gpt_generation(model))
 }
 
-/// Simple glob matching with `*` wildcards. Mirrors the helper in
-/// `llm_config.rs` — keep them in sync if either ever grows regex or
-/// character-class support.
-fn glob_match(pattern: &str, input: &str) -> bool {
-    if let Some(prefix) = pattern.strip_suffix('*') {
-        if let Some(rest) = prefix.strip_prefix('*') {
-            // `*foo*` — substring match.
-            return input.contains(rest);
-        }
-        return input.starts_with(prefix);
-    }
-    if let Some(suffix) = pattern.strip_prefix('*') {
-        return input.ends_with(suffix);
-    }
-    if pattern.contains('*') {
-        let parts: Vec<&str> = pattern.split('*').collect();
-        if parts.len() == 2 {
-            return input.starts_with(parts[0]) && input.ends_with(parts[1]);
-        }
-        return input == pattern;
-    }
-    input == pattern
-}
+// Model-pattern matching for capability rules. Shared workspace semantics
+// live in `harn-glob` (this used to be a hand-mirrored copy of the
+// `llm_config.rs` helper with a "keep them in sync" comment).
+use harn_glob::match_name as glob_match;
 
 #[cfg(test)]
 mod tests {

--- a/crates/harn-vm/src/llm/mock.rs
+++ b/crates/harn-vm/src/llm/mock.rs
@@ -396,40 +396,10 @@ fn build_mock_result(mock: &LlmMock, last_msg_len: usize) -> LlmResult {
     }
 }
 
-/// Multi-segment glob match: split on `*` and check segments appear in order.
-/// Handles `*`, `prefix*`, `*suffix`, `*contains*`, `pre*mid*suf`, etc.
-fn mock_glob_match(pattern: &str, text: &str) -> bool {
-    if pattern == "*" {
-        return true;
-    }
-    if !pattern.contains('*') {
-        return pattern == text;
-    }
-    let parts: Vec<&str> = pattern.split('*').collect();
-    let mut remaining = text;
-    for (i, part) in parts.iter().enumerate() {
-        if part.is_empty() {
-            continue;
-        }
-        if i == 0 {
-            if !remaining.starts_with(part) {
-                return false;
-            }
-            remaining = &remaining[part.len()..];
-        } else if i == parts.len() - 1 {
-            if !remaining.ends_with(part) {
-                return false;
-            }
-            remaining = "";
-        } else {
-            match remaining.find(part) {
-                Some(pos) => remaining = &remaining[pos + part.len()..],
-                None => return false,
-            }
-        }
-    }
-    true
-}
+// Mock prompt patterns match free prose, where `?`/`[`/`{` are ordinary
+// characters — only `*` is a wildcard. The shared prose matcher keeps that
+// contract (`*`-only ordered segments).
+use harn_glob::match_prose as mock_glob_match;
 
 fn collect_mock_match_strings(value: &serde_json::Value, out: &mut Vec<String>) {
     match value {

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -2501,23 +2501,9 @@ fn refs_contain_selector(refs: &BTreeSet<String>, selector: &str) -> bool {
         .is_some_and(|selector| refs.contains(&selector))
 }
 
-/// Simple glob matching for patterns like "claude-*", "qwen/*", "ollama:*".
-fn glob_match(pattern: &str, input: &str) -> bool {
-    if let Some(prefix) = pattern.strip_suffix('*') {
-        input.starts_with(prefix)
-    } else if let Some(suffix) = pattern.strip_prefix('*') {
-        input.ends_with(suffix)
-    } else if pattern.contains('*') {
-        let parts: Vec<&str> = pattern.split('*').collect();
-        if parts.len() == 2 {
-            input.starts_with(parts[0]) && input.ends_with(parts[1])
-        } else {
-            input == pattern
-        }
-    } else {
-        input == pattern
-    }
-}
+// Model-pattern matching for forms like "claude-*", "qwen/*", "ollama:*".
+// Shared workspace semantics live in `harn-glob`.
+use harn_glob::match_name as glob_match;
 
 fn dirs_or_home() -> Option<String> {
     crate::user_dirs::home_dir().map(|home| home.to_string_lossy().into_owned())

--- a/crates/harn-vm/src/metadata.rs
+++ b/crates/harn-vm/src/metadata.rs
@@ -1436,30 +1436,35 @@ fn scan_dir_recursive(
     }
 }
 
-/// Simple glob matching (supports * and ** patterns).
+/// Scan-pattern matching. Patterns with wildcards use the shared glob
+/// matcher in name mode (`*` crosses `/`, so the historical `*.rs` form keeps
+/// matching nested entries during the recursive scan); wildcard-free patterns
+/// keep their historical substring semantics.
 fn glob_match(pattern: &str, path: &str) -> bool {
-    if pattern.contains("**") {
-        let parts: Vec<&str> = pattern.split("**").collect();
-        if parts.len() == 2 {
-            let prefix = parts[0].trim_end_matches('/');
-            let suffix = parts[1].trim_start_matches('/');
-            let prefix_ok = prefix.is_empty() || path.starts_with(prefix);
-            let suffix_ok = suffix.is_empty() || path.ends_with(suffix);
-            return prefix_ok && suffix_ok;
-        }
+    if pattern.contains('*') || pattern.contains('?') {
+        harn_glob::match_name(pattern, path)
+    } else {
+        path.contains(pattern)
     }
-    if pattern.contains('*') {
-        let parts: Vec<&str> = pattern.split('*').collect();
-        if parts.len() == 2 {
-            return path.starts_with(parts[0]) && path.ends_with(parts[1]);
-        }
-    }
-    path.contains(pattern)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn scan_pattern_matching_globs_and_substrings() {
+        // Historical recursive-scan form: `*` crosses directory separators.
+        assert!(glob_match("*.rs", "src/nested/main.rs"));
+        // `**` forms match too (the previous hand-rolled matcher rejected
+        // `**/*.rs` because it compared the second `*` literally).
+        assert!(glob_match("**/*.rs", "src/nested/main.rs"));
+        assert!(glob_match("src/**", "src/nested/main.rs"));
+        assert!(!glob_match("*.toml", "src/main.rs"));
+        // Wildcard-free patterns keep substring semantics.
+        assert!(glob_match("nested", "src/nested/main.rs"));
+        assert!(!glob_match("missing", "src/nested/main.rs"));
+    }
 
     fn temp_path(name: &str) -> PathBuf {
         let unique = std::time::SystemTime::now()

--- a/crates/harn-vm/src/orchestration/hooks.rs
+++ b/crates/harn-vm/src/orchestration/hooks.rs
@@ -535,25 +535,10 @@ pub fn clear_file_edit_queue() {
     FILE_EDIT_QUEUE.with(|queue| queue.borrow_mut().clear());
 }
 
-pub(crate) fn glob_match(pattern: &str, name: &str) -> bool {
-    if pattern == "*" {
-        return true;
-    }
-    if pattern.contains('*') || pattern.contains('?') || pattern.contains('[') {
-        if let Ok(glob) = globset::Glob::new(pattern) {
-            if glob.compile_matcher().is_match(name) {
-                return true;
-            }
-        }
-    }
-    if let Some(prefix) = pattern.strip_suffix('*') {
-        return name.starts_with(prefix);
-    }
-    if let Some(suffix) = pattern.strip_prefix('*') {
-        return name.ends_with(suffix);
-    }
-    pattern == name
-}
+// The workspace-wide name matcher (re-exported as
+// `crate::orchestration::glob_match` for the tool-surface, permission, and
+// step-runtime call sites). Semantics live in `harn-glob`.
+pub(crate) use harn_glob::match_name as glob_match;
 
 pub fn register_tool_hook(hook: ToolHook) {
     if let Some(pre) = hook.pre {

--- a/crates/harn-vm/src/orchestration/merge_captain_audit.rs
+++ b/crates/harn-vm/src/orchestration/merge_captain_audit.rs
@@ -173,37 +173,9 @@ impl ToolPattern {
     }
 }
 
-fn glob_match(pattern: &str, value: &str) -> bool {
-    if !pattern.contains('*') {
-        return pattern == value;
-    }
-    let parts: Vec<&str> = pattern.split('*').collect();
-    let mut cursor = 0usize;
-    let last = parts.len().saturating_sub(1);
-    for (i, part) in parts.iter().enumerate() {
-        if part.is_empty() {
-            if i == 0 || i == last {
-                continue;
-            }
-            continue;
-        }
-        if i == 0 && !pattern.starts_with('*') {
-            if !value[cursor..].starts_with(part) {
-                return false;
-            }
-            cursor += part.len();
-            continue;
-        }
-        if i == last && !pattern.ends_with('*') {
-            return value[cursor..].ends_with(part);
-        }
-        match value[cursor..].find(part) {
-            Some(idx) => cursor += idx + part.len(),
-            None => return false,
-        }
-    }
-    pattern.ends_with('*') || cursor == value.len()
-}
+// Golden-fixture tool patterns promise `*`-only wildcards (everything else
+// literal), which is exactly the shared prose matcher's contract.
+use harn_glob::match_prose as glob_match;
 
 /// One state-machine step in the golden fixture.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -69,6 +69,7 @@ MAX_ATTEMPTS=3
 # Crates to publish, in dependency order. Used by the per-crate fallback
 # when `cargo publish --workspace` bails out partway through.
 WORKSPACE_CRATES=(
+  harn-glob
   harn-lexer
   harn-parser
   harn-ir


### PR DESCRIPTION
## What

Consolidates **seven** hand-rolled `glob_match` implementations into a new tiny `crates/harn-glob` crate with three explicit contracts:

| Contract | Semantics | Call sites |
|---|---|---|
| `match_path` | slash-aware: `*`/`?` stay inside a directory, `**` crosses, `**/` matches zero dirs (git/globset convention) | harn-ir invariant globs, harn-cli skills |
| `match_name` | full glob (`*`, `?`, `[..]`, `{a,b}` via globset), `*` crosses `/`; per-thread compiled cache; legacy affix fallback for unparsable patterns | orchestration hooks (and its `tool_surface`/`permissions`/`step_runtime` consumers), llm_config model overrides, llm capabilities rules, metadata scan (wildcard patterns) |
| `match_prose` | `*`-only ordered segments, `?`/`[`/`{` literal — for free-text targets | llm mock prompt matchers, merge-captain golden-fixture tool patterns |

## Why

Pattern semantics silently differed per subsystem — a security/correctness-grade DRY violation:

- hook routing honored `?`/`[...]` while model-override matching did not
- the metadata scanner matched the `*` in `**/*.rs` **literally**, so `**` scan patterns never matched anything
- `capabilities.rs` carried a hand-mirrored copy of the `llm_config.rs` helper with an explicit *"keep them in sync"* comment
- harn-ir's invariant matcher lacked the `**/`-matches-zero-dirs convention, so `src/**/*.rs` rejected `src/main.rs`

## Deliberate behavior upgrades (patch-level)

- invariant globs: `src/**/*.rs` now matches `src/main.rs`
- metadata scan: `**` patterns work (previously broken); bare patterns keep historical substring semantics; `*.rs` keeps matching nested entries
- model patterns gain multi-star/`?`/`[..]` support (previously fell back to literal/equality)

`match_name` is behind a default `name` feature so low layers (harn-ir, harn-cli) take harn-glob without the globset dependency. Publish order updated in `scripts/publish.sh`; all pre-existing call-site tests preserved and passing against the shared semantics.

Archaeology note: surveyed harn + burin-code + harn-bump-fleet for the most egregious DRY/layering violations this session; this was the top-ranked in-repo item (7 divergent copies, security-relevant matching). The top cross-boundary item (burin-code#2018 command-catalog single-sourcing) ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)