### PR TITLE
fix: cross-cutting bug sweep round 2 — 13 root-cause fixes

### DIFF
--- a/changelog.d/bug-sweep-2-2026-06-11.fixed.md
+++ b/changelog.d/bug-sweep-2-2026-06-11.fixed.md
@@ -1,0 +1,70 @@
+- **Cross-cutting bug sweep, round 2 (13 root-cause fixes).**
+  - *Compiler — nested assignment wrote to the wrong target.* Every
+    multi-segment assignment path collapsed to its root variable and final
+    accessor: `a.b.c = v` silently wrote `a.c`, `a["b"]["c"] = v` wrote
+    `a["c"]`, `xs[0][1] = v` replaced `xs[1]`, `m.list[0] = v` wrote
+    `m["0"]`, and `p[0].x = v` threw. Nested paths are now desugared into a
+    scope-contained chain of temporaries that reads down, assigns the leaf,
+    and writes back up — preserving `let` immutability at the root.
+  - *Compiler — compound subscript indices evaluated twice.*
+    `xs[idx()] += 1` called `idx()` once for the read and again for the
+    write; side-effecting indices are now hoisted into a temp and evaluated
+    exactly once.
+  - *Compiler — invalid assignment targets compiled as silent no-ops.*
+    `get_thing().x = 99` compiled and did nothing; it is now a compile
+    error naming the unsupported target form.
+  - *Compiler — module-level statements were silently dropped in pipeline
+    mode.* Assignments and expression statements between a binding and a
+    pipeline declaration never executed (`var n = 1` then `n = 2` left the
+    pipeline seeing 1, and a module-level `log(...)` never printed). All
+    module statements now run in source order before declarations, matching
+    script mode.
+  - *Runtime — index assignment on unsupported types was a silent no-op.*
+    `s[0] = "Z"` on a string and `xs["a"] = 9` on a list left the value
+    untouched and reported nothing; both now raise the same class of type
+    error the read path and property path already raised.
+  - *Codegen security — `${…}` interpolation injection.* The `harn try`
+    scaffolding and the composition/crystallize code generators escaped
+    quotes and backslashes when embedding values in generated Harn source,
+    but not `${`, so a value containing `${host_call(...)}` executed as
+    code when the generated program compiled. All generators (and
+    `harn fmt`) now share one round-trip-tested
+    `harn_lexer::escape_string_literal`.
+  - *ACP — `session/cancel` skipped authentication.* The only session
+    method without the `reject_unauthenticated` gate, letting any
+    unauthenticated peer cancel a running session. Guard added, plus a
+    drift test asserting every `session/*` dispatch arm checks auth.
+  - *LLM providers — `Retry-After` dropped on errors.* Gemini, Azure
+    OpenAI, Bedrock, and Vertex hardcoded `None` for the rate-limit
+    backoff hint that Anthropic/OpenAI/Ollama already threaded through;
+    all providers now share one header-extraction helper.
+  - *LSP — find-references returned whole declarations.* References for a
+    function, parameter, or binding highlighted the entire declaration
+    span; results now narrow to the identifier token, sharing the same
+    refinement rename already used.
+  - *Typechecker — subscript inference ignored intersections.* `x["a"]` on
+    an intersection type inferred gradual (accepting any assignment) while
+    `x.a` resolved the member type; the subscript path now mirrors the
+    property path.
+  - *CLI — divergent TOML escaping produced invalid TOML.* The connector
+    scaffolding's escape helper skipped `\n`/`\t`/`\r` (and all other
+    control characters), so generated specs with multi-line values did not
+    parse; consolidated with `harn rules`' copy into one shared helper that
+    escapes the full control range. Three identical `html_escape` copies
+    and a JUnit `xml_escape` were also unified.
+  - *Tests — one flaky test failed as sixteen.* A scheduler-sensitive
+    rate-limit assertion poisoned the shared LLM env lock and cascaded into
+    15 unrelated failures. The env lock now recovers from poisoning and the
+    flaky yield-count assertions are deterministic diagnostic timeouts.
+  - *Tests — the two rate-limit reset scopes are now decoupled.* The
+    rate-limiter registry is process-global, but reset ran at a single
+    level: `reset_llm_state` wiped the whole registry, which (a) corrupted a
+    sibling rate-limit test's counters when an unrelated parallel test reset
+    mid-assertion, yet (b) was *required* for the sequential CLI test runner
+    to clear a leaked retry-after cooldown between cases. The two needs now
+    have two functions: `reset_llm_state` (parallel-safe; scrubs only leaked
+    runtime overrides) and a full-wipe `reset_rate_limit_registry` reached
+    via `reset_thread_local_state`, which only runs in sequential /
+    separate-process contexts. This fixes a conformance fidelity test that
+    hung for its full per-test timeout when a prior test's mock-429 cooldown
+    leaked onto the paused-clock LLM call. Two contract tests pin each half.

--- a/conformance/errors/runtime/subscript_assign_list_string_index.error
+++ b/conformance/errors/runtime/subscript_assign_list_string_index.error
@@ -1,0 +1,1 @@
+cannot index into list with string

--- a/conformance/errors/runtime/subscript_assign_list_string_index.harn
+++ b/conformance/errors/runtime/subscript_assign_list_string_index.harn
@@ -1,0 +1,4 @@
+pipeline test(task) {
+  var xs = [1, 2]
+  xs["a"] = 9
+}

--- a/conformance/errors/runtime/subscript_assign_string.error
+++ b/conformance/errors/runtime/subscript_assign_string.error
@@ -1,0 +1,1 @@
+cannot assign by index into string

--- a/conformance/errors/runtime/subscript_assign_string.harn
+++ b/conformance/errors/runtime/subscript_assign_string.harn
@@ -1,0 +1,4 @@
+pipeline test(task) {
+  var s = "ab"
+  s[0] = "Z"
+}

--- a/conformance/errors/semantic/assign_to_call_result.error
+++ b/conformance/errors/semantic/assign_to_call_result.error
@@ -1,0 +1,1 @@
+invalid assignment target

--- a/conformance/errors/semantic/assign_to_call_result.harn
+++ b/conformance/errors/semantic/assign_to_call_result.harn
@@ -1,0 +1,7 @@
+fn get_thing() {
+  return {x: 1}
+}
+
+pipeline test(task) {
+  get_thing().x = 99
+}

--- a/conformance/tests/language/module_statements_run.expected
+++ b/conformance/tests/language/module_statements_run.expected
@@ -1,0 +1,2 @@
+[harn] module init ran
+[harn] module statements: all tests passed

--- a/conformance/tests/language/module_statements_run.harn
+++ b/conformance/tests/language/module_statements_run.harn
@@ -1,0 +1,18 @@
+// Module-level statements (assignments, expression statements) execute in
+// source order before any pipeline runs — the same semantics as script
+// mode. They used to be silently dropped when the file declared a pipeline.
+var counter = 1
+
+counter = counter + 1
+
+var nested = {a: {b: 0}}
+
+nested.a.b = counter
+
+log("module init ran")
+
+pipeline test(task) {
+  assert_eq(counter, 2, "module-level reassignment is visible in the pipeline")
+  assert_eq(nested.a.b, 2, "module-level nested assignment is visible in the pipeline")
+  log("module statements: all tests passed")
+}

--- a/conformance/tests/language/nested_assignment.expected
+++ b/conformance/tests/language/nested_assignment.expected
@@ -1,0 +1,2 @@
+[harn] index evaluated
+[harn] nested assignment: all tests passed

--- a/conformance/tests/language/nested_assignment.harn
+++ b/conformance/tests/language/nested_assignment.harn
@@ -1,0 +1,53 @@
+fn bump_index() {
+  log("index evaluated")
+  return 1
+}
+
+pipeline test(task) {
+  // Nested property path writes the leaf, not `root.<final>`
+  var a = {b: {c: 1}, c: 99}
+  a.b.c = 2
+  assert_eq(a.b.c, 2, "nested property assignment writes the leaf")
+  assert_eq(a.c, 99, "nested property assignment leaves siblings alone")
+  // Nested subscript path
+  var d = {b: {c: 1}}
+  d["b"]["c"] = 5
+  assert_eq(d.b.c, 5, "nested subscript assignment writes the leaf")
+  // Nested list-of-lists
+  var xs = [[1, 2], [3, 4]]
+  xs[0][1] = 99
+  assert_eq(xs[0][1], 99, "nested list assignment writes the inner cell")
+  assert_eq(xs[1][0], 3, "nested list assignment leaves siblings alone")
+  // Mixed property + subscript
+  var m = {list: [1, 2]}
+  m.list[0] = 7
+  assert_eq(m.list[0], 7, "property-then-subscript writes through the path")
+  var p = [{x: 1}]
+  p[0].x = 8
+  assert_eq(p[0].x, 8, "subscript-then-property writes through the path")
+  // Deep chain
+  var deep = {l1: {l2: {l3: {v: 1}}}}
+  deep.l1.l2.l3.v = 42
+  assert_eq(deep.l1.l2.l3.v, 42, "four-level path writes the leaf")
+  // Compound assignment through a nested path
+  var acc = {inner: {n: 0}}
+  for i in 1 to 3 {
+    acc.inner.n += i
+  }
+  assert_eq(acc.inner.n, 6, "compound assignment accumulates through the path")
+  // A side-effecting index in a compound assignment evaluates exactly once
+  var nums = [10, 20]
+  nums[bump_index()] += 5
+  assert_eq(nums[1], 25, "compound subscript writes through the hoisted index")
+  // Immutability still holds through a nested path
+  let frozen = {b: {c: 1}}
+  var rejected = false
+  try {
+    frozen.b.c = 9
+  } catch (e) {
+    rejected = true
+  }
+  assert_eq(rejected, true, "let roots stay immutable through nested paths")
+  assert_eq(frozen.b.c, 1, "rejected nested write leaves the value untouched")
+  log("nested assignment: all tests passed")
+}

--- a/crates/harn-cli/src/commands/connect/callback.rs
+++ b/crates/harn-cli/src/commands/connect/callback.rs
@@ -210,23 +210,8 @@ pub(super) fn html_response(status: u16, message: &str) -> String {
     } else {
         "Authorization Failed"
     };
-    let escaped_message = html_escape(message);
+    let escaped_message = crate::format::escape_html(message);
     format!(
         "{status_line}\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n<!doctype html><html><head><meta charset=\"utf-8\"><title>{title}</title></head><body><h1>{title}</h1><p>{escaped_message}</p></body></html>"
     )
-}
-
-fn html_escape(text: &str) -> String {
-    let mut escaped = String::with_capacity(text.len());
-    for ch in text.chars() {
-        match ch {
-            '&' => escaped.push_str("&amp;"),
-            '<' => escaped.push_str("&lt;"),
-            '>' => escaped.push_str("&gt;"),
-            '"' => escaped.push_str("&quot;"),
-            '\'' => escaped.push_str("&#39;"),
-            _ => escaped.push(ch),
-        }
-    }
-    escaped
 }

--- a/crates/harn-cli/src/commands/connector.rs
+++ b/crates/harn-cli/src/commands/connector.rs
@@ -815,8 +815,8 @@ fn run_install_import_smoke(package_dir: &Path, metadata_ok: bool) -> ConnectorG
     let consumer = temp.path();
     let manifest = format!(
         "[package]\nname = \"connector-smoke-consumer\"\nversion = \"0.0.0\"\n\n[dependencies]\n\"{}\" = {{ path = \"{}\" }}\n",
-        toml_escape_basic_string(&package_name),
-        toml_escape_basic_string(&package_dependency_path)
+        crate::format::escape_toml_basic_string(&package_name),
+        crate::format::escape_toml_basic_string(&package_dependency_path)
     );
     if let Err(error) = fs::write(consumer.join("harn.toml"), manifest) {
         return gate_check_from_findings(
@@ -889,10 +889,6 @@ fn package_dependency_path(package_dir: &Path) -> Result<String, String> {
                 package_dir.display()
             )
         })
-}
-
-fn toml_escape_basic_string(value: &str) -> String {
-    value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 fn validate_doc_examples(package_dir: &Path) -> ConnectorGateCheck {

--- a/crates/harn-cli/src/commands/eval_prompt.rs
+++ b/crates/harn-cli/src/commands/eval_prompt.rs
@@ -1038,17 +1038,17 @@ fn render_html(report: &PromptReport) -> String {
     out.push_str("</style></head><body>");
     out.push_str(&format!(
         "<h1>harn eval prompt</h1><div class=\"meta\">{} · mode: {}</div>",
-        html_escape(&report.template_path.to_string_lossy()),
+        crate::format::escape_html(&report.template_path.to_string_lossy()),
         report.mode,
     ));
     out.push_str("<div class=\"grid\">");
     for render in &report.renders {
         out.push_str(&format!(
             "<div class=\"card\"><h2>{} <span class=\"meta\">({} / {} · {})</span></h2>",
-            html_escape(&render.selector),
-            html_escape(&render.provider),
-            html_escape(&render.model),
-            html_escape(&render.family),
+            crate::format::escape_html(&render.selector),
+            crate::format::escape_html(&render.provider),
+            crate::format::escape_html(&render.model),
+            crate::format::escape_html(&render.family),
         ));
         if !render.auth_available {
             out.push_str("<p class=\"skip\">auth: not configured</p>");
@@ -1057,11 +1057,14 @@ fn render_html(report: &PromptReport) -> String {
             (_, Some(error)) => {
                 out.push_str(&format!(
                     "<p class=\"err\">render error: {}</p>",
-                    html_escape(error)
+                    crate::format::escape_html(error)
                 ));
             }
             (Some(rendered), _) => {
-                out.push_str(&format!("<pre>{}</pre>", html_escape(rendered)));
+                out.push_str(&format!(
+                    "<pre>{}</pre>",
+                    crate::format::escape_html(rendered)
+                ));
             }
             _ => {}
         }
@@ -1071,11 +1074,14 @@ fn render_html(report: &PromptReport) -> String {
             } else if let Some(err) = run.error.as_ref() {
                 out.push_str(&format!(
                     "<p class=\"err\">run error: {}</p>",
-                    html_escape(err)
+                    crate::format::escape_html(err)
                 ));
             } else if let Some(response) = run.response.as_ref() {
                 out.push_str("<h3>response</h3>");
-                out.push_str(&format!("<pre>{}</pre>", html_escape(response)));
+                out.push_str(&format!(
+                    "<pre>{}</pre>",
+                    crate::format::escape_html(response)
+                ));
             }
         }
         out.push_str("</div>");
@@ -1089,15 +1095,15 @@ fn render_html(report: &PromptReport) -> String {
         for fixture in &context_eval.fixtures {
             out.push_str(&format!(
                 "<h3>{}</h3><ul>",
-                html_escape(&fixture.path.to_string_lossy()),
+                crate::format::escape_html(&fixture.path.to_string_lossy()),
             ));
             for case in &fixture.cases {
                 out.push_str(&format!(
                     "<li><strong>{}</strong>: {} · score {:.3} · selected [{}] · tokens {}/{}</li>",
-                    html_escape(&case.id),
+                    crate::format::escape_html(&case.id),
                     if case.pass { "pass" } else { "fail" },
                     case.score.overall,
-                    html_escape(&case.selected_artifact_ids.join(", ")),
+                    crate::format::escape_html(&case.selected_artifact_ids.join(", ")),
                     case.budget.total_tokens,
                     case.budget.budget_tokens,
                 ));
@@ -1108,26 +1114,11 @@ fn render_html(report: &PromptReport) -> String {
     if let Some(judge) = report.judge.as_ref() {
         out.push_str(&format!(
             "<h2>Judge ({})</h2><pre>{}</pre>",
-            html_escape(&judge.judge_model),
-            html_escape(&judge.verdict),
+            crate::format::escape_html(&judge.judge_model),
+            crate::format::escape_html(&judge.verdict),
         ));
     }
     out.push_str("</body></html>\n");
-    out
-}
-
-fn html_escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '&' => out.push_str("&amp;"),
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '"' => out.push_str("&quot;"),
-            '\'' => out.push_str("&#39;"),
-            _ => out.push(c),
-        }
-    }
     out
 }
 

--- a/crates/harn-cli/src/commands/mcp/mod.rs
+++ b/crates/harn-cli/src/commands/mcp/mod.rs
@@ -648,7 +648,7 @@ fn html_response(status: u16, message: &str) -> String {
         400 => ("Authorization Failed", "#c76b19", "Retry Needed"),
         _ => ("Callback Error", "#b42318", "Invalid Request"),
     };
-    let message = html_escape(message);
+    let message = crate::format::escape_html(message);
     format!(
         r#"{status_line}
 Content-Type: text/html; charset=utf-8
@@ -682,21 +682,6 @@ p {{ margin: 0; color: #c6cfdb; font-size: 15px; line-height: 1.55; }}
 </body>
 </html>"#
     )
-}
-
-fn html_escape(text: &str) -> String {
-    let mut escaped = String::with_capacity(text.len());
-    for ch in text.chars() {
-        match ch {
-            '&' => escaped.push_str("&amp;"),
-            '<' => escaped.push_str("&lt;"),
-            '>' => escaped.push_str("&gt;"),
-            '"' => escaped.push_str("&quot;"),
-            '\'' => escaped.push_str("&#39;"),
-            _ => escaped.push(ch),
-        }
-    }
-    escaped
 }
 
 #[cfg(test)]

--- a/crates/harn-cli/src/commands/rules_cli.rs
+++ b/crates/harn-cli/src/commands/rules_cli.rs
@@ -36,8 +36,8 @@ pub(crate) fn resolve_rules(
             .ok_or_else(|| format!("unknown language `{lang_name}`"))?;
         let toml = format!(
             "id = \"scan\"\nlanguage = \"{}\"\n[rule]\npattern = \"{}\"\n",
-            toml_escape(lang_name),
-            toml_escape(pattern),
+            crate::format::escape_toml_basic_string(lang_name),
+            crate::format::escape_toml_basic_string(pattern),
         );
         Ok(vec![RuleSpec { toml, language }])
     } else if let Some(rule_file) = rule_file {
@@ -282,21 +282,5 @@ fn collect_files(paths: &[String]) -> Vec<PathBuf> {
     }
     out.sort();
     out.dedup();
-    out
-}
-
-/// Escape a string for a TOML basic (double-quoted) string.
-fn toml_escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for ch in s.chars() {
-        match ch {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\t' => out.push_str("\\t"),
-            '\r' => out.push_str("\\r"),
-            _ => out.push(ch),
-        }
-    }
     out
 }

--- a/crates/harn-cli/src/commands/try_cmd_legacy.rs
+++ b/crates/harn-cli/src/commands/try_cmd_legacy.rs
@@ -8,14 +8,19 @@ pub(super) async fn run(args: TryArgs, provider: &str, model: &str) {
 
     use crate::commands::run::{execute_run, CliLlmMockMode, RunOutcome, RunProfileOptions};
 
-    let escaped = escape_for_harn_string(&args.prompt);
+    let escaped = harn_lexer::escape_string_literal(&args.prompt);
     let max_iters = args.max_iterations;
-    let provider = escape_for_harn_string(provider);
-    let model = escape_for_harn_string(model);
+    let provider = harn_lexer::escape_string_literal(provider);
+    let model = harn_lexer::escape_string_literal(model);
     let tool_format_line = args
         .tool_format
         .as_deref()
-        .map(|value| format!("    tool_format: \"{}\",\n", escape_for_harn_string(value)))
+        .map(|value| {
+            format!(
+                "    tool_format: \"{}\",\n",
+                harn_lexer::escape_string_literal(value)
+            )
+        })
         .unwrap_or_default();
     let override_reason_line = args
         .override_reason
@@ -23,7 +28,7 @@ pub(super) async fn run(args: TryArgs, provider: &str, model: &str) {
         .map(|value| {
             format!(
                 "    tool_format_override_reason: \"{}\",\n",
-                escape_for_harn_string(value)
+                harn_lexer::escape_string_literal(value)
             )
         })
         .unwrap_or_default();
@@ -74,12 +79,4 @@ pub(super) async fn run(args: TryArgs, provider: &str, model: &str) {
     if outcome.exit_code != 0 {
         std::process::exit(outcome.exit_code);
     }
-}
-
-fn escape_for_harn_string(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t")
 }

--- a/crates/harn-cli/src/format.rs
+++ b/crates/harn-cli/src/format.rs
@@ -69,6 +69,50 @@ pub(crate) fn escape_md(value: &str) -> String {
     value.replace('|', "\\|")
 }
 
+/// Escape `&`, `<`, `>`, `"`, and `'` for embedding text in HTML or XML
+/// output. Uses `&#39;` for the apostrophe because it is valid in both
+/// (`&apos;` is XML-only). The eval-prompt report, MCP landing page, OAuth
+/// callback page, and JUnit report writer had each grown a private copy.
+pub(crate) fn escape_html(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Escape a string for a TOML basic (double-quoted) string: backslash,
+/// double quote, and the control characters TOML forbids raw in basic
+/// strings. `harn rules` and `harn connector` scaffolding had divergent
+/// copies — the connector one skipped control characters, so a value with a
+/// newline produced invalid TOML.
+pub(crate) fn escape_toml_basic_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\r' => out.push_str("\\r"),
+            // Remaining C0 control chars (and DEL) must be escaped in TOML
+            // basic strings.
+            c if (c as u32) < 0x20 || c == '\u{7f}' => {
+                out.push_str(&format!("\\u{:04X}", c as u32));
+            }
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,6 +121,25 @@ mod tests {
     fn timestamp_uses_rfc3339() {
         let value = OffsetDateTime::UNIX_EPOCH;
         assert_eq!(format_timestamp_rfc3339(value), "1970-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn escape_html_handles_all_five_specials() {
+        assert_eq!(
+            escape_html(r#"<a href="x">&'b'</a>"#),
+            "&lt;a href=&quot;x&quot;&gt;&amp;&#39;b&#39;&lt;/a&gt;"
+        );
+    }
+
+    #[test]
+    fn escape_toml_basic_string_escapes_control_characters() {
+        assert_eq!(
+            escape_toml_basic_string("a\"b\\c\nd\te\rf"),
+            "a\\\"b\\\\c\\nd\\te\\rf"
+        );
+        // Other C0 controls (the case the old connector copy missed
+        // entirely) become \uXXXX escapes.
+        assert_eq!(escape_toml_basic_string("bell\u{7}"), "bell\\u0007");
     }
 
     #[test]

--- a/crates/harn-cli/src/test_report.rs
+++ b/crates/harn-cli/src/test_report.rs
@@ -100,14 +100,6 @@ impl TestReport {
     }
 }
 
-fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
-}
-
 fn ensure_parent_writable(path: &Path) -> Result<(), String> {
     let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
     if let Some(parent) = parent {
@@ -132,7 +124,7 @@ pub fn write_junit(path: &str, report: &TestReport) -> Result<PathBuf, String> {
     ensure_parent_writable(&path_buf)?;
 
     let suite_time = report.duration_ms as f64 / 1000.0;
-    let suite_name = xml_escape(&report.suite);
+    let suite_name = crate::format::escape_html(&report.suite);
     let tests = report.summary.total;
     let failures = report.summary.failed + report.summary.timed_out;
     let skipped = report.summary.skipped;
@@ -147,9 +139,9 @@ pub fn write_junit(path: &str, report: &TestReport) -> Result<PathBuf, String> {
     ));
     for case in &report.cases {
         let time = case.duration_ms as f64 / 1000.0;
-        let escaped_name = xml_escape(&case.name);
-        let escaped_classname = xml_escape(&case.classname);
-        let escaped_file = xml_escape(&case.file);
+        let escaped_name = crate::format::escape_html(&case.name);
+        let escaped_classname = crate::format::escape_html(&case.classname);
+        let escaped_file = crate::format::escape_html(&case.file);
         xml.push_str(&format!(
             "    <testcase name=\"{escaped_name}\" classname=\"{escaped_classname}\" file=\"{escaped_file}\" time=\"{time:.3}\""
         ));
@@ -159,7 +151,7 @@ pub fn write_junit(path: &str, report: &TestReport) -> Result<PathBuf, String> {
         }
         xml.push_str(">\n");
         let body = case.message.as_deref().unwrap_or_default();
-        let escaped_body = xml_escape(body);
+        let escaped_body = crate::format::escape_html(body);
         if case.outcome.is_skipped() {
             xml.push_str(&format!("      <skipped message=\"{escaped_body}\" />\n"));
         } else if case.outcome.is_failure() {

--- a/crates/harn-fmt/src/helpers.rs
+++ b/crates/harn-fmt/src/helpers.rs
@@ -240,13 +240,7 @@ pub(crate) fn format_pattern(pattern: &BindingPattern) -> String {
 
 /// Escape a string for embedding in double-quoted output.
 pub(crate) fn escape_string(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t")
-        .replace('\0', "\\0")
-        .replace("${", "\\${")
+    harn_lexer::escape_string_literal(s)
 }
 
 /// Render a raw-string literal value, choosing the narrowest delimiter that

--- a/crates/harn-lexer/src/lexer.rs
+++ b/crates/harn-lexer/src/lexer.rs
@@ -972,6 +972,32 @@ fn strip_indent(text: &str, n: usize) -> String {
     stripped.strip_suffix('\n').unwrap_or(&stripped).to_string()
 }
 
+/// Escape `value` so it round-trips as the body of a double-quoted Harn
+/// string literal: the lexer's escape set (`\n`, `\r`, `\t`, `\0`, `\\`,
+/// `\"`) plus `\$` before `{` so a value containing `${…}` renders as text
+/// instead of becoming live interpolation when the generated source is
+/// compiled. This is the single source of truth for code generators — the
+/// CLI's `harn try` scaffolding and the VM's composition/crystallize
+/// codegen had each grown a private copy that forgot `${`, letting a value
+/// like `${host_call(...)}` execute.
+pub fn escape_string_literal(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\0' => out.push_str("\\0"),
+            '$' if chars.peek() == Some(&'{') => out.push_str("\\$"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
 /// Remove a trailing-newline-only literal segment (for multiline strings
 /// where the last segment before `"""` is just whitespace).
 fn strip_trailing_newline_segments(mut segments: Vec<StringSegment>) -> Vec<StringSegment> {
@@ -986,6 +1012,29 @@ fn strip_trailing_newline_segments(mut segments: Vec<StringSegment>) -> Vec<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn escape_string_literal_round_trips_through_the_lexer() {
+        for original in [
+            "plain text",
+            "with \"quotes\" and \\backslash",
+            "newline\ntab\tcr\r",
+            "interpolation ${1 + 1} stays text",
+            "already-escaped \\${x}",
+            "plain $dollar and ${nested ${inner}}",
+        ] {
+            let literal = format!("\"{}\"", escape_string_literal(original));
+            let mut lexer = Lexer::new(&literal);
+            let tokens = lexer.tokenize().expect("escaped literal must lex");
+            let TokenKind::StringLiteral(ref value) = tokens[0].kind else {
+                panic!(
+                    "expected a plain string token for {literal:?}, got {:?}",
+                    tokens[0].kind
+                );
+            };
+            assert_eq!(value, original, "round trip through {literal:?}");
+        }
+    }
 
     #[test]
     fn shebang_at_offset_zero_is_skipped() {

--- a/crates/harn-lsp/src/handlers/definition.rs
+++ b/crates/harn-lsp/src/handlers/definition.rs
@@ -16,7 +16,7 @@ use crate::constants::is_builtin;
 use crate::helpers::{
     lsp_position_to_offset, offset_to_position, span_to_full_range, word_at_position,
 };
-use crate::references::find_references;
+use crate::references::{find_references, identifier_token_spans_within};
 use crate::symbols::HarnSymbolKind;
 use crate::HarnLsp;
 
@@ -260,7 +260,15 @@ impl HarnLsp {
             return Ok(None);
         }
 
-        let locations: Vec<Location> = ref_spans
+        // Raw AST spans cover whole declarations for definition sites;
+        // narrow each hit to the identifier token so the references list
+        // doesn't highlight entire functions.
+        let token_spans = identifier_token_spans_within(&source, &word, &ref_spans);
+        if token_spans.is_empty() {
+            return Ok(None);
+        }
+
+        let locations: Vec<Location> = token_spans
             .iter()
             .map(|span| Location {
                 uri: uri.clone(),
@@ -315,30 +323,17 @@ impl HarnLsp {
 
         // AST reference spans cover whole declarations, so rescan the lexer
         // tokens within each span to pin down the exact identifier position.
-        let mut edits = Vec::new();
-        let mut seen_offsets = std::collections::HashSet::new();
-
-        let mut lexer = Lexer::new(&source);
-        if let Ok(tokens) = lexer.tokenize() {
-            for token in &tokens {
-                if let TokenKind::Identifier(ref name) = token.kind {
-                    if name == &old_name && !seen_offsets.contains(&token.span.start) {
-                        let in_ref = ref_spans
-                            .iter()
-                            .any(|rs| token.span.start >= rs.start && token.span.end <= rs.end);
-                        if in_ref {
-                            seen_offsets.insert(token.span.start);
-                            let start = offset_to_position(&source, token.span.start);
-                            let end = offset_to_position(&source, token.span.end);
-                            edits.push(TextEdit {
-                                range: Range { start, end },
-                                new_text: new_name.clone(),
-                            });
-                        }
-                    }
-                }
-            }
-        }
+        let mut edits: Vec<TextEdit> =
+            identifier_token_spans_within(&source, &old_name, &ref_spans)
+                .into_iter()
+                .map(|span| TextEdit {
+                    range: Range {
+                        start: offset_to_position(&source, span.start),
+                        end: offset_to_position(&source, span.end),
+                    },
+                    new_text: new_name.clone(),
+                })
+                .collect();
 
         if edits.is_empty() {
             return Ok(None);

--- a/crates/harn-lsp/src/references.rs
+++ b/crates/harn-lsp/src/references.rs
@@ -1,15 +1,52 @@
-use harn_lexer::Span;
+use harn_lexer::{Lexer, Span, TokenKind};
 use harn_parser::{Node, SNode};
 
 use crate::symbols::binding_pattern_names;
 
 /// Find all identifier references matching `target_name` in the AST.
+///
+/// Definition sites contribute their *whole declaration span* (the AST does
+/// not keep a separate span for the declared name), so callers that need
+/// exact positions must refine the result with
+/// [`identifier_token_spans_within`].
 pub(crate) fn find_references(program: &[SNode], target_name: &str) -> Vec<Span> {
     let mut refs = Vec::new();
     for snode in program {
         collect_references(snode, target_name, &mut refs);
     }
     refs
+}
+
+/// Refine raw AST reference spans down to the exact identifier tokens.
+///
+/// Re-lexes `source` and keeps each `name` identifier token that falls
+/// inside one of `ref_spans`, deduplicated by offset. This is what makes
+/// find-references and rename point at the identifier itself instead of
+/// highlighting an entire `fn`/`pipeline`/`let` declaration.
+pub(crate) fn identifier_token_spans_within(
+    source: &str,
+    name: &str,
+    ref_spans: &[Span],
+) -> Vec<Span> {
+    let mut spans = Vec::new();
+    let mut seen_offsets = std::collections::HashSet::new();
+    let mut lexer = Lexer::new(source);
+    let Ok(tokens) = lexer.tokenize() else {
+        return spans;
+    };
+    for token in &tokens {
+        if let TokenKind::Identifier(ref token_name) = token.kind {
+            if token_name == name
+                && ref_spans
+                    .iter()
+                    .any(|rs| token.span.start >= rs.start && token.span.end <= rs.end)
+                && seen_offsets.insert(token.span.start)
+            {
+                spans.push(token.span);
+            }
+        }
+    }
+    spans
 }
 
 fn collect_references(snode: &SNode, target_name: &str, refs: &mut Vec<Span>) {
@@ -302,5 +339,41 @@ fn collect_references(snode: &SNode, target_name: &str, refs: &mut Vec<Span>) {
         }
         // Terminals
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(source: &str) -> Vec<SNode> {
+        harn_parser::parse_source(source).expect("parse")
+    }
+
+    #[test]
+    fn references_to_fn_param_refine_to_identifier_tokens() {
+        let source = "fn process(data) {\n  return data\n}\n";
+        let program = parse(source);
+        let raw = find_references(&program, "data");
+        // The declaration contributes the whole `fn` span; refinement must
+        // shrink every hit to the 4-byte identifier itself.
+        let refined = identifier_token_spans_within(source, "data", &raw);
+        assert_eq!(refined.len(), 2, "param + body use; got {refined:?}");
+        for span in &refined {
+            assert_eq!(span.end - span.start, "data".len(), "span {span:?}");
+            assert_eq!(&source[span.start..span.end], "data");
+        }
+    }
+
+    #[test]
+    fn references_to_let_binding_refine_to_identifier_tokens() {
+        let source = "pipeline t(task) {\n  let total = 1\n  log(total)\n}\n";
+        let program = parse(source);
+        let raw = find_references(&program, "total");
+        let refined = identifier_token_spans_within(source, "total", &raw);
+        assert_eq!(refined.len(), 2, "binding + use; got {refined:?}");
+        for span in &refined {
+            assert_eq!(&source[span.start..span.end], "total");
+        }
     }
 }

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -1285,6 +1285,18 @@ impl TypeChecker {
                 }
                 (!inferred.is_empty()).then(|| simplify_union(inferred))
             }
+            // Mirrors the Intersection arm of `infer_property_type_from_type`
+            // — `x["a"]` and `x.a` must resolve the same set of types.
+            TypeExpr::Intersection(members) => {
+                for member in members {
+                    if let Some(member_type) =
+                        self.infer_subscript_type_from_type(member, index, scope, optional)
+                    {
+                        return Some(member_type);
+                    }
+                }
+                optional.then(|| TypeExpr::Named("nil".into()))
+            }
             TypeExpr::List(inner) => Some(*inner.clone()),
             TypeExpr::DictType(_, value) => Some(*value.clone()),
             TypeExpr::Shape(fields) => {

--- a/crates/harn-parser/src/typechecker/tests/nil_safety.rs
+++ b/crates/harn-parser/src/typechecker/tests/nil_safety.rs
@@ -59,6 +59,18 @@ fn optional_subscript_on_nil_is_allowed() {
 }
 
 #[test]
+fn subscript_on_intersection_resolves_member_type() {
+    // `x["a"]` must resolve through intersections the same way `x.a` does
+    // (the subscript path used to fall through to gradual, silently
+    // accepting any assignment).
+    let errs = errors(
+        "pipeline t(task) { let x: {a: int} & {b: string} = {a: 1, b: \"s\"}\n\
+         let y: string = x[\"a\"] }",
+    );
+    assert!(has(&errs, "expected string"), "got: {errs:?}");
+}
+
+#[test]
 fn optional_subscript_unknown_shape_key_infers_nil() {
     // `x?["b"]` on a shape without a `b` field is statically nil, so
     // assigning it to `int` must be a mismatch — same standard as

--- a/crates/harn-serve/src/adapters/acp/dispatch.rs
+++ b/crates/harn-serve/src/adapters/acp/dispatch.rs
@@ -140,6 +140,12 @@ impl AcpServer {
                 self.handle_session_prompt(&id, &params).await;
             }
             "session/cancel" => {
+                // `reject_unauthenticated` only answers when `id` is non-null,
+                // so the notification form is silently ignored when
+                // unauthenticated rather than processed.
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
                 self.handle_session_cancel(&id, &params);
             }
             "session/cancel_tool_call" => {

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -1485,7 +1485,9 @@ fn sanitize_visible_assistant_text_keeps_normal_json() {
 
 #[test]
 fn acp_agent_capabilities_use_canonical_initialize_shape() {
-    let _guard = acp_env_lock().lock().unwrap();
+    let _guard = acp_env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let _env = EnvSnapshot::capture(&[
         "HARN_LLM_PROVIDER",
         "HARN_LLM_MODEL",
@@ -1598,7 +1600,9 @@ async fn acp_provider_catalog_method_matches_export_artifact_with_overrides() {
 
 #[test]
 fn acp_prompt_capabilities_follow_configured_model_aliases() {
-    let _guard = acp_env_lock().lock().unwrap();
+    let _guard = acp_env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let _env = EnvSnapshot::capture(&[
         "HARN_LLM_PROVIDER",
         "HARN_LLM_MODEL",
@@ -1809,6 +1813,44 @@ fn parse_oauth_redirect_url_requires_code() {
     let error =
         parse_oauth_redirect_url("http://127.0.0.1/cb?state=xyz").expect_err("missing code");
     assert!(error.contains("code"), "{error}");
+}
+
+/// Drift guard: every `session/*` dispatch arm must gate on
+/// `reject_unauthenticated`. `session/cancel` shipped without the guard once
+/// (any unauthenticated peer could cancel a running session); this keeps the
+/// next session method from repeating that.
+#[test]
+fn every_session_dispatch_arm_checks_authentication() {
+    let src = include_str!("dispatch.rs");
+    let lines: Vec<&str> = src.lines().collect();
+    // Match-arm patterns in the dispatch match are indented exactly 12
+    // spaces; arm bodies are indented deeper. Collect each session arm's
+    // body by scanning to the next same-indent pattern.
+    let is_pattern =
+        |line: &str| line.starts_with("            \"") && !line.starts_with("             ");
+    let mut checked = 0;
+    for (i, line) in lines.iter().enumerate() {
+        if !is_pattern(line) || !line.contains("\"session/") {
+            continue;
+        }
+        let method = line.trim();
+        let body: String = lines[i + 1..]
+            .iter()
+            .take_while(|l| !is_pattern(l))
+            .copied()
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            body.contains("reject_unauthenticated"),
+            "dispatch arm {method} does not call reject_unauthenticated"
+        );
+        checked += 1;
+    }
+    assert!(
+        checked >= 10,
+        "expected to find the session/* dispatch arms in dispatch.rs (found {checked}); \
+         if the match moved, update this test's pattern detection"
+    );
 }
 
 mod commands;

--- a/crates/harn-vm/src/compiler/state.rs
+++ b/crates/harn-vm/src/compiler/state.rs
@@ -1134,37 +1134,40 @@ impl Compiler {
         Ok(())
     }
 
-    /// Extract the root variable name from a (possibly nested) access expression.
-    pub(super) fn root_var_name(&self, node: &SNode) -> Option<String> {
-        match &node.node {
-            Node::Identifier(name) => Some(name.clone()),
-            Node::PropertyAccess { object, .. } | Node::OptionalPropertyAccess { object, .. } => {
-                self.root_var_name(object)
-            }
-            Node::SubscriptAccess { object, .. } | Node::OptionalSubscriptAccess { object, .. } => {
-                self.root_var_name(object)
-            }
-            _ => None,
-        }
-    }
-
     pub(super) fn compile_top_level_declarations(
         &mut self,
         program: &[SNode],
     ) -> Result<(), CompileError> {
-        // Phase 1: evaluate module-level `let` / `var` bindings first, in
-        // source order. This ensures function closures compiled in phase 2
+        // Phase 1: execute module-level *statements* first, in source order —
+        // bindings, assignments, expression statements, control flow. Running
+        // bindings before phase 2 ensures function closures compiled there
         // capture these names in their env snapshot via `Op::Closure` —
         // fixing the "Undefined variable: FOO" surprise where a top-level
-        // `let FOO = "..."` was silently dropped because it wasn't in this
-        // match list. Keep in step with the import-time init path in
+        // `let FOO = "..."` was silently dropped because it wasn't compiled
+        // at all. Non-binding statements used to be silently dropped in
+        // pipeline mode (`n = 2` or `log(...)` between a binding and a
+        // pipeline simply never ran); they now execute exactly like script
+        // mode. Keep in step with the import-time init path in
         // `crates/harn-vm/src/vm/imports.rs` (`module_state` construction).
         for sn in program {
-            if matches!(
-                &sn.node,
-                Node::LetBinding { .. } | Node::VarBinding { .. } | Node::ConstBinding { .. }
-            ) {
-                self.compile_node(sn)?;
+            let handled_elsewhere = matches!(
+                peel_node(sn),
+                Node::Pipeline { .. }
+                    | Node::ImportDecl { .. }
+                    | Node::SelectiveImport { .. }
+                    | Node::OverrideDecl { .. }
+                    | Node::EvalPackDecl { .. }
+                    | Node::FnDecl { .. }
+                    | Node::ToolDecl { .. }
+                    | Node::SkillDecl { .. }
+                    | Node::ImplBlock { .. }
+                    | Node::StructDecl { .. }
+                    | Node::EnumDecl { .. }
+                    | Node::InterfaceDecl { .. }
+                    | Node::TypeDecl { .. }
+            );
+            if !handled_elsewhere {
+                self.compile_discarded_stmt(sn)?;
             }
         }
         // Phase 2: compile type and function declarations. Function closures

--- a/crates/harn-vm/src/compiler/statements.rs
+++ b/crates/harn-vm/src/compiler/statements.rs
@@ -75,8 +75,10 @@ impl Compiler {
                 self.assign_type_fact(name, value_type);
             }
         } else if let Node::PropertyAccess { object, property } = &target.node {
-            if let Some(var_name) = self.root_var_name(object) {
-                let var_idx = self.string_constant(&var_name);
+            if let Node::Identifier(var_name) = &object.node {
+                // Single-level `x.prop (op)= value` — SetProperty reads the
+                // variable, sets the property, and writes it back.
+                let var_idx = self.string_constant(var_name);
                 let prop_idx = self.string_constant(property);
                 if let Some(op) = op {
                     self.compile_node(target)?;
@@ -85,7 +87,6 @@ impl Compiler {
                 } else {
                     self.compile_node(value)?;
                 }
-                // SetProperty reads var_idx from env, sets prop, writes back.
                 // The variable name index is encoded as a second u16.
                 self.chunk.emit_u16(Op::SetProperty, prop_idx, self.line);
                 let hi = (var_idx >> 8) as u8;
@@ -96,21 +97,193 @@ impl Compiler {
                 self.chunk.columns.push(self.column);
                 self.chunk.lines.push(self.line);
                 self.chunk.columns.push(self.column);
+            } else {
+                self.compile_path_assignment(target, value, op)?;
             }
         } else if let Node::SubscriptAccess { object, index } = &target.node {
-            if let Some(var_name) = self.root_var_name(object) {
-                let var_idx = self.string_constant(&var_name);
-                if let Some(op) = op {
-                    self.compile_node(target)?;
-                    self.compile_node(value)?;
-                    self.emit_compound_op(op)?;
+            if let Node::Identifier(var_name) = &object.node {
+                // Single-level `x[index] (op)= value`. A compound op reads the
+                // target before writing it, and both the read and the write
+                // need the index — so an index with potential side effects is
+                // hoisted into a temp to keep it evaluated exactly once.
+                if op.is_some() && !Self::is_effect_free_index(index) {
+                    self.compile_path_assignment(target, value, op)?;
                 } else {
-                    self.compile_node(value)?;
+                    let var_idx = self.string_constant(var_name);
+                    if let Some(op) = op {
+                        self.compile_node(target)?;
+                        self.compile_node(value)?;
+                        self.emit_compound_op(op)?;
+                    } else {
+                        self.compile_node(value)?;
+                    }
+                    self.compile_node(index)?;
+                    self.chunk.emit_u16(Op::SetSubscript, var_idx, self.line);
                 }
-                self.compile_node(index)?;
-                self.chunk.emit_u16(Op::SetSubscript, var_idx, self.line);
+            } else {
+                self.compile_path_assignment(target, value, op)?;
             }
+        } else {
+            return Err(CompileError {
+                message: format!(
+                    "invalid assignment target: expected a variable, property path \
+                     (`x.a.b`), or subscript path (`x[i][j]`), found {}",
+                    Self::describe_assignment_target(&target.node)
+                ),
+                line: target.span.line as u32,
+            });
         }
+        Ok(())
+    }
+
+    /// True when re-evaluating `index` cannot run user code or change between
+    /// the read and write halves of a compound assignment.
+    fn is_effect_free_index(index: &SNode) -> bool {
+        matches!(
+            index.node,
+            Node::Identifier(_)
+                | Node::IntLiteral(_)
+                | Node::FloatLiteral(_)
+                | Node::StringLiteral(_)
+                | Node::RawStringLiteral(_)
+                | Node::BoolLiteral(_)
+        )
+    }
+
+    /// Human description of a non-assignable target for the compile error.
+    fn describe_assignment_target(node: &Node) -> &'static str {
+        match node {
+            Node::FunctionCall { .. } => "a function call result",
+            Node::MethodCall { .. } | Node::OptionalMethodCall { .. } => "a method call result",
+            Node::SliceAccess { .. } => "a slice",
+            Node::OptionalPropertyAccess { .. } | Node::OptionalSubscriptAccess { .. } => {
+                "an optional-chained access (`?.` / `?[]`)"
+            }
+            _ => "an expression",
+        }
+    }
+
+    /// Lower an assignment through a nested access path (`a.b.c = v`,
+    /// `a["b"]["c"] = v`, `xs[0][1] = v`, `m.list[0] = v`, …) or a
+    /// single-level compound subscript whose index has side effects.
+    ///
+    /// `SetProperty`/`SetSubscript` only know how to write one level deep on
+    /// a named binding, so deeper paths are desugared into a scope-contained
+    /// chain of temporaries: hoist each computed index once, copy each path
+    /// prefix into a temp, perform the single-level leaf assignment on the
+    /// innermost temp, then write each temp back into its parent. (The naive
+    /// lowering used to collapse the path to its root variable and final
+    /// accessor, so `a.b.c = v` silently wrote `a.c`.)
+    fn compile_path_assignment(
+        &mut self,
+        target: &SNode,
+        value: &SNode,
+        op: &Option<String>,
+    ) -> Result<(), CompileError> {
+        enum Seg {
+            Prop(String),
+            Index(SNode),
+        }
+
+        // Collect the access path, root-first. Anything that is not a plain
+        // property/subscript chain rooted at an identifier is not assignable.
+        let mut segs: Vec<Seg> = Vec::new();
+        let mut cur = target;
+        let root = loop {
+            match &cur.node {
+                Node::PropertyAccess { object, property } => {
+                    segs.push(Seg::Prop(property.clone()));
+                    cur = object;
+                }
+                Node::SubscriptAccess { object, index } => {
+                    segs.push(Seg::Index((**index).clone()));
+                    cur = object;
+                }
+                Node::Identifier(name) => break name.clone(),
+                _ => {
+                    return Err(CompileError {
+                        message: format!(
+                            "invalid assignment target: expected a variable, property path \
+                             (`x.a.b`), or subscript path (`x[i][j]`), found {}",
+                            Self::describe_assignment_target(&cur.node)
+                        ),
+                        line: cur.span.line as u32,
+                    });
+                }
+            }
+        };
+        segs.reverse();
+        let span = target.span;
+        self.temp_counter += 1;
+        let id = self.temp_counter;
+
+        // The temps live in their own scope so they never leak into (or
+        // shadow anything in) the surrounding code.
+        self.begin_scope();
+
+        // 1. Hoist computed indices into temps, in source order, so each
+        //    index expression is evaluated exactly once.
+        let seg_nodes: Vec<Seg> = segs
+            .into_iter()
+            .enumerate()
+            .map(|(i, seg)| -> Result<Seg, CompileError> {
+                match seg {
+                    Seg::Prop(p) => Ok(Seg::Prop(p)),
+                    Seg::Index(idx) if Self::is_effect_free_index(&idx) => Ok(Seg::Index(idx)),
+                    Seg::Index(idx) => {
+                        let name = format!("__asg{id}_k{i}__");
+                        self.compile_node(&idx)?;
+                        self.emit_define_binding(&name, false);
+                        Ok(Seg::Index(SNode::new(Node::Identifier(name), idx.span)))
+                    }
+                }
+            })
+            .collect::<Result<_, _>>()?;
+
+        let access = |obj_name: &str, seg: &Seg| -> SNode {
+            let object = Box::new(SNode::new(Node::Identifier(obj_name.to_string()), span));
+            match seg {
+                Seg::Prop(p) => SNode::new(
+                    Node::PropertyAccess {
+                        object,
+                        property: p.clone(),
+                    },
+                    span,
+                ),
+                Seg::Index(idx) => SNode::new(
+                    Node::SubscriptAccess {
+                        object,
+                        index: Box::new(idx.clone()),
+                    },
+                    span,
+                ),
+            }
+        };
+
+        // 2. Copy each path prefix into a mutable temp, walking down.
+        let n = seg_nodes.len();
+        let mut prefix_names: Vec<String> = vec![root];
+        for (i, seg) in seg_nodes.iter().enumerate().take(n - 1) {
+            let get_expr = access(prefix_names.last().expect("non-empty"), seg);
+            self.compile_node(&get_expr)?;
+            let name = format!("__asg{id}_t{i}__");
+            self.emit_define_binding(&name, true);
+            prefix_names.push(name);
+        }
+
+        // 3. Single-level leaf assignment on the innermost temp (or the root
+        //    itself when the only reason we are here is an effectful index).
+        let leaf_target = access(prefix_names.last().expect("non-empty"), &seg_nodes[n - 1]);
+        self.compile_assignment(&leaf_target, value, op)?;
+
+        // 4. Write each temp back into its parent, walking up.
+        for i in (0..n - 1).rev() {
+            let wb_target = access(&prefix_names[i], &seg_nodes[i]);
+            let wb_value = SNode::new(Node::Identifier(prefix_names[i + 1].clone()), span);
+            self.compile_assignment(&wb_target, &wb_value, &None)?;
+        }
+
+        self.end_scope();
         Ok(())
     }
 

--- a/crates/harn-vm/src/composition/mod.rs
+++ b/crates/harn-vm/src/composition/mod.rs
@@ -930,7 +930,7 @@ fn composition_source(manifest: &BindingManifest, snippet: &str) -> String {
 }
 
 fn escape_harn_string(value: &str) -> String {
-    value.replace('\\', "\\\\").replace('"', "\\\"")
+    harn_lexer::escape_string_literal(value)
 }
 
 fn validate_composition_program(

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -428,6 +428,14 @@ pub fn json_schema_for_typed_params(params: &[harn_parser::TypedParam]) -> serde
 /// Reset all thread-local state that can leak between test runs.
 pub fn reset_thread_local_state() {
     llm::reset_llm_state();
+    // `reset_thread_local_state` only runs in sequential / separate-process
+    // contexts (the CLI test runner between cases, integration-test binaries,
+    // per-job worker resets) — never from the parallel in-process unit tests
+    // that share the rate-limiter registry. So unlike `reset_llm_state`, it is
+    // safe (and necessary for test isolation) to fully wipe the registry here,
+    // clearing retry-after cooldowns that would otherwise stall a later test's
+    // LLM call under a paused clock.
+    llm::reset_rate_limit_registry();
     llm_config::clear_user_overrides();
     http::reset_http_state();
     channels::reset_channel_state();

--- a/crates/harn-vm/src/llm/api.rs
+++ b/crates/harn-vm/src/llm/api.rs
@@ -33,7 +33,8 @@ pub(crate) use auth::apply_auth_headers;
 pub(crate) use completion::vm_call_completion_full;
 pub use context_window::fetch_provider_max_context;
 pub(crate) use errors::{
-    classify_llm_error, classify_provider_http_error, LlmErrorInfo, LlmErrorKind, LlmErrorReason,
+    classify_llm_error, classify_provider_http_error, retry_after_header, LlmErrorInfo,
+    LlmErrorKind, LlmErrorReason,
 };
 pub(crate) use ollama::apply_ollama_runtime_settings;
 pub(crate) use ollama::ollama_unload_grace_duration_from_env;
@@ -430,7 +431,7 @@ mod tests {
         vm_call_llm_full, vm_call_llm_full_streaming, vm_call_llm_full_streaming_offthread,
         LlmRequestPayload, ThinkingConfig,
     };
-    use crate::llm::env_lock;
+    use crate::llm::env_guard;
 
     struct ScopedEnvVar {
         key: &'static str,
@@ -582,7 +583,7 @@ mod tests {
 
     #[test]
     fn disabled_llm_calls_reject_real_provider_before_transport() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _disabled = ScopedEnvVar::set(crate::llm::LLM_CALLS_DISABLED_ENV, "1");
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -619,7 +620,7 @@ mod tests {
 
     #[test]
     fn disabled_llm_calls_still_allow_mock_provider() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _disabled = ScopedEnvVar::set(crate::llm::LLM_CALLS_DISABLED_ENV, "1");
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -638,7 +639,7 @@ mod tests {
             install_fake_llm_script, FakeLlmEvent, FakeLlmScript, FakeStopReason,
         };
 
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         // Even with HARN_LLM_CALLS_DISABLED, the fake must pass through —
         // it never hits the network, so it must not be gated by that env.
         let _disabled = ScopedEnvVar::set(crate::llm::LLM_CALLS_DISABLED_ENV, "1");
@@ -1031,7 +1032,7 @@ mod tests {
 
     #[test]
     fn anthropic_interleaved_thinking_beta_header_is_sent_for_supported_model() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _allow_llm_transport = allow_stubbed_llm_transport();
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -1089,7 +1090,7 @@ mod tests {
 
     #[test]
     fn offthread_streaming_completes_inside_localset() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _allow_llm_transport = allow_stubbed_llm_transport();
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
@@ -1144,7 +1145,7 @@ mod tests {
 
     #[test]
     fn ollama_empty_content_done_frame_retries_once() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _allow_llm_transport = allow_stubbed_llm_transport();
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
@@ -1194,7 +1195,7 @@ mod tests {
 
     #[test]
     fn ollama_chat_applies_env_runtime_overrides() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _allow_llm_transport = allow_stubbed_llm_transport();
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
@@ -1254,7 +1255,7 @@ mod tests {
 
     #[test]
     fn ollama_qwen_text_tool_route_bypasses_chat_parser_with_raw_generate() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _allow_llm_transport = allow_stubbed_llm_transport();
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
@@ -1326,7 +1327,7 @@ mod tests {
 
     #[test]
     fn ollama_warmup_applies_shared_runtime_settings() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _allow_llm_transport = allow_stubbed_llm_transport();
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
@@ -1389,7 +1390,7 @@ mod tests {
         extra_headers: &'static str,
         body: &'static str,
     ) -> String {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _allow_llm_transport = allow_stubbed_llm_transport();
         let server = spawn_openai_error_stub(status_line, extra_headers, body);
         let addr = server.addr();

--- a/crates/harn-vm/src/llm/api/completion.rs
+++ b/crates/harn-vm/src/llm/api/completion.rs
@@ -21,11 +21,7 @@ async fn completion_json_response(
 ) -> Result<serde_json::Value, VmError> {
     if !response.status().is_success() {
         let status = response.status();
-        let retry_after = response
-            .headers()
-            .get("retry-after")
-            .and_then(|value| value.to_str().ok())
-            .map(str::to_string);
+        let retry_after = super::retry_after_header(response.headers());
         let body = response.text().await.unwrap_or_default();
         let message =
             super::classify_provider_http_error(provider, status, retry_after.as_deref(), &body)

--- a/crates/harn-vm/src/llm/api/errors.rs
+++ b/crates/harn-vm/src/llm/api/errors.rs
@@ -78,6 +78,16 @@ pub(crate) struct LlmErrorInfo {
     pub(crate) message: String,
 }
 
+/// Extract the `Retry-After` header for threading into
+/// [`classify_provider_http_error`]. Read it before consuming the response
+/// body — `Response::text()` takes the response by value.
+pub(crate) fn retry_after_header(headers: &reqwest::header::HeaderMap) -> Option<String> {
+    headers
+        .get("retry-after")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string)
+}
+
 /// Build a tagged, provider-prefixed error message from a non-2xx HTTP
 /// response so downstream agent loops can react (e.g. trigger compaction on
 /// `context_overflow`, back off on `rate_limited`, surface everything else as

--- a/crates/harn-vm/src/llm/api/ollama.rs
+++ b/crates/harn-vm/src/llm/api/ollama.rs
@@ -752,7 +752,7 @@ async fn ollama_warmup(
 mod tests {
     use super::*;
     use crate::http::framing::{http_content_length_from_header_lines, TEST_HTTP_MAX_BODY_BYTES};
-    use crate::llm::env_lock;
+    use crate::llm::env_guard;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::sync::{Arc, Mutex};
@@ -792,7 +792,7 @@ mod tests {
 
     #[test]
     fn runtime_settings_use_harn_env_before_ollama_env() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _env = [
             ScopedEnvVar::set("HARN_OLLAMA_NUM_CTX", "131072"),
             ScopedEnvVar::set("OLLAMA_CONTEXT_LENGTH", "32768"),
@@ -806,7 +806,7 @@ mod tests {
 
     #[test]
     fn runtime_settings_apply_harn_defaults() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _env = [
             ScopedEnvVar::remove("HARN_OLLAMA_NUM_CTX"),
             ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),
@@ -821,7 +821,7 @@ mod tests {
 
     #[test]
     fn runtime_settings_use_catalog_context_after_env_and_overrides() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _env = [
             ScopedEnvVar::remove("HARN_OLLAMA_NUM_CTX"),
             ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),
@@ -887,7 +887,7 @@ mod tests {
 
     #[test]
     fn provider_overrides_beat_env_and_normalize_keep_alive() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _env = [
             ScopedEnvVar::set("HARN_OLLAMA_NUM_CTX", "131072"),
             ScopedEnvVar::set("HARN_OLLAMA_KEEP_ALIVE", "5m"),
@@ -903,7 +903,7 @@ mod tests {
 
     #[test]
     fn apply_runtime_settings_maps_ollama_overrides_to_native_shape() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _env = [
             ScopedEnvVar::remove("HARN_OLLAMA_NUM_CTX"),
             ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),
@@ -932,7 +932,7 @@ mod tests {
 
     #[test]
     fn apply_runtime_settings_uses_catalog_context_when_body_has_model() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _env = [
             ScopedEnvVar::remove("HARN_OLLAMA_NUM_CTX"),
             ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),
@@ -1024,7 +1024,7 @@ mod tests {
 
     #[test]
     fn ollama_readiness_verifies_model_and_warms_matched_tag() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _env = [
             ScopedEnvVar::set("HARN_OLLAMA_NUM_CTX", "65536"),
             ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),
@@ -1100,7 +1100,7 @@ mod tests {
 
     #[test]
     fn ollama_readiness_observes_loaded_runner_and_reports_no_drift() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _env = [
             ScopedEnvVar::set("HARN_OLLAMA_NUM_CTX", "32768"),
             ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),
@@ -1145,7 +1145,7 @@ mod tests {
 
     #[test]
     fn ollama_readiness_flags_context_drift_when_loaded_exceeds_expected() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _env = [
             ScopedEnvVar::set("HARN_OLLAMA_NUM_CTX", "32768"),
             ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),
@@ -1184,7 +1184,7 @@ mod tests {
 
     #[test]
     fn ollama_readiness_uses_alias_resolved_runtime_settings() {
-        let _guard = env_lock().lock().expect("env lock");
+        let _guard = env_guard();
         let _env = [
             ScopedEnvVar::remove("HARN_OLLAMA_NUM_CTX"),
             ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -422,11 +422,7 @@ async fn vm_call_llm_api_with_body_inner(
             .await?;
             if !response.status().is_success() {
                 let status = response.status();
-                let retry_after = response
-                    .headers()
-                    .get("retry-after")
-                    .and_then(|v| v.to_str().ok())
-                    .map(|s| s.to_string());
+                let retry_after = super::retry_after_header(response.headers());
                 let body = response.text().await.unwrap_or_default();
                 let msg = classify_transport_http_error(
                     provider,
@@ -506,11 +502,7 @@ async fn vm_call_llm_api_with_body_inner(
     // parse results and the agent loop retries against the same bad context.
     if !response.status().is_success() {
         let status = response.status();
-        let retry_after = response
-            .headers()
-            .get("retry-after")
-            .and_then(|v| v.to_str().ok())
-            .map(|s| s.to_string());
+        let retry_after = super::retry_after_header(response.headers());
         let body = response.text().await.unwrap_or_default();
         let msg = classify_transport_http_error(
             provider,

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -1878,7 +1878,7 @@ mod tests {
 
     #[test]
     fn test_llm_rate_limit_sets_and_queries_rich_details() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         crate::llm::reset_llm_state();
         let provider = VmValue::String(std::sync::Arc::from("quota-builtin-provider"));
         let mut out = String::new();
@@ -2028,7 +2028,7 @@ mod tests {
 
     #[test]
     fn test_llm_resolved_options_user_wins_over_defaults() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         llm_config::clear_user_overrides();
         let mut overlay = llm_config::ProvidersConfig::default();
         let mut model_defaults = BTreeMap::new();
@@ -2065,7 +2065,7 @@ mod tests {
 
     #[test]
     fn test_llm_resolved_options_default_fills_unspecified() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         llm_config::clear_user_overrides();
         let mut overlay = llm_config::ProvidersConfig::default();
         let mut model_defaults = BTreeMap::new();
@@ -2092,7 +2092,7 @@ mod tests {
 
     #[test]
     fn test_llm_resolved_options_resolves_provider() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_default_provider = std::env::var("HARN_DEFAULT_PROVIDER").ok();
         unsafe {
             std::env::remove_var("HARN_DEFAULT_PROVIDER");

--- a/crates/harn-vm/src/llm/cost.rs
+++ b/crates/harn-vm/src/llm/cost.rs
@@ -1131,7 +1131,7 @@ mod tests {
 
     #[test]
     fn calculate_cost_uses_catalog_model_pricing() {
-        let _guard = crate::llm::env_lock().lock().unwrap();
+        let _guard = crate::llm::env_guard();
         let mut overlay = crate::llm_config::ProvidersConfig::default();
         overlay.models.insert(
             "gpt-4o-mini".to_string(),
@@ -1182,7 +1182,7 @@ mod tests {
 
     #[test]
     fn calculate_cost_is_zero_for_unknown_model() {
-        let _guard = crate::llm::env_lock().lock().unwrap();
+        let _guard = crate::llm::env_guard();
         crate::llm_config::clear_user_overrides();
         assert_eq!(
             calculate_cost("definitely-unpriced-model", 1_000, 1_000),
@@ -1192,9 +1192,7 @@ mod tests {
 
     #[test]
     fn calculate_cost_for_provider_falls_back_to_provider_economics() {
-        let _guard = crate::llm::env_lock()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::llm::env_guard();
         crate::llm_config::clear_user_overrides();
         let cost =
             calculate_cost_for_provider("openai", "some-bespoke-openai-deployment", 1_000, 1_000);
@@ -1209,7 +1207,7 @@ mod tests {
 
     #[test]
     fn pricing_detail_reports_source() {
-        let _guard = crate::llm::env_lock().lock().unwrap();
+        let _guard = crate::llm::env_guard();
         crate::llm_config::clear_user_overrides();
         let exact = pricing_detail_for("anthropic", "claude-sonnet-4-20250514").unwrap();
         assert_eq!(exact.source, PricingSource::CatalogModel);
@@ -1246,7 +1244,7 @@ mod tests {
 
     #[test]
     fn fast_tier_bills_premium_pricing_when_served_fast() {
-        let _guard = crate::llm::env_lock().lock().unwrap();
+        let _guard = crate::llm::env_guard();
         crate::llm_config::clear_user_overrides();
 
         // Opus 4.8 fast mode is 2x standard ($5/$25 -> $10/$50 per MTok).
@@ -1273,7 +1271,7 @@ mod tests {
 
     #[test]
     fn cache_savings_uses_catalog_cache_pricing() {
-        let _guard = crate::llm::env_lock().lock().unwrap();
+        let _guard = crate::llm::env_guard();
         crate::llm_config::clear_user_overrides();
 
         let savings =
@@ -1296,7 +1294,7 @@ mod tests {
 
     #[test]
     fn token_budget_guard_restores_prior_state_on_drop() {
-        let _guard_outer = crate::llm::env_lock().lock().unwrap();
+        let _guard_outer = crate::llm::env_guard();
         reset_cost_state();
 
         let outer = install_llm_token_budget(100);
@@ -1321,7 +1319,7 @@ mod tests {
 
     #[test]
     fn set_budget_rearms_in_place_without_resetting_accumulation() {
-        let _guard_outer = crate::llm::env_lock().lock().unwrap();
+        let _guard_outer = crate::llm::env_guard();
         reset_cost_state();
 
         // Install a $1.00 cap and spend $0.60 against it.
@@ -1352,7 +1350,7 @@ mod tests {
 
     #[test]
     fn set_token_budget_rearms_in_place_without_resetting_accumulation() {
-        let _guard_outer = crate::llm::env_lock().lock().unwrap();
+        let _guard_outer = crate::llm::env_guard();
         reset_cost_state();
 
         let _budget = install_llm_token_budget(100);
@@ -1371,7 +1369,7 @@ mod tests {
 
     #[test]
     fn token_budget_raises_categorized_error_when_exhausted() {
-        let _guard_outer = crate::llm::env_lock().lock().unwrap();
+        let _guard_outer = crate::llm::env_guard();
         reset_cost_state();
         let _budget = install_llm_token_budget(10);
 

--- a/crates/harn-vm/src/llm/healthcheck.rs
+++ b/crates/harn-vm/src/llm/healthcheck.rs
@@ -372,7 +372,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     #[allow(clippy::await_holding_lock)]
     async fn sends_configured_probe_request_with_candidate_key() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let captured = Arc::new(Mutex::new(None));
         let (base_url, server) = spawn_healthcheck_stub(200, r#"{"ok":true}"#, captured.clone());
         install_provider(
@@ -419,7 +419,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     #[allow(clippy::await_holding_lock)]
     async fn reports_missing_credentials_without_network() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         unsafe {
             std::env::remove_var("HARN_TEST_PROVIDER_KEY");
         }
@@ -451,7 +451,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     #[allow(clippy::await_holding_lock)]
     async fn returns_stable_failure_shape_for_http_errors() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let captured = Arc::new(Mutex::new(None));
         let (base_url, server) = spawn_healthcheck_stub(401, r#"{"error":"bad key"}"#, captured);
         install_provider(

--- a/crates/harn-vm/src/llm/helpers/mod.rs
+++ b/crates/harn-vm/src/llm/helpers/mod.rs
@@ -97,7 +97,7 @@ mod tests {
         // Share the crate-wide LLM env lock so this test cannot race with
         // sibling modules (e.g. llm::api streaming classification tests) that
         // also mutate LOCAL_LLM_BASE_URL.
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_base = std::env::var("LOCAL_LLM_BASE_URL").ok();
         let prev_model = std::env::var("LOCAL_LLM_MODEL").ok();
         let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
@@ -146,7 +146,7 @@ mod tests {
         // `llm_call(..., {model: "anthropic/claude-sonnet-4-6"})`
         // ends up at the local Ollama endpoint and returns a 404
         // `model_unavailable`.
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_base = std::env::var("LOCAL_LLM_BASE_URL").ok();
         let prev_local_model = std::env::var("LOCAL_LLM_MODEL").ok();
         let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
@@ -223,7 +223,7 @@ mod tests {
 
     #[test]
     fn extract_llm_options_rejects_removed_transcript_key() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
         let prev_harn_model = std::env::var("HARN_LLM_MODEL").ok();
         unsafe {
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn model_tier_prefers_reachable_env_provider_and_model() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_harn_model = std::env::var("HARN_LLM_MODEL").ok();
         let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
         let prev_local_model = std::env::var("LOCAL_LLM_MODEL").ok();
@@ -311,7 +311,7 @@ mod tests {
 
     #[test]
     fn model_tier_falls_back_to_reachable_local_provider_when_default_alias_is_unavailable() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_harn_model = std::env::var("HARN_LLM_MODEL").ok();
         let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
         let prev_local_model = std::env::var("LOCAL_LLM_MODEL").ok();
@@ -357,7 +357,7 @@ mod tests {
 
     #[test]
     fn raw_env_model_is_accepted_when_env_provider_matches() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_harn_model = std::env::var("HARN_LLM_MODEL").ok();
         let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
 
@@ -387,7 +387,7 @@ mod tests {
         // `provider: "auto"` must fall through to inference. With a `local:`
         // model prefix that inference should resolve to Ollama rather than
         // the local OpenAI-compatible provider or Anthropic.
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
         let prev_harn_model = std::env::var("HARN_LLM_MODEL").ok();
         let prev_base = std::env::var("LOCAL_LLM_BASE_URL").ok();
@@ -452,7 +452,7 @@ mod tests {
 
     #[test]
     fn provider_auto_unknown_model_warns_and_uses_default_provider() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
         let prev_harn_model = std::env::var("HARN_LLM_MODEL").ok();
         let prev_default_provider = std::env::var("HARN_DEFAULT_PROVIDER").ok();
@@ -514,7 +514,7 @@ mod tests {
 
     #[test]
     fn openrouter_provider_fallback_uses_current_valid_model_id() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_harn_model = std::env::var("HARN_LLM_MODEL").ok();
         let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
         let prev_local_model = std::env::var("LOCAL_LLM_MODEL").ok();
@@ -557,7 +557,7 @@ mod tests {
         // resolvers must surface that pin in place of the env-driven
         // default so the next `llm_call` honours it without each
         // builtin threading the session id manually.
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_harn_model = std::env::var("HARN_LLM_MODEL").ok();
         let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
         unsafe {
@@ -600,7 +600,7 @@ mod tests {
 
     #[test]
     fn explicit_call_site_model_wins_over_session_pin() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_harn_model = std::env::var("HARN_LLM_MODEL").ok();
         let prev_harn_provider = std::env::var("HARN_LLM_PROVIDER").ok();
         unsafe {

--- a/crates/harn-vm/src/llm/helpers/options/routing_tests.rs
+++ b/crates/harn-vm/src/llm/helpers/options/routing_tests.rs
@@ -217,7 +217,7 @@ fn clear_merge_role_env() {
 
 #[test]
 fn model_role_defaults_fill_missing_llm_options() {
-    let _guard = crate::llm::env_lock().lock().unwrap();
+    let _guard = crate::llm::env_guard();
     clear_merge_role_env();
     let mut overlay = ProvidersConfig::default();
     overlay.model_roles.insert(
@@ -252,7 +252,7 @@ fn model_role_defaults_fill_missing_llm_options() {
 
 #[test]
 fn explicit_options_win_over_model_role_defaults() {
-    let _guard = crate::llm::env_lock().lock().unwrap();
+    let _guard = crate::llm::env_guard();
     clear_merge_role_env();
     let mut overlay = ProvidersConfig::default();
     overlay.model_roles.insert(
@@ -291,7 +291,7 @@ fn explicit_options_win_over_model_role_defaults() {
 
 #[test]
 fn merge_model_role_has_env_overrides() {
-    let _guard = crate::llm::env_lock().lock().unwrap();
+    let _guard = crate::llm::env_guard();
     crate::llm_config::clear_user_overrides();
     clear_merge_role_env();
     std::env::set_var("HARN_LLM_MERGE_PROVIDER", "mock");
@@ -310,7 +310,7 @@ fn merge_model_role_has_env_overrides() {
 
 #[test]
 fn model_role_aliases_do_not_override_exact_role_defaults() {
-    let _guard = crate::llm::env_lock().lock().unwrap();
+    let _guard = crate::llm::env_guard();
     clear_merge_role_env();
     let mut overlay = ProvidersConfig::default();
     overlay.model_roles.insert(
@@ -356,7 +356,7 @@ fn model_role_aliases_do_not_override_exact_role_defaults() {
 
 #[test]
 fn model_role_env_aliases_do_not_override_exact_role_env() {
-    let _guard = crate::llm::env_lock().lock().unwrap();
+    let _guard = crate::llm::env_guard();
     crate::llm_config::clear_user_overrides();
     clear_merge_role_env();
     std::env::set_var("HARN_LLM_FAST_APPLY_PROVIDER", "mock");
@@ -379,7 +379,7 @@ fn model_role_env_aliases_do_not_override_exact_role_env() {
 
 #[test]
 fn model_role_config_keys_normalize_like_call_options() {
-    let _guard = crate::llm::env_lock().lock().unwrap();
+    let _guard = crate::llm::env_guard();
     clear_merge_role_env();
     let mut overlay = ProvidersConfig::default();
     overlay.model_roles.insert(
@@ -420,7 +420,7 @@ fn fast_options(model: &str) -> BTreeMap<String, VmValue> {
 
 #[test]
 fn fast_opts_into_tier_for_supported_model_and_guards_others() {
-    let _guard = crate::llm::env_lock().lock().unwrap();
+    let _guard = crate::llm::env_guard();
     crate::llm_config::clear_user_overrides();
     std::env::set_var("ANTHROPIC_API_KEY", "test-key");
     std::env::set_var("OPENAI_API_KEY", "test-key");

--- a/crates/harn-vm/src/llm/introspection.rs
+++ b/crates/harn-vm/src/llm/introspection.rs
@@ -347,7 +347,7 @@ mod tests {
 
     #[test]
     fn harness_env_wins_over_default() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         reset_env_harness();
         assert_eq!(harness_identifier(), "harn");
         unsafe {

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -153,6 +153,17 @@ pub(crate) fn env_lock() -> &'static std::sync::Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+/// Acquire the env lock, recovering from poisoning. The mutex only
+/// serializes process-env mutation — a panicking holder leaves nothing
+/// corrupted behind — so treating poison as fatal just cascades one failing
+/// test into failures in every sibling test that touches LLM env vars.
+#[cfg(test)]
+pub(crate) fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+    env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 pub const LLM_CALLS_DISABLED_ENV: &str = "HARN_LLM_CALLS_DISABLED";
 
 pub fn estimate_text_tokens(text: &str) -> i64 {
@@ -271,7 +282,27 @@ pub use self::trace::{
     take_agent_trace, take_trace, AgentTraceEvent, LlmTraceEntry,
 };
 
-/// Reset all thread-local LLM state (cost, trace, mock, rate limits). Call between test runs.
+/// Fully wipe the process-global rate-limiter registry (config-derived
+/// limiters, retry-after cooldowns, usage windows, and runtime overrides).
+///
+/// This is deliberately **not** part of [`reset_llm_state`]: that runs from
+/// parallel unit tests where wiping the shared registry corrupts a sibling
+/// rate-limit test's counters mid-assertion. Only sequential or
+/// separate-process contexts — the CLI test runner between cases, integration
+/// test binaries, and per-job worker resets — may safely call this, which they
+/// do via [`crate::reset_thread_local_state`].
+pub fn reset_rate_limit_registry() {
+    rate_limit::reset_rate_limit_state();
+}
+
+/// Reset thread-local LLM state (cost, trace, mock, providers). Call between
+/// test runs.
+///
+/// Note: the process-global rate-limiter registry is intentionally left alone
+/// here (only leaked *runtime overrides* are scrubbed) so concurrently running
+/// rate-limit tests aren't corrupted. Contexts that need full rate-limit
+/// isolation call [`reset_rate_limit_registry`] via
+/// [`crate::reset_thread_local_state`].
 pub fn reset_llm_state() {
     call::clear_in_flight_llm_calls();
     introspection::reset_snapshot();
@@ -279,7 +310,10 @@ pub fn reset_llm_state() {
     trace::reset_trace_state();
     trace::reset_agent_trace_state();
     provider::register_default_providers();
-    rate_limit::reset_rate_limit_state();
+    // Deliberately the override-scoped reset, not the full registry wipe:
+    // the limiter registry is process-global, and a full wipe here raced
+    // (and corrupted) concurrently running rate-limit tests.
+    rate_limit::reset_runtime_rate_limit_overrides();
     routing::clear_policy_registry();
     mock::reset_llm_mock_state();
     autonomy_budget::reset_autonomy_budget_state();

--- a/crates/harn-vm/src/llm/providers/azure_openai.rs
+++ b/crates/harn-vm/src/llm/providers/azure_openai.rs
@@ -108,10 +108,16 @@ impl AzureOpenAiProvider {
             .map_err(|error| vm_err(format!("azure_openai API error: {error}")))?;
         if !response.status().is_success() {
             let status = response.status();
+            let retry_after = crate::llm::api::retry_after_header(response.headers());
             let body = response.text().await.unwrap_or_default();
             return Err(vm_err(
-                crate::llm::api::classify_provider_http_error("azure_openai", status, None, &body)
-                    .message,
+                crate::llm::api::classify_provider_http_error(
+                    "azure_openai",
+                    status,
+                    retry_after.as_deref(),
+                    &body,
+                )
+                .message,
             ));
         }
         let json: serde_json::Value = response
@@ -155,7 +161,7 @@ impl LlmProviderChat for AzureOpenAiProvider {
 mod tests {
     use super::*;
     use crate::llm::api::{LlmRequestPayload, ThinkingConfig};
-    use crate::llm::env_lock;
+    use crate::llm::env_guard;
     use serde_json::json;
 
     struct ScopedEnv {
@@ -187,7 +193,7 @@ mod tests {
 
     #[test]
     fn deployment_url_uses_model_and_api_version() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = env_guard();
         let _endpoint = ScopedEnv::set("AZURE_OPENAI_ENDPOINT", "https://acct.openai.azure.com/");
         let _api_version = ScopedEnv::set("AZURE_OPENAI_API_VERSION", "2025-01-01-preview");
         let _deployment = ScopedEnv::remove("AZURE_OPENAI_DEPLOYMENT");
@@ -201,7 +207,7 @@ mod tests {
 
     #[test]
     fn auth_prefers_api_key_then_bearer_token() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = env_guard();
         let _key = ScopedEnv::set("AZURE_OPENAI_API_KEY", "key");
         let _token = ScopedEnv::set("AZURE_OPENAI_AD_TOKEN", "token");
         assert_eq!(

--- a/crates/harn-vm/src/llm/providers/bedrock.rs
+++ b/crates/harn-vm/src/llm/providers/bedrock.rs
@@ -152,10 +152,16 @@ impl BedrockProvider {
             .map_err(|error| vm_err(format!("bedrock API error: {error}")))?;
         if !response.status().is_success() {
             let status = response.status();
+            let retry_after = crate::llm::api::retry_after_header(response.headers());
             let body = response.text().await.unwrap_or_default();
             return Err(vm_err(
-                crate::llm::api::classify_provider_http_error("bedrock", status, None, &body)
-                    .message,
+                crate::llm::api::classify_provider_http_error(
+                    "bedrock",
+                    status,
+                    retry_after.as_deref(),
+                    &body,
+                )
+                .message,
             ));
         }
         let json: serde_json::Value = response
@@ -573,7 +579,7 @@ mod tests {
 
     #[test]
     fn blank_region_override_falls_back_to_env() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let saved: Vec<(&str, Option<String>)> = BEDROCK_REGION_ENV_VARS
             .iter()
             .map(|name| (*name, std::env::var(name).ok()))

--- a/crates/harn-vm/src/llm/providers/gemini.rs
+++ b/crates/harn-vm/src/llm/providers/gemini.rs
@@ -190,10 +190,16 @@ impl GeminiProvider {
         })?;
         if !response.status().is_success() {
             let status = response.status();
+            let retry_after = crate::llm::api::retry_after_header(response.headers());
             let body = response.text().await.unwrap_or_default();
             return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
-                crate::llm::api::classify_provider_http_error("gemini", status, None, &body)
-                    .message,
+                crate::llm::api::classify_provider_http_error(
+                    "gemini",
+                    status,
+                    retry_after.as_deref(),
+                    &body,
+                )
+                .message,
             ))));
         }
         let json: serde_json::Value = response.json().await.map_err(|error| {

--- a/crates/harn-vm/src/llm/providers/ollama.rs
+++ b/crates/harn-vm/src/llm/providers/ollama.rs
@@ -235,11 +235,7 @@ impl OllamaProvider {
         })?;
         if !response.status().is_success() {
             let status = response.status();
-            let retry_after = response
-                .headers()
-                .get("retry-after")
-                .and_then(|v| v.to_str().ok())
-                .map(|s| s.to_string());
+            let retry_after = crate::llm::api::retry_after_header(response.headers());
             let body = response.text().await.unwrap_or_default();
             let msg = Self::classify_http_error(status, retry_after.as_deref(), &body).message;
             return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(msg))));
@@ -682,7 +678,7 @@ mod tests {
 
     #[test]
     fn defaults_ollama_runtime_settings() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let _env = [
             ScopedEnvVar::remove("HARN_OLLAMA_NUM_CTX"),
             ScopedEnvVar::remove("OLLAMA_CONTEXT_LENGTH"),

--- a/crates/harn-vm/src/llm/providers/openai_responses.rs
+++ b/crates/harn-vm/src/llm/providers/openai_responses.rs
@@ -64,11 +64,7 @@ impl OpenAiResponsesProvider {
 
         if !response.status().is_success() {
             let status = response.status();
-            let retry_after = response
-                .headers()
-                .get("retry-after")
-                .and_then(|value| value.to_str().ok())
-                .map(str::to_string);
+            let retry_after = crate::llm::api::retry_after_header(response.headers());
             let body = response.text().await.unwrap_or_default();
             let msg = crate::llm::providers::OpenAiCompatibleProvider::classify_http_error(
                 "openai",

--- a/crates/harn-vm/src/llm/providers/vertex.rs
+++ b/crates/harn-vm/src/llm/providers/vertex.rs
@@ -207,10 +207,16 @@ impl VertexProvider {
             .map_err(|error| vm_err(format!("vertex API error: {error}")))?;
         if !response.status().is_success() {
             let status = response.status();
+            let retry_after = crate::llm::api::retry_after_header(response.headers());
             let body = response.text().await.unwrap_or_default();
             return Err(vm_err(
-                crate::llm::api::classify_provider_http_error("vertex", status, None, &body)
-                    .message,
+                crate::llm::api::classify_provider_http_error(
+                    "vertex",
+                    status,
+                    retry_after.as_deref(),
+                    &body,
+                )
+                .message,
             ));
         }
         let json: serde_json::Value = response

--- a/crates/harn-vm/src/llm/rate_limit.rs
+++ b/crates/harn-vm/src/llm/rate_limit.rs
@@ -816,6 +816,31 @@ pub(crate) fn reset_rate_limit_state() {
         .clear();
 }
 
+/// Reset rate-limit state only if a runtime override (via `llm_rate_limit`)
+/// was actually installed — the one piece of rate-limit state a test run can
+/// leak into the next.
+///
+/// `reset_llm_state` used to call [`reset_rate_limit_state`] unconditionally,
+/// but the limiter registry is *process-global*, and `reset_thread_local_state`
+/// runs from ~150 test setups in parallel — each call wiped the usage counters
+/// that concurrently running rate-limit tests were asserting on. With this
+/// guard, the common no-override case leaves the global registry untouched;
+/// the wipe (and lazy re-init from config) only happens when there is
+/// genuinely something to clean up.
+pub(crate) fn reset_runtime_rate_limit_overrides() {
+    let mut overrides = runtime_overrides()
+        .lock()
+        .expect("rate limiter runtime override mutex poisoned");
+    if overrides.is_empty() {
+        return;
+    }
+    overrides.clear();
+    drop(overrides);
+    let mut registry = registry().lock().expect("rate limiter mutex poisoned");
+    registry.limiters.clear();
+    registry.initialized_from_config = false;
+}
+
 #[cfg(test)]
 fn get_model_rate_limits(provider: &str, model: &str) -> Option<crate::llm_config::RateLimitsDef> {
     ensure_initialized_from_config();
@@ -997,7 +1022,7 @@ mod tests {
 
     #[test]
     fn init_from_config_loads_model_rate_limits_from_catalog_overlay() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         reset_test_rate_limit_state();
         install_quota_overlay();
         init_from_config();
@@ -1016,7 +1041,7 @@ mod tests {
 
     #[test]
     fn provider_env_override_sets_tpm() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         reset_test_rate_limit_state();
         install_quota_overlay();
         std::env::set_var("HARN_RATE_LIMIT_QUOTA_TPM", "1000000");
@@ -1030,7 +1055,7 @@ mod tests {
 
     #[test]
     fn legacy_provider_rpm_env_still_sets_provider_bucket() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         reset_rate_limit_state();
         std::env::set_var("HARN_RATE_LIMIT_TESTPROVIDER", "42");
         init_from_config();
@@ -1041,7 +1066,7 @@ mod tests {
 
     #[test]
     fn concurrency_queue_does_not_consume_request_quota_until_started() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let _durable_disabled = EnvVarGuard::set_value(DURABLE_RATE_LIMIT_ENABLED_ENV, "0");
         reset_test_rate_limit_state();
         install_concurrency_overlay();
@@ -1056,11 +1081,21 @@ mod tests {
             let first = acquire_permit("queue").await.expect("first permit");
             assert_eq!(provider_request_usage("queue"), 1);
 
-            let second = tokio::spawn(async { acquire_permit("queue").await });
-            for _ in 0..5 {
-                tokio::task::yield_now().await;
+            let mut second = tokio::spawn(async { acquire_permit("queue").await });
+            // The second acquire must stay parked behind the first permit.
+            // Poll under a real-time timeout instead of counting yields —
+            // yield counting is scheduler-sensitive, and when this fires it
+            // also surfaces *what* completed instead of a bare is_finished.
+            if let Ok(join) =
+                tokio::time::timeout(std::time::Duration::from_millis(100), &mut second).await
+            {
+                let outcome = match join {
+                    Ok(Ok(_permit)) => "a second permit was granted".to_string(),
+                    Ok(Err(error)) => format!("acquire failed: {error:?}"),
+                    Err(join_error) => format!("task panicked: {join_error}"),
+                };
+                panic!("second acquire completed while the first permit was held ({outcome})");
             }
-            assert!(!second.is_finished());
             assert_eq!(provider_request_usage("queue"), 1);
 
             drop(first);
@@ -1078,7 +1113,7 @@ mod tests {
 
     #[test]
     fn durable_concurrency_queue_does_not_consume_request_quota_until_started() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         reset_test_rate_limit_state();
         install_concurrency_overlay();
         let temp = tempfile::tempdir().expect("tempdir");
@@ -1095,11 +1130,19 @@ mod tests {
             let first = acquire_permit("queue").await.expect("first permit");
             assert_eq!(durable_usage(&state_path, "llm:provider:queue:rpm"), 1);
 
-            let second = tokio::spawn(async { acquire_permit("queue").await });
-            for _ in 0..5 {
-                tokio::task::yield_now().await;
+            let mut second = tokio::spawn(async { acquire_permit("queue").await });
+            // See concurrency_queue_does_not_consume_request_quota_until_started
+            // for why this polls under a timeout instead of counting yields.
+            if let Ok(join) =
+                tokio::time::timeout(std::time::Duration::from_millis(100), &mut second).await
+            {
+                let outcome = match join {
+                    Ok(Ok(_permit)) => "a second permit was granted".to_string(),
+                    Ok(Err(error)) => format!("acquire failed: {error:?}"),
+                    Err(join_error) => format!("task panicked: {join_error}"),
+                };
+                panic!("second acquire completed while the first permit was held ({outcome})");
             }
-            assert!(!second.is_finished());
             assert_eq!(durable_usage(&state_path, "llm:provider:queue:rpm"), 1);
 
             drop(first);
@@ -1117,7 +1160,7 @@ mod tests {
 
     #[test]
     fn durable_state_path_coordinates_after_process_local_reset() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         reset_test_rate_limit_state();
         install_durable_overlay();
         let temp = tempfile::tempdir().expect("tempdir");
@@ -1151,6 +1194,101 @@ mod tests {
                 "second process-local registry should wait on durable SQLite state"
             );
         });
+
+        reset_test_rate_limit_state();
+    }
+
+    // ---------------------------------------------------------------------
+    // Reset-scope contract.
+    //
+    // The rate-limiter registry is process-global. Two reset levels exist and
+    // MUST stay decoupled:
+    //
+    //   * `reset_llm_state` (runs from parallel in-process unit tests) only
+    //     scrubs leaked *runtime overrides* — it must NOT wipe a config-derived
+    //     registry, or it would corrupt a concurrently asserting sibling test.
+    //   * `reset_rate_limit_state` (the full wipe, reached in sequential /
+    //     separate-process contexts via `reset_thread_local_state`) clears
+    //     everything, including retry-after cooldowns.
+    //
+    // These two tests pin each half of that contract so a future refactor can't
+    // silently re-merge them — the failure mode was a leaked cooldown stalling a
+    // later conformance test's mocked LLM call under a paused clock for the full
+    // per-test timeout.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn full_registry_reset_clears_retry_after_cooldown() {
+        let _guard = crate::llm::env_guard();
+        reset_test_rate_limit_state();
+        install_quota_overlay();
+        init_from_config();
+
+        let keys = limiter_keys("quota", "quota-model");
+        let request = RateLimitRequest::default();
+        let now_ms = 0;
+
+        // A provider 429 installs a long retry-after cooldown on the route.
+        {
+            let mut registry = registry().lock().expect("registry");
+            for key in &keys {
+                limiter_for_key(&mut registry.limiters, key).observe_retry_after(now_ms, 60_000);
+            }
+            assert!(
+                check_wait_for_keys(&mut registry, &keys, request, now_ms).is_some(),
+                "cooldown should force a wait before reset"
+            );
+        }
+
+        // The full wipe (what `reset_thread_local_state` performs between
+        // sequential tests) must clear the cooldown so the next test's call
+        // doesn't stall on a paused clock.
+        reset_rate_limit_state();
+        init_from_config();
+        {
+            let mut registry = registry().lock().expect("registry");
+            assert!(
+                check_wait_for_keys(&mut registry, &keys, request, now_ms).is_none(),
+                "cooldown must not survive a full registry reset"
+            );
+        }
+
+        reset_test_rate_limit_state();
+    }
+
+    #[test]
+    fn runtime_override_reset_preserves_config_registry() {
+        let _guard = crate::llm::env_guard();
+        reset_test_rate_limit_state();
+        install_quota_overlay();
+        init_from_config();
+
+        let provider_bucket = provider_key("quota");
+        assert!(
+            registry()
+                .lock()
+                .expect("registry")
+                .limiters
+                .contains_key(&provider_bucket),
+            "config init should populate the provider limiter"
+        );
+
+        // The override-scoped reset (what `reset_llm_state` runs from parallel
+        // unit tests, with no runtime override installed) must leave the
+        // config-derived registry untouched — otherwise it would wipe usage
+        // counters a concurrent rate-limit test is asserting on.
+        reset_runtime_rate_limit_overrides();
+
+        let registry = registry().lock().expect("registry");
+        assert!(
+            registry.initialized_from_config,
+            "config-init flag must survive an override-only reset"
+        );
+        assert!(
+            registry.limiters.contains_key(&provider_bucket),
+            "config limiters must survive an override-only reset"
+        );
+        drop(registry);
 
         reset_test_rate_limit_state();
     }

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -2589,7 +2589,7 @@ mod tests {
 
     #[test]
     fn test_infer_provider_from_defaults() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_default_provider = std::env::var("HARN_DEFAULT_PROVIDER").ok();
         unsafe {
             std::env::remove_var("HARN_DEFAULT_PROVIDER");
@@ -2624,7 +2624,7 @@ mod tests {
 
     #[test]
     fn test_openrouter_inference_requires_one_slash() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_default_provider = std::env::var("HARN_DEFAULT_PROVIDER").ok();
         unsafe {
             std::env::remove_var("HARN_DEFAULT_PROVIDER");
@@ -2643,7 +2643,7 @@ mod tests {
 
     #[test]
     fn test_cerebras_inference_beats_openrouter_slash_fallback() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_default_provider = std::env::var("HARN_DEFAULT_PROVIDER").ok();
         unsafe {
             std::env::remove_var("HARN_DEFAULT_PROVIDER");
@@ -2667,7 +2667,7 @@ mod tests {
         // not be misrouted by the generic `gpt-*` / single-slash inference
         // fallbacks. Regression for harn#2142 (model-info routed
         // `gpt-oss-120b` to openai, breaking Burin TUI credential checks).
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_default_provider = std::env::var("HARN_DEFAULT_PROVIDER").ok();
         unsafe {
             std::env::remove_var("HARN_DEFAULT_PROVIDER");
@@ -3067,7 +3067,7 @@ mod tests {
 
     #[test]
     fn test_default_provider_env_override_for_unknown_model() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_default_provider = std::env::var("HARN_DEFAULT_PROVIDER").ok();
         unsafe {
             std::env::set_var("HARN_DEFAULT_PROVIDER", "openai");
@@ -3091,7 +3091,7 @@ mod tests {
 
     #[test]
     fn test_unknown_model_family_ignores_default_provider_fallback() {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_default_provider = std::env::var("HARN_DEFAULT_PROVIDER").ok();
         unsafe {
             std::env::set_var("HARN_DEFAULT_PROVIDER", "ollama");

--- a/crates/harn-vm/src/orchestration/crystallize/util.rs
+++ b/crates/harn-vm/src/orchestration/crystallize/util.rs
@@ -96,5 +96,5 @@ pub(super) fn sanitize_identifier(raw: &str) -> String {
 }
 
 pub(super) fn escape_harn_string(value: &str) -> String {
-    value.replace('\\', "\\\\").replace('"', "\\\"")
+    harn_lexer::escape_string_literal(value)
 }

--- a/crates/harn-vm/src/stdlib/process.rs
+++ b/crates/harn-vm/src/stdlib/process.rs
@@ -1239,7 +1239,7 @@ mod tests {
     fn runtime_paths_uses_configurable_state_roots() {
         let _runtime_paths_env_lock = crate::runtime_paths::test_env_lock()
             .lock()
-            .expect("runtime paths env lock");
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let _env_guard = RuntimePathsEnvGuard::capture();
         let base =
             std::env::temp_dir().join(format!("harn-process-runtime-{}", uuid::Uuid::now_v7()));

--- a/crates/harn-vm/src/stdlib/review.rs
+++ b/crates/harn-vm/src/stdlib/review.rs
@@ -743,7 +743,7 @@ mod tests {
     }
 
     fn with_mock_provider<T>(f: impl FnOnce() -> T) -> T {
-        let _guard = crate::llm::env_lock().lock().expect("env lock");
+        let _guard = crate::llm::env_guard();
         let prev_provider = std::env::var("HARN_LLM_PROVIDER").ok();
         let prev_model = std::env::var("HARN_LLM_MODEL").ok();
         unsafe {

--- a/crates/harn-vm/src/vm/ops/collections.rs
+++ b/crates/harn-vm/src/vm/ops/collections.rs
@@ -539,11 +539,12 @@ impl super::super::Vm {
             let slot = &mut frame.local_slots[slot_idx];
             match &mut slot.value {
                 VmValue::List(items) => {
-                    if let Some(i) = index.as_int() {
-                        let idx = resolve_list_assign_index(i, items.len())?;
-                        Arc::make_mut(items)[idx] = new_value;
-                        slot.synced = false;
-                    }
+                    let Some(i) = index.as_int() else {
+                        return Err(Self::list_index_type_error(&index));
+                    };
+                    let idx = resolve_list_assign_index(i, items.len())?;
+                    Arc::make_mut(items)[idx] = new_value;
+                    slot.synced = false;
                     return Ok(());
                 }
                 VmValue::Dict(map) => {
@@ -552,7 +553,7 @@ impl super::super::Vm {
                     slot.synced = false;
                     return Ok(());
                 }
-                _ => return Ok(()),
+                other => return Err(Self::subscript_assign_type_error(other)),
             }
         }
 
@@ -563,14 +564,15 @@ impl super::super::Vm {
         if let Some(obj) = self.env.get(var_name) {
             match obj {
                 VmValue::List(items) => {
-                    if let Some(i) = index.as_int() {
-                        let mut new_items =
-                            Arc::try_unwrap(items).unwrap_or_else(|items| (*items).clone());
-                        let idx = resolve_list_assign_index(i, new_items.len())?;
-                        new_items[idx] = new_value;
-                        self.env
-                            .assign(var_name, VmValue::List(std::sync::Arc::new(new_items)))?;
-                    }
+                    let Some(i) = index.as_int() else {
+                        return Err(Self::list_index_type_error(&index));
+                    };
+                    let mut new_items =
+                        Arc::try_unwrap(items).unwrap_or_else(|items| (*items).clone());
+                    let idx = resolve_list_assign_index(i, new_items.len())?;
+                    new_items[idx] = new_value;
+                    self.env
+                        .assign(var_name, VmValue::List(std::sync::Arc::new(new_items)))?;
                 }
                 VmValue::Dict(map) => {
                     let key = index.display();
@@ -579,10 +581,27 @@ impl super::super::Vm {
                     self.env
                         .assign(var_name, VmValue::Dict(std::sync::Arc::new(new_map)))?;
                 }
-                _ => {}
+                other => return Err(Self::subscript_assign_type_error(&other)),
             }
         }
         Ok(())
+    }
+
+    /// Index-assignment on a list requires an int index — mirrors the read
+    /// path's "cannot index into list with …" wording.
+    fn list_index_type_error(index: &VmValue) -> VmError {
+        VmError::TypeError(format!("cannot index into list with {}", index.type_name()))
+    }
+
+    /// Index-assignment is only supported on lists and dicts. This used to
+    /// be a silent no-op (e.g. `s[0] = "Z"` on a string left `s` untouched);
+    /// it is now the same class of error the property path raises.
+    fn subscript_assign_type_error(target: &VmValue) -> VmError {
+        VmError::TypeError(format!(
+            "cannot assign by index into {}; only lists and dicts support \
+             index assignment",
+            target.type_name()
+        ))
     }
 
     pub(super) fn execute_concat(&mut self) {


### PR DESCRIPTION
## Cross-cutting bug sweep, round 2 (13 root-cause fixes)

A second adversarial sweep across compiler, runtime, typechecker, LSP, providers, and test isolation. Each behavior gains conformance and/or unit coverage.

### Compiler / runtime correctness
- **Nested assignment wrote to the wrong target.** `a.b.c = v` silently wrote `a.c`; `a["b"]["c"]`, `xs[0][1]`, `m.list[0]` similarly collapsed to root+leaf, and `p[0].x = v` threw. Nested paths are now desugared into a scope-contained chain of temporaries (read down → assign leaf → write back up), preserving `let`-root immutability.
- **Compound subscript indices evaluated twice.** `xs[idx()] += 1` called `idx()` for both the read and the write; side-effecting indices are hoisted into a temp and evaluated once.
- **Invalid assignment targets compiled as silent no-ops.** `get_thing().x = 99` did nothing; now a compile error naming the unsupported target form.
- **Module-level statements were dropped in pipeline mode.** Assignments/expression statements between a binding and a pipeline decl never ran; all module statements now execute in source order before declarations, matching script mode.
- **Index assignment on unsupported runtime types was a silent no-op.** `s[0] = "Z"` on a string / `xs["a"] = 9` on a list now raise the same class of type error the read and property paths already did.

### Security
- **`${…}` interpolation injection in code generators.** `harn try` scaffolding and the composition/crystallize generators escaped quotes/backslashes but not `${`, so an embedded `${host_call(...)}` executed when the generated program compiled. All generators (and `harn fmt`) now share one round-trip-tested `harn_lexer::escape_string_literal`.
- **ACP `session/cancel` skipped authentication.** The only session method without the `reject_unauthenticated` gate. Guard added, plus a drift test asserting every `session/*` arm checks auth.

### Providers / typechecker / LSP / CLI
- **`Retry-After` dropped on errors** by Gemini, Azure OpenAI, Bedrock, and Vertex; all providers now share one header-extraction helper.
- **LSP find-references returned whole declarations**; results now narrow to the identifier token.
- **Subscript type inference ignored intersections** (`x["a"]` inferred gradual while `x.a` resolved the member); the subscript path mirrors the property path.
- **Divergent TOML escaping produced invalid TOML**; the connector helper skipped control chars. Consolidated with `harn rules`' copy; three `html_escape` copies and a JUnit `xml_escape` also unified.

### Test isolation (flaky / hanging tests)
- **LLM env-lock poison cascade** — one flaky rate-limit assertion poisoned the shared env lock and cascaded into 16 failures. The lock now recovers from poisoning; scheduler-sensitive yield-count asserts became deterministic timeouts.
- **Decoupled the two rate-limit reset scopes.** The rate-limiter registry is process-global. `reset_llm_state` (runs from *parallel* unit tests) must not wipe it — it scrubs only leaked runtime overrides — while `reset_thread_local_state` (only ever sequential / separate-process) does the full `reset_rate_limit_registry()` wipe. This fixes a conformance fidelity test that **hung for its full per-test timeout** when a prior mock-429 cooldown leaked onto a paused-clock LLM call (`acquire_permit_for` loops on throttle rather than erroring). Two contract tests pin each half.

### Verification
- `make conformance`: **1606 passed, 0 failed** (incl. 5 new fixtures + 3 new error fixtures).
- `cargo test -p harn-vm --lib llm::` green 5×; new `rate_limit.rs` contract tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
