### PR TITLE
feat(llm): machine-readable fallback_code on complementary_reviewer (#3280)

### DIFF
--- a/changelog.d/3280.added.md
+++ b/changelog.d/3280.added.md
@@ -1,0 +1,5 @@
+- `complementary_reviewer` now returns a stable, machine-readable `fallback_code` whenever it falls back to the
+  author model — one of `unknown_author_family`, `no_diff_family_within_price`, `no_diff_family_serverless`, or
+  `all_diff_family_excluded` (absent on the success path). Callers that require a structurally independent reviewer
+  can branch on `fallback` + `fallback_code` to hard-fail a degraded self-review instead of parsing the
+  human-readable `reason`/`fallback_reason` prose.

--- a/crates/harn-stdlib/src/stdlib/llm/catalog.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/catalog.harn
@@ -130,6 +130,18 @@ pub fn lineage_of(model_id) {
  * Options: `{author_model, author_provider?, intent?, max_price_multiplier?}`.
  * `intent` is `"review"`, `"critique"`, or `"plan_review"`.
  *
+ * Returns `{intent, author, reviewer, fallback, reason, ...}`. When no priced
+ * different-family reviewer is available the selector does NOT fail; it returns
+ * `fallback == true` with `reviewer == author` (self-review). A caller that
+ * needs structural independence must check `fallback` and refuse to proceed,
+ * branching on the machine-readable `fallback_code` rather than parsing the
+ * human-readable `reason`/`fallback_reason`. `fallback_code` is one of:
+ *   - `"unknown_author_family"`       — author family unresolved
+ *   - `"no_diff_family_within_price"` — a peer exists but exceeds max_price_multiplier
+ *   - `"no_diff_family_serverless"`   — no active serverless cross-family peer cataloged
+ *   - `"all_diff_family_excluded"`    — peers exist but were all excluded
+ * It is absent on the success path (`fallback == false`).
+ *
  * @effects: []
  * @errors: ["llm_complementary_reviewer: ..."]
  * @api_stability: experimental

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -935,8 +935,44 @@ pub struct ComplementaryReviewerSelection {
     pub reviewer: ComplementaryModelIdentity,
     pub fallback: bool,
     pub fallback_reason: Option<String>,
+    /// Machine-readable reason a caller can branch on when `fallback` is
+    /// `true`, distinct from the human-readable `fallback_reason`/`reason`
+    /// prose. `None` on the success path. Lets a caller hard-fail an
+    /// independent-review step rather than silently degrade to self-review.
+    /// See [`ReviewerFallbackCode`] for the stable set of values.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_code: Option<String>,
     pub reason: String,
     pub estimated_incremental_cost: Option<ComplementaryCostEstimate>,
+}
+
+/// Stable, machine-readable reasons `pick_complementary_reviewer` falls back
+/// to the author model. Serialized as the `fallback_code` string so harn
+/// pipelines and Rust callers can branch deterministically instead of parsing
+/// prose. New variants are additive; existing codes are append-only contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReviewerFallbackCode {
+    /// The author model's family could not be resolved, so no independent
+    /// family comparison is possible.
+    UnknownAuthorFamily,
+    /// Different-family candidates exist but none satisfy `max_price_multiplier`.
+    NoDiffFamilyWithinPrice,
+    /// No active, serverless, different-family reviewer is cataloged at all.
+    NoDiffFamilyServerless,
+    /// Different-family candidates exist but were all excluded (e.g. every
+    /// one declares `avoid_as_reviewer_for` the author).
+    AllDiffFamilyExcluded,
+}
+
+impl ReviewerFallbackCode {
+    pub fn as_code(self) -> &'static str {
+        match self {
+            Self::UnknownAuthorFamily => "unknown_author_family",
+            Self::NoDiffFamilyWithinPrice => "no_diff_family_within_price",
+            Self::NoDiffFamilyServerless => "no_diff_family_serverless",
+            Self::AllDiffFamilyExcluded => "all_diff_family_excluded",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -2244,24 +2280,29 @@ pub fn pick_complementary_reviewer(
         author_entry.and_then(|model| model.pricing.clone()),
     );
 
-    let fallback = |fallback_reason: String| ComplementaryReviewerSelection {
-        intent: options.intent.as_str().to_string(),
-        reviewer: author_identity.clone(),
-        estimated_incremental_cost: cost_estimate(
-            author_identity.pricing.as_ref(),
-            author_identity.pricing.as_ref(),
-        ),
-        author: author_identity.clone(),
-        fallback: true,
-        reason: format!(
-            "using author model {} because {fallback_reason}",
-            author_identity.id
-        ),
-        fallback_reason: Some(fallback_reason),
-    };
+    let fallback =
+        |code: ReviewerFallbackCode, fallback_reason: String| ComplementaryReviewerSelection {
+            intent: options.intent.as_str().to_string(),
+            reviewer: author_identity.clone(),
+            estimated_incremental_cost: cost_estimate(
+                author_identity.pricing.as_ref(),
+                author_identity.pricing.as_ref(),
+            ),
+            author: author_identity.clone(),
+            fallback: true,
+            reason: format!(
+                "using author model {} because {fallback_reason}",
+                author_identity.id
+            ),
+            fallback_reason: Some(fallback_reason),
+            fallback_code: Some(code.as_code().to_string()),
+        };
 
     if author_identity.family == "unknown" {
-        return fallback("author model family is unknown".to_string());
+        return fallback(
+            ReviewerFallbackCode::UnknownAuthorFamily,
+            "author model family is unknown".to_string(),
+        );
     }
 
     let preferred_families = author_entry
@@ -2333,16 +2374,21 @@ pub fn pick_complementary_reviewer(
     let Some(best) = candidates.into_iter().next() else {
         if rejected_by_price > 0 {
             let cap = options.max_price_multiplier.unwrap_or_default();
-            return fallback(format!(
-                "no different-family reviewer satisfied max_price_multiplier {cap}"
-            ));
+            return fallback(
+                ReviewerFallbackCode::NoDiffFamilyWithinPrice,
+                format!("no different-family reviewer satisfied max_price_multiplier {cap}"),
+            );
         }
         if diff_family_seen == 0 {
             return fallback(
+                ReviewerFallbackCode::NoDiffFamilyServerless,
                 "no active serverless different-family reviewer is cataloged".to_string(),
             );
         }
-        return fallback("all different-family reviewer candidates were excluded".to_string());
+        return fallback(
+            ReviewerFallbackCode::AllDiffFamilyExcluded,
+            "all different-family reviewer candidates were excluded".to_string(),
+        );
     };
 
     let estimate = cost_estimate(
@@ -2357,6 +2403,7 @@ pub fn pick_complementary_reviewer(
         reviewer: best.identity,
         fallback: false,
         fallback_reason: None,
+        fallback_code: None,
     }
 }
 
@@ -2900,6 +2947,9 @@ mod tests {
         assert_ne!(selection.reviewer.family, selection.author.family);
         assert_eq!(selection.reviewer.tier, "frontier");
         assert!(selection.estimated_incremental_cost.is_some());
+        // Success path carries no machine-readable fallback code, so a caller
+        // can treat `fallback_code.is_some()` as "must not self-review".
+        assert_eq!(selection.fallback_code, None, "{selection:?}");
     }
 
     #[test]
@@ -2918,6 +2968,40 @@ mod tests {
             .fallback_reason
             .as_deref()
             .is_some_and(|reason| reason.contains("max_price_multiplier")));
+        // The machine-readable code is stable regardless of the prose; a caller
+        // hard-fails an independent-review step by branching on this, never by
+        // parsing `fallback_reason`.
+        assert_eq!(
+            selection.fallback_code.as_deref(),
+            Some(ReviewerFallbackCode::NoDiffFamilyWithinPrice.as_code()),
+            "{selection:?}"
+        );
+        assert_eq!(
+            ReviewerFallbackCode::NoDiffFamilyWithinPrice.as_code(),
+            "no_diff_family_within_price"
+        );
+    }
+
+    #[test]
+    fn test_reviewer_fallback_codes_are_stable_strings() {
+        // Append-only contract: harn pipelines and Rust callers branch on these
+        // exact strings, so changing one is a breaking change.
+        assert_eq!(
+            ReviewerFallbackCode::UnknownAuthorFamily.as_code(),
+            "unknown_author_family"
+        );
+        assert_eq!(
+            ReviewerFallbackCode::NoDiffFamilyWithinPrice.as_code(),
+            "no_diff_family_within_price"
+        );
+        assert_eq!(
+            ReviewerFallbackCode::NoDiffFamilyServerless.as_code(),
+            "no_diff_family_serverless"
+        );
+        assert_eq!(
+            ReviewerFallbackCode::AllDiffFamilyExcluded.as_code(),
+            "all_diff_family_excluded"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #3280.

## What

`pick_complementary_reviewer` already returned `fallback: bool` + a human-readable `fallback_reason`, but a caller could not branch deterministically on *why* the selector degraded to self-review without parsing prose. This adds a stable, machine-readable `fallback_code`:

- `unknown_author_family` — author family unresolved
- `no_diff_family_within_price` — a peer exists but exceeds `max_price_multiplier`
- `no_diff_family_serverless` — no active serverless cross-family peer cataloged
- `all_diff_family_excluded` — peers exist but were all excluded

It is `None`/absent on the success path. Surfaced through the serde-derived `llm_complementary_reviewer` builtin (no builtin-signature change) and documented in `catalog.harn`'s `complementary_reviewer`.

## Why

Lets a downstream private host that routes a second, independent reviewer model assert **structural independence** (reviewer family != author family) and hard-fail / disable a degraded review step, rather than silently degrading to self-review when the local catalog has no priced cross-family peer.

## Tests

- success path → `fallback_code == None`
- price-cap fallback → `no_diff_family_within_price`
- `ReviewerFallbackCode::as_code()` strings are append-only stable contract

`cargo test -p harn-vm --lib reviewer` (3 pass), `cargo clippy -p harn-vm` clean, `cargo fmt --check` clean, builtin-registry-alignment unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)