### PR TITLE
feat(providers): --capabilities-overlay on export/validate — structured capabilities for overlay-declared models

### DIFF
--- a/changelog.d/3267-capabilities-overlay.added.md
+++ b/changelog.d/3267-capabilities-overlay.added.md
@@ -1,0 +1,6 @@
+- `harn providers export` / `harn providers validate` accept `--capabilities-overlay <path>` (capabilities.toml
+layout): overlay-declared private/local models can claim structured capabilities (native tools, vision, prompt
+caching, reasoning modes) in the exported artifact instead of relying on legacy `capabilities` tags or post-export
+patching. The serve runtime honors the same data through the manifest `[capabilities]` section, so exported and
+served catalogs agree; new `harn_vm::llm::capabilities::parse_capabilities_toml` parses without mutating thread
+state (#3267)

--- a/crates/harn-cli/src/cli/providers.rs
+++ b/crates/harn-cli/src/cli/providers.rs
@@ -49,6 +49,11 @@ pub(crate) struct ProvidersValidateArgs {
     /// Merge an additional providers.toml-style overlay before validating.
     #[arg(long)]
     pub overlay: Option<PathBuf>,
+    /// Merge a capabilities.toml-style overlay (same layout as the built-in
+    /// capability matrix) before validating, so overlay-declared private or
+    /// local models can claim structured capabilities.
+    #[arg(long = "capabilities-overlay")]
+    pub capabilities_overlay: Option<PathBuf>,
     /// Also verify checked-in generated artifacts match the current catalog.
     #[arg(long = "check-artifacts")]
     pub check_artifacts: bool,
@@ -97,6 +102,13 @@ pub(crate) struct ProvidersExportArgs {
     /// Merge an additional providers.toml-style overlay before exporting.
     #[arg(long)]
     pub overlay: Option<PathBuf>,
+    /// Merge a capabilities.toml-style overlay (same layout as the built-in
+    /// capability matrix) before exporting, so overlay-declared private or
+    /// local models can claim structured capabilities. The serve runtime
+    /// honors the same file through the manifest `[capabilities]` section,
+    /// keeping exported and served catalogs in agreement.
+    #[arg(long = "capabilities-overlay")]
+    pub capabilities_overlay: Option<PathBuf>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/harn-cli/src/commands/providers/artifacts.rs
+++ b/crates/harn-cli/src/commands/providers/artifacts.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use harn_vm::llm::capabilities::CapabilitiesFile;
 use harn_vm::llm_config::ProvidersConfig;
 use serde_json::json;
 
@@ -8,12 +9,14 @@ use crate::cli::{ProvidersExportArgs, ProvidersValidateArgs};
 
 pub(crate) fn run_validate(args: &ProvidersValidateArgs) -> Result<(), String> {
     let overlay = load_overlay(args.overlay.as_deref())?;
+    let capabilities = load_capabilities_overlay(args.capabilities_overlay.as_deref())?;
     // Generation is hermetic: validate the artifact built from the compiled-in
-    // embedded catalog (plus any explicit `--overlay`), never the developer's
-    // home config or environment. Otherwise a personal
-    // `~/.config/harn/providers.toml` would leak aliases/providers into the
-    // catalog we validate and ship.
-    let artifact = harn_vm::provider_catalog::artifact_embedded(overlay.as_ref());
+    // embedded catalog (plus any explicit `--overlay` /
+    // `--capabilities-overlay`), never the developer's home config or
+    // environment. Otherwise a personal `~/.config/harn/providers.toml` would
+    // leak aliases/providers into the catalog we validate and ship.
+    let artifact =
+        harn_vm::provider_catalog::artifact_embedded(overlay.as_ref(), capabilities.as_ref());
     let logical = harn_vm::provider_catalog::validate_artifact(&artifact);
     let schema = harn_vm::provider_catalog::schema_value();
     let artifact_value = serde_json::to_value(&artifact)
@@ -22,7 +25,7 @@ pub(crate) fn run_validate(args: &ProvidersValidateArgs) -> Result<(), String> {
     validate_against_schema(&schema, &artifact_value, &mut schema_errors)?;
     let mut drift = Vec::new();
     if args.check_artifacts {
-        drift = artifact_drift(&args.artifact_dir, overlay.as_ref())?;
+        drift = artifact_drift(&args.artifact_dir, overlay.as_ref(), capabilities.as_ref())?;
     }
 
     if args.json {
@@ -65,9 +68,11 @@ pub(crate) fn run_validate(args: &ProvidersValidateArgs) -> Result<(), String> {
 
 pub(crate) fn run_export(args: &ProvidersExportArgs) -> Result<(), String> {
     let overlay = load_overlay(args.overlay.as_deref())?;
-    // Export from the embedded catalog only (plus any explicit `--overlay`) so
-    // the checked-in artifacts are a pure function of the source tree.
-    let artifacts = generated_artifacts(overlay.as_ref())?;
+    let capabilities = load_capabilities_overlay(args.capabilities_overlay.as_deref())?;
+    // Export from the embedded catalog only (plus any explicit `--overlay` /
+    // `--capabilities-overlay`) so the checked-in artifacts are a pure
+    // function of the source tree.
+    let artifacts = generated_artifacts(overlay.as_ref(), capabilities.as_ref())?;
     if args.check {
         let drift = artifact_drift_from(&args.output_dir, &artifacts)?;
         if drift.is_empty() {
@@ -110,6 +115,29 @@ fn load_overlay(path: Option<&Path>) -> Result<Option<ProvidersConfig>, String> 
     Ok(Some(overlay))
 }
 
+/// Parse an explicit `--capabilities-overlay` capabilities.toml file (the same
+/// layout as the built-in capability matrix). Like `load_overlay`, the parsed
+/// file is threaded explicitly rather than installed as thread-local state so
+/// generation stays hermetic.
+fn load_capabilities_overlay(path: Option<&Path>) -> Result<Option<CapabilitiesFile>, String> {
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    let src = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "failed to read capabilities overlay {}: {error}",
+            path.display()
+        )
+    })?;
+    let overlay = harn_vm::llm::capabilities::parse_capabilities_toml(&src).map_err(|error| {
+        format!(
+            "failed to parse capabilities overlay {}: {error}",
+            path.display()
+        )
+    })?;
+    Ok(Some(overlay))
+}
+
 fn validate_against_schema(
     schema: &serde_json::Value,
     artifact: &serde_json::Value,
@@ -134,11 +162,12 @@ struct GeneratedArtifact {
 
 fn generated_artifacts(
     overlay: Option<&ProvidersConfig>,
+    capabilities: Option<&CapabilitiesFile>,
 ) -> Result<Vec<GeneratedArtifact>, String> {
     Ok(vec![
         GeneratedArtifact {
             relative_path: "provider-catalog.json",
-            body: harn_vm::provider_catalog::artifact_json_embedded(overlay)
+            body: harn_vm::provider_catalog::artifact_json_embedded(overlay, capabilities)
                 .map_err(|error| format!("failed to generate catalog JSON: {error}"))?,
         },
         GeneratedArtifact {
@@ -148,19 +177,23 @@ fn generated_artifacts(
         },
         GeneratedArtifact {
             relative_path: "harn-provider-catalog.ts",
-            body: harn_vm::provider_catalog::typescript_binding_embedded(overlay)
+            body: harn_vm::provider_catalog::typescript_binding_embedded(overlay, capabilities)
                 .map_err(|error| format!("failed to generate TypeScript binding: {error}"))?,
         },
         GeneratedArtifact {
             relative_path: "HarnProviderCatalog.swift",
-            body: harn_vm::provider_catalog::swift_binding_embedded(overlay)
+            body: harn_vm::provider_catalog::swift_binding_embedded(overlay, capabilities)
                 .map_err(|error| format!("failed to generate Swift binding: {error}"))?,
         },
     ])
 }
 
-fn artifact_drift(dir: &Path, overlay: Option<&ProvidersConfig>) -> Result<Vec<String>, String> {
-    artifact_drift_from(dir, &generated_artifacts(overlay)?)
+fn artifact_drift(
+    dir: &Path,
+    overlay: Option<&ProvidersConfig>,
+    capabilities: Option<&CapabilitiesFile>,
+) -> Result<Vec<String>, String> {
+    artifact_drift_from(dir, &generated_artifacts(overlay, capabilities)?)
 }
 
 fn artifact_drift_from(dir: &Path, artifacts: &[GeneratedArtifact]) -> Result<Vec<String>, String> {
@@ -181,7 +214,7 @@ mod tests {
 
     #[test]
     fn generated_artifacts_include_downstream_bindings() {
-        let artifacts = generated_artifacts(None).expect("artifacts generate");
+        let artifacts = generated_artifacts(None, None).expect("artifacts generate");
         let names: Vec<_> = artifacts
             .iter()
             .map(|artifact| artifact.relative_path)
@@ -196,9 +229,61 @@ mod tests {
     fn generated_catalog_validates_against_schema() {
         let schema = harn_vm::provider_catalog::schema_value();
         let artifact =
-            serde_json::to_value(harn_vm::provider_catalog::artifact_embedded(None)).unwrap();
+            serde_json::to_value(harn_vm::provider_catalog::artifact_embedded(None, None)).unwrap();
         let mut errors = Vec::new();
         validate_against_schema(&schema, &artifact, &mut errors).expect("schema compiles");
         assert!(errors.is_empty(), "schema errors: {errors:?}");
+    }
+
+    #[test]
+    fn capabilities_overlay_changes_exported_structured_fields() {
+        // A providers overlay declares a private route; the capabilities
+        // overlay is what grants it structured capabilities (the capability
+        // matrix is the source of truth — `models.*.capabilities` tags are
+        // legacy parse-only). The exported artifact must reflect both.
+        let overlay = harn_vm::llm_config::parse_config_toml(
+            r#"
+[providers.private]
+display_name = "Private"
+base_url = "http://127.0.0.1:9000"
+auth_style = "none"
+chat_endpoint = "/v1/chat/completions"
+
+[models."private/fast"]
+name = "Private Fast"
+provider = "private"
+context_window = 8192
+"#,
+        )
+        .expect("overlay parses");
+        let capabilities = harn_vm::llm::capabilities::parse_capabilities_toml(
+            r#"
+[[provider.private]]
+model_match = "*"
+native_tools = true
+vision = true
+prompt_caching = true
+"#,
+        )
+        .expect("capabilities overlay parses");
+
+        let without = harn_vm::provider_catalog::artifact_embedded(Some(&overlay), None);
+        let with =
+            harn_vm::provider_catalog::artifact_embedded(Some(&overlay), Some(&capabilities));
+        let row = |artifact: &harn_vm::provider_catalog::ProviderCatalogArtifact| {
+            artifact
+                .models
+                .iter()
+                .find(|model| model.id == "private/fast")
+                .expect("private model is exported")
+                .clone()
+        };
+        let (before, after) = (row(&without), row(&with));
+        assert!(!before.tool_support.native);
+        assert!(after.tool_support.native);
+        assert!(!before.prompt_cache);
+        assert!(after.prompt_cache);
+        assert!(!before.modalities.input.contains(&"image".to_string()));
+        assert!(after.modalities.input.contains(&"image".to_string()));
     }
 }

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -678,9 +678,16 @@ pub fn clear_user_overrides() {
 /// same layout used by the built-in `capabilities.toml`) and install as
 /// the current thread's override.
 pub fn set_user_overrides_toml(src: &str) -> Result<(), String> {
-    let parsed: CapabilitiesFile = toml::from_str(src).map_err(|e| e.to_string())?;
-    set_user_overrides(Some(parsed));
+    set_user_overrides(Some(parse_capabilities_toml(src)?));
     Ok(())
+}
+
+/// Parse a capabilities TOML document (the same layout used by the built-in
+/// `capabilities.toml`) without installing it anywhere, for callers that
+/// thread an explicit capability overlay instead of mutating thread state
+/// (e.g. `harn providers export --capabilities-overlay`).
+pub fn parse_capabilities_toml(src: &str) -> Result<CapabilitiesFile, String> {
+    toml::from_str(src).map_err(|e| e.to_string())
 }
 
 /// Extract the `[capabilities]` section from a full `harn.toml` source

--- a/crates/harn-vm/src/provider_catalog.rs
+++ b/crates/harn-vm/src/provider_catalog.rs
@@ -182,13 +182,19 @@ pub fn artifact() -> ProviderCatalogArtifact {
 /// `explicit_overlay` is an optional declared overlay (e.g. a `--overlay` file
 /// named on the command line); it is reproducible input, not ambient machine
 /// state, so it is merged on top of the embedded base while staying hermetic.
+/// `explicit_capabilities` is the matching declared capability overlay (e.g. a
+/// `--capabilities-overlay` file): without one, only the built-in capability
+/// matrix is consulted — never the thread-local capability user-overrides the
+/// CLI may have installed.
 pub fn artifact_embedded(
     explicit_overlay: Option<&llm_config::ProvidersConfig>,
+    explicit_capabilities: Option<&llm::capabilities::CapabilitiesFile>,
 ) -> ProviderCatalogArtifact {
     let config = llm_config::embedded_config(explicit_overlay);
-    // `Explicit(None)` consults only the built-in capability matrix, never the
-    // thread-local capability user-overrides the CLI may have installed.
-    artifact_from_config(&config, CatalogCapabilityOverrides::Explicit(None))
+    artifact_from_config(
+        &config,
+        CatalogCapabilityOverrides::Explicit(explicit_capabilities),
+    )
 }
 
 /// Build a catalog artifact for a runtime that has captured explicit provider
@@ -272,8 +278,9 @@ pub fn artifact_json() -> Result<String, serde_json::Error> {
 /// `provider-catalog.json` artifact. See [`artifact_embedded`].
 pub fn artifact_json_embedded(
     explicit_overlay: Option<&llm_config::ProvidersConfig>,
+    explicit_capabilities: Option<&llm::capabilities::CapabilitiesFile>,
 ) -> Result<String, serde_json::Error> {
-    artifact_to_json(&artifact_embedded(explicit_overlay))
+    artifact_to_json(&artifact_embedded(explicit_overlay, explicit_capabilities))
 }
 
 /// `[suppress]` route selectors parsed as `(provider, model_id)` pairs.

--- a/crates/harn-vm/src/provider_catalog/bindings.rs
+++ b/crates/harn-vm/src/provider_catalog/bindings.rs
@@ -8,9 +8,11 @@ pub fn typescript_binding() -> Result<String, serde_json::Error> {
 /// checked-in `harn-provider-catalog.ts` artifact. See [`artifact_embedded`].
 pub fn typescript_binding_embedded(
     explicit_overlay: Option<&crate::llm_config::ProvidersConfig>,
+    explicit_capabilities: Option<&crate::llm::capabilities::CapabilitiesFile>,
 ) -> Result<String, serde_json::Error> {
     Ok(typescript_binding_from_json(&artifact_json_embedded(
         explicit_overlay,
+        explicit_capabilities,
     )?))
 }
 
@@ -33,9 +35,11 @@ pub fn swift_binding() -> Result<String, serde_json::Error> {
 /// `HarnProviderCatalog.swift` artifact. See [`artifact_embedded`].
 pub fn swift_binding_embedded(
     explicit_overlay: Option<&crate::llm_config::ProvidersConfig>,
+    explicit_capabilities: Option<&crate::llm::capabilities::CapabilitiesFile>,
 ) -> Result<String, serde_json::Error> {
     Ok(swift_binding_from_json(&artifact_json_embedded(
         explicit_overlay,
+        explicit_capabilities,
     )?))
 }
 

--- a/crates/harn-vm/src/provider_catalog/tests.rs
+++ b/crates/harn-vm/src/provider_catalog/tests.rs
@@ -780,10 +780,10 @@ fn catalog_mentions_leak(artifact: &ProviderCatalogArtifact) -> bool {
 fn embedded_artifact_generation_is_hermetic_against_ambient_overlay() {
     // Baseline generated with no ambient config at all.
     llm_config::clear_user_overrides();
-    let baseline = artifact_embedded(None);
-    let baseline_json = artifact_json_embedded(None).expect("baseline json");
-    let baseline_ts = typescript_binding_embedded(None).expect("baseline ts");
-    let baseline_swift = swift_binding_embedded(None).expect("baseline swift");
+    let baseline = artifact_embedded(None, None);
+    let baseline_json = artifact_json_embedded(None, None).expect("baseline json");
+    let baseline_ts = typescript_binding_embedded(None, None).expect("baseline ts");
+    let baseline_swift = swift_binding_embedded(None, None).expect("baseline swift");
 
     assert!(
         !catalog_mentions_leak(&baseline),
@@ -803,23 +803,23 @@ fn embedded_artifact_generation_is_hermetic_against_ambient_overlay() {
             "runtime artifact() must still reflect the ambient overlay"
         );
 
-        let polluted = artifact_embedded(None);
+        let polluted = artifact_embedded(None, None);
         assert!(
             !catalog_mentions_leak(&polluted),
             "embedded catalog leaked ambient overlay aliases/providers/models"
         );
         assert_eq!(
-            artifact_json_embedded(None).expect("polluted json"),
+            artifact_json_embedded(None, None).expect("polluted json"),
             baseline_json,
             "embedded provider-catalog.json must be byte-identical with/without ambient overlay"
         );
         assert_eq!(
-            typescript_binding_embedded(None).expect("polluted ts"),
+            typescript_binding_embedded(None, None).expect("polluted ts"),
             baseline_ts,
             "embedded TypeScript binding must be byte-identical with/without ambient overlay"
         );
         assert_eq!(
-            swift_binding_embedded(None).expect("polluted swift"),
+            swift_binding_embedded(None, None).expect("polluted swift"),
             baseline_swift,
             "embedded Swift binding must be byte-identical with/without ambient overlay"
         );
@@ -827,7 +827,7 @@ fn embedded_artifact_generation_is_hermetic_against_ambient_overlay() {
 
     // After dropping the overlay, generation is unchanged.
     assert_eq!(
-        artifact_json_embedded(None).expect("cleared json"),
+        artifact_json_embedded(None, None).expect("cleared json"),
         baseline_json
     );
 }
@@ -839,7 +839,7 @@ fn embedded_artifact_honors_explicit_declared_overlay() {
     // An *explicit* declared overlay (e.g. a `--overlay` file named on the
     // command line) is reproducible input, not ambient machine state, so the
     // hermetic generator merges it on top of the embedded base.
-    let artifact = artifact_embedded(Some(&overlay));
+    let artifact = artifact_embedded(Some(&overlay), None);
     assert!(
         catalog_mentions_leak(&artifact),
         "explicit overlay should be merged into the embedded catalog"

--- a/docs/src/llm/provider-catalog-refresh.md
+++ b/docs/src/llm/provider-catalog-refresh.md
@@ -144,6 +144,29 @@ Because an overlay's `[models]` entries replace whole rows, pairing a
 new row with a `[suppress]` entry for the old id also expresses a route
 rename — no post-export patching required.
 
+Structured capability fields (`tool_support`, `modalities`,
+`reasoning`, `prompt_cache`) come from the capability matrix, not from
+`models.*.capabilities` tags (legacy, parse-only). For overlay-declared
+private or local models, pass a matching capabilities overlay (the same
+layout as the built-in `capabilities.toml`):
+
+```bash
+harn providers export --overlay providers.toml \
+  --capabilities-overlay capabilities.toml --output-dir out
+```
+
+```toml
+[[provider.private]]
+model_match = "*"
+native_tools = true
+vision = true
+prompt_caching = true
+```
+
+The serve runtime honors the same data via the manifest
+`[capabilities]` section, so the exported artifact and the live
+`_harn/providerCatalog` / `GET /v1/provider-catalog` responses agree.
+
 ## Runtime surfaces
 
 Thin clients should prefer the live harn-serve catalog when a runtime is


### PR DESCRIPTION
Refs #3267 (completes the capability-projection remainder; the `[suppress]` half shipped in #3268). Unblocks burin-labs/burin-code#2215 at the next release + repin.

## What

`harn providers export` / `harn providers validate` accept `--capabilities-overlay <path>` — a capabilities.toml-layout file (`[[provider.X]] model_match = "*" native_tools = true ...`) threaded hermetically through `artifact_embedded` / `artifact_json_embedded` / the TS+Swift bindings, exactly mirroring `--overlay`: declared reproducible input, never thread-local state. New `harn_vm::llm::capabilities::parse_capabilities_toml` parses without installing overrides (and `set_user_overrides_toml` now delegates to it).

## Why

The capability matrix is the source of truth for the artifact's structured fields (`tool_support`, `modalities`, `reasoning`, `prompt_cache`) — `models.*.capabilities` tags are legacy parse-only (`with_effective_capability_tags` overwrites them). That's correct, but it left embedders whose providers.toml overlay declares private/local models with no way to get real capabilities into the **exported** artifact; burin patches the JSON post-export in JS (`applyBurinOverlayCapabilities`), which is exactly the export/serve parity gap #3267 describes. The serve runtime already honors the same data via the manifest `[capabilities]` section and `artifact_with_overrides`, so with this flag the exported artifact and the live `_harn/providerCatalog` / `GET /v1/provider-catalog` responses agree for the same inputs.

Deliberately NOT capability-tag projection: projecting legacy tags into structured fields would create a second, weaker source of truth alongside the matrix. The overlay file uses the same rule schema the matrix itself uses.

## Verification

- New test `capabilities_overlay_changes_exported_structured_fields`: a providers overlay declares a private route; without the capabilities overlay the exported row has matrix defaults (`native: false`, no image modality, no prompt cache), with it the structured fields flip. Plus existing artifacts + provider_catalog suites updated for the threaded parameter (26/26 + 3/3 green).
- Baseline artifacts unchanged: no capabilities overlay in the embedded generation path (`Explicit(None)` behavior is identical).
- Docs: `docs/src/llm/provider-catalog-refresh.md` gains the flag + example; changelog fragment included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)