### PR TITLE
Fix cross-cutting validation edge cases

### DIFF
--- a/changelog.d/3269.fixed.md
+++ b/changelog.d/3269.fixed.md
@@ -1,0 +1,7 @@
+- **Cross-cutting validation fixes (#3269).** Glob `**/` patterns now stay on
+  directory boundaries and name globs honor brace alternates; schema validation
+  and export now enforce enum/`uniqueItems` collection constraints and emit
+  valid JSON/OpenAPI for `any`, `set`, and nullable unions; MCP file upload
+  `accept` matching honors wildcards and extensions; OAuth dynamic registration
+  accepts loopback IPv6 and 127/8 redirect hosts; and MCP OAuth resource
+  audiences are matched exactly.

--- a/crates/harn-cli/src/commands/mcp/oauth_resource.rs
+++ b/crates/harn-cli/src/commands/mcp/oauth_resource.rs
@@ -458,11 +458,9 @@ fn normalize_path(path: &str) -> String {
 }
 
 fn audience_matches(actual: &[String], expected: &[String]) -> bool {
-    actual.iter().any(|actual| {
-        expected
-            .iter()
-            .any(|expected| actual.eq_ignore_ascii_case(expected))
-    })
+    actual
+        .iter()
+        .any(|actual| expected.iter().any(|expected| actual == expected))
 }
 
 fn split_list_env(name: &str) -> Vec<String> {
@@ -496,4 +494,21 @@ fn env_nonempty(name: &str) -> Option<String> {
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audience_matching_is_exact() {
+        assert!(audience_matches(
+            &["https://mcp.example.test/mcp".to_string()],
+            &["https://mcp.example.test/mcp".to_string()]
+        ));
+        assert!(!audience_matches(
+            &["https://MCP.example.test/mcp".to_string()],
+            &["https://mcp.example.test/mcp".to_string()]
+        ));
+    }
 }

--- a/crates/harn-glob/src/lib.rs
+++ b/crates/harn-glob/src/lib.rs
@@ -42,8 +42,20 @@ fn match_path_bytes(pat: &[u8], mut pi: usize, path: &[u8], mut si: usize) -> bo
                 let double = pat.get(pi + 1) == Some(&b'*');
                 let mut next_pi = if double { pi + 2 } else { pi + 1 };
                 if double && pat.get(next_pi) == Some(&b'/') {
-                    // `**/` also matches zero directories.
                     next_pi += 1;
+                    // `**/` matches zero or more complete directory segments.
+                    // It must not start the next pattern in the middle of a
+                    // segment (`**/bar` should not match `foobar`).
+                    if match_path_bytes(pat, next_pi, path, si) {
+                        return true;
+                    }
+                    for try_si in si..path.len() {
+                        if path[try_si] == b'/' && match_path_bytes(pat, next_pi, path, try_si + 1)
+                        {
+                            return true;
+                        }
+                    }
+                    return false;
                 }
                 if next_pi >= pat.len() {
                     if double {
@@ -122,7 +134,7 @@ pub fn match_name(pattern: &str, name: &str) -> bool {
 fn has_name_meta(pattern: &str) -> bool {
     pattern
         .bytes()
-        .any(|byte| matches!(byte, b'*' | b'?' | b'['))
+        .any(|byte| matches!(byte, b'*' | b'?' | b'[' | b'{'))
 }
 
 #[cfg(feature = "name")]
@@ -225,6 +237,16 @@ mod tests {
     }
 
     #[test]
+    fn path_double_star_slash_stays_on_directory_boundaries() {
+        assert!(match_path("**/bar", "bar"));
+        assert!(match_path("**/bar", "foo/bar"));
+        assert!(!match_path("**/bar", "foobar"));
+        assert!(match_path("src/**/main.rs", "src/main.rs"));
+        assert!(match_path("src/**/main.rs", "src/bin/main.rs"));
+        assert!(!match_path("src/**/main.rs", "src/binmain.rs"));
+    }
+
+    #[test]
     fn path_question_mark_matches_one_non_separator() {
         assert!(match_path("src/ma?n.rs", "src/main.rs"));
         assert!(!match_path("src/ma?n.rs", "src/man.rs"));
@@ -289,6 +311,13 @@ mod tests {
         assert!(!match_name("gpt-?o", "gpt-44o"));
         assert!(match_name("file[12]", "file1"));
         assert!(!match_name("file[12]", "file3"));
+    }
+
+    #[test]
+    fn name_brace_alternates_use_glob_syntax() {
+        assert!(match_name("gpt-{4o,5}", "gpt-4o"));
+        assert!(match_name("gpt-{4o,5}", "gpt-5"));
+        assert!(!match_name("gpt-{4o,5}", "gpt-4.1"));
     }
 
     #[test]

--- a/crates/harn-vm/src/mcp_file_upload.rs
+++ b/crates/harn-vm/src/mcp_file_upload.rs
@@ -349,28 +349,35 @@ fn resolve_upload_path(path: &str) -> PathBuf {
 }
 
 fn infer_media_type(path: &Path) -> String {
-    match path
-        .extension()
+    path.extension()
         .and_then(|extension| extension.to_str())
-        .map(|extension| extension.to_ascii_lowercase())
-        .as_deref()
+        .and_then(media_type_for_extension)
+        .unwrap_or("application/octet-stream")
+        .to_string()
+}
+
+fn media_type_for_extension(extension: &str) -> Option<&'static str> {
+    match extension
+        .trim()
+        .trim_start_matches('.')
+        .to_ascii_lowercase()
+        .as_str()
     {
-        Some("pdf") => "application/pdf",
-        Some("mp3") => "audio/mpeg",
-        Some("wav") => "audio/wav",
-        Some("m4a") => "audio/mp4",
-        Some("mp4") => "video/mp4",
-        Some("mpeg") | Some("mpg") => "video/mpeg",
-        Some("png") => "image/png",
-        Some("jpg") | Some("jpeg") => "image/jpeg",
-        Some("gif") => "image/gif",
-        Some("webp") => "image/webp",
-        Some("txt") => "text/plain",
-        Some("csv") => "text/csv",
-        Some("json") => "application/json",
-        _ => "application/octet-stream",
+        "pdf" => Some("application/pdf"),
+        "mp3" => Some("audio/mpeg"),
+        "wav" => Some("audio/wav"),
+        "m4a" => Some("audio/mp4"),
+        "mp4" => Some("video/mp4"),
+        "mpeg" | "mpg" => Some("video/mpeg"),
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        "txt" => Some("text/plain"),
+        "csv" => Some("text/csv"),
+        "json" => Some("application/json"),
+        _ => None,
     }
-    .to_string()
 }
 
 fn validate_media_type(media_type: &str) -> Result<(), VmError> {
@@ -584,32 +591,46 @@ fn hex_value(byte: u8) -> Option<u8> {
 }
 
 fn media_type_matches_accept(media_type: &str, accept: &[&str]) -> bool {
-    let media = media_type
-        .split(';')
-        .next()
-        .unwrap_or(media_type)
-        .trim()
-        .to_ascii_lowercase();
-    let Some((media_type_part, media_subtype_part)) = media.split_once('/') else {
+    if accept.is_empty() {
+        return true;
+    }
+    let Some((media_type_part, media_subtype_part)) = media_type_parts(media_type) else {
         return false;
     };
-    let mut saw_mime_pattern = false;
-    for raw in accept {
-        let pattern = raw.trim().to_ascii_lowercase();
-        if pattern.is_empty() || pattern.starts_with('.') {
-            continue;
+    accept.iter().any(|raw| {
+        let pattern = raw.trim();
+        if pattern.is_empty() {
+            return false;
         }
-        let Some((type_part, subtype_part)) = pattern.split_once('/') else {
-            continue;
-        };
-        saw_mime_pattern = true;
-        if type_part == media_type_part
-            && (subtype_part == "*" || subtype_part == media_subtype_part)
-        {
-            return true;
+        if pattern.starts_with('.') {
+            return media_type_for_extension(pattern).is_some_and(|mapped| {
+                mime_pattern_matches(&media_type_part, &media_subtype_part, mapped)
+            });
         }
+        mime_pattern_matches(&media_type_part, &media_subtype_part, pattern)
+    })
+}
+
+fn media_type_parts(raw: &str) -> Option<(String, String)> {
+    let media = raw
+        .split(';')
+        .next()
+        .unwrap_or(raw)
+        .trim()
+        .to_ascii_lowercase();
+    let (type_part, subtype_part) = media.split_once('/')?;
+    if type_part.is_empty() || subtype_part.is_empty() {
+        return None;
     }
-    !saw_mime_pattern
+    Some((type_part.to_string(), subtype_part.to_string()))
+}
+
+fn mime_pattern_matches(media_type_part: &str, media_subtype_part: &str, pattern: &str) -> bool {
+    let Some((type_part, subtype_part)) = media_type_parts(pattern) else {
+        return false;
+    };
+    (type_part == "*" || type_part == media_type_part)
+        && (subtype_part == "*" || subtype_part == media_subtype_part)
 }
 
 pub fn redact_data_uris_for_logs(value: &JsonValue) -> JsonValue {
@@ -754,6 +775,52 @@ mod tests {
             &json_schema(),
         )
         .expect_err("wrong media type should fail");
+        assert!(err.contains("does not match accept"));
+    }
+
+    #[test]
+    fn accept_matching_supports_wildcards_and_extensions() {
+        assert!(media_type_matches_accept("image/png", &["*/*"]));
+        assert!(media_type_matches_accept("image/png", &["image/*"]));
+        assert!(media_type_matches_accept("image/png", &[".png"]));
+        assert!(media_type_matches_accept(
+            "image/jpeg; charset=binary",
+            &[".jpg"]
+        ));
+        assert!(!media_type_matches_accept("text/plain", &[".png"]));
+        assert!(!media_type_matches_accept("image/png", &[".unknown"]));
+    }
+
+    #[test]
+    fn extension_only_file_input_accept_rejects_wrong_media_type() {
+        reset_for_tests();
+        FILE_UPLOAD_CONFIG.with(|cell| {
+            *cell.borrow_mut() = Some(FileUploadConfig {
+                spec_revision: SPEC_REVISION.to_string(),
+            });
+        });
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "string",
+                    "format": "uri",
+                    "x-mcp-file": {
+                        "accept": [".png"]
+                    }
+                }
+            }
+        });
+        validate_file_inputs_for_call(
+            &serde_json::json!({"image": "data:image/png;base64,aGk="}),
+            &schema,
+        )
+        .expect("matching extension media type");
+        let err = validate_file_inputs_for_call(
+            &serde_json::json!({"image": "data:text/plain;base64,aGk="}),
+            &schema,
+        )
+        .expect_err("extension accept must constrain media type");
         assert!(err.contains("does not match accept"));
     }
 

--- a/crates/harn-vm/src/schema/canonicalize.rs
+++ b/crates/harn-vm/src/schema/canonicalize.rs
@@ -166,6 +166,9 @@ fn canonicalize_schema_dict(
     if let Some(max_items) = schema.get("max_items").or_else(|| schema.get("maxItems")) {
         out.insert("max_items".to_string(), max_items.clone());
     }
+    if schema_bool(schema, "unique_items") || schema_bool(schema, "uniqueItems") {
+        out.insert("unique_items".to_string(), VmValue::Bool(true));
+    }
     if let Some(pattern) = schema.get("pattern") {
         out.insert("pattern".to_string(), pattern.clone());
     }
@@ -245,16 +248,6 @@ fn canonicalize_schema_dict(
             );
         }
         _ => {}
-    }
-
-    if matches!(schema.get("uniqueItems"), Some(VmValue::Bool(true)))
-        && schema_type_name(&out) == Some("list")
-        && !out.contains_key("x-harn-type")
-    {
-        out.insert(
-            "x-harn-type".to_string(),
-            VmValue::String(std::sync::Arc::from("set")),
-        );
     }
 
     if out.get("x-harn-type").map(|v| v.display()) == Some("set".to_string()) {
@@ -522,7 +515,12 @@ fn canonical_to_json_schema_with(
                         serde_json::Value::String("array".into()),
                     );
                     out.insert("uniqueItems".to_string(), serde_json::Value::Bool(true));
+                    out.insert(
+                        "x-harn-type".to_string(),
+                        serde_json::Value::String("set".into()),
+                    );
                 }
+                "any" => {}
                 "closure" => {
                     out.insert(
                         "type".to_string(),
@@ -566,6 +564,9 @@ fn canonical_to_json_schema_with(
         }
         if let Some(max_items) = schema_i64(schema_dict, "max_items") {
             out.insert("maxItems".to_string(), serde_json::json!(max_items));
+        }
+        if schema_bool(schema_dict, "unique_items") {
+            out.insert("uniqueItems".to_string(), serde_json::Value::Bool(true));
         }
         if let Some(VmValue::String(pattern)) = schema_dict.get("pattern") {
             out.insert(
@@ -630,7 +631,7 @@ fn canonical_to_json_schema_with(
                 .map(|value| canonical_to_json_schema_with(value, openapi_style, traversal))
                 .collect::<Result<Vec<_>, _>>()?;
             if openapi_style && branches.len() == 2 {
-                let null_index = branches.iter().position(|value| value == "null");
+                let null_index = branches.iter().position(json_schema_is_null_type);
                 if let Some(null_index) = null_index {
                     let other_index = usize::from(null_index == 0);
                     if let Some(other_type) = branches[other_index].as_object_mut() {
@@ -724,6 +725,14 @@ fn canonical_to_json_schema_with(
 
         Ok(serde_json::Value::Object(out))
     })
+}
+
+fn json_schema_is_null_type(value: &serde_json::Value) -> bool {
+    value
+        .as_object()
+        .and_then(|object| object.get("type"))
+        .and_then(serde_json::Value::as_str)
+        == Some("null")
 }
 
 fn json_type_for_harn(type_name: &str) -> serde_json::Value {

--- a/crates/harn-vm/src/schema/tests.rs
+++ b/crates/harn-vm/src/schema/tests.rs
@@ -7,7 +7,8 @@ use super::limits::{DEFAULT_SCHEMA_MAX_DEPTH, DEFAULT_SCHEMA_MAX_REF_EXPANSIONS}
 use super::transform::{merge_schema_dicts, schema_partial_dict};
 use super::validate::{validate_schema_value, ValidationOptions};
 use super::{
-    schema_assert_param, schema_is_value, schema_result_value, schema_to_openapi_schema_value,
+    schema_assert_param, schema_is_value, schema_result_value, schema_to_json_schema_value,
+    schema_to_openapi_schema_value,
 };
 
 fn s(v: &str) -> VmValue {
@@ -309,6 +310,31 @@ fn union_still_applies_sibling_constraints() {
 }
 
 #[test]
+fn enum_constraints_apply_to_collection_values() {
+    let list_schema = make_vm_dict(vec![(
+        "enum",
+        make_list(vec![make_list(vec![VmValue::Int(1), VmValue::Int(2)])]),
+    )]);
+    assert!(schema_is_value(
+        &make_list(vec![VmValue::Int(1), VmValue::Int(2)]),
+        &list_schema
+    )
+    .unwrap());
+    assert!(!schema_is_value(
+        &make_list(vec![VmValue::Int(2), VmValue::Int(1)]),
+        &list_schema
+    )
+    .unwrap());
+
+    let dict_schema = make_vm_dict(vec![(
+        "enum",
+        make_list(vec![make_vm_dict(vec![("name", s("Ada"))])]),
+    )]);
+    assert!(schema_is_value(&make_vm_dict(vec![("name", s("Ada"))]), &dict_schema).unwrap());
+    assert!(!schema_is_value(&make_vm_dict(vec![("name", s("Grace"))]), &dict_schema).unwrap());
+}
+
+#[test]
 fn export_openapi_nullable() {
     let schema = make_vm_dict(vec![
         ("type", s("string")),
@@ -318,6 +344,44 @@ fn export_openapi_nullable() {
     let dict = exported.as_dict().unwrap();
     assert_eq!(dict.get("type").unwrap().display(), "string");
     assert_eq!(dict.get("nullable").unwrap().display(), "true");
+}
+
+#[test]
+fn export_openapi_nullable_type_union() {
+    let schema = make_vm_dict(vec![("type", make_list(vec![s("string"), s("null")]))]);
+    let exported = schema_to_openapi_schema_value(&schema).unwrap();
+    let dict = exported.as_dict().unwrap();
+    assert_eq!(dict.get("type").unwrap().display(), "string");
+    assert_eq!(dict.get("nullable").unwrap().display(), "true");
+    assert!(!dict.contains_key("oneOf"));
+}
+
+#[test]
+fn export_json_schema_omits_invalid_any_type() {
+    let schema = make_vm_dict(vec![("type", s("any"))]);
+    let exported = schema_to_json_schema_value(&schema).unwrap();
+    let dict = exported.as_dict().unwrap();
+    assert!(!dict.contains_key("type"));
+}
+
+#[test]
+fn json_schema_unique_items_validates_lists_without_requiring_harn_set() {
+    let schema = make_vm_dict(vec![
+        ("type", s("array")),
+        ("uniqueItems", VmValue::Bool(true)),
+    ]);
+    assert!(schema_is_value(&make_list(vec![VmValue::Int(1), VmValue::Int(2)]), &schema).unwrap());
+    assert!(!schema_is_value(&make_list(vec![VmValue::Int(1), VmValue::Int(1)]), &schema).unwrap());
+}
+
+#[test]
+fn export_set_schema_keeps_harn_marker() {
+    let schema = make_vm_dict(vec![("type", s("set"))]);
+    let exported = schema_to_json_schema_value(&schema).unwrap();
+    let dict = exported.as_dict().unwrap();
+    assert_eq!(dict.get("type").unwrap().display(), "array");
+    assert_eq!(dict.get("uniqueItems").unwrap().display(), "true");
+    assert_eq!(dict.get("x-harn-type").unwrap().display(), "set");
 }
 
 #[test]

--- a/crates/harn-vm/src/schema/validate.rs
+++ b/crates/harn-vm/src/schema/validate.rs
@@ -230,6 +230,7 @@ fn validate_against_schema_inner(
                 validate_object_fields(map, None, schema, root_schema, path, options, context);
             normalized = next_value;
             errors.extend(next_errors);
+            validate_enum_membership(&normalized, schema, path, &mut errors);
         }
         VmValue::StructInstance { layout, .. } => {
             let fields = normalized.struct_fields_map().unwrap_or_default();
@@ -244,6 +245,7 @@ fn validate_against_schema_inner(
             );
             normalized = next_value;
             errors.extend(next_errors);
+            validate_enum_membership(&normalized, schema, path, &mut errors);
         }
         VmValue::List(items) | VmValue::Set(items) => {
             if let Some(min_items) = schema_i64(schema, "min_items") {
@@ -288,6 +290,13 @@ fn validate_against_schema_inner(
                     _ => VmValue::List(std::sync::Arc::new(normalized_items)),
                 };
             }
+            if schema_bool(schema, "unique_items") && !items_are_unique(&normalized) {
+                errors.push(format!(
+                    "at {}: expected items to be unique",
+                    location_label(path)
+                ));
+            }
+            validate_enum_membership(&normalized, schema, path, &mut errors);
         }
         VmValue::String(text) => {
             let length = text.chars().count() as i64;
@@ -502,6 +511,22 @@ fn validate_object_fields(
     };
 
     (normalized, errors)
+}
+
+fn items_are_unique(value: &VmValue) -> bool {
+    let items = match value {
+        VmValue::List(items) | VmValue::Set(items) => items,
+        _ => return true,
+    };
+    for (index, item) in items.iter().enumerate() {
+        if items[index + 1..]
+            .iter()
+            .any(|candidate| values_equal(item, candidate))
+        {
+            return false;
+        }
+    }
+    true
 }
 
 fn validate_numeric_constraints(

--- a/crates/harn-vm/src/stdlib/oauth_dynreg.rs
+++ b/crates/harn-vm/src/stdlib/oauth_dynreg.rs
@@ -51,6 +51,7 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::net::IpAddr;
 use std::sync::Mutex;
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -436,7 +437,7 @@ fn validate_redirect_uri(value: &str) -> Result<(), String> {
             let host = url
                 .host_str()
                 .ok_or_else(|| "must specify a host".to_string())?;
-            if host == "localhost" || host == "127.0.0.1" || host == "[::1]" {
+            if is_loopback_redirect_host(host) {
                 Ok(())
             } else {
                 Err(format!(
@@ -448,6 +449,17 @@ fn validate_redirect_uri(value: &str) -> Result<(), String> {
             "scheme `{scheme}` is not allowed; use `https` or loopback `http`"
         )),
     }
+}
+
+fn is_loopback_redirect_host(host: &str) -> bool {
+    let host = host
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(host);
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<IpAddr>()
+            .is_ok_and(|address| address.is_loopback())
 }
 
 fn validate_enum_list(
@@ -895,6 +907,22 @@ mod tests {
         let mut errors = Vec::new();
         validate_metadata(&m, &mut errors);
         assert!(errors.is_empty(), "expected no errors, got {errors:?}");
+    }
+
+    #[test]
+    fn ipv6_and_127_range_loopback_http_redirects_pass() {
+        for redirect_uri in [
+            "http://[::1]:8765/callback",
+            "http://127.10.20.30:8765/callback",
+        ] {
+            let m = metadata_with_redirect(redirect_uri);
+            let mut errors = Vec::new();
+            validate_metadata(&m, &mut errors);
+            assert!(
+                errors.is_empty(),
+                "expected {redirect_uri} to pass, got {errors:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a sweep of unambiguous edge-case bugs across glob matching, schema canonicalization/validation, MCP file upload validation, OAuth dynamic registration, and MCP OAuth resource audience checks.

Highlights:
- Keep `**/` path globs on directory boundaries and enable documented brace alternates for name globs.
- Apply schema enum checks to collection values, validate JSON Schema `uniqueItems` on lists, preserve Harn set metadata on export, omit invalid JSON Schema `type: any`, and export nullable OpenAPI unions correctly.
- Make MCP file upload `accept` matching honor `*/*`, MIME wildcards, and extension-only accept lists without silently accepting all media.
- Accept all loopback IP redirect hosts for OAuth dynamic registration, including bracketed IPv6 and 127/8 addresses.
- Match MCP OAuth resource audiences exactly instead of case-insensitively.

## Verification

- `cargo fmt --all`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/harn-bugfix-sweep-tests-target cargo test -p harn-glob`
- `CARGO_TARGET_DIR=/tmp/harn-bugfix-sweep-tests-target cargo test -p harn-vm schema::tests::`
- `CARGO_TARGET_DIR=/tmp/harn-bugfix-sweep-tests-target cargo test -p harn-vm mcp_file_upload::tests::`
- `CARGO_TARGET_DIR=/tmp/harn-bugfix-sweep-tests-target cargo test -p harn-vm oauth_dynreg`
- `CARGO_TARGET_DIR=/tmp/harn-bugfix-sweep-tests-target cargo test -p harn-cli audience_matching_is_exact`
- `CARGO_TARGET_DIR=/tmp/harn-bugfix-sweep-target cargo clippy --workspace --all-targets --all-features -- -D clippy::correctness -D clippy::suspicious`
- Pre-commit hook: passed, including changed-package clippy
- Pre-push hook: passed targeted local checks