### PR TITLE
fix(ci): pin scala_repro_fixture.scala to LF so the Windows test slice stops failing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,9 @@ scripts/release_smoke.sh eol=lf
 # out with LF on every platform — autocrlf on Windows would otherwise
 # break `checked_session_bundle_fixtures_match_export`.
 spec/session-bundles/fixtures/*.json eol=lf
+
+# The Scala cascade-repro fixture is embedded via include_str! and asserted
+# to start with real LF newlines (`scala3_indented_match_cascade_is_flagged_
+# not_localized`); autocrlf on the Windows runners otherwise checks it out
+# with CRLF and breaks the test deterministically.
+crates/harn-hostlib/src/ast/scala_repro_fixture.scala eol=lf


### PR DESCRIPTION
Every main CI run since #3256 merged has failed the required **Rust on Windows (build + smoke test)** job:

```
thread 'ast::parse_errors::tests::scala3_indented_match_cascade_is_flagged_not_localized' panicked:
fixture must have real newlines after the package clause
```

The fixture is embedded via `include_str!` and the test (correctly) asserts the body starts with `package rulekit\n\n`. Windows runners check the `.scala` file out with CRLF under autocrlf, so the assert fails deterministically — which also wedges the merge queue for every open PR.

Fix: pin the fixture to `eol=lf` in `.gitattributes`, following the existing precedent for smoke fixtures and session-bundle fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)