### PR TITLE
Skip binary files in rules hostlib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2690,6 +2690,7 @@ dependencies = [
  "harn-rules",
  "harn-vm",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/changelog.d/2257.fixed.md
+++ b/changelog.d/2257.fixed.md
@@ -1,0 +1,3 @@
+- `rules.search` and related path-based rule builtins now skip non-UTF8 files
+  such as `.DS_Store` instead of failing the whole run; scanner tests also pin
+  Scala sealed-trait symbol discovery.

--- a/crates/harn-hostlib/src/scanner/symbols.rs
+++ b/crates/harn-hostlib/src/scanner/symbols.rs
@@ -468,6 +468,16 @@ mod tests {
     }
 
     #[test]
+    fn extracts_scala_sealed_trait_symbol() {
+        let src = "package rulekit\n\nsealed trait Rule:\n  def name: String\n";
+        let symbols = extract_symbols(src, "scala", "Rule.scala");
+        assert!(
+            symbols.iter().any(|s| s.name == "Rule"),
+            "expected sealed trait Rule to be indexed, got {symbols:?}"
+        );
+    }
+
+    #[test]
     fn ids_are_stable_per_file_name_line() {
         let src = "fn one() {}\nfn two() {}\n";
         let symbols = extract_symbols(src, "rs", "lib.rs");

--- a/crates/harn-rules-hostlib/Cargo.toml
+++ b/crates/harn-rules-hostlib/Cargo.toml
@@ -20,5 +20,8 @@ harn-lint = { path = "../harn-lint", version = "0.8" }
 harn-parser = { path = "../harn-parser", version = "0.8" }
 serde_json = "1"
 
+[dev-dependencies]
+tempfile = "3"
+
 [lints]
 workspace = true

--- a/crates/harn-rules-hostlib/src/lib.rs
+++ b/crates/harn-rules-hostlib/src/lib.rs
@@ -459,8 +459,8 @@ fn compile_rule(
 }
 
 /// Load the fileset: inline `source` (+ `language`) for a single buffer, or
-/// `paths` read from disk (language inferred per file; undetectable files
-/// are skipped).
+/// `paths` read from disk (language inferred per file; non-UTF8 and
+/// undetectable files are skipped).
 fn load_files(
     builtin: &'static str,
     dict: &BTreeMap<String, VmValue>,
@@ -490,10 +490,13 @@ fn load_files(
     }
     let mut files = Vec::new();
     for path in paths {
-        let contents = std::fs::read_to_string(&path).map_err(|e| HostlibError::Backend {
+        let bytes = std::fs::read(&path).map_err(|e| HostlibError::Backend {
             builtin,
             message: format!("read `{path}`: {e}"),
         })?;
+        let Ok(contents) = String::from_utf8(bytes) else {
+            continue;
+        };
         if let Some(file) = SourceFile::detect(&path, contents) {
             files.push(file);
         }
@@ -874,6 +877,37 @@ mod tests {
             _ => panic!(),
         };
         assert_eq!(s(get(get(&matches[0], "captures"), "FN")), "foo");
+    }
+
+    #[test]
+    fn search_skips_non_utf8_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join("calls.ts");
+        let binary_path = dir.path().join(".DS_Store");
+        std::fs::write(&source_path, b"foo();\n").unwrap();
+        std::fs::write(&binary_path, [0xff, 0xfe, 0xfd]).unwrap();
+
+        let result = search_run(&[dict(&[
+            ("rule", str_vm(SEARCH_RULE)),
+            (
+                "paths",
+                VmValue::List(Arc::new(vec![
+                    str_vm(source_path.display().to_string()),
+                    str_vm(binary_path.display().to_string()),
+                ])),
+            ),
+        ])])
+        .unwrap();
+
+        assert_eq!(int(get(&result, "match_count")), 1);
+        let matches = match get(&result, "matches") {
+            VmValue::List(l) => l.clone(),
+            _ => panic!(),
+        };
+        assert_eq!(
+            s(get(&matches[0], "path")),
+            source_path.display().to_string()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- skip non-UTF8 files in path-based `rules.*` hostlib loading so binary files like `.DS_Store` do not fail the whole run
- add a public `rules.search(paths: ...)` regression for binary-file skips
- add a scanner regression pinning Scala `sealed trait Rule` symbol discovery

## Verification
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/Users/ksinder/.codex/worktrees/41d7/target-harn-2257 cargo test -p harn-rules-hostlib search_skips_non_utf8_paths`
- `CARGO_TARGET_DIR=/Users/ksinder/.codex/worktrees/41d7/target-harn-2257 cargo test -p harn-hostlib extracts_scala_sealed_trait_symbol --lib`
- `CARGO_TARGET_DIR=/Users/ksinder/.codex/worktrees/41d7/target-harn-2257 cargo test -p harn-rules-hostlib`
- `CARGO_TARGET_DIR=/Users/ksinder/.codex/worktrees/41d7/target-harn-2257 cargo test -p harn-hostlib scanner::symbols --lib`
- pre-commit hook: markdownlint, rustfmt, prompt-prose self-test, full-workspace clippy
- pre-push hook: markdownlint and targeted local Rust checks
