### PR TITLE
Add frontier provider catalog routes

### DIFF
--- a/changelog.d/provider-frontier-refresh.added.md
+++ b/changelog.d/provider-frontier-refresh.added.md
@@ -1,0 +1,4 @@
+- Added current Qwen 3.7, KAT-Coder-Pro V2, Step 3.7 Flash, Together DeepSeek
+  V4 Pro, Together GLM 5.1, and Together MiniMax M2.7 routes to the provider
+  catalog, including live pricing, aliases, and capability rows for
+  provider-specific streaming/tool behavior.

--- a/conformance/tests/scenarios/provider_capabilities_basic.harn
+++ b/conformance/tests/scenarios/provider_capabilities_basic.harn
@@ -104,6 +104,35 @@ pipeline test(task) {
   assert(!kimi27.top_p_supported, "Kimi K2.7 Code has fixed top_p")
   assert(!kimi27.frequency_penalty_supported, "Kimi K2.7 Code has fixed penalties")
   assert(!kimi27.presence_penalty_supported, "Kimi K2.7 Code has fixed penalties")
+  let qwen37_plus = provider_capabilities("openrouter", "qwen/qwen3.7-plus")
+  assert(qwen37_plus.native_tools, "OpenRouter Qwen3.7 Plus exposes native tools")
+  assert(qwen37_plus.prompt_caching, "OpenRouter Qwen3.7 Plus exposes prompt caching")
+  assert(qwen37_plus.vision_supported, "OpenRouter Qwen3.7 Plus accepts image input")
+  assert(
+    qwen37_plus.auto_reasoning_overrides.agent == "off",
+    "Qwen3.7 Plus disables reasoning for agent tool loops",
+  )
+  let qwen37_max = provider_capabilities("together", "Qwen/Qwen3.7-Max")
+  assert(qwen37_max.native_tools, "Together Qwen3.7 Max exposes native tools")
+  assert(qwen37_max.prompt_caching, "Together Qwen3.7 Max exposes prompt caching")
+  assert(qwen37_max.requires_streaming, "Together Qwen3.7 Max requires streaming transport")
+  let kat = provider_capabilities("openrouter", "kwaipilot/kat-coder-pro-v2")
+  assert(kat.native_tools, "OpenRouter KAT-Coder-Pro V2 exposes native tools")
+  assert(kat.prompt_caching, "OpenRouter KAT-Coder-Pro V2 exposes prompt caching")
+  let step37 = provider_capabilities("openrouter", "stepfun/step-3.7-flash")
+  assert(step37.native_tools, "OpenRouter Step 3.7 Flash exposes native tools")
+  assert(step37.prompt_caching, "OpenRouter Step 3.7 Flash exposes prompt caching")
+  assert(!step37.reasoning_disable_supported, "OpenRouter Step 3.7 Flash requires reasoning")
+  let glm51 = provider_capabilities("together", "zai-org/GLM-5.1")
+  assert(glm51.native_tools, "Together GLM 5.1 exposes native tools")
+  assert(
+    glm51.auto_reasoning_overrides.agent == "off",
+    "Together GLM 5.1 supports reasoning-off tool loops",
+  )
+  let minimax27 = provider_capabilities("together", "MiniMaxAI/MiniMax-M2.7")
+  assert(minimax27.native_tools, "Together MiniMax M2.7 exposes native tools")
+  assert(minimax27.prompt_caching, "Together MiniMax M2.7 exposes prompt caching")
+  assert(!minimax27.reasoning_text_promotable, "Together MiniMax M2.7 keeps reasoning private")
   // OpenRouter inherits the openai family.
   let routed = provider_capabilities("openrouter", "gpt-5.4")
   assert(routed.defer_loading, "openrouter inherits openai defer_loading")

--- a/crates/harn-vm/src/llm/api/openai_normalize.rs
+++ b/crates/harn-vm/src/llm/api/openai_normalize.rs
@@ -119,6 +119,7 @@ pub(super) fn extract_openai_delta_field_str<'a>(
 pub(super) fn normalize_openai_message_text(
     message: &serde_json::Value,
     finish_reason: Option<&str>,
+    promote_reasoning_to_text: bool,
 ) -> (String, String) {
     let raw_text = extract_openai_message_field_as_text(message, &["content"]);
     let reasoning_text = extract_openai_message_field_as_text(
@@ -152,7 +153,12 @@ pub(super) fn normalize_openai_message_text(
         .get("tool_calls")
         .and_then(serde_json::Value::as_array)
         .is_some_and(|calls| !calls.is_empty());
-    if !truncated && !has_tool_call && text.is_empty() && !extracted_thinking.is_empty() {
+    if promote_reasoning_to_text
+        && !truncated
+        && !has_tool_call
+        && text.is_empty()
+        && !extracted_thinking.is_empty()
+    {
         text = extracted_thinking.clone();
     }
     (text, extracted_thinking)
@@ -241,7 +247,7 @@ mod tests {
         let message = serde_json::json!({
             "reasoning": "hello from reasoning"
         });
-        let (visible, thinking) = normalize_openai_message_text(&message, Some("stop"));
+        let (visible, thinking) = normalize_openai_message_text(&message, Some("stop"), true);
         assert_eq!(visible, "hello from reasoning");
         assert_eq!(thinking, "hello from reasoning");
     }
@@ -252,7 +258,7 @@ mod tests {
             "content": "<think>inline reasoning</think>visible answer",
             "reasoning": "separate reasoning"
         });
-        let (visible, thinking) = normalize_openai_message_text(&message, Some("stop"));
+        let (visible, thinking) = normalize_openai_message_text(&message, Some("stop"), true);
         assert_eq!(visible, "visible answer");
         assert_eq!(thinking, "separate reasoning\ninline reasoning");
     }
@@ -266,7 +272,7 @@ mod tests {
             "content": "",
             "reasoning": "Let me think step by step about the problem. First I need to"
         });
-        let (visible, thinking) = normalize_openai_message_text(&message, Some("length"));
+        let (visible, thinking) = normalize_openai_message_text(&message, Some("length"), true);
         assert_eq!(visible, "", "truncated reasoning leaked into visible text");
         assert_eq!(
             thinking,
@@ -283,7 +289,7 @@ mod tests {
             "content": "",
             "reasoning": "the answer is 42"
         });
-        let (visible, thinking) = normalize_openai_message_text(&message, Some("stop"));
+        let (visible, thinking) = normalize_openai_message_text(&message, Some("stop"), true);
         assert_eq!(visible, "the answer is 42");
         assert_eq!(thinking, "the answer is 42");
     }
@@ -305,7 +311,7 @@ mod tests {
                 "function": {"name": "look", "arguments": "{\"path\":\"parser.rs\"}"}
             }]
         });
-        let (visible, thinking) = normalize_openai_message_text(&message, Some("tool_calls"));
+        let (visible, thinking) = normalize_openai_message_text(&message, Some("tool_calls"), true);
         assert_eq!(
             visible, "",
             "reasoning leaked into visible text on a tool-call turn"
@@ -322,9 +328,22 @@ mod tests {
             "content": "visible answer",
             "reasoning_details": "minimax private trace"
         });
-        let (visible, thinking) = normalize_openai_message_text(&message, Some("stop"));
+        let (visible, thinking) = normalize_openai_message_text(&message, Some("stop"), true);
         assert_eq!(visible, "visible answer");
         assert_eq!(thinking, "minimax private trace");
+    }
+
+    #[test]
+    fn normalize_openai_message_text_can_keep_reasoning_private_without_content() {
+        let message = serde_json::json!({
+            "content": "",
+            "reasoning": "private trace ending with OK"
+        });
+
+        let (visible, thinking) = normalize_openai_message_text(&message, Some("stop"), false);
+
+        assert_eq!(visible, "");
+        assert_eq!(thinking, "private trace ending with OK");
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/api/response.rs
+++ b/crates/harn-vm/src/llm/api/response.rs
@@ -740,7 +740,9 @@ pub(crate) fn parse_llm_response(
             ))))
         })?;
         let finish_reason = choice["finish_reason"].as_str();
-        let (text, extracted_thinking) = normalize_openai_message_text(message, finish_reason);
+        let caps = crate::llm::capabilities::lookup(provider, model);
+        let (text, extracted_thinking) =
+            normalize_openai_message_text(message, finish_reason, caps.reasoning_text_promotable);
         let reasoning_summary = extract_openai_reasoning_summary(json, message);
         let mut blocks = if text.is_empty() {
             Vec::new()

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -331,14 +331,21 @@ async fn vm_call_llm_api_with_body_inner(
         .unwrap_or(false);
 
     let resolved = crate::llm::helpers::ResolvedProvider::resolve(provider);
+    let caps = crate::llm::capabilities::lookup(provider, model);
     let use_stream_transport = if is_ollama && !opts.stream {
         crate::events::log_warn(
             "llm",
             "stream=false is not supported by Ollama, using streaming",
         );
         true
+    } else if caps.requires_streaming && !opts.stream {
+        crate::events::log_warn(
+            "llm",
+            &format!("{provider} model {model} requires streaming, using stream=true"),
+        );
+        true
     } else {
-        wants_streaming || is_ollama
+        wants_streaming || is_ollama || caps.requires_streaming
     };
 
     if !is_ollama {

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -352,6 +352,11 @@ pub struct ProviderRule {
     /// request field instead of legacy `max_tokens`.
     #[serde(default)]
     pub requires_completion_tokens: Option<bool>,
+    /// Whether this route rejects non-streaming chat-completion requests.
+    /// Harn forces streaming for such routes so callers can keep provider-
+    /// neutral `stream` preferences.
+    #[serde(default)]
+    pub requires_streaming: Option<bool>,
     /// Whether this route accepts OpenAI's `reasoning_effort` request field.
     #[serde(default)]
     pub reasoning_effort_supported: Option<bool>,
@@ -364,6 +369,16 @@ pub struct ProviderRule {
     /// floor at `minimal`.
     #[serde(default)]
     pub reasoning_none_supported: Option<bool>,
+    /// Whether this route accepts an explicit enabled/disabled reasoning switch
+    /// set to false. Some OpenRouter endpoints require reasoning and return
+    /// 400 when sent `reasoning: {enabled:false}`.
+    #[serde(default)]
+    pub reasoning_disable_supported: Option<bool>,
+    /// Whether reasoning-only clean stops may be promoted into visible text.
+    /// Disable this for providers whose `reasoning` field is always private
+    /// trace, even when `content` is empty.
+    #[serde(default)]
+    pub reasoning_text_promotable: Option<bool>,
     /// Provider-specific reasoning request shape for OpenAI-compatible
     /// transports. Known values are `openrouter`, `enabled`, and `minimax`.
     #[serde(default)]
@@ -492,9 +507,12 @@ pub struct Capabilities {
     pub server_parser: String,
     pub honors_chat_template_kwargs: bool,
     pub requires_completion_tokens: bool,
+    pub requires_streaming: bool,
     pub reasoning_effort_supported: bool,
     pub reasoning_effort_levels: Vec<String>,
     pub reasoning_none_supported: bool,
+    pub reasoning_disable_supported: bool,
+    pub reasoning_text_promotable: bool,
     pub reasoning_wire_format: Option<String>,
     pub seed_supported: bool,
     pub top_k_supported: bool,
@@ -561,9 +579,12 @@ impl Default for Capabilities {
             server_parser: "none".to_string(),
             honors_chat_template_kwargs: false,
             requires_completion_tokens: false,
+            requires_streaming: false,
             reasoning_effort_supported: false,
             reasoning_effort_levels: Vec::new(),
             reasoning_none_supported: false,
+            reasoning_disable_supported: true,
+            reasoning_text_promotable: true,
             reasoning_wire_format: None,
             seed_supported: true,
             top_k_supported: true,
@@ -1202,9 +1223,12 @@ fn defaults_to_caps(defaults: &ProviderDefaults) -> Capabilities {
         server_parser: None,
         honors_chat_template_kwargs: None,
         requires_completion_tokens: None,
+        requires_streaming: None,
         reasoning_effort_supported: None,
         reasoning_effort_levels: None,
         reasoning_none_supported: None,
+        reasoning_disable_supported: None,
+        reasoning_text_promotable: None,
         reasoning_wire_format: None,
         seed_supported: None,
         top_k_supported: None,
@@ -1294,9 +1318,12 @@ fn rule_to_caps(rule: &ProviderRule, defaults: &ProviderDefaults) -> Capabilitie
             .unwrap_or_else(|| "none".to_string()),
         honors_chat_template_kwargs: rule.honors_chat_template_kwargs.unwrap_or(false),
         requires_completion_tokens: rule.requires_completion_tokens.unwrap_or(false),
+        requires_streaming: rule.requires_streaming.unwrap_or(false),
         reasoning_effort_supported: rule.reasoning_effort_supported.unwrap_or(false),
         reasoning_effort_levels: rule.reasoning_effort_levels.clone().unwrap_or_default(),
         reasoning_none_supported: rule.reasoning_none_supported.unwrap_or(false),
+        reasoning_disable_supported: rule.reasoning_disable_supported.unwrap_or(true),
+        reasoning_text_promotable: rule.reasoning_text_promotable.unwrap_or(true),
         reasoning_wire_format: rule
             .reasoning_wire_format
             .clone()
@@ -1876,12 +1903,64 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
     }
 
     #[test]
+    fn qwen37_routes_record_prompt_cache_vision_and_streaming_quirks() {
+        reset();
+        let plus = lookup("openrouter", "qwen/qwen3.7-plus");
+        assert!(plus.native_tools);
+        assert!(plus.prompt_caching);
+        assert!(plus.vision_supported);
+        assert_eq!(plus.preferred_tool_format.as_deref(), Some("native"));
+        assert_eq!(plus.thinking_modes, vec!["enabled"]);
+        assert_eq!(
+            plus.auto_reasoning_overrides
+                .get("agent")
+                .map(String::as_str),
+            Some("off"),
+            "Qwen tool-bearing agent turns should disable reasoning automatically",
+        );
+
+        let max = lookup("openrouter", "qwen/qwen3.7-max");
+        assert!(max.native_tools);
+        assert!(max.prompt_caching);
+        assert!(!max.vision_supported);
+        assert_eq!(max.thinking_modes, vec!["enabled"]);
+
+        let together = lookup("together", "Qwen/Qwen3.7-Max");
+        assert!(together.native_tools);
+        assert!(together.prompt_caching);
+        assert!(together.requires_streaming);
+        assert!(!together.honors_chat_template_kwargs);
+
+        let glm = lookup("together", "zai-org/GLM-5.1");
+        assert!(glm.native_tools);
+        assert!(glm.prompt_caching);
+        assert_eq!(
+            glm.auto_reasoning_overrides
+                .get("agent")
+                .map(String::as_str),
+            Some("off"),
+        );
+
+        let minimax = lookup("together", "MiniMaxAI/MiniMax-M2.7");
+        assert!(minimax.native_tools);
+        assert!(minimax.prompt_caching);
+        assert!(!minimax.reasoning_text_promotable);
+
+        let step = lookup("openrouter", "stepfun/step-3.7-flash");
+        assert!(step.native_tools);
+        assert!(step.prompt_caching);
+        assert!(!step.reasoning_disable_supported);
+        assert_eq!(step.thinking_modes, vec!["enabled"]);
+    }
+
+    #[test]
     fn openrouter_structured_routes_cover_current_open_models() {
         reset();
         for model in [
             "deepseek/deepseek-v4-flash",
             "mistralai/devstral-small",
             "meta-llama/llama-4-scout",
+            "kwaipilot/kat-coder-pro-v2",
         ] {
             let caps = lookup("openrouter", model);
             assert!(caps.native_tools, "{model} should expose native tools");

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -101,6 +101,12 @@
 #                     accepted reasoning_effort values when the provider
 #                     accepts only a subset of Harn's neutral enum.
 #   reasoning_none_supported: whether reasoning_effort="none" is accepted.
+#   reasoning_disable_supported:
+#                     whether `reasoning: {enabled:false}` is accepted when
+#                     the provider uses an enabled/disabled reasoning switch.
+#   reasoning_text_promotable:
+#                     whether a reasoning-only clean stop may be promoted into
+#                     visible text when the provider omits content.
 #   reasoning_wire_format:
 #                     OpenAI-compatible non-standard reasoning transport:
 #                     openrouter, enabled, or minimax.
@@ -1624,6 +1630,54 @@ prefers_xml_tools = true
 thinking_block_style = "thinking_blocks"
 
 [[provider.openrouter]]
+model_match = "qwen/qwen3.7-plus"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+reasoning_none_supported = true
+auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
+prompt_caching = true
+cache_breakpoint_style = "last_block"
+vision_supported = true
+vision = true
+server_parser = "none"
+honors_chat_template_kwargs = false
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
+thinking_disable_directive = "/no_think"
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "delimited"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.openrouter]]
+model_match = "qwen/qwen3.7-max"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+reasoning_none_supported = true
+auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
+prompt_caching = true
+cache_breakpoint_style = "last_block"
+server_parser = "none"
+honors_chat_template_kwargs = false
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
+thinking_disable_directive = "/no_think"
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "delimited"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.openrouter]]
 model_match = "qwen/qwen3.6-plus"
 native_tools = true
 preferred_tool_format = "native"
@@ -1857,6 +1911,28 @@ structured_output = "native"
 thinking_modes = ["enabled"]
 server_parser = "none"
 honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
+thinking_disable_directive = "/no_think"
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "delimited"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.together]]
+model_match = "Qwen/Qwen3.7-Max"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
+prompt_caching = true
+requires_streaming = true
+server_parser = "none"
+honors_chat_template_kwargs = false
 recommended_endpoint = "/v1/chat/completions"
 text_tool_wire_format_supported = true
 thinking_disable_directive = "/no_think"
@@ -2424,7 +2500,27 @@ native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
+auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
+prompt_caching = true
 honors_chat_template_kwargs = false
+reasoning_text_promotable = false
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.together]]
+model_match = "minimaxai/minimax-m2.7*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+prompt_caching = true
+honors_chat_template_kwargs = false
+reasoning_text_promotable = false
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
 structured_output_mode = "native_json"
@@ -2893,6 +2989,7 @@ vision = true
 vision_supported = true
 video_supported = true
 prompt_caching = true
+reasoning_text_promotable = false
 text_tool_wire_format_supported = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
@@ -2917,6 +3014,7 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
 prompt_caching = true
+reasoning_text_promotable = false
 
 [[provider.minimax]]
 model_match = "minimax-m2.5*"
@@ -2932,6 +3030,7 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
+reasoning_text_promotable = false
 
 [[provider.minimax]]
 model_match = "minimax-m2*"
@@ -2947,6 +3046,7 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
+reasoning_text_promotable = false
 
 [[provider.minimax]]
 model_match = "minimax-text-*"
@@ -3045,6 +3145,42 @@ native_tools = true
 preferred_tool_format = "native"
 text_tool_wire_format_supported = true
 structured_output = "native"
+
+[[provider.openrouter]]
+model_match = "kwaipilot/kat-coder-pro-v2"
+native_tools = true
+preferred_tool_format = "native"
+tool_mode_parity = "interchangeable"
+tool_mode_parity_notes = "Live OpenRouter probe on 2026-06-12 returned a valid provider-native tool call for KAT-Coder-Pro V2."
+prompt_caching = true
+text_tool_wire_format_supported = true
+structured_output = "native"
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "none"
+
+[[provider.openrouter]]
+model_match = "stepfun/step-3.7-flash"
+native_tools = true
+preferred_tool_format = "native"
+tool_mode_parity = "interchangeable"
+tool_mode_parity_notes = "Live OpenRouter probe on 2026-06-12 returned a valid provider-native tool call for Step 3.7 Flash with reasoning enabled."
+prompt_caching = true
+structured_output = "native"
+thinking_modes = ["enabled"]
+reasoning_disable_supported = false
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
 
 # --- source: 90-families/provider-family.toml ---
 [provider_family]

--- a/crates/harn-vm/src/llm/capability_sources/00-base.toml
+++ b/crates/harn-vm/src/llm/capability_sources/00-base.toml
@@ -97,6 +97,12 @@
 #                     accepted reasoning_effort values when the provider
 #                     accepts only a subset of Harn's neutral enum.
 #   reasoning_none_supported: whether reasoning_effort="none" is accepted.
+#   reasoning_disable_supported:
+#                     whether `reasoning: {enabled:false}` is accepted when
+#                     the provider uses an enabled/disabled reasoning switch.
+#   reasoning_text_promotable:
+#                     whether a reasoning-only clean stop may be promoted into
+#                     visible text when the provider omits content.
 #   reasoning_wire_format:
 #                     OpenAI-compatible non-standard reasoning transport:
 #                     openrouter, enabled, or minimax.

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/30-qwen-routed.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/30-qwen-routed.toml
@@ -201,6 +201,54 @@ prefers_xml_tools = true
 thinking_block_style = "thinking_blocks"
 
 [[provider.openrouter]]
+model_match = "qwen/qwen3.7-plus"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+reasoning_none_supported = true
+auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
+prompt_caching = true
+cache_breakpoint_style = "last_block"
+vision_supported = true
+vision = true
+server_parser = "none"
+honors_chat_template_kwargs = false
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
+thinking_disable_directive = "/no_think"
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "delimited"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.openrouter]]
+model_match = "qwen/qwen3.7-max"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+reasoning_none_supported = true
+auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
+prompt_caching = true
+cache_breakpoint_style = "last_block"
+server_parser = "none"
+honors_chat_template_kwargs = false
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
+thinking_disable_directive = "/no_think"
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "delimited"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.openrouter]]
 model_match = "qwen/qwen3.6-plus"
 native_tools = true
 preferred_tool_format = "native"
@@ -434,6 +482,28 @@ structured_output = "native"
 thinking_modes = ["enabled"]
 server_parser = "none"
 honors_chat_template_kwargs = true
+recommended_endpoint = "/v1/chat/completions"
+text_tool_wire_format_supported = true
+thinking_disable_directive = "/no_think"
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "delimited"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.together]]
+model_match = "Qwen/Qwen3.7-Max"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
+prompt_caching = true
+requires_streaming = true
+server_parser = "none"
+honors_chat_template_kwargs = false
 recommended_endpoint = "/v1/chat/completions"
 text_tool_wire_format_supported = true
 thinking_disable_directive = "/no_think"

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/60-together.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/60-together.toml
@@ -69,7 +69,27 @@ native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
+auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }
+prompt_caching = true
 honors_chat_template_kwargs = false
+reasoning_text_promotable = false
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.together]]
+model_match = "minimaxai/minimax-m2.7*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+prompt_caching = true
+honors_chat_template_kwargs = false
+reasoning_text_promotable = false
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
 structured_output_mode = "native_json"
@@ -106,4 +126,3 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "none"
-

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/97-minimax.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/97-minimax.toml
@@ -17,6 +17,7 @@ vision = true
 vision_supported = true
 video_supported = true
 prompt_caching = true
+reasoning_text_promotable = false
 text_tool_wire_format_supported = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
@@ -41,6 +42,7 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
 prompt_caching = true
+reasoning_text_promotable = false
 
 [[provider.minimax]]
 model_match = "minimax-m2.5*"
@@ -56,6 +58,7 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
+reasoning_text_promotable = false
 
 [[provider.minimax]]
 model_match = "minimax-m2*"
@@ -71,6 +74,7 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
+reasoning_text_promotable = false
 
 [[provider.minimax]]
 model_match = "minimax-text-*"
@@ -85,4 +89,3 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "none"
-

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/99-openrouter-new-families.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/99-openrouter-new-families.toml
@@ -43,3 +43,39 @@ native_tools = true
 preferred_tool_format = "native"
 text_tool_wire_format_supported = true
 structured_output = "native"
+
+[[provider.openrouter]]
+model_match = "kwaipilot/kat-coder-pro-v2"
+native_tools = true
+preferred_tool_format = "native"
+tool_mode_parity = "interchangeable"
+tool_mode_parity_notes = "Live OpenRouter probe on 2026-06-12 returned a valid provider-native tool call for KAT-Coder-Pro V2."
+prompt_caching = true
+text_tool_wire_format_supported = true
+structured_output = "native"
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "none"
+
+[[provider.openrouter]]
+model_match = "stepfun/step-3.7-flash"
+native_tools = true
+preferred_tool_format = "native"
+tool_mode_parity = "interchangeable"
+tool_mode_parity_notes = "Live OpenRouter probe on 2026-06-12 returned a valid provider-native tool call for Step 3.7 Flash with reasoning enabled."
+prompt_caching = true
+structured_output = "native"
+thinking_modes = ["enabled"]
+reasoning_disable_supported = false
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"

--- a/crates/harn-vm/src/llm/catalog_sources/30-aliases/aliases.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/30-aliases/aliases.toml
@@ -125,6 +125,68 @@ provider = "openrouter"
 id = "moonshotai/kimi-k2.7-code"
 provider = "openrouter"
 
+# Qwen 3.7 via OpenRouter/Together. Keep bare aliases on OpenRouter because it
+# exposes both Max and Plus; Together currently serves only Max.
+[aliases."qwen3.7"]
+id = "qwen/qwen3.7-max"
+provider = "openrouter"
+
+[aliases."qwen3.7-max"]
+id = "qwen/qwen3.7-max"
+provider = "openrouter"
+
+[aliases."qwen3.7-plus"]
+id = "qwen/qwen3.7-plus"
+provider = "openrouter"
+
+[aliases."openrouter-qwen3.7-max"]
+id = "qwen/qwen3.7-max"
+provider = "openrouter"
+
+[aliases."openrouter-qwen3.7-plus"]
+id = "qwen/qwen3.7-plus"
+provider = "openrouter"
+
+[aliases."together-qwen3.7-max"]
+id = "Qwen/Qwen3.7-Max"
+provider = "together"
+
+# OpenRouter-only coding specialist.
+[aliases."kat-coder-pro-v2"]
+id = "kwaipilot/kat-coder-pro-v2"
+provider = "openrouter"
+
+[aliases."openrouter-kat-coder-pro-v2"]
+id = "kwaipilot/kat-coder-pro-v2"
+provider = "openrouter"
+
+# Together mirror of DeepSeek V4 Pro.
+[aliases."together-deepseek"]
+id = "deepseek-ai/DeepSeek-V4-Pro"
+provider = "together"
+
+[aliases."together-deepseek-v4-pro"]
+id = "deepseek-ai/DeepSeek-V4-Pro"
+provider = "together"
+
+# StepFun long-context agent route via OpenRouter.
+[aliases."step-3.7-flash"]
+id = "stepfun/step-3.7-flash"
+provider = "openrouter"
+
+[aliases."openrouter-step-3.7-flash"]
+id = "stepfun/step-3.7-flash"
+provider = "openrouter"
+
+# Together mirrors for current GLM/MiniMax agent routes.
+[aliases."together-glm-5.1"]
+id = "zai-org/GLM-5.1"
+provider = "together"
+
+[aliases."together-minimax-m2.7"]
+id = "MiniMaxAI/MiniMax-M2.7"
+provider = "together"
+
 # qwen3.6 has no working Ollama route — Ollama's qwen3.5-family server-side
 # tool-call parser 500s on text-tool output (ollama/ollama#14986, #14570).
 # Use the llamacpp provider for local qwen3.x.

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/20-open-weight-openrouter.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/20-open-weight-openrouter.toml
@@ -38,7 +38,7 @@ name = "DeepSeek V3.2"
 provider = "openrouter"
 context_window = 131072
 capabilities = ["tools", "streaming"]
-pricing = { input_per_mtok = 0.28, output_per_mtok = 0.42 }
+pricing = { input_per_mtok = 0.2288, output_per_mtok = 0.3432 }
 tier = "mid"
 open_weight = true
 strengths = ["coding", "tool_use", "cheap"]

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/25-openrouter-frontier-agents.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/25-openrouter-frontier-agents.toml
@@ -1,0 +1,46 @@
+# Current OpenRouter-hosted coding/agent models that are not direct provider
+# defaults. Pricing snapshots are from OpenRouter's live `/api/v1/models`.
+
+tier = "frontier"
+open_weight = false
+strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning", "vision"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "deepseek", "kimi"]
+[models."qwen/qwen3.7-plus"]
+name = "Qwen3.7 Plus"
+provider = "openrouter"
+context_window = 1000000
+capabilities = ["tools", "vision", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.32, output_per_mtok = 1.28, cache_read_per_mtok = 0.064, cache_write_per_mtok = 0.40 }
+
+tier = "frontier"
+open_weight = false
+strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "deepseek", "kimi"]
+[models."qwen/qwen3.7-max"]
+name = "Qwen3.7 Max"
+provider = "openrouter"
+context_window = 1000000
+capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 1.25, output_per_mtok = 3.75, cache_read_per_mtok = 0.25, cache_write_per_mtok = 1.5625 }
+
+tier = "mid"
+open_weight = false
+strengths = ["coding", "agentic", "tool_use", "long_context", "speed"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "deepseek"]
+[models."kwaipilot/kat-coder-pro-v2"]
+name = "KAT-Coder-Pro V2"
+provider = "openrouter"
+context_window = 256000
+capabilities = ["tools", "streaming", "prompt_caching"]
+pricing = { input_per_mtok = 0.30, output_per_mtok = 1.20, cache_read_per_mtok = 0.06 }
+
+tier = "mid"
+open_weight = false
+strengths = ["agentic", "long_context", "tool_use", "reasoning", "speed"]
+complementary_with = ["qwen", "deepseek", "kimi", "minimax", "zai-glm"]
+[models."stepfun/step-3.7-flash"]
+name = "Step 3.7 Flash"
+provider = "openrouter"
+context_window = 256000
+capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.20, output_per_mtok = 1.15, cache_read_per_mtok = 0.04 }

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/26-together-frontier-agents.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/26-together-frontier-agents.toml
@@ -1,0 +1,47 @@
+# Current Together serverless frontier/agent routes observed through
+# `GET /v1/models`. Keep rows here when Harn supports the provider but the
+# model is absent from direct-provider catalogs.
+
+tier = "frontier"
+open_weight = false
+strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "deepseek", "kimi"]
+[models."Qwen/Qwen3.7-Max"]
+name = "Qwen3.7 Max (Together)"
+provider = "together"
+context_window = 1000000
+capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 1.25, output_per_mtok = 3.75, cache_read_per_mtok = 0.125 }
+
+tier = "frontier"
+open_weight = true
+strengths = ["reasoning", "coding", "tool_use", "long_context"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "kimi"]
+[models."deepseek-ai/DeepSeek-V4-Pro"]
+name = "DeepSeek V4 Pro (Together)"
+provider = "together"
+context_window = 512000
+capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 1.74, output_per_mtok = 3.48, cache_read_per_mtok = 0.20 }
+
+tier = "frontier"
+open_weight = true
+strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "deepseek"]
+[models."zai-org/GLM-5.1"]
+name = "GLM 5.1 (Together)"
+provider = "together"
+context_window = 202752
+capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 1.40, output_per_mtok = 4.40, cache_read_per_mtok = 0.26 }
+
+tier = "frontier"
+open_weight = true
+strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "deepseek"]
+[models."MiniMaxAI/MiniMax-M2.7"]
+name = "MiniMax M2.7 (Together)"
+provider = "together"
+context_window = 196608
+capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.30, output_per_mtok = 1.20, cache_read_per_mtok = 0.06 }

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/60-deepseek-openrouter-qwen.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/60-deepseek-openrouter-qwen.toml
@@ -56,7 +56,7 @@ name = "DeepSeek V4 Flash (via OpenRouter)"
 provider = "openrouter"
 context_window = 1048576
 capabilities = ["tools", "streaming"]
-pricing = { input_per_mtok = 0.0983, output_per_mtok = 0.1966, cache_read_per_mtok = 0.0197 }
+pricing = { input_per_mtok = 0.098, output_per_mtok = 0.196, cache_read_per_mtok = 0.020 }
 tier = "mid"
 open_weight = true
 strengths = ["speed", "cheap", "tool_use", "reasoning", "long_context"]
@@ -76,4 +76,3 @@ name = "Qwen3.5 9B"
 provider = "openrouter"
 context_window = 131072
 capabilities = ["tools", "streaming"]
-

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -1343,12 +1343,24 @@ pub(crate) fn capabilities_to_vm_value(
         VmValue::Bool(caps.requires_completion_tokens),
     );
     dict.insert(
+        "requires_streaming".to_string(),
+        VmValue::Bool(caps.requires_streaming),
+    );
+    dict.insert(
         "reasoning_effort_supported".to_string(),
         VmValue::Bool(caps.reasoning_effort_supported),
     );
     dict.insert(
         "reasoning_none_supported".to_string(),
         VmValue::Bool(caps.reasoning_none_supported),
+    );
+    dict.insert(
+        "reasoning_disable_supported".to_string(),
+        VmValue::Bool(caps.reasoning_disable_supported),
+    );
+    dict.insert(
+        "reasoning_text_promotable".to_string(),
+        VmValue::Bool(caps.reasoning_text_promotable),
     );
     dict.insert(
         "reasoning_wire_format".to_string(),
@@ -1387,6 +1399,20 @@ pub(crate) fn capabilities_to_vm_value(
             caps.allowed_tool_choice_modes
                 .iter()
                 .map(|mode| VmValue::String(std::sync::Arc::from(mode.as_str())))
+                .collect(),
+        )),
+    );
+    dict.insert(
+        "auto_reasoning_overrides".to_string(),
+        VmValue::Dict(std::sync::Arc::new(
+            caps.auto_reasoning_overrides
+                .iter()
+                .map(|(task, mode)| {
+                    (
+                        task.clone(),
+                        VmValue::String(std::sync::Arc::from(mode.clone())),
+                    )
+                })
                 .collect(),
         )),
     );

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -723,6 +723,68 @@ provider = "openrouter"
 id = "moonshotai/kimi-k2.7-code"
 provider = "openrouter"
 
+# Qwen 3.7 via OpenRouter/Together. Keep bare aliases on OpenRouter because it
+# exposes both Max and Plus; Together currently serves only Max.
+[aliases."qwen3.7"]
+id = "qwen/qwen3.7-max"
+provider = "openrouter"
+
+[aliases."qwen3.7-max"]
+id = "qwen/qwen3.7-max"
+provider = "openrouter"
+
+[aliases."qwen3.7-plus"]
+id = "qwen/qwen3.7-plus"
+provider = "openrouter"
+
+[aliases."openrouter-qwen3.7-max"]
+id = "qwen/qwen3.7-max"
+provider = "openrouter"
+
+[aliases."openrouter-qwen3.7-plus"]
+id = "qwen/qwen3.7-plus"
+provider = "openrouter"
+
+[aliases."together-qwen3.7-max"]
+id = "Qwen/Qwen3.7-Max"
+provider = "together"
+
+# OpenRouter-only coding specialist.
+[aliases."kat-coder-pro-v2"]
+id = "kwaipilot/kat-coder-pro-v2"
+provider = "openrouter"
+
+[aliases."openrouter-kat-coder-pro-v2"]
+id = "kwaipilot/kat-coder-pro-v2"
+provider = "openrouter"
+
+# Together mirror of DeepSeek V4 Pro.
+[aliases."together-deepseek"]
+id = "deepseek-ai/DeepSeek-V4-Pro"
+provider = "together"
+
+[aliases."together-deepseek-v4-pro"]
+id = "deepseek-ai/DeepSeek-V4-Pro"
+provider = "together"
+
+# StepFun long-context agent route via OpenRouter.
+[aliases."step-3.7-flash"]
+id = "stepfun/step-3.7-flash"
+provider = "openrouter"
+
+[aliases."openrouter-step-3.7-flash"]
+id = "stepfun/step-3.7-flash"
+provider = "openrouter"
+
+# Together mirrors for current GLM/MiniMax agent routes.
+[aliases."together-glm-5.1"]
+id = "zai-org/GLM-5.1"
+provider = "together"
+
+[aliases."together-minimax-m2.7"]
+id = "MiniMaxAI/MiniMax-M2.7"
+provider = "together"
+
 # qwen3.6 has no working Ollama route — Ollama's qwen3.5-family server-side
 # tool-call parser 500s on text-tool output (ollama/ollama#14986, #14570).
 # Use the llamacpp provider for local qwen3.x.
@@ -1407,7 +1469,7 @@ name = "DeepSeek V3.2"
 provider = "openrouter"
 context_window = 131072
 capabilities = ["tools", "streaming"]
-pricing = { input_per_mtok = 0.28, output_per_mtok = 0.42 }
+pricing = { input_per_mtok = 0.2288, output_per_mtok = 0.3432 }
 tier = "mid"
 open_weight = true
 strengths = ["coding", "tool_use", "cheap"]
@@ -1444,6 +1506,103 @@ api_dialect = "openai_chat"
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.15, output_per_mtok = 0.60 }
 architecture = { parameter_count_b = 117.0, active_parameter_count_b = 5.1, moe = true, license = "Apache-2.0", source_url = "https://developers.openai.com/api/docs/models/gpt-oss-120b", last_verified = "2026-06-05" }
+
+# --- source: 60-models/25-openrouter-frontier-agents.toml ---
+# Current OpenRouter-hosted coding/agent models that are not direct provider
+# defaults. Pricing snapshots are from OpenRouter's live `/api/v1/models`.
+
+tier = "frontier"
+open_weight = false
+strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning", "vision"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "deepseek", "kimi"]
+[models."qwen/qwen3.7-plus"]
+name = "Qwen3.7 Plus"
+provider = "openrouter"
+context_window = 1000000
+capabilities = ["tools", "vision", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.32, output_per_mtok = 1.28, cache_read_per_mtok = 0.064, cache_write_per_mtok = 0.40 }
+
+tier = "frontier"
+open_weight = false
+strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "deepseek", "kimi"]
+[models."qwen/qwen3.7-max"]
+name = "Qwen3.7 Max"
+provider = "openrouter"
+context_window = 1000000
+capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 1.25, output_per_mtok = 3.75, cache_read_per_mtok = 0.25, cache_write_per_mtok = 1.5625 }
+
+tier = "mid"
+open_weight = false
+strengths = ["coding", "agentic", "tool_use", "long_context", "speed"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "deepseek"]
+[models."kwaipilot/kat-coder-pro-v2"]
+name = "KAT-Coder-Pro V2"
+provider = "openrouter"
+context_window = 256000
+capabilities = ["tools", "streaming", "prompt_caching"]
+pricing = { input_per_mtok = 0.30, output_per_mtok = 1.20, cache_read_per_mtok = 0.06 }
+
+tier = "mid"
+open_weight = false
+strengths = ["agentic", "long_context", "tool_use", "reasoning", "speed"]
+complementary_with = ["qwen", "deepseek", "kimi", "minimax", "zai-glm"]
+[models."stepfun/step-3.7-flash"]
+name = "Step 3.7 Flash"
+provider = "openrouter"
+context_window = 256000
+capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.20, output_per_mtok = 1.15, cache_read_per_mtok = 0.04 }
+
+# --- source: 60-models/26-together-frontier-agents.toml ---
+# Current Together serverless frontier/agent routes observed through
+# `GET /v1/models`. Keep rows here when Harn supports the provider but the
+# model is absent from direct-provider catalogs.
+
+tier = "frontier"
+open_weight = false
+strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "deepseek", "kimi"]
+[models."Qwen/Qwen3.7-Max"]
+name = "Qwen3.7 Max (Together)"
+provider = "together"
+context_window = 1000000
+capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 1.25, output_per_mtok = 3.75, cache_read_per_mtok = 0.125 }
+
+tier = "frontier"
+open_weight = true
+strengths = ["reasoning", "coding", "tool_use", "long_context"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "kimi"]
+[models."deepseek-ai/DeepSeek-V4-Pro"]
+name = "DeepSeek V4 Pro (Together)"
+provider = "together"
+context_window = 512000
+capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 1.74, output_per_mtok = 3.48, cache_read_per_mtok = 0.20 }
+
+tier = "frontier"
+open_weight = true
+strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "deepseek"]
+[models."zai-org/GLM-5.1"]
+name = "GLM 5.1 (Together)"
+provider = "together"
+context_window = 202752
+capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 1.40, output_per_mtok = 4.40, cache_read_per_mtok = 0.26 }
+
+tier = "frontier"
+open_weight = true
+strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "deepseek"]
+[models."MiniMaxAI/MiniMax-M2.7"]
+name = "MiniMax M2.7 (Together)"
+provider = "together"
+context_window = 196608
+capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.30, output_per_mtok = 1.20, cache_read_per_mtok = 0.06 }
 
 # --- source: 60-models/30-cerebras.toml ---
 # Cerebras-hosted open-weight models. Serverless rows mirror
@@ -1729,7 +1888,7 @@ name = "DeepSeek V4 Flash (via OpenRouter)"
 provider = "openrouter"
 context_window = 1048576
 capabilities = ["tools", "streaming"]
-pricing = { input_per_mtok = 0.0983, output_per_mtok = 0.1966, cache_read_per_mtok = 0.0197 }
+pricing = { input_per_mtok = 0.098, output_per_mtok = 0.196, cache_read_per_mtok = 0.020 }
 tier = "mid"
 open_weight = true
 strengths = ["speed", "cheap", "tool_use", "reasoning", "long_context"]

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -203,8 +203,12 @@ impl OpenAiCompatibleProvider {
                     // directive shrinks the candidate set to zero -> 404 "No
                     // endpoints found" (e.g. qwen/qwen3-coder json_object calls).
                     // The disable is a no-op for these models anyway, so skip it.
+                    // A smaller set of routes (for example Step 3.7 Flash)
+                    // support reasoning but reject explicit disable directives;
+                    // omit the field there and let the endpoint's mandatory
+                    // reasoning default apply.
                     let skip_disable = is_openrouter_reasoning_disable(&reasoning)
-                        && !model_declares_reasoning(&caps);
+                        && (!model_declares_reasoning(&caps) || !caps.reasoning_disable_supported);
                     if !skip_disable {
                         body["reasoning"] = reasoning;
                     }
@@ -1037,6 +1041,21 @@ mod tests {
         assert_eq!(
             body["reasoning"]["enabled"], false,
             "reasoning-capable model must keep the explicit disable: {body}"
+        );
+    }
+
+    #[test]
+    fn openrouter_mandatory_reasoning_model_omits_unsupported_disable() {
+        let mut payload = base_request_payload();
+        payload.provider = "openrouter".to_string();
+        payload.model = "stepfun/step-3.7-flash".to_string();
+        payload.thinking = ThinkingConfig::Disabled;
+        payload.output_format = crate::llm::api::OutputFormat::JsonObject;
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+
+        assert!(
+            body.get("reasoning").is_none(),
+            "mandatory-reasoning route must omit unsupported disable: {body}"
         );
     }
 

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -112,6 +112,8 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `openrouter` | `anthropic/claude-haiku-*` | `>=4.5` | `enabled` | no | no | no | no | yes | no | `tool_use` | `xml` | `xml_tagged` | yes | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
 | `openrouter` | `anthropic/claude-sonnet-*` | `>=4.6` | `adaptive` | no | no | no | no | yes | no | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
 | `openrouter` | `anthropic/claude-opus-*` | `>=4.6` | `adaptive` | no | no | no | no | yes | no | `tool_use` | `xml` | `xml_tagged` | no | `system` | `xml` | `thinking_blocks` | `native` | yes | yes | `unknown` | yes | yes |
+| `openrouter` | `qwen/qwen3.7-plus` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `openrouter` | `qwen/qwen3.7-max` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `openrouter` | `qwen/qwen3.6-plus` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `openrouter` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `qwen/qwen3-coder-plus` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `text` | yes | yes | `native_unreliable` | yes | yes |
@@ -139,6 +141,9 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `openrouter` | `minimax/minimax-m2.7*` | `any` | no | no | no | no | no | yes | no | `delimited` | `plain` | `none` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `minimax/minimax-m2*` | `any` | no | no | no | no | no | yes | no | `delimited` | `plain` | `none` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `z-ai/glm-5*` | `any` | no | no | no | no | no | yes | no | `native` | `plain` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `kwaipilot/kat-coder-pro-v2` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `interchangeable` | yes | yes |
+| `openrouter` | `stepfun/step-3.7-flash` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `interchangeable` | yes | yes |
+| `together` | `Qwen/Qwen3.7-Max` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `together` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `together` | `qwen/qwen3-coder*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `together` | `qwen/*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
@@ -146,7 +151,8 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `together` | `openai/gpt-oss-*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `json` | no | yes | `text_only` | yes | no |
 | `together` | `deepseek-ai/deepseek-v4*` | `any` | `enabled,effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
 | `together` | `moonshotai/kimi-k2*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `together` | `zai-org/glm-5*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `zai-org/glm-5*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `together` | `minimaxai/minimax-m2.7*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `together` | `google/gemma-4*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `together` | `moonshotai/*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `vertex` | `gemini-*` | `any` | no | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
@@ -231,6 +237,7 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `openrouter` | `google/gemini-2.5-flash` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `google/gemma-4-26b-a4b-it` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `google/gemma-4-31b-it` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `openrouter` | `kwaipilot/kat-coder-pro-v2` | `native` | `interchangeable` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `minimax/minimax-m2` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `minimax/minimax-m2.7` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `minimax/minimax-m3` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
@@ -240,11 +247,18 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `openrouter` | `moonshotai/kimi-k2.7-code` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `openai/gpt-oss-120b` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `qwen/qwen3-coder` | `text` | `native_unreliable` | - | - | - | - | - | `data not yet collected` |
+| `openrouter` | `qwen/qwen3.7-max` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `openrouter` | `qwen/qwen3.7-plus` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `openrouter` | `stepfun/step-3.7-flash` | `native` | `interchangeable` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `z-ai/glm-5` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `z-ai/glm-5.1` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `z-ai/glm-5v-turbo` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `together` | `MiniMaxAI/MiniMax-M2.7` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `together` | `Qwen/Qwen3-Coder-Next-FP8` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `together` | `Qwen/Qwen3.7-Max` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `together` | `deepseek-ai/DeepSeek-V4-Pro` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `together` | `google/gemma-4-31B-it` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `together` | `zai-org/GLM-5.1` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `xai` | `grok-build-0.1` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `zai` | `glm-5` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `zai` | `glm-5.1` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -6204,8 +6204,8 @@ public let harnProviderCatalogJSON = #"""
       },
       "prompt_cache": true,
       "pricing": {
-        "input_per_mtok": 0.28,
-        "output_per_mtok": 0.42,
+        "input_per_mtok": 0.2288,
+        "output_per_mtok": 0.3432,
         "cache_read_per_mtok": null,
         "cache_write_per_mtok": null
       },
@@ -6282,9 +6282,9 @@ public let harnProviderCatalogJSON = #"""
       },
       "prompt_cache": true,
       "pricing": {
-        "input_per_mtok": 0.0983,
-        "output_per_mtok": 0.1966,
-        "cache_read_per_mtok": 0.0197,
+        "input_per_mtok": 0.098,
+        "output_per_mtok": 0.196,
+        "cache_read_per_mtok": 0.02,
         "cache_write_per_mtok": null
       },
       "deprecation": {
@@ -6607,6 +6607,85 @@ public let harnProviderCatalogJSON = #"""
         "reasoning",
         "coding",
         "cheap"
+      ]
+    },
+    {
+      "id": "kwaipilot/kat-coder-pro-v2",
+      "name": "KAT-Coder-Pro V2",
+      "provider": "openrouter",
+      "aliases": [
+        "kat-coder-pro-v2",
+        "openrouter-kat-coder-pro-v2"
+      ],
+      "context_window": 256000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "interchangeable",
+        "parity_notes": "Live OpenRouter probe on 2026-06-12 returned a valid provider-native tool call for KAT-Coder-Pro V2.",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.3,
+        "output_per_mtok": 1.2,
+        "cache_read_per_mtok": 0.06,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "structured_output"
+      ],
+      "family": "openrouter",
+      "lineage": "openrouter",
+      "complementary_with": [
+        "qwen",
+        "deepseek",
+        "kimi",
+        "minimax",
+        "zai-glm"
+      ],
+      "tier": "mid",
+      "open_weight": false,
+      "strengths": [
+        "agentic",
+        "long_context",
+        "tool_use",
+        "reasoning",
+        "speed"
       ]
     },
     {
@@ -7212,11 +7291,22 @@ public let harnProviderCatalogJSON = #"""
       ],
       "family": "openai-gpt",
       "lineage": "openai-legacy",
-      "tier": "mid",
-      "open_weight": true,
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": false,
       "strengths": [
-        "cheap",
-        "tool_use"
+        "agentic",
+        "coding",
+        "long_context",
+        "tool_use",
+        "reasoning",
+        "vision"
       ]
     },
     {
@@ -7288,6 +7378,253 @@ public let harnProviderCatalogJSON = #"""
       "benchmarks": {
         "swe_bench_verified": 67.0
       }
+    },
+    {
+      "id": "qwen/qwen3.7-max",
+      "name": "Qwen3.7 Max",
+      "provider": "openrouter",
+      "aliases": [
+        "openrouter-qwen3.7-max",
+        "qwen3.7",
+        "qwen3.7-max"
+      ],
+      "context_window": 1000000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": true,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 1.25,
+        "output_per_mtok": 3.75,
+        "cache_read_per_mtok": 0.25,
+        "cache_write_per_mtok": 1.5625
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "qwen",
+      "lineage": "qwen3",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "mid",
+      "open_weight": false,
+      "strengths": [
+        "coding",
+        "agentic",
+        "tool_use",
+        "long_context",
+        "speed"
+      ]
+    },
+    {
+      "id": "qwen/qwen3.7-plus",
+      "name": "Qwen3.7 Plus",
+      "provider": "openrouter",
+      "aliases": [
+        "openrouter-qwen3.7-plus",
+        "qwen3.7-plus"
+      ],
+      "context_window": 1000000,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": true,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.32,
+        "output_per_mtok": 1.28,
+        "cache_read_per_mtok": 0.064,
+        "cache_write_per_mtok": 0.4
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "qwen",
+      "lineage": "qwen3",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": false,
+      "strengths": [
+        "agentic",
+        "coding",
+        "long_context",
+        "tool_use",
+        "reasoning"
+      ]
+    },
+    {
+      "id": "stepfun/step-3.7-flash",
+      "name": "Step 3.7 Flash",
+      "provider": "openrouter",
+      "aliases": [
+        "openrouter-step-3.7-flash",
+        "step-3.7-flash"
+      ],
+      "context_window": 256000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "interchangeable",
+        "parity_notes": "Live OpenRouter probe on 2026-06-12 returned a valid provider-native tool call for Step 3.7 Flash with reasoning enabled.",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.2,
+        "output_per_mtok": 1.15,
+        "cache_read_per_mtok": 0.04,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "openrouter",
+      "lineage": "openrouter",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": false,
+      "strengths": [
+        "agentic",
+        "coding",
+        "long_context",
+        "tool_use",
+        "reasoning"
+      ]
     },
     {
       "id": "z-ai/glm-5",
@@ -7485,6 +7822,76 @@ public let harnProviderCatalogJSON = #"""
       ]
     },
     {
+      "id": "MiniMaxAI/MiniMax-M2.7",
+      "name": "MiniMax M2.7 (Together)",
+      "provider": "together",
+      "aliases": [
+        "together-minimax-m2.7"
+      ],
+      "context_window": 196608,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.3,
+        "output_per_mtok": 1.2,
+        "cache_read_per_mtok": 0.06,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "minimax",
+      "lineage": "minimax",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "cheap",
+        "tool_use"
+      ]
+    },
+    {
       "id": "Qwen/Qwen3-Coder-Next-FP8",
       "name": "Qwen3 Coder Next FP8 (Together, dedicated)",
       "provider": "together",
@@ -7557,6 +7964,168 @@ public let harnProviderCatalogJSON = #"""
       ]
     },
     {
+      "id": "Qwen/Qwen3.7-Max",
+      "name": "Qwen3.7 Max (Together)",
+      "provider": "together",
+      "aliases": [
+        "together-qwen3.7-max"
+      ],
+      "context_window": 1000000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 1.25,
+        "output_per_mtok": 3.75,
+        "cache_read_per_mtok": 0.125,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "qwen",
+      "lineage": "qwen3",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "reasoning",
+        "coding",
+        "tool_use",
+        "long_context"
+      ]
+    },
+    {
+      "id": "deepseek-ai/DeepSeek-V4-Pro",
+      "name": "DeepSeek V4 Pro (Together)",
+      "provider": "together",
+      "aliases": [
+        "together-deepseek",
+        "together-deepseek-v4-pro"
+      ],
+      "context_window": 512000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "reasoning_summary"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled",
+          "effort"
+        ],
+        "effort_supported": true,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 1.74,
+        "output_per_mtok": 3.48,
+        "cache_read_per_mtok": 0.2,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ],
+      "family": "deepseek",
+      "lineage": "deepseek",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "agentic",
+        "coding",
+        "long_context",
+        "tool_use",
+        "reasoning"
+      ]
+    },
+    {
       "id": "google/gemma-4-31B-it",
       "name": "Gemma 4 31B (Together)",
       "provider": "together",
@@ -7626,6 +8195,86 @@ public let harnProviderCatalogJSON = #"""
         "vision",
         "reasoning",
         "coding"
+      ]
+    },
+    {
+      "id": "zai-org/GLM-5.1",
+      "name": "GLM 5.1 (Together)",
+      "provider": "together",
+      "aliases": [
+        "together-glm-5.1"
+      ],
+      "context_window": 202752,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 1.4,
+        "output_per_mtok": 4.4,
+        "cache_read_per_mtok": 0.26,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "glm",
+      "lineage": "glm",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "agentic",
+        "coding",
+        "long_context",
+        "tool_use",
+        "reasoning"
       ]
     },
     {
@@ -7955,6 +8604,11 @@ public let harnProviderCatalogJSON = #"""
       "provider": "anthropic"
     },
     {
+      "name": "kat-coder-pro-v2",
+      "model_id": "kwaipilot/kat-coder-pro-v2",
+      "provider": "openrouter"
+    },
+    {
       "name": "kimi-k2.7-code",
       "model_id": "moonshotai/kimi-k2.7-code",
       "provider": "openrouter"
@@ -8147,14 +8801,49 @@ public let harnProviderCatalogJSON = #"""
       "provider": "openrouter"
     },
     {
+      "name": "openrouter-kat-coder-pro-v2",
+      "model_id": "kwaipilot/kat-coder-pro-v2",
+      "provider": "openrouter"
+    },
+    {
       "name": "openrouter-kimi-k2.7-code",
       "model_id": "moonshotai/kimi-k2.7-code",
+      "provider": "openrouter"
+    },
+    {
+      "name": "openrouter-qwen3.7-max",
+      "model_id": "qwen/qwen3.7-max",
+      "provider": "openrouter"
+    },
+    {
+      "name": "openrouter-qwen3.7-plus",
+      "model_id": "qwen/qwen3.7-plus",
+      "provider": "openrouter"
+    },
+    {
+      "name": "openrouter-step-3.7-flash",
+      "model_id": "stepfun/step-3.7-flash",
       "provider": "openrouter"
     },
     {
       "name": "opus",
       "model_id": "claude-opus-4-8",
       "provider": "anthropic"
+    },
+    {
+      "name": "qwen3.7",
+      "model_id": "qwen/qwen3.7-max",
+      "provider": "openrouter"
+    },
+    {
+      "name": "qwen3.7-max",
+      "model_id": "qwen/qwen3.7-max",
+      "provider": "openrouter"
+    },
+    {
+      "name": "qwen3.7-plus",
+      "model_id": "qwen/qwen3.7-plus",
+      "provider": "openrouter"
     },
     {
       "name": "small",
@@ -8165,6 +8854,11 @@ public let harnProviderCatalogJSON = #"""
       "name": "sonnet",
       "model_id": "claude-sonnet-4-6",
       "provider": "anthropic"
+    },
+    {
+      "name": "step-3.7-flash",
+      "model_id": "stepfun/step-3.7-flash",
+      "provider": "openrouter"
     },
     {
       "name": "tier/frontier",
@@ -8182,8 +8876,33 @@ public let harnProviderCatalogJSON = #"""
       "provider": "openrouter"
     },
     {
+      "name": "together-deepseek",
+      "model_id": "deepseek-ai/DeepSeek-V4-Pro",
+      "provider": "together"
+    },
+    {
+      "name": "together-deepseek-v4-pro",
+      "model_id": "deepseek-ai/DeepSeek-V4-Pro",
+      "provider": "together"
+    },
+    {
       "name": "together-gemma4-31b",
       "model_id": "google/gemma-4-31B-it",
+      "provider": "together"
+    },
+    {
+      "name": "together-glm-5.1",
+      "model_id": "zai-org/GLM-5.1",
+      "provider": "together"
+    },
+    {
+      "name": "together-minimax-m2.7",
+      "model_id": "MiniMaxAI/MiniMax-M2.7",
+      "provider": "together"
+    },
+    {
+      "name": "together-qwen3.7-max",
+      "model_id": "Qwen/Qwen3.7-Max",
       "provider": "together"
     }
   ],

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -5940,8 +5940,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       },
       "prompt_cache": true,
       "pricing": {
-        "input_per_mtok": 0.28,
-        "output_per_mtok": 0.42,
+        "input_per_mtok": 0.2288,
+        "output_per_mtok": 0.3432,
         "cache_read_per_mtok": null,
         "cache_write_per_mtok": null
       },
@@ -6018,9 +6018,9 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       },
       "prompt_cache": true,
       "pricing": {
-        "input_per_mtok": 0.0983,
-        "output_per_mtok": 0.1966,
-        "cache_read_per_mtok": 0.0197,
+        "input_per_mtok": 0.098,
+        "output_per_mtok": 0.196,
+        "cache_read_per_mtok": 0.02,
         "cache_write_per_mtok": null
       },
       "deprecation": {
@@ -6343,6 +6343,85 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "reasoning",
         "coding",
         "cheap"
+      ]
+    },
+    {
+      "id": "kwaipilot/kat-coder-pro-v2",
+      "name": "KAT-Coder-Pro V2",
+      "provider": "openrouter",
+      "aliases": [
+        "kat-coder-pro-v2",
+        "openrouter-kat-coder-pro-v2"
+      ],
+      "context_window": 256000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "interchangeable",
+        "parity_notes": "Live OpenRouter probe on 2026-06-12 returned a valid provider-native tool call for KAT-Coder-Pro V2.",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.3,
+        "output_per_mtok": 1.2,
+        "cache_read_per_mtok": 0.06,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "structured_output"
+      ],
+      "family": "openrouter",
+      "lineage": "openrouter",
+      "complementary_with": [
+        "qwen",
+        "deepseek",
+        "kimi",
+        "minimax",
+        "zai-glm"
+      ],
+      "tier": "mid",
+      "open_weight": false,
+      "strengths": [
+        "agentic",
+        "long_context",
+        "tool_use",
+        "reasoning",
+        "speed"
       ]
     },
     {
@@ -6948,11 +7027,22 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       ],
       "family": "openai-gpt",
       "lineage": "openai-legacy",
-      "tier": "mid",
-      "open_weight": true,
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": false,
       "strengths": [
-        "cheap",
-        "tool_use"
+        "agentic",
+        "coding",
+        "long_context",
+        "tool_use",
+        "reasoning",
+        "vision"
       ]
     },
     {
@@ -7024,6 +7114,253 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "benchmarks": {
         "swe_bench_verified": 67.0
       }
+    },
+    {
+      "id": "qwen/qwen3.7-max",
+      "name": "Qwen3.7 Max",
+      "provider": "openrouter",
+      "aliases": [
+        "openrouter-qwen3.7-max",
+        "qwen3.7",
+        "qwen3.7-max"
+      ],
+      "context_window": 1000000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": true,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 1.25,
+        "output_per_mtok": 3.75,
+        "cache_read_per_mtok": 0.25,
+        "cache_write_per_mtok": 1.5625
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "qwen",
+      "lineage": "qwen3",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "mid",
+      "open_weight": false,
+      "strengths": [
+        "coding",
+        "agentic",
+        "tool_use",
+        "long_context",
+        "speed"
+      ]
+    },
+    {
+      "id": "qwen/qwen3.7-plus",
+      "name": "Qwen3.7 Plus",
+      "provider": "openrouter",
+      "aliases": [
+        "openrouter-qwen3.7-plus",
+        "qwen3.7-plus"
+      ],
+      "context_window": 1000000,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": true,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.32,
+        "output_per_mtok": 1.28,
+        "cache_read_per_mtok": 0.064,
+        "cache_write_per_mtok": 0.4
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "qwen",
+      "lineage": "qwen3",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": false,
+      "strengths": [
+        "agentic",
+        "coding",
+        "long_context",
+        "tool_use",
+        "reasoning"
+      ]
+    },
+    {
+      "id": "stepfun/step-3.7-flash",
+      "name": "Step 3.7 Flash",
+      "provider": "openrouter",
+      "aliases": [
+        "openrouter-step-3.7-flash",
+        "step-3.7-flash"
+      ],
+      "context_window": 256000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "interchangeable",
+        "parity_notes": "Live OpenRouter probe on 2026-06-12 returned a valid provider-native tool call for Step 3.7 Flash with reasoning enabled.",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.2,
+        "output_per_mtok": 1.15,
+        "cache_read_per_mtok": 0.04,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "openrouter",
+      "lineage": "openrouter",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": false,
+      "strengths": [
+        "agentic",
+        "coding",
+        "long_context",
+        "tool_use",
+        "reasoning"
+      ]
     },
     {
       "id": "z-ai/glm-5",
@@ -7221,6 +7558,76 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       ]
     },
     {
+      "id": "MiniMaxAI/MiniMax-M2.7",
+      "name": "MiniMax M2.7 (Together)",
+      "provider": "together",
+      "aliases": [
+        "together-minimax-m2.7"
+      ],
+      "context_window": 196608,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.3,
+        "output_per_mtok": 1.2,
+        "cache_read_per_mtok": 0.06,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "minimax",
+      "lineage": "minimax",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "cheap",
+        "tool_use"
+      ]
+    },
+    {
       "id": "Qwen/Qwen3-Coder-Next-FP8",
       "name": "Qwen3 Coder Next FP8 (Together, dedicated)",
       "provider": "together",
@@ -7293,6 +7700,168 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       ]
     },
     {
+      "id": "Qwen/Qwen3.7-Max",
+      "name": "Qwen3.7 Max (Together)",
+      "provider": "together",
+      "aliases": [
+        "together-qwen3.7-max"
+      ],
+      "context_window": 1000000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 1.25,
+        "output_per_mtok": 3.75,
+        "cache_read_per_mtok": 0.125,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "qwen",
+      "lineage": "qwen3",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "reasoning",
+        "coding",
+        "tool_use",
+        "long_context"
+      ]
+    },
+    {
+      "id": "deepseek-ai/DeepSeek-V4-Pro",
+      "name": "DeepSeek V4 Pro (Together)",
+      "provider": "together",
+      "aliases": [
+        "together-deepseek",
+        "together-deepseek-v4-pro"
+      ],
+      "context_window": 512000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "reasoning_summary"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled",
+          "effort"
+        ],
+        "effort_supported": true,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 1.74,
+        "output_per_mtok": 3.48,
+        "cache_read_per_mtok": 0.2,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ],
+      "family": "deepseek",
+      "lineage": "deepseek",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "agentic",
+        "coding",
+        "long_context",
+        "tool_use",
+        "reasoning"
+      ]
+    },
+    {
       "id": "google/gemma-4-31B-it",
       "name": "Gemma 4 31B (Together)",
       "provider": "together",
@@ -7362,6 +7931,86 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "vision",
         "reasoning",
         "coding"
+      ]
+    },
+    {
+      "id": "zai-org/GLM-5.1",
+      "name": "GLM 5.1 (Together)",
+      "provider": "together",
+      "aliases": [
+        "together-glm-5.1"
+      ],
+      "context_window": 202752,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 1.4,
+        "output_per_mtok": 4.4,
+        "cache_read_per_mtok": 0.26,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "glm",
+      "lineage": "glm",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "agentic",
+        "coding",
+        "long_context",
+        "tool_use",
+        "reasoning"
       ]
     },
     {
@@ -7691,6 +8340,11 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "provider": "anthropic"
     },
     {
+      "name": "kat-coder-pro-v2",
+      "model_id": "kwaipilot/kat-coder-pro-v2",
+      "provider": "openrouter"
+    },
+    {
       "name": "kimi-k2.7-code",
       "model_id": "moonshotai/kimi-k2.7-code",
       "provider": "openrouter"
@@ -7883,14 +8537,49 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "provider": "openrouter"
     },
     {
+      "name": "openrouter-kat-coder-pro-v2",
+      "model_id": "kwaipilot/kat-coder-pro-v2",
+      "provider": "openrouter"
+    },
+    {
       "name": "openrouter-kimi-k2.7-code",
       "model_id": "moonshotai/kimi-k2.7-code",
+      "provider": "openrouter"
+    },
+    {
+      "name": "openrouter-qwen3.7-max",
+      "model_id": "qwen/qwen3.7-max",
+      "provider": "openrouter"
+    },
+    {
+      "name": "openrouter-qwen3.7-plus",
+      "model_id": "qwen/qwen3.7-plus",
+      "provider": "openrouter"
+    },
+    {
+      "name": "openrouter-step-3.7-flash",
+      "model_id": "stepfun/step-3.7-flash",
       "provider": "openrouter"
     },
     {
       "name": "opus",
       "model_id": "claude-opus-4-8",
       "provider": "anthropic"
+    },
+    {
+      "name": "qwen3.7",
+      "model_id": "qwen/qwen3.7-max",
+      "provider": "openrouter"
+    },
+    {
+      "name": "qwen3.7-max",
+      "model_id": "qwen/qwen3.7-max",
+      "provider": "openrouter"
+    },
+    {
+      "name": "qwen3.7-plus",
+      "model_id": "qwen/qwen3.7-plus",
+      "provider": "openrouter"
     },
     {
       "name": "small",
@@ -7901,6 +8590,11 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "name": "sonnet",
       "model_id": "claude-sonnet-4-6",
       "provider": "anthropic"
+    },
+    {
+      "name": "step-3.7-flash",
+      "model_id": "stepfun/step-3.7-flash",
+      "provider": "openrouter"
     },
     {
       "name": "tier/frontier",
@@ -7918,8 +8612,33 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "provider": "openrouter"
     },
     {
+      "name": "together-deepseek",
+      "model_id": "deepseek-ai/DeepSeek-V4-Pro",
+      "provider": "together"
+    },
+    {
+      "name": "together-deepseek-v4-pro",
+      "model_id": "deepseek-ai/DeepSeek-V4-Pro",
+      "provider": "together"
+    },
+    {
       "name": "together-gemma4-31b",
       "model_id": "google/gemma-4-31B-it",
+      "provider": "together"
+    },
+    {
+      "name": "together-glm-5.1",
+      "model_id": "zai-org/GLM-5.1",
+      "provider": "together"
+    },
+    {
+      "name": "together-minimax-m2.7",
+      "model_id": "MiniMaxAI/MiniMax-M2.7",
+      "provider": "together"
+    },
+    {
+      "name": "together-qwen3.7-max",
+      "model_id": "Qwen/Qwen3.7-Max",
       "provider": "together"
     }
   ],

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -5686,8 +5686,8 @@
       },
       "prompt_cache": true,
       "pricing": {
-        "input_per_mtok": 0.28,
-        "output_per_mtok": 0.42,
+        "input_per_mtok": 0.2288,
+        "output_per_mtok": 0.3432,
         "cache_read_per_mtok": null,
         "cache_write_per_mtok": null
       },
@@ -5764,9 +5764,9 @@
       },
       "prompt_cache": true,
       "pricing": {
-        "input_per_mtok": 0.0983,
-        "output_per_mtok": 0.1966,
-        "cache_read_per_mtok": 0.0197,
+        "input_per_mtok": 0.098,
+        "output_per_mtok": 0.196,
+        "cache_read_per_mtok": 0.02,
         "cache_write_per_mtok": null
       },
       "deprecation": {
@@ -6089,6 +6089,85 @@
         "reasoning",
         "coding",
         "cheap"
+      ]
+    },
+    {
+      "id": "kwaipilot/kat-coder-pro-v2",
+      "name": "KAT-Coder-Pro V2",
+      "provider": "openrouter",
+      "aliases": [
+        "kat-coder-pro-v2",
+        "openrouter-kat-coder-pro-v2"
+      ],
+      "context_window": 256000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "interchangeable",
+        "parity_notes": "Live OpenRouter probe on 2026-06-12 returned a valid provider-native tool call for KAT-Coder-Pro V2.",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.3,
+        "output_per_mtok": 1.2,
+        "cache_read_per_mtok": 0.06,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "structured_output"
+      ],
+      "family": "openrouter",
+      "lineage": "openrouter",
+      "complementary_with": [
+        "qwen",
+        "deepseek",
+        "kimi",
+        "minimax",
+        "zai-glm"
+      ],
+      "tier": "mid",
+      "open_weight": false,
+      "strengths": [
+        "agentic",
+        "long_context",
+        "tool_use",
+        "reasoning",
+        "speed"
       ]
     },
     {
@@ -6694,11 +6773,22 @@
       ],
       "family": "openai-gpt",
       "lineage": "openai-legacy",
-      "tier": "mid",
-      "open_weight": true,
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": false,
       "strengths": [
-        "cheap",
-        "tool_use"
+        "agentic",
+        "coding",
+        "long_context",
+        "tool_use",
+        "reasoning",
+        "vision"
       ]
     },
     {
@@ -6770,6 +6860,253 @@
       "benchmarks": {
         "swe_bench_verified": 67.0
       }
+    },
+    {
+      "id": "qwen/qwen3.7-max",
+      "name": "Qwen3.7 Max",
+      "provider": "openrouter",
+      "aliases": [
+        "openrouter-qwen3.7-max",
+        "qwen3.7",
+        "qwen3.7-max"
+      ],
+      "context_window": 1000000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": true,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 1.25,
+        "output_per_mtok": 3.75,
+        "cache_read_per_mtok": 0.25,
+        "cache_write_per_mtok": 1.5625
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "qwen",
+      "lineage": "qwen3",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "mid",
+      "open_weight": false,
+      "strengths": [
+        "coding",
+        "agentic",
+        "tool_use",
+        "long_context",
+        "speed"
+      ]
+    },
+    {
+      "id": "qwen/qwen3.7-plus",
+      "name": "Qwen3.7 Plus",
+      "provider": "openrouter",
+      "aliases": [
+        "openrouter-qwen3.7-plus",
+        "qwen3.7-plus"
+      ],
+      "context_window": 1000000,
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": true,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.32,
+        "output_per_mtok": 1.28,
+        "cache_read_per_mtok": 0.064,
+        "cache_write_per_mtok": 0.4
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "qwen",
+      "lineage": "qwen3",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": false,
+      "strengths": [
+        "agentic",
+        "coding",
+        "long_context",
+        "tool_use",
+        "reasoning"
+      ]
+    },
+    {
+      "id": "stepfun/step-3.7-flash",
+      "name": "Step 3.7 Flash",
+      "provider": "openrouter",
+      "aliases": [
+        "openrouter-step-3.7-flash",
+        "step-3.7-flash"
+      ],
+      "context_window": 256000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "interchangeable",
+        "parity_notes": "Live OpenRouter probe on 2026-06-12 returned a valid provider-native tool call for Step 3.7 Flash with reasoning enabled.",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.2,
+        "output_per_mtok": 1.15,
+        "cache_read_per_mtok": 0.04,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "openrouter",
+      "lineage": "openrouter",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": false,
+      "strengths": [
+        "agentic",
+        "coding",
+        "long_context",
+        "tool_use",
+        "reasoning"
+      ]
     },
     {
       "id": "z-ai/glm-5",
@@ -6967,6 +7304,76 @@
       ]
     },
     {
+      "id": "MiniMaxAI/MiniMax-M2.7",
+      "name": "MiniMax M2.7 (Together)",
+      "provider": "together",
+      "aliases": [
+        "together-minimax-m2.7"
+      ],
+      "context_window": 196608,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.3,
+        "output_per_mtok": 1.2,
+        "cache_read_per_mtok": 0.06,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "minimax",
+      "lineage": "minimax",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "cheap",
+        "tool_use"
+      ]
+    },
+    {
       "id": "Qwen/Qwen3-Coder-Next-FP8",
       "name": "Qwen3 Coder Next FP8 (Together, dedicated)",
       "provider": "together",
@@ -7039,6 +7446,168 @@
       ]
     },
     {
+      "id": "Qwen/Qwen3.7-Max",
+      "name": "Qwen3.7 Max (Together)",
+      "provider": "together",
+      "aliases": [
+        "together-qwen3.7-max"
+      ],
+      "context_window": 1000000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 1.25,
+        "output_per_mtok": 3.75,
+        "cache_read_per_mtok": 0.125,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "qwen",
+      "lineage": "qwen3",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "reasoning",
+        "coding",
+        "tool_use",
+        "long_context"
+      ]
+    },
+    {
+      "id": "deepseek-ai/DeepSeek-V4-Pro",
+      "name": "DeepSeek V4 Pro (Together)",
+      "provider": "together",
+      "aliases": [
+        "together-deepseek",
+        "together-deepseek-v4-pro"
+      ],
+      "context_window": 512000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "reasoning_summary"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled",
+          "effort"
+        ],
+        "effort_supported": true,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 1.74,
+        "output_per_mtok": 3.48,
+        "cache_read_per_mtok": 0.2,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "extended_thinking",
+        "structured_output"
+      ],
+      "family": "deepseek",
+      "lineage": "deepseek",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "agentic",
+        "coding",
+        "long_context",
+        "tool_use",
+        "reasoning"
+      ]
+    },
+    {
       "id": "google/gemma-4-31B-it",
       "name": "Gemma 4 31B (Together)",
       "provider": "together",
@@ -7108,6 +7677,86 @@
         "vision",
         "reasoning",
         "coding"
+      ]
+    },
+    {
+      "id": "zai-org/GLM-5.1",
+      "name": "GLM 5.1 (Together)",
+      "provider": "together",
+      "aliases": [
+        "together-glm-5.1"
+      ],
+      "context_window": 202752,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 1.4,
+        "output_per_mtok": 4.4,
+        "cache_read_per_mtok": 0.26,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "glm",
+      "lineage": "glm",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "agentic",
+        "coding",
+        "long_context",
+        "tool_use",
+        "reasoning"
       ]
     },
     {
@@ -7437,6 +8086,11 @@
       "provider": "anthropic"
     },
     {
+      "name": "kat-coder-pro-v2",
+      "model_id": "kwaipilot/kat-coder-pro-v2",
+      "provider": "openrouter"
+    },
+    {
       "name": "kimi-k2.7-code",
       "model_id": "moonshotai/kimi-k2.7-code",
       "provider": "openrouter"
@@ -7629,14 +8283,49 @@
       "provider": "openrouter"
     },
     {
+      "name": "openrouter-kat-coder-pro-v2",
+      "model_id": "kwaipilot/kat-coder-pro-v2",
+      "provider": "openrouter"
+    },
+    {
       "name": "openrouter-kimi-k2.7-code",
       "model_id": "moonshotai/kimi-k2.7-code",
+      "provider": "openrouter"
+    },
+    {
+      "name": "openrouter-qwen3.7-max",
+      "model_id": "qwen/qwen3.7-max",
+      "provider": "openrouter"
+    },
+    {
+      "name": "openrouter-qwen3.7-plus",
+      "model_id": "qwen/qwen3.7-plus",
+      "provider": "openrouter"
+    },
+    {
+      "name": "openrouter-step-3.7-flash",
+      "model_id": "stepfun/step-3.7-flash",
       "provider": "openrouter"
     },
     {
       "name": "opus",
       "model_id": "claude-opus-4-8",
       "provider": "anthropic"
+    },
+    {
+      "name": "qwen3.7",
+      "model_id": "qwen/qwen3.7-max",
+      "provider": "openrouter"
+    },
+    {
+      "name": "qwen3.7-max",
+      "model_id": "qwen/qwen3.7-max",
+      "provider": "openrouter"
+    },
+    {
+      "name": "qwen3.7-plus",
+      "model_id": "qwen/qwen3.7-plus",
+      "provider": "openrouter"
     },
     {
       "name": "small",
@@ -7647,6 +8336,11 @@
       "name": "sonnet",
       "model_id": "claude-sonnet-4-6",
       "provider": "anthropic"
+    },
+    {
+      "name": "step-3.7-flash",
+      "model_id": "stepfun/step-3.7-flash",
+      "provider": "openrouter"
     },
     {
       "name": "tier/frontier",
@@ -7664,8 +8358,33 @@
       "provider": "openrouter"
     },
     {
+      "name": "together-deepseek",
+      "model_id": "deepseek-ai/DeepSeek-V4-Pro",
+      "provider": "together"
+    },
+    {
+      "name": "together-deepseek-v4-pro",
+      "model_id": "deepseek-ai/DeepSeek-V4-Pro",
+      "provider": "together"
+    },
+    {
       "name": "together-gemma4-31b",
       "model_id": "google/gemma-4-31B-it",
+      "provider": "together"
+    },
+    {
+      "name": "together-glm-5.1",
+      "model_id": "zai-org/GLM-5.1",
+      "provider": "together"
+    },
+    {
+      "name": "together-minimax-m2.7",
+      "model_id": "MiniMaxAI/MiniMax-M2.7",
+      "provider": "together"
+    },
+    {
+      "name": "together-qwen3.7-max",
+      "model_id": "Qwen/Qwen3.7-Max",
       "provider": "together"
     }
   ],


### PR DESCRIPTION
## Summary
- add current OpenRouter/Together frontier routes for Qwen 3.7, KAT-Coder-Pro V2, Step 3.7 Flash, Together DeepSeek V4 Pro, Together GLM 5.1, and Together MiniMax M2.7
- encode provider quirks for streaming-only Qwen 3.7, mandatory-reasoning Step 3.7, and MiniMax private reasoning handling
- refresh generated provider catalog/matrix artifacts and DeepSeek OpenRouter pricing

## Validation
- cargo fmt --all --check
- git diff --check
- cargo test -p harn-vm normalize_openai_message_text_can_keep_reasoning_private_without_content --lib -j1
- cargo test -p harn-vm openrouter_mandatory_reasoning_model_omits_unsupported_disable --lib -j1
- cargo test -p harn-vm qwen37_routes_record_prompt_cache_vision_and_streaming_quirks --lib -j1
- cargo run --quiet --bin harn -- test conformance --filter provider_capabilities_basic
- make check-provider-capabilities check-provider-catalog check-provider-matrix check-provider-support
- live Harn route smoke using OpenRouter/Together keys from ~/projects/burin-code/.env