### PR TITLE
catalog: fix MiniMax M2.7 OR pricing + add M2.5 mirror; pin OR capability precedence

### DIFF
--- a/changelog.d/catalog-or-defaults.changed.md
+++ b/changelog.d/catalog-or-defaults.changed.md
@@ -1,0 +1,5 @@
+- Corrected the MiniMax M2.7 OpenRouter mirror price to the current
+  $0.25/Mtok input / $1.00/Mtok output, and added the MiniMax M2.5 OpenRouter
+  mirror (`minimax/minimax-m2.5`, 205K context, tools/streaming). The M2.5
+  mirror inherits native-tool capabilities from the existing
+  `minimax/minimax-m2*` capability rule, so no new capability row was needed.

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -2342,6 +2342,52 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
     }
 
     #[test]
+    fn openrouter_specific_rules_win_and_family_inheritance_is_preserved() {
+        // Capability resolution is first-match-wins over fragment order
+        // (`first_matching_rule_in_file` -> `Iterator::find`), and when no
+        // `provider.openrouter` rule matches it walks the `[provider_family]`
+        // chain (openrouter -> openai). Both contracts must hold so that:
+        //   1. a specific OpenRouter carve-out beats a broader OpenRouter rule,
+        //   2. gpt-/o-family slugs routed through OpenRouter still inherit the
+        //      rich openai-family capability set (a blanket `*` openrouter row
+        //      would shadow this — see the catalog-or-defaults report).
+        reset();
+
+        // 1. Specific carve-out wins: deepseek/deepseek-v3.2 is pinned to the
+        // Harn text-tool channel even though the broader deepseek/deepseek-v3*
+        // rule below it would otherwise resolve `native`.
+        let deepseek = lookup("openrouter", "deepseek/deepseek-v3.2");
+        assert_eq!(
+            deepseek.preferred_tool_format.as_deref(),
+            Some("text"),
+            "deepseek-v3.2 text carve-out must win over the broader deepseek-v3* rule"
+        );
+        assert_eq!(
+            deepseek.tool_mode_parity.as_deref(),
+            Some("native_unreliable")
+        );
+        // The broader sibling still resolves native for non-3.2 v3 slugs.
+        assert_eq!(
+            lookup("openrouter", "deepseek/deepseek-v3-base")
+                .preferred_tool_format
+                .as_deref(),
+            Some("native")
+        );
+
+        // 2. Family inheritance preserved: an openai-prefixed slug routed via
+        // OpenRouter still picks up openai-family reasoning fields.
+        let prefixed = lookup("openrouter", "openai/o4-mini");
+        assert!(prefixed.requires_completion_tokens);
+        assert!(prefixed.reasoning_effort_supported);
+
+        // The newly added MiniMax M2.5 OR mirror resolves native via the
+        // existing `minimax/minimax-m2*` rule.
+        let m25 = lookup("openrouter", "minimax/minimax-m2.5");
+        assert!(m25.native_tools);
+        assert_eq!(m25.preferred_tool_format.as_deref(), Some("native"));
+    }
+
+    #[test]
     fn enterprise_routes_expose_format_preferences() {
         reset();
         let bedrock_claude = lookup("bedrock", "anthropic.claude-opus-4-7-v1:0");

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/40-minimax.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/40-minimax.toml
@@ -107,10 +107,19 @@ name = "MiniMax M2.7 (via OpenRouter)"
 provider = "openrouter"
 context_window = 204800
 capabilities = ["tools", "streaming"]
-pricing = { input_per_mtok = 0.40, output_per_mtok = 1.50 }
+pricing = { input_per_mtok = 0.25, output_per_mtok = 1.00 }
 tier = "frontier"
 open_weight = true
 strengths = ["coding", "agentic", "tool_use", "reasoning", "long_context"]
+[models."minimax/minimax-m2.5"]
+name = "MiniMax M2.5 (via OpenRouter)"
+provider = "openrouter"
+context_window = 205000
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 0.15, output_per_mtok = 0.90 }
+tier = "frontier"
+open_weight = true
+strengths = ["coding", "agentic", "tool_use", "long_context"]
 [models."minimax/minimax-m2"]
 name = "MiniMax M2 (via OpenRouter)"
 provider = "openrouter"

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -1763,10 +1763,19 @@ name = "MiniMax M2.7 (via OpenRouter)"
 provider = "openrouter"
 context_window = 204800
 capabilities = ["tools", "streaming"]
-pricing = { input_per_mtok = 0.40, output_per_mtok = 1.50 }
+pricing = { input_per_mtok = 0.25, output_per_mtok = 1.00 }
 tier = "frontier"
 open_weight = true
 strengths = ["coding", "agentic", "tool_use", "reasoning", "long_context"]
+[models."minimax/minimax-m2.5"]
+name = "MiniMax M2.5 (via OpenRouter)"
+provider = "openrouter"
+context_window = 205000
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 0.15, output_per_mtok = 0.90 }
+tier = "frontier"
+open_weight = true
+strengths = ["coding", "agentic", "tool_use", "long_context"]
 [models."minimax/minimax-m2"]
 name = "MiniMax M2 (via OpenRouter)"
 provider = "openrouter"

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -239,6 +239,7 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `openrouter` | `google/gemma-4-31b-it` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `kwaipilot/kat-coder-pro-v2` | `native` | `interchangeable` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `minimax/minimax-m2` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `openrouter` | `minimax/minimax-m2.5` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `minimax/minimax-m2.7` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `minimax/minimax-m3` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `mistralai/mistral-large-2512` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -6754,6 +6754,72 @@ public let harnProviderCatalogJSON = #"""
       ]
     },
     {
+      "id": "minimax/minimax-m2.5",
+      "name": "MiniMax M2.5 (via OpenRouter)",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 205000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "delimited",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "none",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.15,
+        "output_per_mtok": 0.9,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "structured_output"
+      ],
+      "family": "minimax",
+      "lineage": "minimax",
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "coding",
+        "agentic",
+        "tool_use",
+        "long_context"
+      ]
+    },
+    {
       "id": "minimax/minimax-m2.7",
       "name": "MiniMax M2.7 (via OpenRouter)",
       "provider": "openrouter",
@@ -6793,8 +6859,8 @@ public let harnProviderCatalogJSON = #"""
       },
       "prompt_cache": false,
       "pricing": {
-        "input_per_mtok": 0.4,
-        "output_per_mtok": 1.5,
+        "input_per_mtok": 0.25,
+        "output_per_mtok": 1.0,
         "cache_read_per_mtok": null,
         "cache_write_per_mtok": null
       },

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -6490,6 +6490,72 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       ]
     },
     {
+      "id": "minimax/minimax-m2.5",
+      "name": "MiniMax M2.5 (via OpenRouter)",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 205000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "delimited",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "none",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.15,
+        "output_per_mtok": 0.9,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "structured_output"
+      ],
+      "family": "minimax",
+      "lineage": "minimax",
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "coding",
+        "agentic",
+        "tool_use",
+        "long_context"
+      ]
+    },
+    {
       "id": "minimax/minimax-m2.7",
       "name": "MiniMax M2.7 (via OpenRouter)",
       "provider": "openrouter",
@@ -6529,8 +6595,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       },
       "prompt_cache": false,
       "pricing": {
-        "input_per_mtok": 0.4,
-        "output_per_mtok": 1.5,
+        "input_per_mtok": 0.25,
+        "output_per_mtok": 1.0,
         "cache_read_per_mtok": null,
         "cache_write_per_mtok": null
       },

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -6236,6 +6236,72 @@
       ]
     },
     {
+      "id": "minimax/minimax-m2.5",
+      "name": "MiniMax M2.5 (via OpenRouter)",
+      "provider": "openrouter",
+      "aliases": [],
+      "context_window": 205000,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "delimited",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "none",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.15,
+        "output_per_mtok": 0.9,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "structured_output"
+      ],
+      "family": "minimax",
+      "lineage": "minimax",
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "coding",
+        "agentic",
+        "tool_use",
+        "long_context"
+      ]
+    },
+    {
       "id": "minimax/minimax-m2.7",
       "name": "MiniMax M2.7 (via OpenRouter)",
       "provider": "openrouter",
@@ -6275,8 +6341,8 @@
       },
       "prompt_cache": false,
       "pricing": {
-        "input_per_mtok": 0.4,
-        "output_per_mtok": 1.5,
+        "input_per_mtok": 0.25,
+        "output_per_mtok": 1.0,
         "cache_read_per_mtok": null,
         "cache_write_per_mtok": null
       },


### PR DESCRIPTION
## What
Small, verified catalog corrections ahead of v0.8.106, plus a regression test pinning OpenRouter capability precedence.

- **MiniMax M2.7 (OpenRouter mirror)** repriced $0.40/$1.50 → **$0.25/$1.00** per Mtok (current OpenRouter price).
- **Added MiniMax M2.5 (OpenRouter mirror)** — `minimax/minimax-m2.5`, 205K ctx, `["tools","streaming"]`, $0.15/$0.90. Resolves `native_tools=true, preferred_format="native"` via the existing `minimax/minimax-m2*` rule (no new capability row needed).
- **New test** `openrouter_specific_rules_win_and_family_inheritance_is_preserved` pinning the two contracts the catalog depends on.

## Investigated and intentionally NOT landed: a blanket `model_match="*"` OpenRouter default
A wildcard OR capability row to "kill per-slug boilerplate" **regresses real behavior** in this engine and was correctly rejected:
- Precedence is first-matching-rule-in-fragment-order, and a provider's own rule list is consulted *before* the `provider_family` (openrouter→openai) fallback (`capabilities.rs:900-936`). A `*` OR row short-circuits the openai-family inheritance that OR-routed `gpt-*`/`o*`/`openai/*` slugs rely on.
- Empirically broke 3 existing tests (gpt-5.4 `defer_loading`/`tool_search`, o4-mini `requires_completion_tokens`, the deepseek distill-slug native=false contract). Globs can't express "not openai/*".
- `audit_tool_capability_coverage` already passes with **zero** wildcard (25/26 priced OR models have explicit rows; only gpt-oss-120b uses family inheritance, deliberately `json`). So no wildcard is needed; the per-slug friction is documented, not a coverage bug.

## Verify
`harn providers build-config`/`build-capabilities`/`export` clean; `validate --check-artifacts` OK; `cargo test -p harn-vm --lib llm::capabilities` → **57 passed, 0 failed** (incl. the coverage audit + the new precedence test). Generated artifacts regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)