### PR TITLE
Add Kimi K2.7 Code provider support

### DIFF
--- a/changelog.d/kimi-k2-7-code.added.md
+++ b/changelog.d/kimi-k2-7-code.added.md
@@ -1,0 +1,3 @@
+- Add Moonshot Kimi K2.7 Code to the OpenRouter provider catalog and
+  normalize its fixed-parameter/tool-choice quirks in the OpenAI-compatible
+  transport.

--- a/conformance/tests/scenarios/provider_capabilities_basic.harn
+++ b/conformance/tests/scenarios/provider_capabilities_basic.harn
@@ -92,6 +92,18 @@ pipeline test(task) {
     !together_kimi.honors_chat_template_kwargs,
     "Together Kimi does not use Qwen chat template kwargs",
   )
+  let kimi27 = provider_capabilities("openrouter", "moonshotai/kimi-k2.7-code")
+  assert(kimi27.native_tools, "OpenRouter Kimi K2.7 Code exposes native tools")
+  assert(kimi27.prompt_caching, "Kimi K2.7 Code exposes prompt cache reads")
+  assert(kimi27.vision_supported, "Kimi K2.7 Code accepts image input")
+  assert(kimi27.video, "Kimi K2.7 Code accepts video input")
+  assert(kimi27.thinking_modes[0] == "enabled", "Kimi K2.7 Code always thinks")
+  assert(kimi27.allowed_tool_choice_modes[0] == "auto", "Kimi K2.7 Code allows auto tool choice")
+  assert(kimi27.allowed_tool_choice_modes[1] == "none", "Kimi K2.7 Code allows none tool choice")
+  assert(!kimi27.temperature_supported, "Kimi K2.7 Code has fixed temperature")
+  assert(!kimi27.top_p_supported, "Kimi K2.7 Code has fixed top_p")
+  assert(!kimi27.frequency_penalty_supported, "Kimi K2.7 Code has fixed penalties")
+  assert(!kimi27.presence_penalty_supported, "Kimi K2.7 Code has fixed penalties")
   // OpenRouter inherits the openai family.
   let routed = provider_capabilities("openrouter", "gpt-5.4")
   assert(routed.defer_loading, "openrouter inherits openai defer_loading")

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -81,6 +81,10 @@ pub struct ProviderDefaults {
     #[serde(default)]
     pub top_k_supported: Option<bool>,
     #[serde(default)]
+    pub temperature_supported: Option<bool>,
+    #[serde(default)]
+    pub top_p_supported: Option<bool>,
+    #[serde(default)]
     pub frequency_penalty_supported: Option<bool>,
     #[serde(default)]
     pub presence_penalty_supported: Option<bool>,
@@ -111,6 +115,12 @@ impl ProviderDefaults {
         }
         if other.top_k_supported.is_some() {
             self.top_k_supported = other.top_k_supported;
+        }
+        if other.temperature_supported.is_some() {
+            self.temperature_supported = other.temperature_supported;
+        }
+        if other.top_p_supported.is_some() {
+            self.top_p_supported = other.top_p_supported;
         }
         if other.frequency_penalty_supported.is_some() {
             self.frequency_penalty_supported = other.frequency_penalty_supported;
@@ -145,6 +155,12 @@ impl ProviderDefaults {
         if self.top_k_supported.is_none() {
             self.top_k_supported = other.top_k_supported;
         }
+        if self.temperature_supported.is_none() {
+            self.temperature_supported = other.temperature_supported;
+        }
+        if self.top_p_supported.is_none() {
+            self.top_p_supported = other.top_p_supported;
+        }
         if self.frequency_penalty_supported.is_none() {
             self.frequency_penalty_supported = other.frequency_penalty_supported;
         }
@@ -162,6 +178,8 @@ impl ProviderDefaults {
             || self.files_api_supported.is_some()
             || self.seed_supported.is_some()
             || self.top_k_supported.is_some()
+            || self.temperature_supported.is_some()
+            || self.top_p_supported.is_some()
             || self.frequency_penalty_supported.is_some()
             || self.presence_penalty_supported.is_some()
     }
@@ -355,9 +373,18 @@ pub struct ProviderRule {
     #[serde(default)]
     pub top_k_supported: Option<bool>,
     #[serde(default)]
+    pub temperature_supported: Option<bool>,
+    #[serde(default)]
+    pub top_p_supported: Option<bool>,
+    #[serde(default)]
     pub frequency_penalty_supported: Option<bool>,
     #[serde(default)]
     pub presence_penalty_supported: Option<bool>,
+    /// Accepted provider-native `tool_choice` modes. Empty means unrestricted
+    /// or unknown. Use this for routes whose native tools work, but whose API
+    /// rejects forced/specified tool choices.
+    #[serde(default)]
+    pub allowed_tool_choice_modes: Option<Vec<String>>,
     /// Preferred endpoint family for this provider/model route. Values
     /// are descriptive labels consumed by providers, e.g.
     /// `/api/generate-raw` for Ollama raw prompt bypass.
@@ -471,8 +498,11 @@ pub struct Capabilities {
     pub reasoning_wire_format: Option<String>,
     pub seed_supported: bool,
     pub top_k_supported: bool,
+    pub temperature_supported: bool,
+    pub top_p_supported: bool,
     pub frequency_penalty_supported: bool,
     pub presence_penalty_supported: bool,
+    pub allowed_tool_choice_modes: Vec<String>,
     pub recommended_endpoint: Option<String>,
     pub text_tool_wire_format_supported: bool,
     pub preferred_tool_format: Option<String>,
@@ -537,8 +567,11 @@ impl Default for Capabilities {
             reasoning_wire_format: None,
             seed_supported: true,
             top_k_supported: true,
+            temperature_supported: true,
+            top_p_supported: true,
             frequency_penalty_supported: true,
             presence_penalty_supported: true,
+            allowed_tool_choice_modes: Vec::new(),
             recommended_endpoint: None,
             text_tool_wire_format_supported: true,
             preferred_tool_format: None,
@@ -1175,8 +1208,11 @@ fn defaults_to_caps(defaults: &ProviderDefaults) -> Capabilities {
         reasoning_wire_format: None,
         seed_supported: None,
         top_k_supported: None,
+        temperature_supported: None,
+        top_p_supported: None,
         frequency_penalty_supported: None,
         presence_penalty_supported: None,
+        allowed_tool_choice_modes: None,
         recommended_endpoint: None,
         text_tool_wire_format_supported: None,
         preferred_tool_format: None,
@@ -1273,6 +1309,14 @@ fn rule_to_caps(rule: &ProviderRule, defaults: &ProviderDefaults) -> Capabilitie
             .top_k_supported
             .or(defaults.top_k_supported)
             .unwrap_or(true),
+        temperature_supported: rule
+            .temperature_supported
+            .or(defaults.temperature_supported)
+            .unwrap_or(true),
+        top_p_supported: rule
+            .top_p_supported
+            .or(defaults.top_p_supported)
+            .unwrap_or(true),
         frequency_penalty_supported: rule
             .frequency_penalty_supported
             .or(defaults.frequency_penalty_supported)
@@ -1281,6 +1325,7 @@ fn rule_to_caps(rule: &ProviderRule, defaults: &ProviderDefaults) -> Capabilitie
             .presence_penalty_supported
             .or(defaults.presence_penalty_supported)
             .unwrap_or(true),
+        allowed_tool_choice_modes: rule.allowed_tool_choice_modes.clone().unwrap_or_default(),
         recommended_endpoint: rule.recommended_endpoint.clone(),
         text_tool_wire_format_supported: rule.text_tool_wire_format_supported.unwrap_or(true),
         preferred_tool_format: Some(rule_preferred_tool_format(rule)),
@@ -1804,6 +1849,30 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
         assert_eq!(caps.tool_search, vec!["hosted", "client"]);
         assert_eq!(caps.reasoning_wire_format.as_deref(), Some("openrouter"));
         assert!(!caps.top_k_supported);
+    }
+
+    #[test]
+    fn openrouter_kimi27_code_records_tool_choice_and_sampling_limits() {
+        reset();
+        let caps = lookup("openrouter", "moonshotai/kimi-k2.7-code");
+        assert!(caps.native_tools);
+        assert!(caps.prompt_caching);
+        assert!(caps.vision_supported);
+        assert!(caps.video);
+        assert_eq!(caps.preferred_tool_format.as_deref(), Some("native"));
+        assert_eq!(caps.thinking_modes, vec!["enabled"]);
+        assert_eq!(caps.allowed_tool_choice_modes, vec!["auto", "none"]);
+        assert!(!caps.temperature_supported);
+        assert!(!caps.top_p_supported);
+        assert!(!caps.frequency_penalty_supported);
+        assert!(!caps.presence_penalty_supported);
+
+        let prior = lookup("openrouter", "moonshotai/kimi-k2.6");
+        assert!(prior.prompt_caching);
+        assert!(prior.vision_supported);
+        assert!(!prior.video);
+        assert!(prior.allowed_tool_choice_modes.is_empty());
+        assert!(prior.temperature_supported);
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -2126,11 +2126,37 @@ prefers_xml_tools = false
 thinking_block_style = "none"
 
 [[provider.openrouter]]
+model_match = "moonshotai/kimi-k2.7-code"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+prompt_caching = true
+vision_supported = true
+video_supported = true
+server_parser = "none"
+honors_chat_template_kwargs = false
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+temperature_supported = false
+top_p_supported = false
+frequency_penalty_supported = false
+presence_penalty_supported = false
+allowed_tool_choice_modes = ["auto", "none"]
+
+[[provider.openrouter]]
 model_match = "moonshotai/kimi-k2*"
 native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
+prompt_caching = true
+vision_supported = true
 server_parser = "none"
 honors_chat_template_kwargs = false
 prefers_xml_scaffolding = false

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/40-deepseek-reasoning.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/40-deepseek-reasoning.toml
@@ -198,11 +198,37 @@ prefers_xml_tools = false
 thinking_block_style = "none"
 
 [[provider.openrouter]]
+model_match = "moonshotai/kimi-k2.7-code"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+prompt_caching = true
+vision_supported = true
+video_supported = true
+server_parser = "none"
+honors_chat_template_kwargs = false
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+temperature_supported = false
+top_p_supported = false
+frequency_penalty_supported = false
+presence_penalty_supported = false
+allowed_tool_choice_modes = ["auto", "none"]
+
+[[provider.openrouter]]
 model_match = "moonshotai/kimi-k2*"
 native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
+prompt_caching = true
+vision_supported = true
 server_parser = "none"
 honors_chat_template_kwargs = false
 prefers_xml_scaffolding = false

--- a/crates/harn-vm/src/llm/catalog_sources/30-aliases/aliases.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/30-aliases/aliases.toml
@@ -115,6 +115,16 @@ provider = "openrouter"
 id = "google/gemma-4-31B-it"
 provider = "together"
 
+# Kimi via OpenRouter. Keep the short alias on the current code-focused route;
+# the full model id remains available for callers that want explicit slugs.
+[aliases."kimi-k2.7-code"]
+id = "moonshotai/kimi-k2.7-code"
+provider = "openrouter"
+
+[aliases."openrouter-kimi-k2.7-code"]
+id = "moonshotai/kimi-k2.7-code"
+provider = "openrouter"
+
 # qwen3.6 has no working Ollama route — Ollama's qwen3.5-family server-side
 # tool-call parser 500s on text-tool output (ollama/ollama#14986, #14570).
 # Use the llamacpp provider for local qwen3.x.

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/20-open-weight-openrouter.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/20-open-weight-openrouter.toml
@@ -47,12 +47,22 @@ complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen",
 name = "Kimi K2.6"
 provider = "openrouter"
 context_window = 262144
-capabilities = ["tools", "streaming"]
-pricing = { input_per_mtok = 0.73, output_per_mtok = 3.49 }
+capabilities = ["tools", "vision", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.68, output_per_mtok = 3.41, cache_read_per_mtok = 0.34 }
 tier = "frontier"
 open_weight = true
-strengths = ["coding", "agentic", "long_context", "tool_use", "reasoning"]
+strengths = ["coding", "agentic", "long_context", "tool_use", "reasoning", "vision"]
 benchmarks = { swe_bench_pro = 58.6, humanitys_last_exam_with_tools = 54.0 }
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "deepseek"]
+[models."moonshotai/kimi-k2.7-code"]
+name = "Kimi K2.7 Code"
+provider = "openrouter"
+context_window = 262144
+capabilities = ["tools", "vision", "video", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.95, output_per_mtok = 4.00, cache_read_per_mtok = 0.19 }
+tier = "frontier"
+open_weight = true
+strengths = ["coding", "agentic", "long_context", "tool_use", "reasoning", "vision"]
 complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "deepseek"]
 [models."openai/gpt-oss-120b"]
 name = "GPT-OSS 120B"
@@ -65,4 +75,3 @@ api_dialect = "openai_chat"
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.15, output_per_mtok = 0.60 }
 architecture = { parameter_count_b = 117.0, active_parameter_count_b = 5.1, moe = true, license = "Apache-2.0", source_url = "https://developers.openai.com/api/docs/models/gpt-oss-120b", last_verified = "2026-06-05" }
-

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -1366,12 +1366,29 @@ pub(crate) fn capabilities_to_vm_value(
         VmValue::Bool(caps.top_k_supported),
     );
     dict.insert(
+        "temperature_supported".to_string(),
+        VmValue::Bool(caps.temperature_supported),
+    );
+    dict.insert(
+        "top_p_supported".to_string(),
+        VmValue::Bool(caps.top_p_supported),
+    );
+    dict.insert(
         "frequency_penalty_supported".to_string(),
         VmValue::Bool(caps.frequency_penalty_supported),
     );
     dict.insert(
         "presence_penalty_supported".to_string(),
         VmValue::Bool(caps.presence_penalty_supported),
+    );
+    dict.insert(
+        "allowed_tool_choice_modes".to_string(),
+        VmValue::List(std::sync::Arc::new(
+            caps.allowed_tool_choice_modes
+                .iter()
+                .map(|mode| VmValue::String(std::sync::Arc::from(mode.as_str())))
+                .collect(),
+        )),
     );
     // Accelerated-serving ("fast mode") tier, read from the catalog so
     // callers can branch on `llm_call(..., { fast: true })` support without

--- a/crates/harn-vm/src/llm/helpers/options/extract.rs
+++ b/crates/harn-vm/src/llm/helpers/options/extract.rs
@@ -723,6 +723,12 @@ pub(super) fn validate_options(opts: &crate::llm::api::LlmCallOptions) {
     if opts.top_k.is_some() && !caps.top_k_supported {
         warn("top_k");
     }
+    if opts.temperature.is_some() && !caps.temperature_supported {
+        warn("temperature");
+    }
+    if opts.top_p.is_some() && !caps.top_p_supported {
+        warn("top_p");
+    }
     if opts.frequency_penalty.is_some() && !caps.frequency_penalty_supported {
         warn("frequency_penalty");
     }

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -713,6 +713,16 @@ provider = "openrouter"
 id = "google/gemma-4-31B-it"
 provider = "together"
 
+# Kimi via OpenRouter. Keep the short alias on the current code-focused route;
+# the full model id remains available for callers that want explicit slugs.
+[aliases."kimi-k2.7-code"]
+id = "moonshotai/kimi-k2.7-code"
+provider = "openrouter"
+
+[aliases."openrouter-kimi-k2.7-code"]
+id = "moonshotai/kimi-k2.7-code"
+provider = "openrouter"
+
 # qwen3.6 has no working Ollama route — Ollama's qwen3.5-family server-side
 # tool-call parser 500s on text-tool output (ollama/ollama#14986, #14570).
 # Use the llamacpp provider for local qwen3.x.
@@ -1406,12 +1416,22 @@ complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen",
 name = "Kimi K2.6"
 provider = "openrouter"
 context_window = 262144
-capabilities = ["tools", "streaming"]
-pricing = { input_per_mtok = 0.73, output_per_mtok = 3.49 }
+capabilities = ["tools", "vision", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.68, output_per_mtok = 3.41, cache_read_per_mtok = 0.34 }
 tier = "frontier"
 open_weight = true
-strengths = ["coding", "agentic", "long_context", "tool_use", "reasoning"]
+strengths = ["coding", "agentic", "long_context", "tool_use", "reasoning", "vision"]
 benchmarks = { swe_bench_pro = 58.6, humanitys_last_exam_with_tools = 54.0 }
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "deepseek"]
+[models."moonshotai/kimi-k2.7-code"]
+name = "Kimi K2.7 Code"
+provider = "openrouter"
+context_window = 262144
+capabilities = ["tools", "vision", "video", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.95, output_per_mtok = 4.00, cache_read_per_mtok = 0.19 }
+tier = "frontier"
+open_weight = true
+strengths = ["coding", "agentic", "long_context", "tool_use", "reasoning", "vision"]
 complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "deepseek"]
 [models."openai/gpt-oss-120b"]
 name = "GPT-OSS 120B"

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -160,10 +160,10 @@ impl OpenAiCompatibleProvider {
             };
             body[token_limit_field] = serde_json::json!(opts.max_tokens);
         }
-        if let Some(temp) = opts.temperature {
+        if let Some(temp) = opts.temperature.filter(|_| caps.temperature_supported) {
             body["temperature"] = serde_json::json!(temp);
         }
-        if let Some(top_p) = opts.top_p {
+        if let Some(top_p) = opts.top_p.filter(|_| caps.top_p_supported) {
             body["top_p"] = serde_json::json!(top_p);
         }
         if let Some(top_k) = opts.top_k.filter(|_| caps.top_k_supported) {
@@ -178,13 +178,19 @@ impl OpenAiCompatibleProvider {
         if let Some(ref stop) = opts.stop {
             body["stop"] = serde_json::json!(stop);
         }
-        if let Some(seed) = opts.seed {
+        if let Some(seed) = opts.seed.filter(|_| caps.seed_supported) {
             body["seed"] = serde_json::json!(seed);
         }
-        if let Some(fp) = opts.frequency_penalty {
+        if let Some(fp) = opts
+            .frequency_penalty
+            .filter(|_| caps.frequency_penalty_supported)
+        {
             body["frequency_penalty"] = serde_json::json!(fp);
         }
-        if let Some(pp) = opts.presence_penalty {
+        if let Some(pp) = opts
+            .presence_penalty
+            .filter(|_| caps.presence_penalty_supported)
+        {
             body["presence_penalty"] = serde_json::json!(pp);
         }
         match caps.reasoning_wire_format.as_deref() {
@@ -269,7 +275,9 @@ impl OpenAiCompatibleProvider {
             }
         }
         if let Some(ref tc) = opts.tool_choice {
-            body["tool_choice"] = tc.clone();
+            if let Some(tool_choice) = normalize_tool_choice_for_capabilities(tc, &caps) {
+                body["tool_choice"] = tool_choice;
+            }
         }
         if caps.honors_chat_template_kwargs {
             // Always set explicitly for compatible Qwen/DeepSeek
@@ -489,6 +497,52 @@ pub(crate) fn apply_openrouter_route_denylist(body: &mut serde_json::Value, deny
         if !already_present {
             ignore_arr.push(serde_json::Value::String(name.clone()));
         }
+    }
+}
+
+fn normalize_tool_choice_for_capabilities(
+    tool_choice: &serde_json::Value,
+    caps: &crate::llm::capabilities::Capabilities,
+) -> Option<serde_json::Value> {
+    if caps.allowed_tool_choice_modes.is_empty() {
+        return Some(tool_choice.clone());
+    }
+
+    let mode = tool_choice_mode(tool_choice);
+    if mode.as_deref().is_some_and(|mode| {
+        caps.allowed_tool_choice_modes
+            .iter()
+            .any(|allowed| allowed == mode)
+    }) {
+        return Some(tool_choice.clone());
+    }
+
+    if caps
+        .allowed_tool_choice_modes
+        .iter()
+        .any(|mode| mode == "auto")
+    {
+        return Some(serde_json::Value::String("auto".to_string()));
+    }
+    if caps
+        .allowed_tool_choice_modes
+        .iter()
+        .any(|mode| mode == "none")
+    {
+        return Some(serde_json::Value::String("none".to_string()));
+    }
+    None
+}
+
+fn tool_choice_mode(tool_choice: &serde_json::Value) -> Option<String> {
+    match tool_choice {
+        serde_json::Value::String(mode) => Some(mode.to_ascii_lowercase()),
+        serde_json::Value::Object(object) => match object.get("type").and_then(|v| v.as_str()) {
+            Some("function") | Some("tool") => Some("required".to_string()),
+            Some(other) => Some(other.to_ascii_lowercase()),
+            None => None,
+        },
+        _ => None,
     }
 }
 
@@ -998,6 +1052,64 @@ mod tests {
 
         assert_eq!(body["reasoning"]["max_tokens"], 2048);
         assert!(body.get("chat_template_kwargs").is_none());
+    }
+
+    #[test]
+    fn openrouter_kimi27_code_normalizes_forced_tool_choice_to_auto() {
+        let mut payload = base_request_payload();
+        payload.provider = "openrouter".to_string();
+        payload.model = "moonshotai/kimi-k2.7-code".to_string();
+        payload.native_tools = Some(vec![json!({
+            "type": "function",
+            "function": {
+                "name": "add_two",
+                "description": "Add two integers.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "integer"},
+                        "b": {"type": "integer"}
+                    },
+                    "required": ["a", "b"]
+                }
+            }
+        })]);
+        payload.tool_choice = Some(json!("required"));
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+
+        assert_eq!(body["tool_choice"], "auto");
+        assert_eq!(body["tools"][0]["function"]["name"], "add_two");
+    }
+
+    #[test]
+    fn openrouter_kimi27_code_keeps_allowed_tool_choice_none() {
+        let mut payload = base_request_payload();
+        payload.provider = "openrouter".to_string();
+        payload.model = "moonshotai/kimi-k2.7-code".to_string();
+        payload.tool_choice = Some(json!("none"));
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+
+        assert_eq!(body["tool_choice"], "none");
+    }
+
+    #[test]
+    fn openrouter_kimi27_code_strips_fixed_sampling_params() {
+        let mut payload = base_request_payload();
+        payload.provider = "openrouter".to_string();
+        payload.model = "moonshotai/kimi-k2.7-code".to_string();
+        payload.temperature = Some(0.2);
+        payload.top_p = Some(0.8);
+        payload.frequency_penalty = Some(0.1);
+        payload.presence_penalty = Some(0.2);
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+
+        assert!(body.get("temperature").is_none());
+        assert!(body.get("top_p").is_none());
+        assert!(body.get("frequency_penalty").is_none());
+        assert!(body.get("presence_penalty").is_none());
     }
 
     #[test]

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -129,7 +129,8 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `openrouter` | `deepseek/deepseek-r1` | `any` | `enabled,effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `mistralai/mistral*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `mistralai/devstral*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `openrouter` | `moonshotai/kimi-k2*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `moonshotai/kimi-k2.7-code` | `any` | `enabled` | yes | no | no | yes | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `openrouter` | `moonshotai/kimi-k2*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `openrouter` | `google/gemini-2.5*` | `any` | `enabled,effort` | yes | yes | yes | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
 | `openrouter` | `google/gemma-4*` | `any` | no | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `meta-llama/llama-4*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
@@ -236,6 +237,7 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `openrouter` | `mistralai/mistral-large-2512` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `mistralai/mistral-small-2603` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `moonshotai/kimi-k2.6` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `openrouter` | `moonshotai/kimi-k2.7-code` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `openai/gpt-oss-120b` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `qwen/qwen3-coder` | `text` | `native_unreliable` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `z-ai/glm-5` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -6980,7 +6980,8 @@ public let harnProviderCatalogJSON = #"""
       "context_window": 262144,
       "modalities": {
         "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -7012,11 +7013,11 @@ public let harnProviderCatalogJSON = #"""
         "interleaved_supported": false,
         "preserve_thinking": false
       },
-      "prompt_cache": false,
+      "prompt_cache": true,
       "pricing": {
-        "input_per_mtok": 0.73,
-        "output_per_mtok": 3.49,
-        "cache_read_per_mtok": null,
+        "input_per_mtok": 0.68,
+        "output_per_mtok": 3.41,
+        "cache_read_per_mtok": 0.34,
         "cache_write_per_mtok": null
       },
       "deprecation": {
@@ -7027,6 +7028,8 @@ public let harnProviderCatalogJSON = #"""
       "capability_tags": [
         "streaming",
         "tools",
+        "vision",
+        "prompt_caching",
         "thinking",
         "structured_output"
       ],
@@ -7046,12 +7049,99 @@ public let harnProviderCatalogJSON = #"""
         "agentic",
         "long_context",
         "tool_use",
-        "reasoning"
+        "reasoning",
+        "vision"
       ],
       "benchmarks": {
         "humanitys_last_exam_with_tools": 54.0,
         "swe_bench_pro": 58.6
       }
+    },
+    {
+      "id": "moonshotai/kimi-k2.7-code",
+      "name": "Kimi K2.7 Code",
+      "provider": "openrouter",
+      "aliases": [
+        "kimi-k2.7-code",
+        "openrouter-kimi-k2.7-code"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.95,
+        "output_per_mtok": 4.0,
+        "cache_read_per_mtok": 0.19,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "video",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "kimi",
+      "lineage": "kimi",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "coding",
+        "agentic",
+        "long_context",
+        "tool_use",
+        "reasoning",
+        "vision"
+      ]
     },
     {
       "id": "openai/gpt-oss-120b",
@@ -7865,6 +7955,11 @@ public let harnProviderCatalogJSON = #"""
       "provider": "anthropic"
     },
     {
+      "name": "kimi-k2.7-code",
+      "model_id": "moonshotai/kimi-k2.7-code",
+      "provider": "openrouter"
+    },
+    {
       "name": "llamacpp-qwen3.6",
       "model_id": "qwen3.6-35b-a3b",
       "provider": "llamacpp"
@@ -8049,6 +8144,11 @@ public let harnProviderCatalogJSON = #"""
     {
       "name": "openrouter-gemma4-31b",
       "model_id": "google/gemma-4-31b-it",
+      "provider": "openrouter"
+    },
+    {
+      "name": "openrouter-kimi-k2.7-code",
+      "model_id": "moonshotai/kimi-k2.7-code",
       "provider": "openrouter"
     },
     {

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -6716,7 +6716,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "context_window": 262144,
       "modalities": {
         "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -6748,11 +6749,11 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "interleaved_supported": false,
         "preserve_thinking": false
       },
-      "prompt_cache": false,
+      "prompt_cache": true,
       "pricing": {
-        "input_per_mtok": 0.73,
-        "output_per_mtok": 3.49,
-        "cache_read_per_mtok": null,
+        "input_per_mtok": 0.68,
+        "output_per_mtok": 3.41,
+        "cache_read_per_mtok": 0.34,
         "cache_write_per_mtok": null
       },
       "deprecation": {
@@ -6763,6 +6764,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "capability_tags": [
         "streaming",
         "tools",
+        "vision",
+        "prompt_caching",
         "thinking",
         "structured_output"
       ],
@@ -6782,12 +6785,99 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "agentic",
         "long_context",
         "tool_use",
-        "reasoning"
+        "reasoning",
+        "vision"
       ],
       "benchmarks": {
         "humanitys_last_exam_with_tools": 54.0,
         "swe_bench_pro": 58.6
       }
+    },
+    {
+      "id": "moonshotai/kimi-k2.7-code",
+      "name": "Kimi K2.7 Code",
+      "provider": "openrouter",
+      "aliases": [
+        "kimi-k2.7-code",
+        "openrouter-kimi-k2.7-code"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.95,
+        "output_per_mtok": 4.0,
+        "cache_read_per_mtok": 0.19,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "video",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "kimi",
+      "lineage": "kimi",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "coding",
+        "agentic",
+        "long_context",
+        "tool_use",
+        "reasoning",
+        "vision"
+      ]
     },
     {
       "id": "openai/gpt-oss-120b",
@@ -7601,6 +7691,11 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "provider": "anthropic"
     },
     {
+      "name": "kimi-k2.7-code",
+      "model_id": "moonshotai/kimi-k2.7-code",
+      "provider": "openrouter"
+    },
+    {
       "name": "llamacpp-qwen3.6",
       "model_id": "qwen3.6-35b-a3b",
       "provider": "llamacpp"
@@ -7785,6 +7880,11 @@ export const harnProviderCatalog: HarnProviderCatalog = {
     {
       "name": "openrouter-gemma4-31b",
       "model_id": "google/gemma-4-31b-it",
+      "provider": "openrouter"
+    },
+    {
+      "name": "openrouter-kimi-k2.7-code",
+      "model_id": "moonshotai/kimi-k2.7-code",
       "provider": "openrouter"
     },
     {

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -6462,7 +6462,8 @@
       "context_window": 262144,
       "modalities": {
         "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -6494,11 +6495,11 @@
         "interleaved_supported": false,
         "preserve_thinking": false
       },
-      "prompt_cache": false,
+      "prompt_cache": true,
       "pricing": {
-        "input_per_mtok": 0.73,
-        "output_per_mtok": 3.49,
-        "cache_read_per_mtok": null,
+        "input_per_mtok": 0.68,
+        "output_per_mtok": 3.41,
+        "cache_read_per_mtok": 0.34,
         "cache_write_per_mtok": null
       },
       "deprecation": {
@@ -6509,6 +6510,8 @@
       "capability_tags": [
         "streaming",
         "tools",
+        "vision",
+        "prompt_caching",
         "thinking",
         "structured_output"
       ],
@@ -6528,12 +6531,99 @@
         "agentic",
         "long_context",
         "tool_use",
-        "reasoning"
+        "reasoning",
+        "vision"
       ],
       "benchmarks": {
         "humanitys_last_exam_with_tools": 54.0,
         "swe_bench_pro": 58.6
       }
+    },
+    {
+      "id": "moonshotai/kimi-k2.7-code",
+      "name": "Kimi K2.7 Code",
+      "provider": "openrouter",
+      "aliases": [
+        "kimi-k2.7-code",
+        "openrouter-kimi-k2.7-code"
+      ],
+      "context_window": 262144,
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.95,
+        "output_per_mtok": 4.0,
+        "cache_read_per_mtok": 0.19,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "video",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "kimi",
+      "lineage": "kimi",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "coding",
+        "agentic",
+        "long_context",
+        "tool_use",
+        "reasoning",
+        "vision"
+      ]
     },
     {
       "id": "openai/gpt-oss-120b",
@@ -7347,6 +7437,11 @@
       "provider": "anthropic"
     },
     {
+      "name": "kimi-k2.7-code",
+      "model_id": "moonshotai/kimi-k2.7-code",
+      "provider": "openrouter"
+    },
+    {
       "name": "llamacpp-qwen3.6",
       "model_id": "qwen3.6-35b-a3b",
       "provider": "llamacpp"
@@ -7531,6 +7626,11 @@
     {
       "name": "openrouter-gemma4-31b",
       "model_id": "google/gemma-4-31b-it",
+      "provider": "openrouter"
+    },
+    {
+      "name": "openrouter-kimi-k2.7-code",
+      "model_id": "moonshotai/kimi-k2.7-code",
       "provider": "openrouter"
     },
     {


### PR DESCRIPTION
## Summary
- add OpenRouter `moonshotai/kimi-k2.7-code` to the Harn provider catalog with aliases, multimodal/thinking/cache metadata, and updated Kimi K2.6 pricing/capabilities
- add provider capability fields for unsupported temperature/top_p and allowed tool_choice modes
- normalize OpenAI-compatible requests so Kimi K2.7 Code drops fixed sampling params and degrades forced tool_choice to `auto`
- regenerate provider catalog, provider capability, matrix, and support artifacts

## Research
- Official Moonshot docs identify the model as `kimi-k2.7-code` with 262,144 context and 65,536 max output: https://platform.kimi.ai/docs/guide/kimi-k2-7-code-quickstart
- Official K2 thinking docs say K2 thinking is always-on and cannot be disabled: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model
- OpenRouter live model listing confirms `moonshotai/kimi-k2.7-code` availability, text/image/video input, cache-read pricing, and tools/reasoning params: https://openrouter.ai/api/v1/models
- Empirical throwaway Harn probes with local `OPENROUTER_API_KEY` showed basic K2.7 calls work, forced/specified tool_choice returns 400, and native tools work when Harn sends `auto`/omits forced choice.

## Verification
- `CARGO_TARGET_DIR=/private/tmp/harn-kimi-k27/.target-codex CARGO_BUILD_JOBS=2 make check-provider-capabilities check-provider-catalog check-provider-matrix check-provider-support`
- `CARGO_TARGET_DIR=/private/tmp/harn-kimi-k27/.target-codex CARGO_BUILD_JOBS=1 cargo test -p harn-vm openrouter_kimi27 --lib -j1`
- `CARGO_TARGET_DIR=/private/tmp/harn-kimi-k27/.target-codex CARGO_BUILD_JOBS=1 cargo run --quiet --bin harn -- test conformance --filter provider_capabilities_basic`
- `cargo fmt --all --check && git diff --check`
- pre-commit and pre-push hooks passed
