### PR TITLE
refactor: VmValue::string + VmDictExt dict-builder sweep (−2,748 LoC, no behavior change)

### DIFF
--- a/crates/harn-cli/src/skill_loader.rs
+++ b/crates/harn-cli/src/skill_loader.rs
@@ -8,6 +8,7 @@
 //! scripts can call `skill_count(skills)` / `skill_find(skills, name)`
 //! without any new language surface.
 
+use harn_vm::VmDictExt;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -178,10 +179,7 @@ pub fn load_skills(inputs: &SkillLoaderInputs) -> LoadedSkills {
         .collect();
 
     let mut registry: BTreeMap<String, VmValue> = BTreeMap::new();
-    registry.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from("skill_registry")),
-    );
+    registry.put_str("_type", "skill_registry");
     registry.insert(
         "skills".to_string(),
         VmValue::List(std::sync::Arc::new(entries)),
@@ -369,27 +367,16 @@ fn build_provenance_report(
 
 fn provenance_to_vm(report: &VerificationReport) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "skill_sha256".to_string(),
-        VmValue::String(std::sync::Arc::from(report.skill_sha256.as_str())),
-    );
+    dict.put_str("skill_sha256", report.skill_sha256.as_str());
     dict.insert("signed".to_string(), VmValue::Bool(report.signed));
     dict.insert("trusted".to_string(), VmValue::Bool(report.trusted));
-    dict.insert(
-        "status".to_string(),
-        VmValue::String(std::sync::Arc::from(status_label(report.status))),
-    );
-    dict.insert(
-        "signature_path".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            report.signature_path.display().to_string(),
-        )),
+    dict.put_str("status", status_label(report.status));
+    dict.put_str(
+        "signature_path",
+        report.signature_path.display().to_string(),
     );
     if let Some(fingerprint) = report.signer_fingerprint.as_deref() {
-        dict.insert(
-            "signer_fingerprint".to_string(),
-            VmValue::String(std::sync::Arc::from(fingerprint)),
-        );
+        dict.put_str("signer_fingerprint", fingerprint);
         dict.insert(
             "author".to_string(),
             signer_policy_input(fingerprint, report.signed_at.as_deref()),
@@ -407,15 +394,9 @@ fn provenance_to_vm(report: &VerificationReport) -> VmValue {
                 _ => BTreeMap::new(),
             };
             item.insert("trusted".to_string(), VmValue::Bool(endorsement.trusted));
-            item.insert(
-                "status".to_string(),
-                VmValue::String(std::sync::Arc::from(status_label(endorsement.status))),
-            );
+            item.put_str("status", status_label(endorsement.status));
             if let Some(error) = endorsement.error.as_deref() {
-                item.insert(
-                    "error".to_string(),
-                    VmValue::String(std::sync::Arc::from(error)),
-                );
+                item.put_str("error", error);
             }
             VmValue::Dict(std::sync::Arc::new(item))
         })
@@ -425,15 +406,9 @@ fn provenance_to_vm(report: &VerificationReport) -> VmValue {
         VmValue::List(std::sync::Arc::new(endorsements)),
     );
     let mut policy_input = BTreeMap::new();
-    policy_input.insert(
-        "action".to_string(),
-        VmValue::String(std::sync::Arc::from("skill.provenance")),
-    );
+    policy_input.put_str("action", "skill.provenance");
     if let Some(fingerprint) = report.signer_fingerprint.as_deref() {
-        policy_input.insert(
-            "author_actor_id".to_string(),
-            VmValue::String(std::sync::Arc::from(fingerprint)),
-        );
+        policy_input.put_str("author_actor_id", fingerprint);
     }
     policy_input.insert(
         "endorser_actor_ids".to_string(),
@@ -454,33 +429,18 @@ fn provenance_to_vm(report: &VerificationReport) -> VmValue {
         VmValue::Dict(std::sync::Arc::new(policy_input)),
     );
     if let Some(error) = report.error.as_deref() {
-        dict.insert(
-            "error".to_string(),
-            VmValue::String(std::sync::Arc::from(error)),
-        );
+        dict.put_str("error", error);
     }
     VmValue::Dict(std::sync::Arc::new(dict))
 }
 
 fn signer_policy_input(fingerprint: &str, signed_at: Option<&str>) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "fingerprint".to_string(),
-        VmValue::String(std::sync::Arc::from(fingerprint)),
-    );
-    dict.insert(
-        "trust_actor_id".to_string(),
-        VmValue::String(std::sync::Arc::from(fingerprint)),
-    );
-    dict.insert(
-        "trust_action".to_string(),
-        VmValue::String(std::sync::Arc::from("skill.provenance")),
-    );
+    dict.put_str("fingerprint", fingerprint);
+    dict.put_str("trust_actor_id", fingerprint);
+    dict.put_str("trust_action", "skill.provenance");
     if let Some(signed_at) = signed_at {
-        dict.insert(
-            "signed_at".to_string(),
-            VmValue::String(std::sync::Arc::from(signed_at)),
-        );
+        dict.put_str("signed_at", signed_at);
     }
     VmValue::Dict(std::sync::Arc::new(dict))
 }

--- a/crates/harn-dap/src/debugger/tests.rs
+++ b/crates/harn-dap/src/debugger/tests.rs
@@ -1,3 +1,4 @@
+use harn_vm::VmDictExt;
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::path::PathBuf;
@@ -1428,10 +1429,7 @@ fn test_hit_condition_matches_parses_all_forms() {
 
     let mut vars = BTreeMap::new();
     vars.insert("count".to_string(), VmValue::Int(5));
-    vars.insert(
-        "label".to_string(),
-        VmValue::String(std::sync::Arc::from("ready")),
-    );
+    vars.put_str("label", "ready");
 
     assert_eq!(check_condition_literal("count >= 5", &vars), Ok(true));
     assert_eq!(

--- a/crates/harn-hostlib/src/error.rs
+++ b/crates/harn-hostlib/src/error.rs
@@ -3,6 +3,7 @@
 //! Builtins translate this into VM-level errors via [`Into<harn_vm::VmError>`]
 //! so that Harn scripts see structured exceptions rather than panics.
 
+use harn_vm::VmDictExt;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -108,11 +109,11 @@ impl From<HostlibError> for VmError {
         let message = err.to_string();
 
         let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
-        dict.insert("kind".to_string(), VmValue::String(Arc::from(kind)));
-        dict.insert("builtin".to_string(), VmValue::String(Arc::from(builtin)));
-        dict.insert("message".to_string(), VmValue::String(Arc::from(message)));
+        dict.put_str("kind", kind);
+        dict.put_str("builtin", builtin);
+        dict.put_str("message", message);
         if let Some(path) = path {
-            dict.insert("path".to_string(), VmValue::String(Arc::from(path)));
+            dict.put_str("path", path);
         }
         VmError::Thrown(VmValue::Dict(Arc::new(dict)))
     }

--- a/crates/harn-hostlib/src/tools/cancel_handle.rs
+++ b/crates/harn-hostlib/src/tools/cancel_handle.rs
@@ -10,6 +10,7 @@
 //! `cancelled: false` means the handle was not found — either it already
 //! completed or the id was invalid.
 
+use harn_vm::VmDictExt;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -37,10 +38,7 @@ pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let cancelled = outcome.cancelled || harn_vm::cancel_long_running_handle(&handle_id);
 
     let mut out = BTreeMap::new();
-    out.insert(
-        "handle_id".to_string(),
-        VmValue::String(Arc::from(handle_id)),
-    );
+    out.put_str("handle_id", handle_id);
     out.insert("cancelled".to_string(), VmValue::Bool(cancelled));
     if let Some(result) = outcome.result {
         out.insert("result".to_string(), result);

--- a/crates/harn-hostlib/src/tools/inspect_test_results.rs
+++ b/crates/harn-hostlib/src/tools/inspect_test_results.rs
@@ -14,6 +14,7 @@
 //! That keeps the contract simple and avoids inventing a cross-session
 //! handle namespace before there's a real consumer for one.
 
+use harn_vm::VmDictExt;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -154,11 +155,8 @@ pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 
 fn record_to_map(record: test_parsers::TestRecord) -> BTreeMap<String, VmValue> {
     let mut map = BTreeMap::new();
-    map.insert("name".to_string(), VmValue::String(Arc::from(record.name)));
-    map.insert(
-        "status".to_string(),
-        VmValue::String(Arc::from(record.status.as_str())),
-    );
+    map.put_str("name", record.name);
+    map.put_str("status", record.status.as_str());
     map.insert(
         "duration_ms".to_string(),
         VmValue::Int(record.duration_ms as i64),

--- a/crates/harn-hostlib/src/tools/mod.rs
+++ b/crates/harn-hostlib/src/tools/mod.rs
@@ -34,6 +34,7 @@
 //! [`HostlibError::Backend`] with an explanatory message. The per-session
 //! opt-in model keeps the deterministic-tool surface sandbox-friendly.
 
+use harn_vm::VmDictExt;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -218,7 +219,7 @@ fn handle_enable(args: &[VmValue]) -> Result<VmValue, HostlibError> {
         permissions::FEATURE_TOOLS_DETERMINISTIC => {
             let newly_enabled = permissions::enable(&feature);
             let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
-            map.insert("feature".to_string(), VmValue::String(Arc::from(feature)));
+            map.put_str("feature", feature);
             map.insert("enabled".to_string(), VmValue::Bool(true));
             map.insert("newly_enabled".to_string(), VmValue::Bool(newly_enabled));
             Ok(VmValue::Dict(Arc::new(map)))

--- a/crates/harn-hostlib/src/tools/proc.rs
+++ b/crates/harn-hostlib/src/tools/proc.rs
@@ -14,12 +14,12 @@
 //! 3. Timeout enforcement is uniform: when a deadline elapses, the child
 //!    is killed and `timed_out: true` is reported in the response.
 
+use harn_vm::VmDictExt;
 use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
-use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, SystemTime};
 
@@ -320,10 +320,7 @@ pub(crate) fn build_response(
         None => builder.nil("handle_id"),
     };
     let mut sandbox = BTreeMap::new();
-    sandbox.insert(
-        "kind".to_string(),
-        VmValue::String(Arc::from(sandbox_kind())),
-    );
+    sandbox.put_str("kind", sandbox_kind());
     sandbox.insert("enforced".to_string(), VmValue::Bool(sandbox_enforced()));
     builder = builder.dict("sandbox", sandbox);
     if let Some(policy_context) = policy_context {
@@ -342,10 +339,7 @@ pub(crate) fn running_response(
 ) -> VmValue {
     let artifacts = planned_artifact_paths(&command_id);
     let mut sandbox = BTreeMap::new();
-    sandbox.insert(
-        "kind".to_string(),
-        VmValue::String(Arc::from(sandbox_kind())),
-    );
+    sandbox.put_str("kind", sandbox_kind());
     sandbox.insert("enforced".to_string(), VmValue::Bool(sandbox_enforced()));
     let mut builder = ResponseBuilder::new()
         .str("command_id", command_id.clone())

--- a/crates/harn-hostlib/src/tools/run_build_command.rs
+++ b/crates/harn-hostlib/src/tools/run_build_command.rs
@@ -13,6 +13,7 @@
 //! - `release: true` and `target` are forwarded as flags where supported
 //!   (cargo, swift, dotnet).
 
+use harn_vm::VmDictExt;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -94,11 +95,8 @@ pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
         .into_iter()
         .map(|d| {
             let mut entry: BTreeMap<String, VmValue> = BTreeMap::new();
-            entry.insert(
-                "severity".to_string(),
-                VmValue::String(Arc::from(d.severity.as_str())),
-            );
-            entry.insert("message".to_string(), VmValue::String(Arc::from(d.message)));
+            entry.put_str("severity", d.severity.as_str());
+            entry.put_str("message", d.message);
             entry.insert(
                 "path".to_string(),
                 d.path

--- a/crates/harn-hostlib/src/tools/run_command.rs
+++ b/crates/harn-hostlib/src/tools/run_command.rs
@@ -17,6 +17,7 @@
 //!   immediately. The result arrives via `agent_inject_feedback` when the
 //!   process exits. See `tools/long_running.rs`.
 
+use harn_vm::VmDictExt;
 use harn_vm::VmValue;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -175,19 +176,10 @@ fn initial_background_snapshot(
         VmValue::Dict(map) => (*map).clone(),
         _ => BTreeMap::new(),
     };
-    response.insert(
-        "feedback_kind".to_string(),
-        VmValue::String(Arc::from("tool_progress")),
-    );
+    response.put_str("feedback_kind", "tool_progress");
     response.insert("duration_ms".to_string(), VmValue::Int(wait_ms as i64));
-    response.insert(
-        "stdout".to_string(),
-        VmValue::String(Arc::from(inline_stdout)),
-    );
-    response.insert(
-        "stderr".to_string(),
-        VmValue::String(Arc::from(inline_stderr)),
-    );
+    response.put_str("stdout", inline_stdout);
+    response.put_str("stderr", inline_stderr);
     response.insert("byte_count".to_string(), VmValue::Int(byte_count as i64));
     response.insert("line_count".to_string(), VmValue::Int(line_count as i64));
     VmValue::Dict(Arc::new(response))
@@ -215,15 +207,9 @@ fn parse_command(
                     param: "command",
                 })?;
             let mut invocation = BTreeMap::new();
-            invocation.insert(
-                "command".to_string(),
-                VmValue::String(std::sync::Arc::from(command)),
-            );
+            invocation.put_str("command", command);
             if let Some(shell_id) = optional_string(NAME, map, "shell_id")? {
-                invocation.insert(
-                    "shell_id".to_string(),
-                    VmValue::String(std::sync::Arc::from(shell_id)),
-                );
+                invocation.put_str("shell_id", shell_id);
             }
             if let Some(shell) = map.get("shell") {
                 match shell {

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -1063,6 +1063,7 @@ async fn acp_fs_mode_commit_and_discard_staged_hostlib_writes() {
         tools::{permissions, ToolsCapability},
         BuiltinRegistry, HostlibCapability,
     };
+    use harn_vm::VmDictExt;
 
     permissions::reset();
     permissions::enable_for_test();

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -9,6 +9,7 @@ use super::{
 };
 use crate::{ApiKeyAuthConfig, AuthMethodConfig, AuthPolicy};
 use harn_vm::visible_text::VisibleTextState;
+use harn_vm::VmDictExt;
 use harn_vm::VmValue;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -1112,15 +1113,9 @@ async fn acp_fs_mode_commit_and_discard_staged_hostlib_writes() {
     ToolsCapability.register_builtins(&mut registry);
     let stage_write = |path: &std::path::Path, content: &str| {
         let mut args = BTreeMap::new();
-        args.insert(
-            "session_id".to_string(),
-            VmValue::String(Arc::from(session_id.as_str())),
-        );
-        args.insert(
-            "path".to_string(),
-            VmValue::String(Arc::from(path.to_string_lossy().as_ref())),
-        );
-        args.insert("content".to_string(), VmValue::String(Arc::from(content)));
+        args.put_str("session_id", session_id.as_str());
+        args.put_str("path", path.to_string_lossy().as_ref());
+        args.put_str("content", content);
         (registry
             .find("hostlib_tools_write_file")
             .expect("write_file builtin")

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -9,7 +9,6 @@ use super::{
 };
 use crate::{ApiKeyAuthConfig, AuthMethodConfig, AuthPolicy};
 use harn_vm::visible_text::VisibleTextState;
-use harn_vm::VmDictExt;
 use harn_vm::VmValue;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/harn-serve/src/adapters/api.rs
+++ b/crates/harn-serve/src/adapters/api.rs
@@ -833,11 +833,7 @@ async fn create_workspace(
         return response;
     }
     let Ok(input) = parse_json_body(&body) else {
-        return api_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_json",
-            "request body must be JSON",
-        );
+        return invalid_json_response();
     };
     let now = now_rfc3339();
     let id = format!("workspace_{}", Uuid::now_v7());
@@ -896,11 +892,7 @@ async fn update_workspace(
         return response;
     }
     let Ok(input) = parse_json_body(&body) else {
-        return api_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_json",
-            "request body must be JSON",
-        );
+        return invalid_json_response();
     };
     let mut inner = state.inner.lock().expect("api state poisoned");
     let Some(workspace) = inner.workspaces.get_mut(&workspace_id) else {
@@ -1000,11 +992,7 @@ async fn write_workspace_file(
         None => return api_error(StatusCode::NOT_FOUND, "not_found", "workspace not found"),
     };
     let Ok(input) = parse_json_body(&body) else {
-        return api_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_json",
-            "request body must be JSON",
-        );
+        return invalid_json_response();
     };
     let path = input
         .get("path")
@@ -1159,11 +1147,7 @@ async fn update_session(
         return response;
     }
     let Ok(input) = parse_json_body(&body) else {
-        return api_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_json",
-            "request body must be JSON",
-        );
+        return invalid_json_response();
     };
     let session = {
         let mut inner = state.inner.lock().expect("api state poisoned");
@@ -1275,11 +1259,7 @@ async fn truncate_session(
         return response;
     }
     let Ok(input) = parse_json_body(&body) else {
-        return api_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_json",
-            "request body must be JSON",
-        );
+        return invalid_json_response();
     };
     let keep_first = match input
         .get("keep_first")
@@ -1401,11 +1381,7 @@ async fn append_session_message(
         return response;
     }
     let Ok(input) = parse_json_body(&body) else {
-        return api_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_json",
-            "request body must be JSON",
-        );
+        return invalid_json_response();
     };
     let message_input = input.get("message").cloned().unwrap_or(input.clone());
     let message = message_resource(&session_id, None, message_input.clone());
@@ -1499,11 +1475,7 @@ async fn submit_task_inner(
         return response;
     }
     let Ok(input) = parse_json_body(&body) else {
-        return api_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_json",
-            "request body must be JSON",
-        );
+        return invalid_json_response();
     };
     let Some(session_id) = path_session_id.or_else(|| {
         input
@@ -1908,11 +1880,7 @@ async fn respond_permission_request(
         return response;
     }
     let Ok(input) = parse_json_body(&body) else {
-        return api_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_json",
-            "request body must be JSON",
-        );
+        return invalid_json_response();
     };
     let approved = input
         .get("approved")
@@ -2147,11 +2115,7 @@ async fn put_permissions_policy(
         return response;
     }
     let Ok(input) = parse_json_body(&body) else {
-        return api_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_json",
-            "request body must be JSON",
-        );
+        return invalid_json_response();
     };
     let policy_value = input.get("policy").cloned().unwrap_or(input.clone());
     let policy: PermissionPolicy = match serde_json::from_value(policy_value) {
@@ -2207,11 +2171,7 @@ async fn create_permission_rule(
         return response;
     }
     let Ok(input) = parse_json_body(&body) else {
-        return api_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_json",
-            "request body must be JSON",
-        );
+        return invalid_json_response();
     };
     let rule: RememberRule = match serde_json::from_value(input) {
         Ok(rule) => rule,
@@ -2290,11 +2250,7 @@ async fn check_permission(
         return response;
     }
     let Ok(input) = parse_json_body(&body) else {
-        return api_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_json",
-            "request body must be JSON",
-        );
+        return invalid_json_response();
     };
     let mut request: PermissionRequest = match serde_json::from_value(input) {
         Ok(request) => request,
@@ -2372,6 +2328,15 @@ fn forbidden_api_error(required: &BTreeSet<String>, granted: &BTreeSet<String>) 
         );
     }
     (StatusCode::FORBIDDEN, Json(json!({ "error": body }))).into_response()
+}
+
+/// 400 response for a request body that failed to parse as JSON.
+fn invalid_json_response() -> Response {
+    api_error(
+        StatusCode::BAD_REQUEST,
+        "invalid_json",
+        "request body must be JSON",
+    )
 }
 
 fn parse_json_body(body: &Bytes) -> Result<Value, serde_json::Error> {

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -16,6 +16,7 @@
 //! the store directly — there is no "policy" config dict that
 //! performs lifecycle as a side effect.
 
+use crate::value::VmDictExt;
 use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::future::Future;
@@ -952,10 +953,7 @@ pub fn inject_prompt_from_live_client(
     let client_id = validate_live_client_id(client_id.into())?;
     ensure_live_controller(id, &client_id, LiveControllerCapability::PromptInjection)?;
     let mut message = BTreeMap::new();
-    message.insert(
-        "role".to_string(),
-        VmValue::String(std::sync::Arc::from("user")),
-    );
+    message.put_str("role", "user");
     message.insert("content".to_string(), content);
     message.insert(
         "metadata".to_string(),
@@ -1869,10 +1867,7 @@ fn compact_transcript_for_budget(
         VmValue::List(std::sync::Arc::new(retained)),
     );
     if let Some(summary) = summary {
-        next.insert(
-            "summary".to_string(),
-            VmValue::String(std::sync::Arc::from(summary)),
-        );
+        next.put_str("summary", summary);
     } else {
         next.remove("summary");
     }
@@ -2665,10 +2660,7 @@ pub fn replace_messages_with_summary(
             VmValue::List(std::sync::Arc::new(vm_messages)),
         );
         if let Some(summary) = summary {
-            next.insert(
-                "summary".to_string(),
-                VmValue::String(std::sync::Arc::from(summary.to_string())),
-            );
+            next.put_str("summary", summary);
         } else {
             next.remove("summary");
         }
@@ -3171,10 +3163,7 @@ fn clone_transcript_with_id(transcript: &VmValue, new_id: &str) -> VmValue {
         return empty_transcript(new_id);
     };
     let mut next = dict.clone();
-    next.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(new_id.to_string())),
-    );
+    next.put_str("id", new_id);
     VmValue::Dict(std::sync::Arc::new(next))
 }
 
@@ -3186,10 +3175,7 @@ fn clone_transcript_with_parent(transcript: &VmValue, parent_id: &str) -> VmValu
     let metadata = match next.get("metadata") {
         Some(VmValue::Dict(metadata)) => {
             let mut metadata = metadata.as_ref().clone();
-            metadata.insert(
-                "parent_session_id".to_string(),
-                VmValue::String(std::sync::Arc::from(parent_id.to_string())),
-            );
+            metadata.put_str("parent_session_id", parent_id);
             VmValue::Dict(std::sync::Arc::new(metadata))
         }
         _ => VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
@@ -3228,10 +3214,7 @@ fn transcript_with_session_metadata(transcript: VmValue, state: &SessionState) -
         _ => BTreeMap::new(),
     };
     if let Some(tool_format) = state.tool_format.as_ref() {
-        metadata.insert(
-            "tool_format".to_string(),
-            VmValue::String(std::sync::Arc::from(tool_format.clone())),
-        );
+        metadata.put_str("tool_format", tool_format.clone());
         metadata.insert("tool_mode_locked".to_string(), VmValue::Bool(true));
     }
     if let Some(system_prompt) = state.system_prompt.as_ref() {
@@ -3297,10 +3280,7 @@ fn session_snapshot(state: &SessionState) -> VmValue {
         })
         .unwrap_or(0);
     next.insert("length".to_string(), VmValue::Int(length));
-    next.insert(
-        "created_at".to_string(),
-        VmValue::String(std::sync::Arc::from(state.created_at.clone())),
-    );
+    next.put_str("created_at", state.created_at.clone());
     next.insert(
         "parent_id".to_string(),
         state

--- a/crates/harn-vm/src/agent_sessions_tests.rs
+++ b/crates/harn-vm/src/agent_sessions_tests.rs
@@ -4,20 +4,15 @@ use crate::agent_events::{
     AgentEventSink,
 };
 use crate::event_log::{active_event_log, EventLog, Topic};
+use crate::value::VmDictExt;
 use futures::StreamExt as _;
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 fn make_msg(role: &str, content: &str) -> VmValue {
     let mut m: BTreeMap<String, VmValue> = BTreeMap::new();
-    m.insert(
-        "role".to_string(),
-        VmValue::String(std::sync::Arc::from(role)),
-    );
-    m.insert(
-        "content".to_string(),
-        VmValue::String(std::sync::Arc::from(content)),
-    );
+    m.put_str("role", role);
+    m.put_str("content", content);
     VmValue::Dict(std::sync::Arc::new(m))
 }
 
@@ -705,18 +700,9 @@ fn inject_identified_user_message_emits_replayable_user_event() {
     register_sink(&id, Arc::new(CapturingSink(captured.clone())));
 
     let mut message = BTreeMap::new();
-    message.insert(
-        "role".to_string(),
-        VmValue::String(std::sync::Arc::from("user")),
-    );
-    message.insert(
-        "content".to_string(),
-        VmValue::String(std::sync::Arc::from("queued follow-up")),
-    );
-    message.insert(
-        "messageId".to_string(),
-        VmValue::String(std::sync::Arc::from("msg_inj_test")),
-    );
+    message.put_str("role", "user");
+    message.put_str("content", "queued follow-up");
+    message.put_str("messageId", "msg_inj_test");
     inject_message(&id, VmValue::Dict(std::sync::Arc::new(message))).unwrap();
 
     let events = captured.lock().expect("capture sink poisoned");

--- a/crates/harn-vm/src/call_budget.rs
+++ b/crates/harn-vm/src/call_budget.rs
@@ -14,6 +14,7 @@
 //! from leaking a tighter budget outward or a wider one back into a
 //! finished inner scope.
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::thread::LocalKey;
@@ -96,33 +97,21 @@ fn charge(
 /// the precise `@budget(...)` field that fired.
 fn budget_exceeded_error(kind: CallBudgetKind, spent: u64, max: u64) -> VmError {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "category".to_string(),
-        VmValue::String(std::sync::Arc::from("budget_exceeded")),
-    );
-    dict.insert(
-        "kind".to_string(),
-        VmValue::String(std::sync::Arc::from("terminal")),
-    );
-    dict.insert(
-        "reason".to_string(),
-        VmValue::String(std::sync::Arc::from("budget_exceeded")),
-    );
-    dict.insert(
-        "limit".to_string(),
-        VmValue::String(std::sync::Arc::from(kind.limit_label())),
-    );
+    dict.put_str("category", "budget_exceeded");
+    dict.put_str("kind", "terminal");
+    dict.put_str("reason", "budget_exceeded");
+    dict.put_str("limit", kind.limit_label());
     dict.insert("limit_value".to_string(), VmValue::Int(max as i64));
     dict.insert("spent".to_string(), VmValue::Int(spent as i64));
-    dict.insert(
-        "message".to_string(),
-        VmValue::String(std::sync::Arc::from(format!(
+    dict.put_str(
+        "message",
+        format!(
             "{} budget exceeded: this dispatch attempted {} of {} permitted {}",
             kind.limit_label(),
             spent,
             max,
             kind.noun(max != 1),
-        ))),
+        ),
     );
     VmError::Thrown(VmValue::Dict(std::sync::Arc::new(dict)))
 }

--- a/crates/harn-vm/src/compiler/state.rs
+++ b/crates/harn-vm/src/compiler/state.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -497,10 +498,7 @@ impl Compiler {
                     }
                 }
                 let mut out = BTreeMap::new();
-                out.insert(
-                    "type".to_string(),
-                    VmValue::String(std::sync::Arc::from("dict")),
-                );
+                out.put_str("type", "dict");
                 out.insert(
                     "properties".to_string(),
                     VmValue::Dict(std::sync::Arc::new(properties)),
@@ -515,10 +513,7 @@ impl Compiler {
             }
             harn_parser::TypeExpr::List(inner) => {
                 let mut out = BTreeMap::new();
-                out.insert(
-                    "type".to_string(),
-                    VmValue::String(std::sync::Arc::from("list")),
-                );
+                out.put_str("type", "list");
                 if let Some(item_schema) = Self::type_expr_to_schema_value(inner) {
                     out.insert("items".to_string(), item_schema);
                 }
@@ -526,10 +521,7 @@ impl Compiler {
             }
             harn_parser::TypeExpr::DictType(key, value) => {
                 let mut out = BTreeMap::new();
-                out.insert(
-                    "type".to_string(),
-                    VmValue::String(std::sync::Arc::from("dict")),
-                );
+                out.put_str("type", "dict");
                 if matches!(key.as_ref(), harn_parser::TypeExpr::Named(name) if name == "string") {
                     if let Some(value_schema) = Self::type_expr_to_schema_value(value) {
                         out.insert("additional_properties".to_string(), value_schema);

--- a/crates/harn-vm/src/durable_rate_limit.rs
+++ b/crates/harn-vm/src/durable_rate_limit.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -482,10 +483,7 @@ fn result_value(
         "retry_after_ms".to_string(),
         VmValue::Int(u64_to_i64(retry_after_ms)),
     );
-    dict.insert(
-        "state_path".to_string(),
-        VmValue::String(Arc::from(state_path.to_string_lossy().into_owned())),
-    );
+    dict.put_str("state_path", state_path.to_string_lossy());
     dict.insert("buckets".to_string(), bucket_list_value(buckets));
     VmValue::Dict(Arc::new(dict))
 }

--- a/crates/harn-vm/src/egress/mod.rs
+++ b/crates/harn-vm/src/egress/mod.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 #[cfg(test)]
@@ -1059,16 +1060,13 @@ fn policy_summary() -> VmValue {
     let mut dict = BTreeMap::new();
     if let Some(configured) = configured {
         dict.insert("configured".to_string(), VmValue::Bool(true));
-        dict.insert(
-            "source".to_string(),
-            VmValue::String(std::sync::Arc::from(configured.source)),
-        );
-        dict.insert(
-            "default".to_string(),
-            VmValue::String(std::sync::Arc::from(match configured.policy.default {
+        dict.put_str("source", configured.source);
+        dict.put_str(
+            "default",
+            match configured.policy.default {
                 DefaultAction::Allow => "allow",
                 DefaultAction::Deny => "deny",
-            })),
+            },
         );
         dict.insert(
             "allow".to_string(),
@@ -1093,12 +1091,12 @@ fn policy_summary() -> VmValue {
             )),
         );
         let (mode, allow_loopback) = effective_ssrf_settings(Some(&configured.policy));
-        dict.insert(
-            "block_private".to_string(),
-            VmValue::String(std::sync::Arc::from(match mode {
+        dict.put_str(
+            "block_private",
+            match mode {
                 SsrfMode::BlockPrivate => "private",
                 SsrfMode::Off => "off",
-            })),
+            },
         );
         dict.insert("allow_loopback".to_string(), VmValue::Bool(allow_loopback));
     } else {
@@ -1272,40 +1270,19 @@ fn vm_error(message: impl Into<String>) -> VmError {
 impl EgressBlocked {
     pub(crate) fn to_vm_error(&self) -> VmError {
         let mut dict = BTreeMap::new();
-        dict.insert(
-            "type".to_string(),
-            VmValue::String(std::sync::Arc::from("EgressBlocked")),
-        );
-        dict.insert(
-            "category".to_string(),
-            VmValue::String(std::sync::Arc::from("egress_blocked")),
-        );
-        dict.insert(
-            "message".to_string(),
-            VmValue::String(std::sync::Arc::from(self.to_string())),
-        );
-        dict.insert(
-            "surface".to_string(),
-            VmValue::String(std::sync::Arc::from(self.surface.as_str())),
-        );
-        dict.insert(
-            "url".to_string(),
-            VmValue::String(std::sync::Arc::from(self.url.as_str())),
-        );
-        dict.insert(
-            "host".to_string(),
-            VmValue::String(std::sync::Arc::from(self.host.as_str())),
-        );
+        dict.put_str("type", "EgressBlocked");
+        dict.put_str("category", "egress_blocked");
+        dict.put_str("message", self.to_string());
+        dict.put_str("surface", self.surface.as_str());
+        dict.put_str("url", self.url.as_str());
+        dict.put_str("host", self.host.as_str());
         dict.insert(
             "port".to_string(),
             self.port
                 .map(|port| VmValue::Int(port as i64))
                 .unwrap_or(VmValue::Nil),
         );
-        dict.insert(
-            "reason".to_string(),
-            VmValue::String(std::sync::Arc::from(self.reason.as_str())),
-        );
+        dict.put_str("reason", self.reason.as_str());
         VmError::Thrown(VmValue::Dict(std::sync::Arc::new(dict)))
     }
 }

--- a/crates/harn-vm/src/harness_net.rs
+++ b/crates/harn-vm/src/harness_net.rs
@@ -16,6 +16,7 @@
 //! `harness.net.*` surface and is bound per-harness so different
 //! agents in the same process can carry different policies.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::net::IpAddr;
 use std::str::FromStr;
@@ -389,33 +390,18 @@ impl NetPolicy {
 /// hosts can route on either consistently.
 pub fn violation_vm_error(audit: &NetPolicyAudit) -> VmError {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "type".to_string(),
-        VmValue::String(std::sync::Arc::from("NetPolicyViolation")),
-    );
-    dict.insert(
-        "category".to_string(),
-        VmValue::String(std::sync::Arc::from("net_policy_violation")),
-    );
-    dict.insert(
-        "message".to_string(),
-        VmValue::String(std::sync::Arc::from(format!(
+    dict.put_str("type", "NetPolicyViolation");
+    dict.put_str("category", "net_policy_violation");
+    dict.put_str(
+        "message",
+        format!(
             "harness.net.{} blocked {}: {}",
             audit.method, audit.url, audit.reason
-        ))),
+        ),
     );
-    dict.insert(
-        "method".to_string(),
-        VmValue::String(std::sync::Arc::from(audit.method.as_str())),
-    );
-    dict.insert(
-        "url".to_string(),
-        VmValue::String(std::sync::Arc::from(audit.url.as_str())),
-    );
-    dict.insert(
-        "host".to_string(),
-        VmValue::String(std::sync::Arc::from(audit.host.as_str())),
-    );
+    dict.put_str("method", audit.method.as_str());
+    dict.put_str("url", audit.url.as_str());
+    dict.put_str("host", audit.host.as_str());
     dict.insert(
         "port".to_string(),
         audit
@@ -423,14 +409,8 @@ pub fn violation_vm_error(audit: &NetPolicyAudit) -> VmError {
             .map(|port| VmValue::Int(port as i64))
             .unwrap_or(VmValue::Nil),
     );
-    dict.insert(
-        "reason".to_string(),
-        VmValue::String(std::sync::Arc::from(audit.reason.as_str())),
-    );
-    dict.insert(
-        "outcome".to_string(),
-        VmValue::String(std::sync::Arc::from(audit.outcome)),
-    );
+    dict.put_str("reason", audit.reason.as_str());
+    dict.put_str("outcome", audit.outcome);
     dict.insert(
         "matched_rule".to_string(),
         audit
@@ -450,18 +430,9 @@ pub fn violation_vm_error(audit: &NetPolicyAudit) -> VmError {
 /// optional-chaining and `?.` syntax.
 pub fn violation_request_value(audit: &NetPolicyAudit) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "method".to_string(),
-        VmValue::String(std::sync::Arc::from(audit.method.as_str())),
-    );
-    dict.insert(
-        "url".to_string(),
-        VmValue::String(std::sync::Arc::from(audit.url.as_str())),
-    );
-    dict.insert(
-        "host".to_string(),
-        VmValue::String(std::sync::Arc::from(audit.host.as_str())),
-    );
+    dict.put_str("method", audit.method.as_str());
+    dict.put_str("url", audit.url.as_str());
+    dict.put_str("host", audit.host.as_str());
     dict.insert(
         "port".to_string(),
         audit
@@ -469,10 +440,7 @@ pub fn violation_request_value(audit: &NetPolicyAudit) -> VmValue {
             .map(|port| VmValue::Int(port as i64))
             .unwrap_or(VmValue::Nil),
     );
-    dict.insert(
-        "reason".to_string(),
-        VmValue::String(std::sync::Arc::from(audit.reason.as_str())),
-    );
+    dict.put_str("reason", audit.reason.as_str());
     dict.insert(
         "matched_rule".to_string(),
         audit

--- a/crates/harn-vm/src/http/client.rs
+++ b/crates/harn-vm/src/http/client.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fs::{File, OpenOptions};
@@ -140,14 +141,8 @@ fn build_http_response(
         "headers".to_string(),
         VmValue::Dict(std::sync::Arc::new(headers)),
     );
-    result.insert(
-        "body".to_string(),
-        VmValue::String(std::sync::Arc::from(body)),
-    );
-    result.insert(
-        "final_url".to_string(),
-        VmValue::String(std::sync::Arc::from(final_url)),
-    );
+    result.put_str("body", body);
+    result.put_str("final_url", final_url);
     result.insert(
         "ok".to_string(),
         VmValue::Bool((200..300).contains(&(status as u16))),
@@ -366,10 +361,7 @@ async fn http_verb_handler(
     };
     if has_body && !(matches!(args.get(1), Some(VmValue::Dict(_))) && args.get(2).is_none()) {
         let body = args.get(1).map(|a| a.display()).unwrap_or_default();
-        options.insert(
-            "body".to_string(),
-            VmValue::String(std::sync::Arc::from(body)),
-        );
+        options.put_str("body", body);
     }
     vm_execute_http_request(method, &url, &options).await
 }
@@ -807,10 +799,7 @@ pub(super) fn parse_http_request_parts(
                 let hv = reqwest::header::HeaderValue::from_str(s)
                     .map_err(|e| vm_error(format!("http: invalid auth header value: {e}")))?;
                 header_map.insert(reqwest::header::AUTHORIZATION, hv);
-                recorded_headers.insert(
-                    "authorization".to_string(),
-                    VmValue::String(std::sync::Arc::from(s.as_ref())),
-                );
+                recorded_headers.put_str("authorization", s.as_ref());
             }
             VmValue::Dict(d) => {
                 if let Some(bearer) = d.get("bearer") {
@@ -819,10 +808,7 @@ pub(super) fn parse_http_request_parts(
                     let hv = reqwest::header::HeaderValue::from_str(&authorization)
                         .map_err(|e| vm_error(format!("http: invalid bearer token: {e}")))?;
                     header_map.insert(reqwest::header::AUTHORIZATION, hv);
-                    recorded_headers.insert(
-                        "authorization".to_string(),
-                        VmValue::String(std::sync::Arc::from(authorization)),
-                    );
+                    recorded_headers.put_str("authorization", authorization);
                 } else if let Some(VmValue::Dict(basic)) = d.get("basic") {
                     let user = basic.get("user").map(|v| v.display()).unwrap_or_default();
                     let password = basic
@@ -836,10 +822,7 @@ pub(super) fn parse_http_request_parts(
                     let hv = reqwest::header::HeaderValue::from_str(&authorization)
                         .map_err(|e| vm_error(format!("http: invalid basic auth: {e}")))?;
                     header_map.insert(reqwest::header::AUTHORIZATION, hv);
-                    recorded_headers.insert(
-                        "authorization".to_string(),
-                        VmValue::String(std::sync::Arc::from(authorization)),
-                    );
+                    recorded_headers.put_str("authorization", authorization);
                 }
             }
             _ => {}
@@ -867,11 +850,9 @@ pub(super) fn parse_http_request_parts(
                 "http: body and multipart options are mutually exclusive",
             ));
         }
-        recorded_headers.insert(
-            "content-type".to_string(),
-            VmValue::String(std::sync::Arc::from(format!(
-                "multipart/form-data; boundary={MULTIPART_MOCK_BOUNDARY}"
-            ))),
+        recorded_headers.put_str(
+            "content-type",
+            format!("multipart/form-data; boundary={MULTIPART_MOCK_BOUNDARY}"),
         );
     }
 

--- a/crates/harn-vm/src/http/mock.rs
+++ b/crates/harn-vm/src/http/mock.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 
@@ -145,17 +146,8 @@ pub(super) fn http_mock_calls_value(redact_sensitive: bool) -> Vec<VmValue> {
             .iter()
             .map(|call| {
                 let mut dict = BTreeMap::new();
-                dict.insert(
-                    "method".to_string(),
-                    VmValue::String(std::sync::Arc::from(call.method.as_str())),
-                );
-                dict.insert(
-                    "url".to_string(),
-                    VmValue::String(std::sync::Arc::from(redact_mock_call_url(
-                        &call.url,
-                        redact_sensitive,
-                    ))),
-                );
+                dict.put_str("method", call.method.as_str());
+                dict.put_str("url", redact_mock_call_url(&call.url, redact_sensitive));
                 dict.insert(
                     "headers".to_string(),
                     VmValue::Dict(std::sync::Arc::new(mock_call_headers_value(

--- a/crates/harn-vm/src/http/mod.rs
+++ b/crates/harn-vm/src/http/mod.rs
@@ -122,10 +122,6 @@ pub(super) fn get_options_arg(args: &[VmValue], index: usize) -> BTreeMap<String
         .unwrap_or_default()
 }
 
-fn vm_string(value: impl AsRef<str>) -> VmValue {
-    VmValue::String(std::sync::Arc::from(value.as_ref()))
-}
-
 fn dict_value(entries: BTreeMap<String, VmValue>) -> VmValue {
     VmValue::Dict(std::sync::Arc::new(entries))
 }
@@ -183,8 +179,8 @@ fn closure_arg(args: &[VmValue], index: usize, builtin: &str) -> Result<Arc<VmCl
 
 fn http_server_handle_value(id: &str) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert("id".to_string(), vm_string(id));
-    dict.insert("kind".to_string(), vm_string("http_server"));
+    dict.insert("id".to_string(), VmValue::string(id));
+    dict.insert("kind".to_string(), VmValue::string("http_server"));
     dict_value(dict)
 }
 
@@ -204,12 +200,16 @@ fn headers_from_value(value: &VmValue) -> BTreeMap<String, VmValue> {
             .map(|headers| {
                 headers
                     .iter()
-                    .map(|(key, value)| (key.to_ascii_lowercase(), vm_string(value.display())))
+                    .map(|(key, value)| {
+                        (key.to_ascii_lowercase(), VmValue::string(value.display()))
+                    })
                     .collect()
             })
             .unwrap_or_else(|| {
                 dict.iter()
-                    .map(|(key, value)| (key.to_ascii_lowercase(), vm_string(value.display())))
+                    .map(|(key, value)| {
+                        (key.to_ascii_lowercase(), VmValue::string(value.display()))
+                    })
                     .collect()
             }),
         _ => BTreeMap::new(),
@@ -220,7 +220,7 @@ fn normalize_headers(value: Option<&VmValue>) -> BTreeMap<String, VmValue> {
     match value.and_then(VmValue::as_dict) {
         Some(headers) => headers
             .iter()
-            .map(|(key, value)| (key.to_ascii_lowercase(), vm_string(value.display())))
+            .map(|(key, value)| (key.to_ascii_lowercase(), VmValue::string(value.display())))
             .collect(),
         None => BTreeMap::new(),
     }
@@ -263,7 +263,7 @@ fn split_path_and_query(raw_path: &str) -> (String, BTreeMap<String, VmValue>) {
     let mut query_map = BTreeMap::new();
     for pair in query.split('&').filter(|part| !part.is_empty()) {
         let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
-        query_map.insert(percent_decode(key), vm_string(percent_decode(value)));
+        query_map.insert(percent_decode(key), VmValue::string(percent_decode(value)));
     }
     (
         if path.is_empty() { "/" } else { path }.to_string(),
@@ -299,14 +299,14 @@ fn request_value(
     let headers = normalize_headers(input.get("headers"));
     let body = String::from_utf8_lossy(body_bytes).into_owned();
     let mut request = BTreeMap::new();
-    request.insert("method".to_string(), vm_string(method));
-    request.insert("path".to_string(), vm_string(path));
+    request.insert("method".to_string(), VmValue::string(method));
+    request.insert("path".to_string(), VmValue::string(path));
     let path_params = dict_value(path_params);
     request.insert("path_params".to_string(), path_params.clone());
     request.insert("params".to_string(), path_params);
     request.insert("query".to_string(), dict_value(query));
     request.insert("headers".to_string(), dict_value(headers));
-    request.insert("body".to_string(), vm_string(body));
+    request.insert("body".to_string(), VmValue::string(body));
     request.insert(
         "raw_body".to_string(),
         if retain_raw_body {
@@ -324,7 +324,7 @@ fn request_value(
         input
             .get("remote_addr")
             .or_else(|| input.get("remote"))
-            .map(|value| vm_string(value.display()))
+            .map(|value| VmValue::string(value.display()))
             .unwrap_or(VmValue::Nil),
     );
     request.insert(
@@ -333,7 +333,7 @@ fn request_value(
             .get("client_ip")
             .or_else(|| input.get("remote_ip"))
             .or_else(|| input.get("ip"))
-            .map(|value| vm_string(value.display()))
+            .map(|value| VmValue::string(value.display()))
             .unwrap_or(VmValue::Nil),
     );
     dict_value(request)
@@ -359,14 +359,14 @@ fn response_with_kind(
     {
         headers.insert(
             "content-type".to_string(),
-            vm_string("application/json; charset=utf-8"),
+            VmValue::string("application/json; charset=utf-8"),
         );
     } else if body_kind == "text"
         && matches!(header_lookup_value(&headers, "content-type"), VmValue::Nil)
     {
         headers.insert(
             "content-type".to_string(),
-            vm_string("text/plain; charset=utf-8"),
+            VmValue::string("text/plain; charset=utf-8"),
         );
     }
     response.insert("status".to_string(), VmValue::Int(status));
@@ -375,17 +375,17 @@ fn response_with_kind(
         "ok".to_string(),
         VmValue::Bool((200..300).contains(&status)),
     );
-    response.insert("body_kind".to_string(), vm_string(body_kind));
+    response.insert("body_kind".to_string(), VmValue::string(body_kind));
     match body {
         VmValue::Bytes(bytes) => {
             response.insert(
                 "body".to_string(),
-                vm_string(String::from_utf8_lossy(&bytes)),
+                VmValue::string(String::from_utf8_lossy(&bytes)),
             );
             response.insert("raw_body".to_string(), VmValue::Bytes(bytes));
         }
         other => {
-            response.insert("body".to_string(), vm_string(other.display()));
+            response.insert("body".to_string(), VmValue::string(other.display()));
             response.insert(
                 "raw_body".to_string(),
                 VmValue::Bytes(std::sync::Arc::new(other.display().into_bytes())),
@@ -426,17 +426,17 @@ fn body_limit_response(limit: usize, actual: usize) -> VmValue {
     let mut headers = BTreeMap::new();
     headers.insert(
         "content-type".to_string(),
-        vm_string("text/plain; charset=utf-8"),
+        VmValue::string("text/plain; charset=utf-8"),
     );
-    headers.insert("connection".to_string(), vm_string("close"));
+    headers.insert("connection".to_string(), VmValue::string("close"));
     headers.insert(
         "x-harn-body-limit".to_string(),
-        vm_string(limit.to_string()),
+        VmValue::string(limit.to_string()),
     );
     response_with_kind(
         413,
         headers,
-        vm_string(format!("request body too large: {actual} > {limit} bytes")),
+        VmValue::string(format!("request body too large: {actual} > {limit} bytes")),
         "text",
     )
 }
@@ -445,13 +445,13 @@ fn not_found_response(method: &str, path: &str) -> VmValue {
     response_with_kind(
         404,
         BTreeMap::new(),
-        vm_string(format!("no route for {method} {path}")),
+        VmValue::string(format!("no route for {method} {path}")),
         "text",
     )
 }
 
 fn unavailable_response(message: &str) -> VmValue {
-    response_with_kind(503, BTreeMap::new(), vm_string(message), "text")
+    response_with_kind(503, BTreeMap::new(), VmValue::string(message), "text")
 }
 
 fn route_template_match(template: &str, path: &str) -> Option<BTreeMap<String, VmValue>> {
@@ -468,10 +468,13 @@ fn route_template_match(template: &str, path: &str) -> Option<BTreeMap<String, V
         if tmpl.starts_with('{') && tmpl.ends_with('}') && tmpl.len() > 2 {
             params.insert(
                 tmpl[1..tmpl.len() - 1].to_string(),
-                vm_string(percent_decode(actual)),
+                VmValue::string(percent_decode(actual)),
             );
         } else if tmpl.starts_with(':') && tmpl.len() > 1 {
-            params.insert(tmpl[1..].to_string(), vm_string(percent_decode(actual)));
+            params.insert(
+                tmpl[1..].to_string(),
+                VmValue::string(percent_decode(actual)),
+            );
         } else if tmpl != actual {
             return None;
         }
@@ -968,8 +971,8 @@ fn register_http_server_builtins(vm: &mut Vm) {
         let body = args
             .first()
             .map(crate::stdlib::json::vm_value_to_json)
-            .map(vm_string)
-            .unwrap_or_else(|| vm_string("null"));
+            .map(VmValue::string)
+            .unwrap_or_else(|| VmValue::string("null"));
         let options = get_options_arg(args, 1);
         let status = options
             .get("status")

--- a/crates/harn-vm/src/http/mod.rs
+++ b/crates/harn-vm/src/http/mod.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -651,14 +652,8 @@ fn register_http_tls_builtins(vm: &mut Vm) {
             )));
         }
         let mut extra = BTreeMap::new();
-        extra.insert(
-            "cert_path".to_string(),
-            VmValue::String(std::sync::Arc::from(cert_path)),
-        );
-        extra.insert(
-            "key_path".to_string(),
-            VmValue::String(std::sync::Arc::from(key_path)),
-        );
+        extra.put_str("cert_path", cert_path);
+        extra.put_str("key_path", key_path);
         Ok(http_server_tls_config_value(
             "pem", true, "https", true, extra,
         ))
@@ -680,14 +675,8 @@ fn register_http_tls_builtins(vm: &mut Vm) {
                     .collect(),
             )),
         );
-        extra.insert(
-            "cert_pem".to_string(),
-            VmValue::String(std::sync::Arc::from(cert.cert.pem())),
-        );
-        extra.insert(
-            "key_pem".to_string(),
-            VmValue::String(std::sync::Arc::from(cert.signing_key.serialize_pem())),
-        );
+        extra.put_str("cert_pem", cert.cert.pem());
+        extra.put_str("key_pem", cert.signing_key.serialize_pem());
         Ok(http_server_tls_config_value(
             "self_signed_dev",
             true,
@@ -1077,15 +1066,9 @@ fn http_server_tls_config_value(
     extra: BTreeMap<String, VmValue>,
 ) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "mode".to_string(),
-        VmValue::String(std::sync::Arc::from(mode)),
-    );
+    dict.put_str("mode", mode);
     dict.insert("terminate_tls".to_string(), VmValue::Bool(terminate_tls));
-    dict.insert(
-        "scheme".to_string(),
-        VmValue::String(std::sync::Arc::from(scheme)),
-    );
+    dict.put_str("scheme", scheme);
     dict.insert("hsts".to_string(), VmValue::Bool(hsts));
     for (key, value) in extra {
         dict.insert(key, value);

--- a/crates/harn-vm/src/http/streaming.rs
+++ b/crates/harn-vm/src/http/streaming.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::net::TcpStream;
@@ -216,28 +217,19 @@ fn receive_timeout_arg(args: &[VmValue], index: usize) -> u64 {
 
 fn timeout_event() -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "type".to_string(),
-        VmValue::String(std::sync::Arc::from("timeout")),
-    );
+    dict.put_str("type", "timeout");
     VmValue::Dict(std::sync::Arc::new(dict))
 }
 
 fn closed_event() -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "type".to_string(),
-        VmValue::String(std::sync::Arc::from("close")),
-    );
+    dict.put_str("type", "close");
     VmValue::Dict(std::sync::Arc::new(dict))
 }
 
 fn sse_server_closed_event() -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "type".to_string(),
-        VmValue::String(std::sync::Arc::from("close")),
-    );
+    dict.put_str("type", "close");
     dict.insert("server_closed".to_string(), VmValue::Bool(true));
     VmValue::Dict(std::sync::Arc::new(dict))
 }
@@ -293,18 +285,9 @@ fn parse_mock_stream_events(value: Option<&VmValue>) -> Vec<MockStreamEvent> {
 
 fn sse_event_value(event: &MockStreamEvent) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "type".to_string(),
-        VmValue::String(std::sync::Arc::from("event")),
-    );
-    dict.insert(
-        "event".to_string(),
-        VmValue::String(std::sync::Arc::from(event.event_type.as_str())),
-    );
-    dict.insert(
-        "data".to_string(),
-        VmValue::String(std::sync::Arc::from(event.data.as_str())),
-    );
+    dict.put_str("type", "event");
+    dict.put_str("event", event.event_type.as_str());
+    dict.put_str("data", event.data.as_str());
     dict.insert(
         "id".to_string(),
         event
@@ -322,11 +305,8 @@ fn sse_event_value(event: &MockStreamEvent) -> VmValue {
 
 fn sse_server_response_value(id: &str, handle: &SseServerHandle) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert("id".to_string(), VmValue::String(std::sync::Arc::from(id)));
-    dict.insert(
-        "type".to_string(),
-        VmValue::String(std::sync::Arc::from("sse_response")),
-    );
+    dict.put_str("id", id);
+    dict.put_str("type", "sse_response");
     dict.insert("status".to_string(), VmValue::Int(handle.status));
     dict.insert(
         "headers".to_string(),
@@ -381,10 +361,7 @@ fn sse_response_headers(options: &BTreeMap<String, VmValue>) -> BTreeMap<String,
         .keys()
         .any(|name| name.eq_ignore_ascii_case("content-type"))
     {
-        headers.insert(
-            "content-type".to_string(),
-            VmValue::String(std::sync::Arc::from("text/event-stream; charset=utf-8")),
-        );
+        headers.put_str("content-type", "text/event-stream; charset=utf-8");
     }
     headers
 }
@@ -575,7 +552,7 @@ pub(super) fn vm_sse_server_response(
 
 fn sse_server_status_value(id: &str, handle: &SseServerHandle) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert("id".to_string(), VmValue::String(std::sync::Arc::from(id)));
+    dict.put_str("id", id);
     dict.insert("status".to_string(), VmValue::Int(handle.status));
     dict.insert(
         "headers".to_string(),
@@ -832,22 +809,13 @@ fn sse_server_mock_frame_value(frame: &str) -> VmValue {
         sse_event_value(&event)
     } else {
         let mut dict = BTreeMap::new();
-        dict.insert(
-            "type".to_string(),
-            VmValue::String(std::sync::Arc::from("comment")),
-        );
-        dict.insert(
-            "comment".to_string(),
-            VmValue::String(std::sync::Arc::from(comments.join("\n"))),
-        );
+        dict.put_str("type", "comment");
+        dict.put_str("comment", comments.join("\n"));
         VmValue::Dict(std::sync::Arc::new(dict))
     };
     if let VmValue::Dict(dict) = &mut value {
         let mut owned = (**dict).clone();
-        owned.insert(
-            "raw".to_string(),
-            VmValue::String(std::sync::Arc::from(frame)),
-        );
+        owned.put_str("raw", frame);
         value = VmValue::Dict(std::sync::Arc::new(owned));
     }
     value
@@ -857,10 +825,7 @@ fn real_sse_event_value(event: SseEvent) -> VmValue {
     match event {
         SseEvent::Open => {
             let mut dict = BTreeMap::new();
-            dict.insert(
-                "type".to_string(),
-                VmValue::String(std::sync::Arc::from("open")),
-            );
+            dict.put_str("type", "open");
             VmValue::Dict(std::sync::Arc::new(dict))
         }
         SseEvent::Message(message) => {
@@ -895,14 +860,8 @@ fn consume_sse_mock(url: &str) -> Option<Vec<MockStreamEvent>> {
 
 fn transport_mock_call_value(call: &TransportMockCall) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "kind".to_string(),
-        VmValue::String(std::sync::Arc::from(call.kind.as_str())),
-    );
-    dict.insert(
-        "url".to_string(),
-        VmValue::String(std::sync::Arc::from(call.url.as_str())),
-    );
+    dict.put_str("kind", call.kind.as_str());
+    dict.put_str("url", call.url.as_str());
     dict.insert(
         "handle".to_string(),
         call.handle
@@ -1050,10 +1009,7 @@ pub(super) async fn vm_sse_receive(stream_id: &str, timeout_ms: u64) -> Result<V
             if !stream.opened {
                 stream.opened = true;
                 let mut dict = BTreeMap::new();
-                dict.insert(
-                    "type".to_string(),
-                    VmValue::String(std::sync::Arc::from("open")),
-                );
+                dict.put_str("type", "open");
                 return Ok(VmValue::Dict(std::sync::Arc::new(dict)));
             }
             let Some(event) = stream.events.pop_front() else {

--- a/crates/harn-vm/src/http/streaming/websocket.rs
+++ b/crates/harn-vm/src/http/streaming/websocket.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::net::{Shutdown, TcpListener, TcpStream};
 use std::sync::{
@@ -132,18 +133,12 @@ fn ws_message_data(message: &MockWsMessage) -> String {
 
 fn closed_event_with(code: Option<u16>, reason: Option<String>) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "type".to_string(),
-        VmValue::String(std::sync::Arc::from("close")),
-    );
+    dict.put_str("type", "close");
     if let Some(code) = code {
         dict.insert("code".to_string(), VmValue::Int(i64::from(code)));
     }
     if let Some(reason) = reason {
-        dict.insert(
-            "reason".to_string(),
-            VmValue::String(std::sync::Arc::from(reason)),
-        );
+        dict.put_str("reason", reason);
     }
     VmValue::Dict(std::sync::Arc::new(dict))
 }
@@ -153,28 +148,18 @@ fn ws_event_value(message: MockWsMessage) -> VmValue {
         return closed_event_with(message.close_code, message.close_reason);
     }
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "type".to_string(),
-        VmValue::String(std::sync::Arc::from(message.message_type.as_str())),
-    );
+    dict.put_str("type", message.message_type.as_str());
     match message.message_type.as_str() {
         "text" => {
-            dict.insert(
-                "data".to_string(),
-                VmValue::String(std::sync::Arc::from(
-                    String::from_utf8_lossy(&message.data).as_ref(),
-                )),
-            );
+            dict.put_str("data", String::from_utf8_lossy(&message.data).as_ref());
         }
         _ => {
             use base64::Engine;
-            dict.insert(
-                "data_base64".to_string(),
-                VmValue::String(std::sync::Arc::from(
-                    base64::engine::general_purpose::STANDARD
-                        .encode(&message.data)
-                        .as_str(),
-                )),
+            dict.put_str(
+                "data_base64",
+                base64::engine::general_purpose::STANDARD
+                    .encode(&message.data)
+                    .as_str(),
             );
         }
     }
@@ -304,15 +289,9 @@ pub(super) fn vm_websocket_server(
         Ok(())
     })?;
     let mut dict = BTreeMap::new();
-    dict.insert("id".to_string(), VmValue::String(std::sync::Arc::from(id)));
-    dict.insert(
-        "addr".to_string(),
-        VmValue::String(std::sync::Arc::from(addr)),
-    );
-    dict.insert(
-        "url".to_string(),
-        VmValue::String(std::sync::Arc::from(url)),
-    );
+    dict.put_str("id", id);
+    dict.put_str("addr", addr);
+    dict.put_str("url", url);
     Ok(VmValue::Dict(std::sync::Arc::new(dict)))
 }
 
@@ -403,15 +382,9 @@ fn register_accepted_websocket(event: WebSocketServerEvent) -> Result<VmValue, V
         Ok(())
     })?;
     let mut metadata = BTreeMap::new();
-    metadata.insert("id".to_string(), VmValue::String(std::sync::Arc::from(id)));
-    metadata.insert(
-        "path".to_string(),
-        VmValue::String(std::sync::Arc::from(path)),
-    );
-    metadata.insert(
-        "peer".to_string(),
-        VmValue::String(std::sync::Arc::from(peer)),
-    );
+    metadata.put_str("id", id);
+    metadata.put_str("path", path);
+    metadata.put_str("peer", peer);
     metadata.insert(
         "headers".to_string(),
         VmValue::Dict(std::sync::Arc::new(

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -1,6 +1,7 @@
 //! Agent loop configuration, builtin registration, and result building
 //! extracted from `agent.rs` for maintainability.
 
+use crate::value::VmDictExt;
 use std::sync::Arc;
 
 use crate::stdlib::harn_entry::register_harn_entrypoint_category;
@@ -29,25 +30,13 @@ const AGENT_CONTROL_BUILTINS: &[&VmBuiltinDef] = &[
 pub(crate) fn agent_feedback_message(kind: &str, content: &str) -> VmValue {
     let mut msg = std::collections::BTreeMap::new();
     if kind == PREFILL_ASSISTANT_FEEDBACK_KIND {
-        msg.insert(
-            "role".to_string(),
-            VmValue::String(std::sync::Arc::from("assistant")),
-        );
-        msg.insert(
-            "content".to_string(),
-            VmValue::String(std::sync::Arc::from(content.to_string())),
-        );
+        msg.put_str("role", "assistant");
+        msg.put_str("content", content);
         return VmValue::Dict(std::sync::Arc::new(msg));
     }
     let body = format!("<runtime_feedback kind=\"{kind}\">\n{content}\n</runtime_feedback>");
-    msg.insert(
-        "role".to_string(),
-        VmValue::String(std::sync::Arc::from("user")),
-    );
-    msg.insert(
-        "content".to_string(),
-        VmValue::String(std::sync::Arc::from(body)),
-    );
+    msg.put_str("role", "user");
+    msg.put_str("content", body);
     VmValue::Dict(std::sync::Arc::new(msg))
 }
 

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -6,6 +6,7 @@
 //! continue/break) lives in Harn; Rust is reduced to data plumbing,
 //! provider/tool capability surfaces, and resource lifecycle.
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -406,14 +407,8 @@ async fn host_agent_session_init(
     .await?;
 
     let mut control = BTreeMap::new();
-    control.insert(
-        "session_id".to_string(),
-        VmValue::String(std::sync::Arc::from(resolved)),
-    );
-    control.insert(
-        "task".to_string(),
-        VmValue::String(std::sync::Arc::from(message)),
-    );
+    control.put_str("session_id", resolved);
+    control.put_str("task", message);
     control.insert(
         "system".to_string(),
         system
@@ -529,14 +524,8 @@ fn agent_init_control_done(
     result: VmValue,
 ) -> VmValue {
     let mut control = BTreeMap::new();
-    control.insert(
-        "session_id".to_string(),
-        VmValue::String(std::sync::Arc::from(session_id.to_string())),
-    );
-    control.insert(
-        "task".to_string(),
-        VmValue::String(std::sync::Arc::from(task.to_string())),
-    );
+    control.put_str("session_id", session_id);
+    control.put_str("task", task);
     control.insert(
         "system".to_string(),
         system
@@ -918,14 +907,8 @@ fn assistant_message_from_llm_result(llm_result: &VmValue) -> VmValue {
         .collect::<Vec<_>>();
     if native_calls_json.is_empty() {
         let mut msg = BTreeMap::new();
-        msg.insert(
-            "role".to_string(),
-            VmValue::String(std::sync::Arc::from("assistant")),
-        );
-        msg.insert(
-            "content".to_string(),
-            VmValue::String(std::sync::Arc::from(text)),
-        );
+        msg.put_str("role", "assistant");
+        msg.put_str("content", text);
         return VmValue::Dict(std::sync::Arc::new(msg));
     }
 
@@ -1019,39 +1002,18 @@ fn tool_result_message_for_provider(
         Some(crate::llm_config::ToolFormatChannel::Text)
     );
     if is_text_channel {
-        msg.insert(
-            "role".to_string(),
-            VmValue::String(std::sync::Arc::from("user")),
-        );
+        msg.put_str("role", "user");
     } else if crate::llm::provider::provider_uses_anthropic_messages(provider, model) {
-        msg.insert(
-            "role".to_string(),
-            VmValue::String(std::sync::Arc::from("tool_result")),
-        );
-        msg.insert(
-            "tool_use_id".to_string(),
-            VmValue::String(std::sync::Arc::from(tool_call_id)),
-        );
+        msg.put_str("role", "tool_result");
+        msg.put_str("tool_use_id", tool_call_id);
     } else {
-        msg.insert(
-            "role".to_string(),
-            VmValue::String(std::sync::Arc::from("tool")),
-        );
-        msg.insert(
-            "name".to_string(),
-            VmValue::String(std::sync::Arc::from(name)),
-        );
+        msg.put_str("role", "tool");
+        msg.put_str("name", name);
         if !tool_call_id.is_empty() {
-            msg.insert(
-                "tool_call_id".to_string(),
-                VmValue::String(std::sync::Arc::from(tool_call_id)),
-            );
+            msg.put_str("tool_call_id", tool_call_id);
         }
     }
-    msg.insert(
-        "content".to_string(),
-        VmValue::String(std::sync::Arc::from(observation)),
-    );
+    msg.put_str("content", observation);
     VmValue::Dict(std::sync::Arc::new(msg))
 }
 
@@ -1387,18 +1349,9 @@ fn host_agent_session_drain_feedback_builtin(
         .into_iter()
         .map(|entry| {
             let mut item = BTreeMap::new();
-            item.insert(
-                "kind".to_string(),
-                VmValue::String(std::sync::Arc::from(entry.kind)),
-            );
-            item.insert(
-                "content".to_string(),
-                VmValue::String(std::sync::Arc::from(entry.content)),
-            );
-            item.insert(
-                "source".to_string(),
-                VmValue::String(std::sync::Arc::from(entry.source)),
-            );
+            item.put_str("kind", entry.kind);
+            item.put_str("content", entry.content);
+            item.put_str("source", entry.source);
             item.insert("sequence".to_string(), VmValue::Int(entry.sequence as i64));
             item.insert("ts_ms".to_string(), VmValue::Int(entry.ts_ms));
             VmValue::Dict(std::sync::Arc::new(item))
@@ -1559,7 +1512,7 @@ fn host_agent_session_active_skills_builtin(
         .into_iter()
         .map(|id| {
             let mut entry = BTreeMap::new();
-            entry.insert("id".to_string(), VmValue::String(std::sync::Arc::from(id)));
+            entry.put_str("id", id);
             VmValue::Dict(std::sync::Arc::new(entry))
         })
         .collect();
@@ -3645,6 +3598,7 @@ mod nested_budget_tests {
     use crate::orchestration::{
         clear_execution_policy_stacks, current_execution_policy, CapabilityPolicy,
     };
+    use crate::value::VmDictExt;
 
     fn policy_value(policy: &CapabilityPolicy) -> VmValue {
         crate::stdlib::json_to_vm_value(&serde_json::to_value(policy).unwrap())
@@ -3703,14 +3657,8 @@ mod nested_budget_tests {
         });
 
         let mut opts_map = BTreeMap::new();
-        opts_map.insert(
-            "_nested_kind".to_string(),
-            VmValue::String(std::sync::Arc::from("sub_agent_run")),
-        );
-        opts_map.insert(
-            "_nested_label".to_string(),
-            VmValue::String(std::sync::Arc::from("research-worker")),
-        );
+        opts_map.put_str("_nested_kind", "sub_agent_run");
+        opts_map.put_str("_nested_label", "research-worker");
         let error = install_session_nested_budget(&opts_map, "ignored").unwrap_err();
         match error {
             VmError::CategorizedError { message, .. } => {

--- a/crates/harn-vm/src/llm/agent_tools.rs
+++ b/crates/harn-vm/src/llm/agent_tools.rs
@@ -587,6 +587,7 @@ mod tests {
     //! loop.
 
     use super::*;
+    use crate::value::VmDictExt;
     use std::collections::BTreeMap;
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
@@ -744,10 +745,7 @@ mod tests {
         // helper picks that up so the dispatch site can tag the
         // executor as `McpServer { server_name }`.
         let mut entry = BTreeMap::new();
-        entry.insert(
-            "_mcp_server".to_string(),
-            VmValue::String(std::sync::Arc::from("linear".to_string())),
-        );
+        entry.put_str("_mcp_server", "linear");
         let tools = tools_dict(vec![("create_issue", entry)]);
         assert_eq!(
             mcp_server_for_tool(Some(&tools), "create_issue"),
@@ -760,14 +758,8 @@ mod tests {
         // OpenAI-shape tools nest `_mcp_server` inside a `function`
         // sub-dict; the search must drill down a level.
         let mut function = BTreeMap::new();
-        function.insert(
-            "name".to_string(),
-            VmValue::String(std::sync::Arc::from("create_issue".to_string())),
-        );
-        function.insert(
-            "_mcp_server".to_string(),
-            VmValue::String(std::sync::Arc::from("linear".to_string())),
-        );
+        function.put_str("name", "create_issue");
+        function.put_str("_mcp_server", "linear");
         let mut entry = BTreeMap::new();
         entry.insert(
             "function".to_string(),
@@ -845,10 +837,7 @@ mod tests {
         );
         let bridge = Arc::new(bridge);
         let mut entry = BTreeMap::new();
-        entry.insert(
-            "_mcp_server".to_string(),
-            VmValue::String(std::sync::Arc::from("linear".to_string())),
-        );
+        entry.put_str("_mcp_server", "linear");
         let tools = tools_dict(vec![("create_issue", entry)]);
         let args = serde_json::json!({});
         let outcome =
@@ -886,14 +875,8 @@ mod tests {
         );
         let bridge = Arc::new(bridge);
         let mut entry = BTreeMap::new();
-        entry.insert(
-            "executor".to_string(),
-            VmValue::String(std::sync::Arc::from("host_bridge")),
-        );
-        entry.insert(
-            "host_capability".to_string(),
-            VmValue::String(std::sync::Arc::from("interaction.ask")),
-        );
+        entry.put_str("executor", "host_bridge");
+        entry.put_str("host_capability", "interaction.ask");
         let tools = tools_dict(vec![("ask_user", entry)]);
         let outcome = dispatch_tool_execution(
             "ask_user",
@@ -913,10 +896,7 @@ mod tests {
         // The dispatcher rejects with ProviderNative as the executor so
         // the ACP event reflects "model already executed this".
         let mut entry = BTreeMap::new();
-        entry.insert(
-            "executor".to_string(),
-            VmValue::String(std::sync::Arc::from("provider_native")),
-        );
+        entry.put_str("executor", "provider_native");
         let tools = tools_dict(vec![("tool_search", entry)]);
         let outcome = dispatch_tool_execution(
             "tool_search",
@@ -943,14 +923,8 @@ mod tests {
         );
         let bridge = Arc::new(bridge);
         let mut entry = BTreeMap::new();
-        entry.insert(
-            "executor".to_string(),
-            VmValue::String(std::sync::Arc::from("mcp_server")),
-        );
-        entry.insert(
-            "mcp_server".to_string(),
-            VmValue::String(std::sync::Arc::from("github")),
-        );
+        entry.put_str("executor", "mcp_server");
+        entry.put_str("mcp_server", "github");
         let tools = tools_dict(vec![("github_search_issues", entry)]);
         let outcome = dispatch_tool_execution(
             "github_search_issues",

--- a/crates/harn-vm/src/llm/api/completion.rs
+++ b/crates/harn-vm/src/llm/api/completion.rs
@@ -3,6 +3,7 @@
 //! `/api/generate`, and a chat-based fallback that wraps the prompt in a
 //! user message and re-enters the chat path.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use crate::value::{VmError, VmValue};
@@ -273,15 +274,9 @@ async fn vm_call_completion_fallback(
     let mut fallback_opts = opts.clone();
     let has_suffix = suffix.is_some_and(|s| !s.is_empty());
     let mut bindings = BTreeMap::new();
-    bindings.insert(
-        "prefix".to_string(),
-        VmValue::String(std::sync::Arc::from(prefix)),
-    );
+    bindings.put_str("prefix", prefix);
     bindings.insert("has_suffix".to_string(), VmValue::Bool(has_suffix));
-    bindings.insert(
-        "suffix".to_string(),
-        VmValue::String(std::sync::Arc::from(suffix.unwrap_or_default())),
-    );
+    bindings.put_str("suffix", suffix.unwrap_or_default());
     let instruction = crate::stdlib::template::render_stdlib_prompt_asset(
         "llm/prompts/completion_fallback_system.harn.prompt",
         Some(&bindings),

--- a/crates/harn-vm/src/llm/api/result.rs
+++ b/crates/harn-vm/src/llm/api/result.rs
@@ -1,6 +1,7 @@
 //! `LlmResult` and the Harn-facing dict builder for `llm_call` return
 //! values, plus the mock-provider completion response.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use super::telemetry::ProviderTelemetry;
@@ -110,10 +111,7 @@ fn build_usage_dict(result: &LlmResult) -> BTreeMap<String, VmValue> {
         // mislabel a local model as a 100% cache miss. Surface the unknown
         // explicitly instead of fabricating a number.
         usage.insert("cache_hit_ratio".to_string(), VmValue::Nil);
-        usage.insert(
-            "cache_visibility".to_string(),
-            VmValue::String(std::sync::Arc::from("unsupported")),
-        );
+        usage.put_str("cache_visibility", "unsupported");
     }
     usage.insert(
         "cache_savings_usd".to_string(),
@@ -132,18 +130,9 @@ pub(crate) fn vm_build_llm_result(
     use crate::stdlib::json_to_vm_value;
 
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "text".to_string(),
-        VmValue::String(std::sync::Arc::from(result.text.as_str())),
-    );
-    dict.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(result.model.as_str())),
-    );
-    dict.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(result.provider.as_str())),
-    );
+    dict.put_str("text", result.text.as_str());
+    dict.put_str("model", result.model.as_str());
+    dict.put_str("provider", result.provider.as_str());
     dict.insert(
         "input_tokens".to_string(),
         VmValue::Int(result.input_tokens),
@@ -261,16 +250,10 @@ pub(crate) fn vm_build_llm_result(
             );
         }
         if let Some(ref body) = parse.done_marker {
-            dict.insert(
-                "done_marker".to_string(),
-                VmValue::String(std::sync::Arc::from(body.as_str())),
-            );
+            dict.put_str("done_marker", body.as_str());
         }
         if !parse.canonical.is_empty() {
-            dict.insert(
-                "canonical_text".to_string(),
-                VmValue::String(std::sync::Arc::from(parse.canonical.as_str())),
-            );
+            dict.put_str("canonical_text", parse.canonical.as_str());
         }
         // Always emit `prose` (fall back to raw text) so callers have a
         // single reliable "the answer" key regardless of whether the model
@@ -280,45 +263,24 @@ pub(crate) fn vm_build_llm_result(
         } else {
             parse.prose.clone()
         };
-        dict.insert(
-            "prose".to_string(),
-            VmValue::String(std::sync::Arc::from(prose.as_str())),
-        );
+        dict.put_str("prose", prose.as_str());
     } else {
-        dict.insert(
-            "prose".to_string(),
-            VmValue::String(std::sync::Arc::from(result.text.as_str())),
-        );
+        dict.put_str("prose", result.text.as_str());
     }
 
     if let Some(ref thinking) = result.thinking {
-        dict.insert(
-            "thinking".to_string(),
-            VmValue::String(std::sync::Arc::from(thinking.as_str())),
-        );
-        dict.insert(
-            "private_reasoning".to_string(),
-            VmValue::String(std::sync::Arc::from(thinking.as_str())),
-        );
+        dict.put_str("thinking", thinking.as_str());
+        dict.put_str("private_reasoning", thinking.as_str());
     }
     if let Some(ref summary) = result.thinking_summary {
-        dict.insert(
-            "thinking_summary".to_string(),
-            VmValue::String(std::sync::Arc::from(summary.as_str())),
-        );
+        dict.put_str("thinking_summary", summary.as_str());
     }
 
     if let Some(ref stop_reason) = result.stop_reason {
-        dict.insert(
-            "stop_reason".to_string(),
-            VmValue::String(std::sync::Arc::from(stop_reason.as_str())),
-        );
+        dict.put_str("stop_reason", stop_reason.as_str());
     }
     if let Some(ref request_id) = result.telemetry.request_id {
-        dict.insert(
-            "provider_response_id".to_string(),
-            VmValue::String(std::sync::Arc::from(request_id.as_str())),
-        );
+        dict.put_str("provider_response_id", request_id.as_str());
     }
 
     if let Some(transcript) = transcript {
@@ -334,10 +296,7 @@ pub(crate) fn vm_build_llm_result(
     } else {
         crate::visible_text::sanitize_visible_assistant_text(&result.text, false)
     };
-    dict.insert(
-        "visible_text".to_string(),
-        VmValue::String(std::sync::Arc::from(visible_text.as_str())),
-    );
+    dict.put_str("visible_text", visible_text.as_str());
     dict.insert(
         "blocks".to_string(),
         VmValue::List(std::sync::Arc::new(

--- a/crates/harn-vm/src/llm/api/schema_stream.rs
+++ b/crates/harn-vm/src/llm/api/schema_stream.rs
@@ -16,6 +16,7 @@
 
 use crate::llm::trace::{emit_agent_event, AgentTraceEvent};
 use crate::stdlib::json_stream::{JsonStreamStatus, StreamSchemaValidator};
+use crate::value::VmDictExt;
 use crate::value::{ErrorCategory, VmError, VmValue};
 
 use super::options::LlmRequestPayload;
@@ -184,39 +185,18 @@ fn parse_abort_message(message: &str) -> Option<SchemaStreamAbort> {
 /// callers (e.g. `llm_call_safe`) still expect a dict envelope.
 pub(crate) fn aborted_result_value(abort: &SchemaStreamAbort) -> VmValue {
     let mut meta = std::collections::BTreeMap::new();
-    meta.insert(
-        "reason".to_string(),
-        VmValue::String(std::sync::Arc::from(abort.reason.as_str())),
-    );
-    meta.insert(
-        "path".to_string(),
-        VmValue::String(std::sync::Arc::from(abort.path.as_str())),
-    );
+    meta.put_str("reason", abort.reason.as_str());
+    meta.put_str("path", abort.path.as_str());
     meta.insert(
         "chunks_consumed".to_string(),
         VmValue::Int(abort.chunks_consumed as i64),
     );
-    meta.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(abort.provider.as_str())),
-    );
-    meta.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(abort.model.as_str())),
-    );
+    meta.put_str("provider", abort.provider.as_str());
+    meta.put_str("model", abort.model.as_str());
     let mut dict = std::collections::BTreeMap::new();
-    dict.insert(
-        "text".to_string(),
-        VmValue::String(std::sync::Arc::from("")),
-    );
-    dict.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(abort.model.as_str())),
-    );
-    dict.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(abort.provider.as_str())),
-    );
+    dict.put_str("text", "");
+    dict.put_str("model", abort.model.as_str());
+    dict.put_str("provider", abort.provider.as_str());
     dict.insert("input_tokens".to_string(), VmValue::Int(0));
     dict.insert("output_tokens".to_string(), VmValue::Int(0));
     dict.insert("data".to_string(), VmValue::Nil);

--- a/crates/harn-vm/src/llm/api/telemetry.rs
+++ b/crates/harn-vm/src/llm/api/telemetry.rs
@@ -15,6 +15,7 @@
 //! - `source` identifies which wire format the values were lifted from so
 //!   eval scripts can route on it without re-deriving provider names.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use crate::value::VmValue;
@@ -295,10 +296,7 @@ impl ProviderTelemetry {
         }
         let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
         if !self.source.is_empty() {
-            dict.insert(
-                "source".to_string(),
-                VmValue::String(std::sync::Arc::from(self.source.as_str())),
-            );
+            dict.put_str("source", self.source.as_str());
         }
         insert_opt_u64(&mut dict, "server_total_ms", self.server_total_ms);
         insert_opt_u64(&mut dict, "server_load_ms", self.server_load_ms);
@@ -317,10 +315,7 @@ impl ProviderTelemetry {
             self.runtime_context_length,
         );
         if let Some(ref model) = self.runtime_loaded_model {
-            dict.insert(
-                "runtime_loaded_model".to_string(),
-                VmValue::String(std::sync::Arc::from(model.as_str())),
-            );
+            dict.put_str("runtime_loaded_model", model.as_str());
         }
         insert_opt_u64(&mut dict, "runtime_memory_bytes", self.runtime_memory_bytes);
         insert_opt_u64(
@@ -329,16 +324,10 @@ impl ProviderTelemetry {
             self.runtime_memory_vram_bytes,
         );
         if let Some(ref expires) = self.runtime_keep_alive_until {
-            dict.insert(
-                "runtime_keep_alive_until".to_string(),
-                VmValue::String(std::sync::Arc::from(expires.as_str())),
-            );
+            dict.put_str("runtime_keep_alive_until", expires.as_str());
         }
         if let Some(ref request_id) = self.request_id {
-            dict.insert(
-                "request_id".to_string(),
-                VmValue::String(std::sync::Arc::from(request_id.as_str())),
-            );
+            dict.put_str("request_id", request_id.as_str());
         }
         Some(VmValue::Dict(std::sync::Arc::new(dict)))
     }

--- a/crates/harn-vm/src/llm/cache.rs
+++ b/crates/harn-vm/src/llm/cache.rs
@@ -1,5 +1,6 @@
 //! Persistent cache primitives used by `std/cache` and LLM wrappers.
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, VecDeque};
 use std::path::{Path, PathBuf};
@@ -101,14 +102,8 @@ const CACHE_BUILTINS: &[&VmBuiltinDef] = &[
 
 fn cache_envelope_base(options: &CacheOptions) -> BTreeMap<String, VmValue> {
     let mut envelope = BTreeMap::new();
-    envelope.insert(
-        "backend".to_string(),
-        VmValue::String(std::sync::Arc::from(options.backend.name())),
-    );
-    envelope.insert(
-        "namespace".to_string(),
-        VmValue::String(std::sync::Arc::from(options.namespace.clone())),
-    );
+    envelope.put_str("backend", options.backend.name());
+    envelope.put_str("namespace", options.namespace.clone());
     envelope
 }
 
@@ -151,10 +146,7 @@ fn cache_put_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
 
     let mut envelope = cache_envelope_base(&options);
     envelope.insert("stored".to_string(), VmValue::Bool(true));
-    envelope.insert(
-        "key".to_string(),
-        VmValue::String(std::sync::Arc::from(key)),
-    );
+    envelope.put_str("key", key);
     Ok(VmValue::Dict(std::sync::Arc::new(envelope)))
 }
 

--- a/crates/harn-vm/src/llm/call.rs
+++ b/crates/harn-vm/src/llm/call.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -409,44 +410,20 @@ pub(crate) fn build_llm_error_dict(err: &VmError, provider: &str, model: &str) -
             .or_insert_with(|| VmValue::String(std::sync::Arc::from(llm_error.reason.as_str())));
         dict.entry("message".to_string())
             .or_insert_with(|| VmValue::String(std::sync::Arc::from(message.as_str())));
-        dict.insert(
-            "provider".to_string(),
-            VmValue::String(std::sync::Arc::from(provider)),
-        );
-        dict.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from(model)),
-        );
+        dict.put_str("provider", provider);
+        dict.put_str("model", model);
         return VmValue::Dict(std::sync::Arc::new(dict));
     }
     let mut dict = std::collections::BTreeMap::new();
-    dict.insert(
-        "category".to_string(),
-        VmValue::String(std::sync::Arc::from(category.as_str())),
-    );
-    dict.insert(
-        "kind".to_string(),
-        VmValue::String(std::sync::Arc::from(llm_error.kind.as_str())),
-    );
-    dict.insert(
-        "reason".to_string(),
-        VmValue::String(std::sync::Arc::from(llm_error.reason.as_str())),
-    );
-    dict.insert(
-        "message".to_string(),
-        VmValue::String(std::sync::Arc::from(message)),
-    );
+    dict.put_str("category", category.as_str());
+    dict.put_str("kind", llm_error.kind.as_str());
+    dict.put_str("reason", llm_error.reason.as_str());
+    dict.put_str("message", message);
     if let Some(ms) = agent_observe::extract_retry_after_ms(err) {
         dict.insert("retry_after_ms".to_string(), VmValue::Int(ms as i64));
     }
-    dict.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(provider)),
-    );
-    dict.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(model)),
-    );
+    dict.put_str("provider", provider);
+    dict.put_str("model", model);
     VmValue::Dict(std::sync::Arc::new(dict))
 }
 
@@ -620,10 +597,7 @@ fn attach_routing_block(
     } else {
         trace.label.clone()
     };
-    routing_dict.insert(
-        "policy".to_string(),
-        VmValue::String(std::sync::Arc::from(label)),
-    );
+    routing_dict.put_str("policy", label);
     routing_dict.insert("attempts".to_string(), routing::trace_to_vm_attempts(trace));
     if let Some(selected) = trace.selected {
         routing_dict.insert("selected".to_string(), VmValue::Int(selected as i64));
@@ -832,22 +806,10 @@ pub(super) fn llm_safe_envelope_err(err: &VmError) -> VmValue {
     let message = llm_error_message(err);
     let llm_error = api::classify_llm_error(category.clone(), &message);
     let mut err_dict = std::collections::BTreeMap::new();
-    err_dict.insert(
-        "category".to_string(),
-        VmValue::String(std::sync::Arc::from(category.as_str())),
-    );
-    err_dict.insert(
-        "kind".to_string(),
-        VmValue::String(std::sync::Arc::from(llm_error.kind.as_str())),
-    );
-    err_dict.insert(
-        "reason".to_string(),
-        VmValue::String(std::sync::Arc::from(llm_error.reason.as_str())),
-    );
-    err_dict.insert(
-        "message".to_string(),
-        VmValue::String(std::sync::Arc::from(message)),
-    );
+    err_dict.put_str("category", category.as_str());
+    err_dict.put_str("kind", llm_error.kind.as_str());
+    err_dict.put_str("reason", llm_error.reason.as_str());
+    err_dict.put_str("message", message);
     let mut dict = std::collections::BTreeMap::new();
     dict.insert("ok".to_string(), VmValue::Bool(false));
     dict.insert("response".to_string(), VmValue::Nil);
@@ -926,10 +888,7 @@ pub(crate) fn rewrite_structured_args(args: Vec<VmValue>) -> Result<Vec<VmValue>
         .entry("output_format".to_string())
         .or_insert_with(|| {
             let mut fmt = std::collections::BTreeMap::new();
-            fmt.insert(
-                "kind".to_string(),
-                VmValue::String(std::sync::Arc::from("json_schema")),
-            );
+            fmt.put_str("kind", "json_schema");
             fmt.insert("schema".to_string(), schema);
             fmt.insert("strict".to_string(), VmValue::Bool(true));
             VmValue::Dict(std::sync::Arc::new(fmt))
@@ -981,22 +940,10 @@ pub(crate) fn structured_safe_envelope_err(err: &VmError) -> VmValue {
     let message = llm_error_message(err);
     let llm_error = api::classify_llm_error(category.clone(), &message);
     let mut err_dict = std::collections::BTreeMap::new();
-    err_dict.insert(
-        "category".to_string(),
-        VmValue::String(std::sync::Arc::from(category.as_str())),
-    );
-    err_dict.insert(
-        "kind".to_string(),
-        VmValue::String(std::sync::Arc::from(llm_error.kind.as_str())),
-    );
-    err_dict.insert(
-        "reason".to_string(),
-        VmValue::String(std::sync::Arc::from(llm_error.reason.as_str())),
-    );
-    err_dict.insert(
-        "message".to_string(),
-        VmValue::String(std::sync::Arc::from(message)),
-    );
+    err_dict.put_str("category", category.as_str());
+    err_dict.put_str("kind", llm_error.kind.as_str());
+    err_dict.put_str("reason", llm_error.reason.as_str());
+    err_dict.put_str("message", message);
     let mut dict = std::collections::BTreeMap::new();
     dict.insert("ok".to_string(), VmValue::Bool(false));
     dict.insert("data".to_string(), VmValue::Nil);

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -90,83 +90,62 @@ pub struct ProviderDefaults {
     pub presence_penalty_supported: Option<bool>,
 }
 
+/// Copies `src` into `dst` when `src` is set (last-writer-wins overlay).
+fn overlay_opt<T: Clone>(dst: &mut Option<T>, src: &Option<T>) {
+    if src.is_some() {
+        dst.clone_from(src);
+    }
+}
+
+/// Copies `src` into `dst` only when `dst` is still unset (fill-the-gaps).
+fn fill_opt<T: Clone>(dst: &mut Option<T>, src: &Option<T>) {
+    if dst.is_none() {
+        dst.clone_from(src);
+    }
+}
+
+/// Visits every `ProviderDefaults` field once, applying `$op` (`overlay_opt`
+/// or `fill_opt`) to each `(dst, src)` pair. The field roster lives here only;
+/// `overlay`/`fill_missing_from` differ solely in the merge rule they pass.
+macro_rules! merge_provider_defaults {
+    ($dst:expr, $src:expr, $op:path) => {{
+        $op(&mut $dst.message_wire_format, &$src.message_wire_format);
+        $op(
+            &mut $dst.native_tool_wire_format,
+            &$src.native_tool_wire_format,
+        );
+        $op(
+            &mut $dst.image_url_input_supported,
+            &$src.image_url_input_supported,
+        );
+        $op(
+            &mut $dst.file_upload_wire_format,
+            &$src.file_upload_wire_format,
+        );
+        $op(&mut $dst.reasoning_wire_format, &$src.reasoning_wire_format);
+        $op(&mut $dst.files_api_supported, &$src.files_api_supported);
+        $op(&mut $dst.seed_supported, &$src.seed_supported);
+        $op(&mut $dst.top_k_supported, &$src.top_k_supported);
+        $op(&mut $dst.temperature_supported, &$src.temperature_supported);
+        $op(&mut $dst.top_p_supported, &$src.top_p_supported);
+        $op(
+            &mut $dst.frequency_penalty_supported,
+            &$src.frequency_penalty_supported,
+        );
+        $op(
+            &mut $dst.presence_penalty_supported,
+            &$src.presence_penalty_supported,
+        );
+    }};
+}
+
 impl ProviderDefaults {
     fn overlay(&mut self, other: &ProviderDefaults) {
-        if other.message_wire_format.is_some() {
-            self.message_wire_format = other.message_wire_format.clone();
-        }
-        if other.native_tool_wire_format.is_some() {
-            self.native_tool_wire_format = other.native_tool_wire_format.clone();
-        }
-        if other.image_url_input_supported.is_some() {
-            self.image_url_input_supported = other.image_url_input_supported;
-        }
-        if other.file_upload_wire_format.is_some() {
-            self.file_upload_wire_format = other.file_upload_wire_format.clone();
-        }
-        if other.reasoning_wire_format.is_some() {
-            self.reasoning_wire_format = other.reasoning_wire_format.clone();
-        }
-        if other.files_api_supported.is_some() {
-            self.files_api_supported = other.files_api_supported;
-        }
-        if other.seed_supported.is_some() {
-            self.seed_supported = other.seed_supported;
-        }
-        if other.top_k_supported.is_some() {
-            self.top_k_supported = other.top_k_supported;
-        }
-        if other.temperature_supported.is_some() {
-            self.temperature_supported = other.temperature_supported;
-        }
-        if other.top_p_supported.is_some() {
-            self.top_p_supported = other.top_p_supported;
-        }
-        if other.frequency_penalty_supported.is_some() {
-            self.frequency_penalty_supported = other.frequency_penalty_supported;
-        }
-        if other.presence_penalty_supported.is_some() {
-            self.presence_penalty_supported = other.presence_penalty_supported;
-        }
+        merge_provider_defaults!(self, other, overlay_opt);
     }
 
     fn fill_missing_from(&mut self, other: &ProviderDefaults) {
-        if self.message_wire_format.is_none() {
-            self.message_wire_format = other.message_wire_format.clone();
-        }
-        if self.native_tool_wire_format.is_none() {
-            self.native_tool_wire_format = other.native_tool_wire_format.clone();
-        }
-        if self.image_url_input_supported.is_none() {
-            self.image_url_input_supported = other.image_url_input_supported;
-        }
-        if self.file_upload_wire_format.is_none() {
-            self.file_upload_wire_format = other.file_upload_wire_format.clone();
-        }
-        if self.reasoning_wire_format.is_none() {
-            self.reasoning_wire_format = other.reasoning_wire_format.clone();
-        }
-        if self.files_api_supported.is_none() {
-            self.files_api_supported = other.files_api_supported;
-        }
-        if self.seed_supported.is_none() {
-            self.seed_supported = other.seed_supported;
-        }
-        if self.top_k_supported.is_none() {
-            self.top_k_supported = other.top_k_supported;
-        }
-        if self.temperature_supported.is_none() {
-            self.temperature_supported = other.temperature_supported;
-        }
-        if self.top_p_supported.is_none() {
-            self.top_p_supported = other.top_p_supported;
-        }
-        if self.frequency_penalty_supported.is_none() {
-            self.frequency_penalty_supported = other.frequency_penalty_supported;
-        }
-        if self.presence_penalty_supported.is_none() {
-            self.presence_penalty_supported = other.presence_penalty_supported;
-        }
+        merge_provider_defaults!(self, other, fill_opt);
     }
 
     fn has_any_field(&self) -> bool {

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use crate::llm_config;
@@ -227,14 +228,8 @@ fn llm_resolved_options_builtin(args: &[VmValue], _out: &mut String) -> Result<V
             out.insert(k.clone(), toml_value_to_vm_value(v));
         }
     }
-    out.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(final_provider)),
-    );
-    out.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(resolved_id)),
-    );
+    out.put_str("provider", final_provider);
+    out.put_str("model", resolved_id);
     Ok(VmValue::Dict(std::sync::Arc::new(out)))
 }
 
@@ -304,18 +299,9 @@ fn llm_pick_model_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue
     };
 
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(id.clone())),
-    );
-    dict.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(provider)),
-    );
-    dict.insert(
-        "tier".to_string(),
-        VmValue::String(std::sync::Arc::from(llm_config::model_tier(&id))),
-    );
+    dict.put_str("id", id.clone());
+    dict.put_str("provider", provider);
+    dict.put_str("tier", llm_config::model_tier(&id));
     Ok(VmValue::Dict(std::sync::Arc::new(dict)))
 }
 
@@ -445,10 +431,7 @@ pub(crate) fn llm_provider_status_value() -> VmValue {
     let mut entries = Vec::with_capacity(names.len());
     for name in names {
         let mut entry = BTreeMap::new();
-        entry.insert(
-            "name".to_string(),
-            VmValue::String(std::sync::Arc::from(name.clone())),
-        );
+        entry.put_str("name", name.clone());
 
         // Providers with `auth_style = "none"` (e.g. local Ollama) and
         // the multi-step auth providers (Bedrock/Vertex) report
@@ -478,10 +461,7 @@ pub(crate) fn llm_provider_status_value() -> VmValue {
             }
         };
         entry.insert("available".to_string(), VmValue::Bool(available));
-        entry.insert(
-            "credential_status".to_string(),
-            VmValue::String(std::sync::Arc::from(credential_status)),
-        );
+        entry.put_str("credential_status", credential_status);
         entries.push(VmValue::Dict(std::sync::Arc::new(entry)));
     }
     VmValue::List(std::sync::Arc::new(entries))
@@ -890,10 +870,7 @@ fn provider_region_value(provider_name: Option<&str>) -> Option<VmValue> {
         _ => None,
     };
     let mut region = BTreeMap::new();
-    region.insert(
-        "override_key".to_string(),
-        VmValue::String(std::sync::Arc::from("region")),
-    );
+    region.put_str("override_key", "region");
     region.insert(
         "envs".to_string(),
         string_list_to_vm_value(envs.iter().map(|s| s.to_string()).collect()),
@@ -914,38 +891,12 @@ fn provider_def_to_vm_value(
     pdef: &llm_config::ProviderDef,
 ) -> VmValue {
     let mut dict = BTreeMap::new();
-    if let Some(display_name) = &pdef.display_name {
-        dict.insert(
-            "display_name".to_string(),
-            VmValue::String(std::sync::Arc::from(display_name.as_str())),
-        );
-    }
-    if let Some(icon) = &pdef.icon {
-        dict.insert(
-            "icon".to_string(),
-            VmValue::String(std::sync::Arc::from(icon.as_str())),
-        );
-    }
-    if let Some(protocol) = &pdef.protocol {
-        dict.insert(
-            "protocol".to_string(),
-            VmValue::String(std::sync::Arc::from(protocol.as_str())),
-        );
-    }
-    dict.insert(
-        "base_url".to_string(),
-        VmValue::String(std::sync::Arc::from(pdef.base_url.as_str())),
-    );
-    if let Some(base_url_env) = &pdef.base_url_env {
-        dict.insert(
-            "base_url_env".to_string(),
-            VmValue::String(std::sync::Arc::from(base_url_env.as_str())),
-        );
-    }
-    dict.insert(
-        "auth_style".to_string(),
-        VmValue::String(std::sync::Arc::from(pdef.auth_style.as_str())),
-    );
+    dict.put_opt_str("display_name", pdef.display_name.as_deref());
+    dict.put_opt_str("icon", pdef.icon.as_deref());
+    dict.put_opt_str("protocol", pdef.protocol.as_deref());
+    dict.put_str("base_url", pdef.base_url.as_str());
+    dict.put_opt_str("base_url_env", pdef.base_url_env.as_deref());
+    dict.put_str("auth_style", pdef.auth_style.as_str());
     dict.insert(
         "auth_envs".to_string(),
         string_list_to_vm_value(llm_config::auth_env_names(&pdef.auth_env)),
@@ -961,22 +912,9 @@ fn provider_def_to_vm_value(
                 .unwrap_or(pdef.auth_style == "none"),
         ),
     );
-    dict.insert(
-        "chat_endpoint".to_string(),
-        VmValue::String(std::sync::Arc::from(pdef.chat_endpoint.as_str())),
-    );
-    if let Some(endpoint) = &pdef.completion_endpoint {
-        dict.insert(
-            "completion_endpoint".to_string(),
-            VmValue::String(std::sync::Arc::from(endpoint.as_str())),
-        );
-    }
-    if let Some(command) = &pdef.command {
-        dict.insert(
-            "command".to_string(),
-            VmValue::String(std::sync::Arc::from(command.as_str())),
-        );
-    }
+    dict.put_str("chat_endpoint", pdef.chat_endpoint.as_str());
+    dict.put_opt_str("completion_endpoint", pdef.completion_endpoint.as_deref());
+    dict.put_opt_str("command", pdef.command.as_deref());
     if !pdef.args.is_empty() {
         dict.insert(
             "args".to_string(),
@@ -989,24 +927,14 @@ fn provider_def_to_vm_value(
             json_to_vm_value(&serde_json::json!(pdef.env)),
         );
     }
-    if let Some(cwd) = &pdef.cwd {
-        dict.insert(
-            "cwd".to_string(),
-            VmValue::String(std::sync::Arc::from(cwd.as_str())),
-        );
-    }
+    dict.put_opt_str("cwd", pdef.cwd.as_deref());
     if !pdef.mcp_servers.is_empty() {
         dict.insert(
             "mcp_servers".to_string(),
             json_to_vm_value(&serde_json::Value::Array(pdef.mcp_servers.clone())),
         );
     }
-    if let Some(header) = &pdef.auth_header {
-        dict.insert(
-            "auth_header".to_string(),
-            VmValue::String(std::sync::Arc::from(header.as_str())),
-        );
-    }
+    dict.put_opt_str("auth_header", pdef.auth_header.as_deref());
     if !pdef.extra_headers.is_empty() {
         let mut headers = BTreeMap::new();
         for (k, v) in &pdef.extra_headers {
@@ -1065,14 +993,8 @@ fn string_list_to_vm_value(items: Vec<String>) -> VmValue {
 
 fn resolved_model_to_vm_value(resolved: &llm_config::ResolvedModel) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(resolved.id.as_str())),
-    );
-    dict.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(resolved.provider.as_str())),
-    );
+    dict.put_str("id", resolved.id.as_str());
+    dict.put_str("provider", resolved.provider.as_str());
     dict.insert(
         "alias".to_string(),
         resolved
@@ -1081,22 +1003,10 @@ fn resolved_model_to_vm_value(resolved: &llm_config::ResolvedModel) -> VmValue {
             .map(|alias| VmValue::String(std::sync::Arc::from(alias)))
             .unwrap_or(VmValue::Nil),
     );
-    dict.insert(
-        "tool_format".to_string(),
-        VmValue::String(std::sync::Arc::from(resolved.tool_format.as_str())),
-    );
-    dict.insert(
-        "tier".to_string(),
-        VmValue::String(std::sync::Arc::from(resolved.tier.as_str())),
-    );
-    dict.insert(
-        "family".to_string(),
-        VmValue::String(std::sync::Arc::from(resolved.family.as_str())),
-    );
-    dict.insert(
-        "lineage".to_string(),
-        VmValue::String(std::sync::Arc::from(resolved.lineage.as_str())),
-    );
+    dict.put_str("tool_format", resolved.tool_format.as_str());
+    dict.put_str("tier", resolved.tier.as_str());
+    dict.put_str("family", resolved.family.as_str());
+    dict.put_str("lineage", resolved.lineage.as_str());
     VmValue::Dict(std::sync::Arc::new(dict))
 }
 
@@ -1135,22 +1045,13 @@ pub(crate) fn capabilities_to_vm_value(
     caps: &super::capabilities::Capabilities,
 ) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(provider.to_string())),
-    );
-    dict.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(model.to_string())),
-    );
+    dict.put_str("provider", provider);
+    dict.put_str("model", model);
     dict.insert("native_tools".to_string(), VmValue::Bool(caps.native_tools));
-    dict.insert(
-        "message_wire_format".to_string(),
-        VmValue::String(std::sync::Arc::from(caps.message_wire_format.clone())),
-    );
-    dict.insert(
-        "native_tool_wire_format".to_string(),
-        VmValue::String(std::sync::Arc::from(caps.native_tool_wire_format.clone())),
+    dict.put_str("message_wire_format", caps.message_wire_format.clone());
+    dict.put_str(
+        "native_tool_wire_format",
+        caps.native_tool_wire_format.clone(),
     );
     dict.insert(
         "text_tool_wire_format_supported".to_string(),
@@ -1226,9 +1127,9 @@ pub(crate) fn capabilities_to_vm_value(
         "prompt_caching".to_string(),
         VmValue::Bool(caps.prompt_caching),
     );
-    dict.insert(
-        "cache_breakpoint_style".to_string(),
-        VmValue::String(std::sync::Arc::from(caps.cache_breakpoint_style.as_str())),
+    dict.put_str(
+        "cache_breakpoint_style",
+        caps.cache_breakpoint_style.as_str(),
     );
     dict.insert(
         "prefers_xml_scaffolding".to_string(),
@@ -1238,9 +1139,9 @@ pub(crate) fn capabilities_to_vm_value(
         "prefers_markdown_scaffolding".to_string(),
         VmValue::Bool(caps.prefers_markdown_scaffolding),
     );
-    dict.insert(
-        "structured_output_mode".to_string(),
-        VmValue::String(std::sync::Arc::from(caps.structured_output_mode.as_str())),
+    dict.put_str(
+        "structured_output_mode",
+        caps.structured_output_mode.as_str(),
     );
     dict.insert(
         "supports_assistant_prefill".to_string(),
@@ -1258,10 +1159,7 @@ pub(crate) fn capabilities_to_vm_value(
         "thinking".to_string(),
         VmValue::Bool(!caps.thinking_modes.is_empty()),
     );
-    dict.insert(
-        "thinking_block_style".to_string(),
-        VmValue::String(std::sync::Arc::from(caps.thinking_block_style.as_str())),
-    );
+    dict.put_str("thinking_block_style", caps.thinking_block_style.as_str());
     dict.insert(
         "thinking_modes".to_string(),
         string_list_to_vm_value(caps.thinking_modes.clone()),
@@ -1314,9 +1212,9 @@ pub(crate) fn capabilities_to_vm_value(
         "prefers_markdown_scaffolding".to_string(),
         VmValue::Bool(caps.prefers_markdown_scaffolding),
     );
-    dict.insert(
-        "structured_output_mode".to_string(),
-        VmValue::String(std::sync::Arc::from(caps.structured_output_mode.as_str())),
+    dict.put_str(
+        "structured_output_mode",
+        caps.structured_output_mode.as_str(),
     );
     dict.insert(
         "supports_assistant_prefill".to_string(),
@@ -1330,10 +1228,7 @@ pub(crate) fn capabilities_to_vm_value(
         "prefers_xml_tools".to_string(),
         VmValue::Bool(caps.prefers_xml_tools),
     );
-    dict.insert(
-        "thinking_block_style".to_string(),
-        VmValue::String(std::sync::Arc::from(caps.thinking_block_style.as_str())),
-    );
+    dict.put_str("thinking_block_style", caps.thinking_block_style.as_str());
     dict.insert(
         "preserve_thinking".to_string(),
         VmValue::Bool(caps.preserve_thinking),
@@ -1433,14 +1328,8 @@ pub(crate) fn capabilities_to_vm_value(
     );
     if let Some(fast_mode) = fast_mode {
         let mut fast = BTreeMap::new();
-        fast.insert(
-            "param".to_string(),
-            VmValue::String(std::sync::Arc::from(fast_mode.param.as_str())),
-        );
-        fast.insert(
-            "value".to_string(),
-            VmValue::String(std::sync::Arc::from(fast_mode.value.as_str())),
-        );
+        fast.put_str("param", fast_mode.param.as_str());
+        fast.put_str("value", fast_mode.value.as_str());
         fast.insert(
             "status".to_string(),
             fast_mode
@@ -1474,18 +1363,9 @@ pub(crate) fn capabilities_to_vm_value(
 
 fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(id.to_string())),
-    );
-    dict.insert(
-        "name".to_string(),
-        VmValue::String(std::sync::Arc::from(model.name.as_str())),
-    );
-    dict.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(model.provider.as_str())),
-    );
+    dict.put_str("id", id);
+    dict.put_str("name", model.name.as_str());
+    dict.put_str("provider", model.provider.as_str());
     dict.insert(
         "context_window".to_string(),
         VmValue::Int(model.context_window as i64),
@@ -1595,20 +1475,8 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
         "quality_tags".to_string(),
         string_list_to_vm_value(model.quality_tags.clone()),
     );
-    dict.insert(
-        "family".to_string(),
-        VmValue::String(std::sync::Arc::from(llm_config::model_family(
-            &model.provider,
-            id,
-        ))),
-    );
-    dict.insert(
-        "lineage".to_string(),
-        VmValue::String(std::sync::Arc::from(llm_config::model_lineage(
-            &model.provider,
-            id,
-        ))),
-    );
+    dict.put_str("family", llm_config::model_family(&model.provider, id));
+    dict.put_str("lineage", llm_config::model_lineage(&model.provider, id));
     dict.insert(
         "complementary_with".to_string(),
         string_list_to_vm_value(model.complementary_with.clone()),
@@ -1617,14 +1485,8 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
         "avoid_as_reviewer_for".to_string(),
         string_list_to_vm_value(model.avoid_as_reviewer_for.clone()),
     );
-    dict.insert(
-        "availability".to_string(),
-        VmValue::String(std::sync::Arc::from(model.availability.as_str())),
-    );
-    dict.insert(
-        "tier".to_string(),
-        VmValue::String(std::sync::Arc::from(llm_config::model_tier(id))),
-    );
+    dict.put_str("availability", model.availability.as_str());
+    dict.put_str("tier", llm_config::model_tier(id));
     dict.insert(
         "open_weight".to_string(),
         model.open_weight.map(VmValue::Bool).unwrap_or(VmValue::Nil),
@@ -1690,14 +1552,8 @@ fn pricing_to_vm_value(pricing: &llm_config::ModelPricing) -> VmValue {
 
 fn fast_mode_to_vm_value(fast: &llm_config::FastModeDef) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "param".to_string(),
-        VmValue::String(std::sync::Arc::from(fast.param.as_str())),
-    );
-    dict.insert(
-        "value".to_string(),
-        VmValue::String(std::sync::Arc::from(fast.value.as_str())),
-    );
+    dict.put_str("param", fast.param.as_str());
+    dict.put_str("value", fast.value.as_str());
     dict.insert(
         "beta_header".to_string(),
         fast.beta_header
@@ -1745,10 +1601,7 @@ fn provider_catalog_to_vm_value() -> VmValue {
                 VmValue::Dict(provider) => provider.as_ref().clone(),
                 _ => unreachable!("provider_def_to_vm_value returns a dict"),
             };
-            provider.insert(
-                "name".to_string(),
-                VmValue::String(std::sync::Arc::from(name.clone())),
-            );
+            provider.put_str("name", name.clone());
             providers.push(VmValue::Dict(std::sync::Arc::new(provider)));
         }
     }
@@ -1794,18 +1647,9 @@ fn provider_catalog_to_vm_value() -> VmValue {
 
 fn alias_def_to_vm_value(name: &str, alias: &llm_config::AliasDef) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "name".to_string(),
-        VmValue::String(std::sync::Arc::from(name.to_string())),
-    );
-    dict.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(alias.id.as_str())),
-    );
-    dict.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(alias.provider.as_str())),
-    );
+    dict.put_str("name", name);
+    dict.put_str("id", alias.id.as_str());
+    dict.put_str("provider", alias.provider.as_str());
     dict.insert(
         "tool_format".to_string(),
         alias
@@ -1841,18 +1685,9 @@ fn healthcheck_model_arg(args: &[VmValue]) -> Option<String> {
 
 fn readiness_result(readiness: &super::ModelReadiness) -> VmValue {
     let mut meta = BTreeMap::new();
-    meta.insert(
-        "category".to_string(),
-        VmValue::String(std::sync::Arc::from(readiness.category.as_str())),
-    );
-    meta.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(readiness.provider.as_str())),
-    );
-    meta.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(readiness.model.as_str())),
-    );
+    meta.put_str("category", readiness.category.as_str());
+    meta.put_str("provider", readiness.provider.as_str());
+    meta.put_str("model", readiness.model.as_str());
     meta.insert(
         "url".to_string(),
         readiness
@@ -1889,10 +1724,7 @@ fn healthcheck_result_with_meta(
 ) -> VmValue {
     let mut dict = BTreeMap::new();
     dict.insert("valid".to_string(), VmValue::Bool(valid));
-    dict.insert(
-        "message".to_string(),
-        VmValue::String(std::sync::Arc::from(message)),
-    );
+    dict.put_str("message", message);
     dict.insert(
         "metadata".to_string(),
         VmValue::Dict(std::sync::Arc::new(meta)),

--- a/crates/harn-vm/src/llm/conversation.rs
+++ b/crates/harn-vm/src/llm/conversation.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use crate::value::{VmError, VmValue};
@@ -420,14 +421,8 @@ pub(crate) fn register_conversation_builtins(vm: &mut Vm) {
             .join("\n");
 
         let mut bindings = BTreeMap::new();
-        bindings.insert(
-            "prompt".to_string(),
-            VmValue::String(std::sync::Arc::from(prompt_override)),
-        );
-        bindings.insert(
-            "formatted".to_string(),
-            VmValue::String(std::sync::Arc::from(formatted)),
-        );
+        bindings.put_str("prompt", prompt_override);
+        bindings.put_str("formatted", formatted);
         let user_message = crate::stdlib::template::render_stdlib_prompt_asset(
             "llm/prompts/transcript_summarize_user.harn.prompt",
             Some(&bindings),
@@ -519,18 +514,9 @@ pub(crate) fn register_conversation_builtins(vm: &mut Vm) {
             let tool_use_id = args.get(1).map(|a| a.display()).unwrap_or_default();
             let result_content = args.get(2).map(|a| a.display()).unwrap_or_default();
             let mut msg = BTreeMap::new();
-            msg.insert(
-                "role".to_string(),
-                VmValue::String(std::sync::Arc::from("tool_result")),
-            );
-            msg.insert(
-                "tool_use_id".to_string(),
-                VmValue::String(std::sync::Arc::from(tool_use_id)),
-            );
-            msg.insert(
-                "content".to_string(),
-                VmValue::String(std::sync::Arc::from(result_content)),
-            );
+            msg.put_str("role", "tool_result");
+            msg.put_str("tool_use_id", tool_use_id);
+            msg.put_str("content", result_content);
             let mut new_messages = (**list).clone();
             new_messages.push(VmValue::Dict(std::sync::Arc::new(msg)));
             Ok(VmValue::List(std::sync::Arc::new(new_messages)))
@@ -541,18 +527,9 @@ pub(crate) fn register_conversation_builtins(vm: &mut Vm) {
             let tool_use_id = args.get(1).map(|a| a.display()).unwrap_or_default();
             let result_content = args.get(2).map(|a| a.display()).unwrap_or_default();
             let mut msg = BTreeMap::new();
-            msg.insert(
-                "role".to_string(),
-                VmValue::String(std::sync::Arc::from("tool_result")),
-            );
-            msg.insert(
-                "tool_use_id".to_string(),
-                VmValue::String(std::sync::Arc::from(tool_use_id)),
-            );
-            msg.insert(
-                "content".to_string(),
-                VmValue::String(std::sync::Arc::from(result_content)),
-            );
+            msg.put_str("role", "tool_result");
+            msg.put_str("tool_use_id", tool_use_id);
+            msg.put_str("content", result_content);
             let mut new_messages = transcript_message_list(d)?;
             new_messages.push(VmValue::Dict(std::sync::Arc::new(msg)));
             Ok(rebuild_transcript(

--- a/crates/harn-vm/src/llm/cost.rs
+++ b/crates/harn-vm/src/llm/cost.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 
@@ -327,22 +328,10 @@ pub(crate) fn budget_exceeded_error(
     limit_value: f64,
 ) -> VmError {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "category".to_string(),
-        VmValue::String(std::sync::Arc::from("budget_exceeded")),
-    );
-    dict.insert(
-        "kind".to_string(),
-        VmValue::String(std::sync::Arc::from("terminal")),
-    );
-    dict.insert(
-        "reason".to_string(),
-        VmValue::String(std::sync::Arc::from("budget_exceeded")),
-    );
-    dict.insert(
-        "limit".to_string(),
-        VmValue::String(std::sync::Arc::from(limit_kind.as_str())),
-    );
+    dict.put_str("category", "budget_exceeded");
+    dict.put_str("kind", "terminal");
+    dict.put_str("reason", "budget_exceeded");
+    dict.put_str("limit", limit_kind.as_str());
     dict.insert("limit_value".to_string(), VmValue::Float(limit_value));
     dict.insert(
         "projected_cost_usd".to_string(),
@@ -360,17 +349,11 @@ pub(crate) fn budget_exceeded_error(
         "projected_output_tokens".to_string(),
         VmValue::Int(projection.projected_output_tokens),
     );
-    dict.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(projection.provider.clone())),
-    );
-    dict.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(projection.model.clone())),
-    );
-    dict.insert(
-        "message".to_string(),
-        VmValue::String(std::sync::Arc::from(format!(
+    dict.put_str("provider", projection.provider.clone());
+    dict.put_str("model", projection.model.clone());
+    dict.put_str(
+        "message",
+        format!(
             "LLM budget exceeded before provider call: {} would exceed {}",
             match limit_kind {
                 BudgetLimitKind::PerCallCost =>
@@ -389,7 +372,7 @@ pub(crate) fn budget_exceeded_error(
                 ),
             },
             limit_kind.as_str(),
-        ))),
+        ),
     );
     VmError::Thrown(VmValue::Dict(std::sync::Arc::new(dict)))
 }
@@ -807,14 +790,8 @@ pub(crate) fn register_cost_builtins(vm: &mut Vm) {
 
 fn pricing_detail_to_vm_value(provider: &str, model: &str, detail: &PricingDetail) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(provider.to_string())),
-    );
-    dict.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(model.to_string())),
-    );
+    dict.put_str("provider", provider);
+    dict.put_str("model", model);
     dict.insert(
         "input_per_mtok".to_string(),
         VmValue::Float(detail.input_per_1k * 1000.0),
@@ -837,10 +814,7 @@ fn pricing_detail_to_vm_value(provider: &str, model: &str, detail: &PricingDetai
             .map(|rate| VmValue::Float(rate * 1000.0))
             .unwrap_or(VmValue::Nil),
     );
-    dict.insert(
-        "source".to_string(),
-        VmValue::String(std::sync::Arc::from(detail.source.as_str())),
-    );
+    dict.put_str("source", detail.source.as_str());
     VmValue::Dict(std::sync::Arc::new(dict))
 }
 
@@ -1045,14 +1019,8 @@ fn llm_compare_costs_builtin(args: &[VmValue], _out: &mut String) -> Result<VmVa
             ) * calls as f64
         });
         let mut row = BTreeMap::new();
-        row.insert(
-            "provider".to_string(),
-            VmValue::String(std::sync::Arc::from(provider.clone())),
-        );
-        row.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from(model.clone())),
-        );
+        row.put_str("provider", provider.clone());
+        row.put_str("model", model.clone());
         row.insert(
             "pricing".to_string(),
             detail
@@ -1099,18 +1067,9 @@ pub(crate) fn project_call_cost(
 
 fn tokenizer_info_to_vm_value(model: &str, info: super::token_count::TokenizerInfo) -> VmValue {
     let mut result = BTreeMap::new();
-    result.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(model)),
-    );
-    result.insert(
-        "model_family".to_string(),
-        VmValue::String(std::sync::Arc::from(info.model_family)),
-    );
-    result.insert(
-        "source".to_string(),
-        VmValue::String(std::sync::Arc::from(info.source.as_str())),
-    );
+    result.put_str("model", model);
+    result.put_str("model_family", info.model_family);
+    result.put_str("source", info.source.as_str());
     result.insert("exact".to_string(), VmValue::Bool(info.exact));
     result.insert(
         "known_model_family".to_string(),

--- a/crates/harn-vm/src/llm/cost_route.rs
+++ b/crates/harn-vm/src/llm/cost_route.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use crate::value::{VmError, VmValue};
@@ -30,24 +31,15 @@ fn route_policy_dict(
     strategy: Option<String>,
 ) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "mode".to_string(),
-        VmValue::String(std::sync::Arc::from(mode.to_string())),
-    );
+    dict.put_str("mode", mode);
     if let Some(target) = target {
-        dict.insert(
-            "target".to_string(),
-            VmValue::String(std::sync::Arc::from(target)),
-        );
+        dict.put_str("target", target);
     }
     if let Some(prefer) = prefer {
         dict.insert("prefer".to_string(), prefer);
     }
     if let Some(strategy) = strategy {
-        dict.insert(
-            "strategy".to_string(),
-            VmValue::String(std::sync::Arc::from(strategy)),
-        );
+        dict.put_str("strategy", strategy);
     }
     VmValue::Dict(std::sync::Arc::new(dict))
 }

--- a/crates/harn-vm/src/llm/helpers/blocks.rs
+++ b/crates/harn-vm/src/llm/helpers/blocks.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use crate::value::VmValue;
@@ -48,16 +49,10 @@ fn normalize_transcript_block(block: &VmValue, default_visibility: &str) -> VmVa
         )])
     });
     if !normalized.contains_key("type") {
-        normalized.insert(
-            "type".to_string(),
-            VmValue::String(std::sync::Arc::from("text")),
-        );
+        normalized.put_str("type", "text");
     }
     if !normalized.contains_key("visibility") {
-        normalized.insert(
-            "visibility".to_string(),
-            VmValue::String(std::sync::Arc::from(default_visibility)),
-        );
+        normalized.put_str("visibility", default_visibility);
     }
     VmValue::Dict(std::sync::Arc::new(normalized))
 }

--- a/crates/harn-vm/src/llm/helpers/messages.rs
+++ b/crates/harn-vm/src/llm/helpers/messages.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use crate::value::{VmError, VmValue};
@@ -74,10 +75,7 @@ pub(crate) fn vm_message(role: &str, content: &str) -> VmValue {
 
 pub(crate) fn vm_message_value(role: &str, content: VmValue) -> VmValue {
     let mut msg = BTreeMap::new();
-    msg.insert(
-        "role".to_string(),
-        VmValue::String(std::sync::Arc::from(role)),
-    );
+    msg.put_str("role", role);
     msg.insert("content".to_string(), content);
     VmValue::Dict(std::sync::Arc::new(msg))
 }
@@ -112,18 +110,9 @@ pub(crate) fn json_messages_to_vm(msg_list: &[serde_json::Value]) -> Vec<VmValue
                                 .and_then(|v| v.as_str())
                                 .unwrap_or_default();
                             let mut result = BTreeMap::new();
-                            result.insert(
-                                "role".to_string(),
-                                VmValue::String(std::sync::Arc::from("tool_result")),
-                            );
-                            result.insert(
-                                "tool_use_id".to_string(),
-                                VmValue::String(std::sync::Arc::from(tool_use_id)),
-                            );
-                            result.insert(
-                                "content".to_string(),
-                                VmValue::String(std::sync::Arc::from(content)),
-                            );
+                            result.put_str("role", "tool_result");
+                            result.put_str("tool_use_id", tool_use_id);
+                            result.put_str("content", content);
                             return Some(VmValue::Dict(std::sync::Arc::new(result)));
                         }
                     }

--- a/crates/harn-vm/src/llm/helpers/mod.rs
+++ b/crates/harn-vm/src/llm/helpers/mod.rs
@@ -89,6 +89,7 @@ pub fn vm_value_to_json(val: &VmValue) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::value::VmDictExt;
     use std::collections::BTreeMap;
     use std::rc::Rc;
 
@@ -399,38 +400,20 @@ mod tests {
         reset_provider_key_cache();
 
         let mut opts: BTreeMap<String, VmValue> = BTreeMap::new();
-        opts.insert(
-            "provider".to_string(),
-            VmValue::String(std::sync::Arc::from("auto")),
-        );
-        opts.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from("local:gemma-4-e4b-it")),
-        );
+        opts.put_str("provider", "auto");
+        opts.put_str("model", "local:gemma-4-e4b-it");
         assert_eq!(vm_resolve_provider(&Some(opts)), "ollama");
 
         // Case-insensitive: "AUTO" should behave the same.
         let mut opts2: BTreeMap<String, VmValue> = BTreeMap::new();
-        opts2.insert(
-            "provider".to_string(),
-            VmValue::String(std::sync::Arc::from("AUTO")),
-        );
-        opts2.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from("local:foo/bar")),
-        );
+        opts2.put_str("provider", "AUTO");
+        opts2.put_str("model", "local:foo/bar");
         assert_eq!(vm_resolve_provider(&Some(opts2)), "ollama");
 
         // Explicit non-auto provider still wins.
         let mut opts3: BTreeMap<String, VmValue> = BTreeMap::new();
-        opts3.insert(
-            "provider".to_string(),
-            VmValue::String(std::sync::Arc::from("anthropic")),
-        );
-        opts3.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from("local:foo")),
-        );
+        opts3.put_str("provider", "anthropic");
+        opts3.put_str("model", "local:foo");
         assert_eq!(vm_resolve_provider(&Some(opts3)), "anthropic");
 
         unsafe {
@@ -620,14 +603,8 @@ mod tests {
         // specific model should not be silently overridden by an ACP
         // pin meant only for "no-option" calls.
         let mut explicit_opts: BTreeMap<String, VmValue> = BTreeMap::new();
-        explicit_opts.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from("gpt-4o-mini")),
-        );
-        explicit_opts.insert(
-            "provider".to_string(),
-            VmValue::String(std::sync::Arc::from("openai")),
-        );
+        explicit_opts.put_str("model", "gpt-4o-mini");
+        explicit_opts.put_str("provider", "openai");
         let opts = Some(explicit_opts);
         let provider = vm_resolve_provider(&opts);
         let model = vm_resolve_model(&opts, &provider);

--- a/crates/harn-vm/src/llm/helpers/opt_get.rs
+++ b/crates/harn-vm/src/llm/helpers/opt_get.rs
@@ -31,6 +31,7 @@ pub(crate) fn opt_bool(options: &Option<BTreeMap<String, VmValue>>, key: &str) -
 
 #[cfg(test)]
 mod tests {
+    use crate::value::VmDictExt;
     use std::collections::BTreeMap;
 
     use crate::value::VmValue;
@@ -48,10 +49,7 @@ mod tests {
     #[test]
     fn opt_str_preserves_string_values() {
         let mut options = BTreeMap::new();
-        options.insert(
-            "path".to_string(),
-            VmValue::String(std::sync::Arc::from("transcripts")),
-        );
+        options.put_str("path", "transcripts");
 
         assert_eq!(
             opt_str(&Some(options), "path"),

--- a/crates/harn-vm/src/llm/helpers/options/defaults.rs
+++ b/crates/harn-vm/src/llm/helpers/options/defaults.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::VmDictExt;
 
 /// Layer the active step's defaults onto the call options dict before
 /// model/provider resolution and budget parsing run. The model override
@@ -22,10 +23,7 @@ pub(super) fn apply_active_step_defaults(options: &mut Option<BTreeMap<String, V
     }
     let opts = options.get_or_insert_with(BTreeMap::new);
     if let Some(model_name) = step_default {
-        opts.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from(model_name)),
-        );
+        opts.put_str("model", model_name);
     }
     if let Some((max_tokens, max_usd)) = step_budget {
         if max_tokens.is_some() || max_usd.is_some() {

--- a/crates/harn-vm/src/llm/helpers/options/output_format_tests.rs
+++ b/crates/harn-vm/src/llm/helpers/options/output_format_tests.rs
@@ -1,13 +1,11 @@
 use super::output::*;
 use super::*;
+use crate::value::VmDictExt;
 
 #[test]
 fn parses_explicit_json_schema_output_format() {
     let mut fmt = BTreeMap::new();
-    fmt.insert(
-        "kind".to_string(),
-        VmValue::String(std::sync::Arc::from("json_schema")),
-    );
+    fmt.put_str("kind", "json_schema");
     fmt.insert(
         "schema".to_string(),
         VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(

--- a/crates/harn-vm/src/llm/helpers/options/routing_tests.rs
+++ b/crates/harn-vm/src/llm/helpers/options/routing_tests.rs
@@ -1,5 +1,6 @@
 use super::extract::*;
 use super::*;
+use crate::value::VmDictExt;
 
 use crate::llm_config::{
     AliasDef, AuthEnv, ModelAvailability, ModelDef, ProviderDef, ProvidersConfig, TierRule,
@@ -148,10 +149,7 @@ fn install_equivalent_routes() {
 
 fn extract_with_policy(policy: &str) -> crate::llm::api::LlmCallOptions {
     let mut options = BTreeMap::new();
-    options.insert(
-        "route_policy".to_string(),
-        VmValue::String(std::sync::Arc::from(policy.to_string())),
-    );
+    options.put_str("route_policy", policy);
     options.insert(
         "fallback_chain".to_string(),
         VmValue::List(std::sync::Arc::new(vec![VmValue::String(
@@ -273,10 +271,7 @@ fn explicit_options_win_over_model_role_defaults() {
     super::super::reset_provider_key_cache();
 
     let mut options = model_role_options("merge");
-    options.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from("mock-explicit".to_string())),
-    );
+    options.put_str("model", "mock-explicit");
     options.insert("max_tokens".to_string(), VmValue::Int(512));
     let opts = extract_with_options(options).expect("options");
 
@@ -410,10 +405,7 @@ fn model_role_config_keys_normalize_like_call_options() {
 
 fn fast_options(model: &str) -> BTreeMap<String, VmValue> {
     let mut options = BTreeMap::new();
-    options.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(model.to_string())),
-    );
+    options.put_str("model", model);
     options.insert("fast".to_string(), VmValue::Bool(true));
     options
 }
@@ -470,14 +462,8 @@ fn fastest_over_quality_selects_lowest_latency_available_candidate() {
 fn preference_list_cheapest_first_sets_route_fallbacks() {
     install_test_routes();
     let mut policy = BTreeMap::new();
-    policy.insert(
-        "mode".to_string(),
-        VmValue::String(std::sync::Arc::from("preference_list".to_string())),
-    );
-    policy.insert(
-        "strategy".to_string(),
-        VmValue::String(std::sync::Arc::from("cheapest_first".to_string())),
-    );
+    policy.put_str("mode", "preference_list");
+    policy.put_str("strategy", "cheapest_first");
     policy.insert(
         "prefer".to_string(),
         VmValue::List(std::sync::Arc::new(vec![
@@ -605,14 +591,8 @@ fn always_policy_accepts_provider_model_selector() {
 #[test]
 fn thinking_dict_enabled_false_disables_thinking() {
     let mut options = BTreeMap::new();
-    options.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from("mock".to_string())),
-    );
-    options.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from("gpt-5.4".to_string())),
-    );
+    options.put_str("provider", "mock");
+    options.put_str("model", "gpt-5.4");
     options.insert(
         "thinking".to_string(),
         VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
@@ -632,14 +612,8 @@ fn thinking_dict_enabled_false_disables_thinking() {
 #[test]
 fn thinking_dict_enabled_budget_parses_typed_config() {
     let mut options = BTreeMap::new();
-    options.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from("mock".to_string())),
-    );
-    options.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from("claude-opus-4-6".to_string())),
-    );
+    options.put_str("provider", "mock");
+    options.put_str("model", "claude-opus-4-6");
     options.insert(
         "thinking".to_string(),
         VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
@@ -671,14 +645,8 @@ fn thinking_dict_enabled_budget_parses_typed_config() {
 #[test]
 fn anthropic_beta_features_parse_and_dedupe_with_interleaved_flag() {
     let mut options = BTreeMap::new();
-    options.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from("mock".to_string())),
-    );
-    options.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from("claude-opus-4-6".to_string())),
-    );
+    options.put_str("provider", "mock");
+    options.put_str("model", "claude-opus-4-6");
     options.insert(
         "anthropic_beta_features".to_string(),
         VmValue::List(std::sync::Arc::new(vec![
@@ -738,14 +706,8 @@ fn anthropic_beta_features_reject_invalid_header_names() {
 #[test]
 fn thinking_effort_parses_typed_level() {
     let mut options = BTreeMap::new();
-    options.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from("mock".to_string())),
-    );
-    options.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from("o3".to_string())),
-    );
+    options.put_str("provider", "mock");
+    options.put_str("model", "o3");
     options.insert(
         "thinking".to_string(),
         VmValue::Dict(std::sync::Arc::new(BTreeMap::from([

--- a/crates/harn-vm/src/llm/helpers/transcript.rs
+++ b/crates/harn-vm/src/llm/helpers/transcript.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
@@ -360,17 +361,9 @@ pub(crate) fn new_transcript_with_event_prefix(
     let mut events = prefix_events;
     events.extend(transcript_events_from_messages(&messages));
     events.extend(extra_events);
-    transcript.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from(TRANSCRIPT_TYPE)),
-    );
+    transcript.put_str("_type", TRANSCRIPT_TYPE);
     transcript.insert("version".to_string(), VmValue::Int(TRANSCRIPT_VERSION));
-    transcript.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            id.unwrap_or_else(|| uuid::Uuid::now_v7().to_string()),
-        )),
-    );
+    transcript.put_str("id", id.unwrap_or_else(|| uuid::Uuid::now_v7().to_string()));
     transcript.insert(
         "messages".to_string(),
         VmValue::List(std::sync::Arc::new(messages)),
@@ -384,19 +377,13 @@ pub(crate) fn new_transcript_with_event_prefix(
         VmValue::List(std::sync::Arc::new(assets)),
     );
     if let Some(summary) = summary {
-        transcript.insert(
-            "summary".to_string(),
-            VmValue::String(std::sync::Arc::from(summary)),
-        );
+        transcript.put_str("summary", summary);
     }
     if let Some(metadata) = metadata {
         transcript.insert("metadata".to_string(), metadata);
     }
     if let Some(state) = state {
-        transcript.insert(
-            "state".to_string(),
-            VmValue::String(std::sync::Arc::from(state)),
-        );
+        transcript.put_str("state", state);
     }
     VmValue::Dict(std::sync::Arc::new(transcript))
 }
@@ -439,26 +426,11 @@ pub(crate) fn transcript_event_from_message(message: &VmValue) -> VmValue {
         "message"
     };
     let mut event = BTreeMap::new();
-    event.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(uuid::Uuid::now_v7().to_string())),
-    );
-    event.insert(
-        "kind".to_string(),
-        VmValue::String(std::sync::Arc::from(kind)),
-    );
-    event.insert(
-        "role".to_string(),
-        VmValue::String(std::sync::Arc::from(role.as_str())),
-    );
-    event.insert(
-        "visibility".to_string(),
-        VmValue::String(std::sync::Arc::from(visibility)),
-    );
-    event.insert(
-        "text".to_string(),
-        VmValue::String(std::sync::Arc::from(text)),
-    );
+    event.put_str("id", uuid::Uuid::now_v7().to_string());
+    event.put_str("kind", kind);
+    event.put_str("role", role.as_str());
+    event.put_str("visibility", visibility);
+    event.put_str("text", text);
     event.insert(
         "blocks".to_string(),
         VmValue::List(std::sync::Arc::new(blocks)),
@@ -523,26 +495,11 @@ pub(crate) fn transcript_event(
     metadata: Option<serde_json::Value>,
 ) -> VmValue {
     let mut event = BTreeMap::new();
-    event.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(uuid::Uuid::now_v7().to_string())),
-    );
-    event.insert(
-        "kind".to_string(),
-        VmValue::String(std::sync::Arc::from(kind)),
-    );
-    event.insert(
-        "role".to_string(),
-        VmValue::String(std::sync::Arc::from(role)),
-    );
-    event.insert(
-        "visibility".to_string(),
-        VmValue::String(std::sync::Arc::from(visibility)),
-    );
-    event.insert(
-        "text".to_string(),
-        VmValue::String(std::sync::Arc::from(text)),
-    );
+    event.put_str("id", uuid::Uuid::now_v7().to_string());
+    event.put_str("kind", kind);
+    event.put_str("role", role);
+    event.put_str("visibility", visibility);
+    event.put_str("text", text);
     event.insert(
         "blocks".to_string(),
         VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
@@ -573,27 +530,15 @@ pub(crate) fn transcript_event(
 
 pub(crate) fn normalize_transcript_asset(value: &VmValue) -> VmValue {
     let mut asset = value.as_dict().cloned().unwrap_or_default();
-    asset.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from(TRANSCRIPT_ASSET_TYPE)),
-    );
+    asset.put_str("_type", TRANSCRIPT_ASSET_TYPE);
     if !asset.contains_key("id") {
-        asset.insert(
-            "id".to_string(),
-            VmValue::String(std::sync::Arc::from(uuid::Uuid::now_v7().to_string())),
-        );
+        asset.put_str("id", uuid::Uuid::now_v7().to_string());
     }
     if !asset.contains_key("kind") {
-        asset.insert(
-            "kind".to_string(),
-            VmValue::String(std::sync::Arc::from("blob")),
-        );
+        asset.put_str("kind", "blob");
     }
     if !asset.contains_key("visibility") {
-        asset.insert(
-            "visibility".to_string(),
-            VmValue::String(std::sync::Arc::from("internal")),
-        );
+        asset.put_str("visibility", "internal");
     }
     if value.as_dict().is_none() {
         asset.insert(

--- a/crates/harn-vm/src/llm/introspection.rs
+++ b/crates/harn-vm/src/llm/introspection.rs
@@ -22,6 +22,7 @@
 //! `runtime_introspection_tools(reg)`. Minimal harnesses that omit the
 //! call get no introspection surface at all.
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 
@@ -103,14 +104,8 @@ pub fn harness_identifier() -> String {
 /// `runtime_introspection()` builtin and the tool surface stay in lockstep.
 pub fn snapshot_to_vm_value(snapshot: Option<&RuntimeIntrospectionSnapshot>) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "harn_version".to_string(),
-        VmValue::String(std::sync::Arc::from(crate::bytecode_cache::HARN_VERSION)),
-    );
-    dict.insert(
-        "harness".to_string(),
-        VmValue::String(std::sync::Arc::from(harness_identifier())),
-    );
+    dict.put_str("harn_version", crate::bytecode_cache::HARN_VERSION);
+    dict.put_str("harness", harness_identifier());
     let Some(snap) = snapshot else {
         for key in [
             "provider",
@@ -127,14 +122,8 @@ pub fn snapshot_to_vm_value(snapshot: Option<&RuntimeIntrospectionSnapshot>) -> 
         dict.insert("capabilities".to_string(), VmValue::Nil);
         return VmValue::Dict(std::sync::Arc::new(dict));
     };
-    dict.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(snap.provider.as_str())),
-    );
-    dict.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(snap.model.as_str())),
-    );
+    dict.put_str("provider", snap.provider.as_str());
+    dict.put_str("model", snap.model.as_str());
     dict.insert(
         "model_alias".to_string(),
         snap.model_alias
@@ -142,18 +131,9 @@ pub fn snapshot_to_vm_value(snapshot: Option<&RuntimeIntrospectionSnapshot>) -> 
             .map(|alias| VmValue::String(std::sync::Arc::from(alias)))
             .unwrap_or(VmValue::Nil),
     );
-    dict.insert(
-        "family".to_string(),
-        VmValue::String(std::sync::Arc::from(snap.family.as_str())),
-    );
-    dict.insert(
-        "tool_format".to_string(),
-        VmValue::String(std::sync::Arc::from(snap.tool_format.as_str())),
-    );
-    dict.insert(
-        "tier".to_string(),
-        VmValue::String(std::sync::Arc::from(snap.tier.as_str())),
-    );
+    dict.put_str("family", snap.family.as_str());
+    dict.put_str("tool_format", snap.tool_format.as_str());
+    dict.put_str("tier", snap.tier.as_str());
     dict.insert(
         "context_window".to_string(),
         snap.context_window

--- a/crates/harn-vm/src/llm/mock.rs
+++ b/crates/harn-vm/src/llm/mock.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -487,30 +488,20 @@ fn mock_error_to_vm_error(err: &MockError) -> VmError {
     if err.has_provider_envelope() {
         let classified = super::api::classify_llm_error(err.category.clone(), &message);
         let mut dict = BTreeMap::new();
-        dict.insert(
-            "category".to_string(),
-            VmValue::String(std::sync::Arc::from(err.category.as_str())),
+        dict.put_str("category", err.category.as_str());
+        dict.put_str(
+            "kind",
+            err.kind
+                .as_deref()
+                .unwrap_or_else(|| classified.kind.as_str()),
         );
-        dict.insert(
-            "kind".to_string(),
-            VmValue::String(std::sync::Arc::from(
-                err.kind
-                    .as_deref()
-                    .unwrap_or_else(|| classified.kind.as_str()),
-            )),
+        dict.put_str(
+            "reason",
+            err.reason
+                .as_deref()
+                .unwrap_or_else(|| classified.reason.as_str()),
         );
-        dict.insert(
-            "reason".to_string(),
-            VmValue::String(std::sync::Arc::from(
-                err.reason
-                    .as_deref()
-                    .unwrap_or_else(|| classified.reason.as_str()),
-            )),
-        );
-        dict.insert(
-            "message".to_string(),
-            VmValue::String(std::sync::Arc::from(message)),
-        );
+        dict.put_str("message", message);
         if let Some(status) = err.status {
             dict.insert("status".to_string(), VmValue::Int(i64::from(status)));
         }

--- a/crates/harn-vm/src/llm/mock_builtins.rs
+++ b/crates/harn-vm/src/llm/mock_builtins.rs
@@ -1,5 +1,6 @@
 use crate::stdlib::json_to_vm_value;
 use crate::stdlib::macros::{harn_builtin, register_builtin_defs, VmBuiltinDef};
+use crate::value::VmDictExt;
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
@@ -204,10 +205,7 @@ fn llm_mock_calls_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValu
         .iter()
         .map(|c| {
             let mut dict = std::collections::BTreeMap::new();
-            dict.insert(
-                "api_mode".to_string(),
-                VmValue::String(std::sync::Arc::from(c.api_mode.as_str())),
-            );
+            dict.put_str("api_mode", c.api_mode.as_str());
             let messages: Vec<VmValue> = c.messages.iter().map(json_to_vm_value).collect();
             dict.insert(
                 "messages".to_string(),

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -724,6 +724,7 @@ mod tests {
     use super::call::{build_schema_nudge, compute_validation_errors, SchemaNudge};
     use super::{execute_llm_call, reset_llm_state, structured_output_errors};
     use crate::llm::mock;
+    use crate::value::VmDictExt;
     use crate::value::VmValue;
 
     fn base_opts() -> LlmCallOptions {
@@ -822,10 +823,7 @@ mod tests {
     fn output_validation_accepts_matching_schema() {
         let opts = base_opts();
         let mut map = std::collections::BTreeMap::new();
-        map.insert(
-            "name".to_string(),
-            VmValue::String(std::sync::Arc::from("Ada")),
-        );
+        map.put_str("name", "Ada");
         let data = VmValue::Dict(std::sync::Arc::new(map));
         let errors = compute_validation_errors(&data, &opts);
         assert!(errors.is_empty(), "schema should pass: {errors:?}");

--- a/crates/harn-vm/src/llm/permissions.rs
+++ b/crates/harn-vm/src/llm/permissions.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::thread_local;
@@ -1126,48 +1127,21 @@ fn permission_request_value(
     reason: &str,
 ) -> VmValue {
     let mut request = BTreeMap::new();
-    request.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from("PermissionRequest")),
-    );
-    request.insert(
-        "tool".to_string(),
-        VmValue::String(std::sync::Arc::from(tool_name.to_string())),
-    );
+    request.put_str("_type", "PermissionRequest");
+    request.put_str("tool", tool_name);
     request.insert("args".to_string(), crate::stdlib::json_to_vm_value(args));
-    request.insert(
-        "session_id".to_string(),
-        VmValue::String(std::sync::Arc::from(session_id.to_string())),
-    );
-    request.insert(
-        "reason".to_string(),
-        VmValue::String(std::sync::Arc::from(reason.to_string())),
-    );
+    request.put_str("session_id", session_id);
+    request.put_str("reason", reason);
     if let Some(context) = crate::triggers::dispatcher::current_dispatch_context() {
-        request.insert(
-            "agent".to_string(),
-            VmValue::String(std::sync::Arc::from(context.agent_id)),
-        );
-        request.insert(
-            "action".to_string(),
-            VmValue::String(std::sync::Arc::from(context.action)),
-        );
-        request.insert(
-            "trace_id".to_string(),
-            VmValue::String(std::sync::Arc::from(context.trigger_event.trace_id.0)),
-        );
-        request.insert(
-            "autonomy_tier".to_string(),
-            VmValue::String(std::sync::Arc::from(context.autonomy_tier.as_str())),
-        );
+        request.put_str("agent", context.agent_id);
+        request.put_str("action", context.action);
+        request.put_str("trace_id", context.trigger_event.trace_id.0);
+        request.put_str("autonomy_tier", context.autonomy_tier.as_str());
         if matches!(
             context.autonomy_tier,
             AutonomyTier::Shadow | AutonomyTier::Suggest
         ) {
-            request.insert(
-                "requested_tier".to_string(),
-                VmValue::String(std::sync::Arc::from(AutonomyTier::ActWithApproval.as_str())),
-            );
+            request.put_str("requested_tier", AutonomyTier::ActWithApproval.as_str());
         }
     }
     request.insert(

--- a/crates/harn-vm/src/llm/routing.rs
+++ b/crates/harn-vm/src/llm/routing.rs
@@ -7,6 +7,7 @@
 //! structured tape event so transcripts and replay can attribute the
 //! outcome to a specific chain link.
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -623,10 +624,7 @@ pub(crate) fn build_routing_policy(config: &BTreeMap<String, VmValue>) -> Result
 
     let mut summary = BTreeMap::new();
     summary.insert(ROUTING_POLICY_TAG.to_string(), VmValue::Bool(true));
-    summary.insert(
-        "label".to_string(),
-        VmValue::String(std::sync::Arc::from(label.clone())),
-    );
+    summary.put_str("label", label.clone());
     summary.insert("chain".to_string(), chain_summary_value(&chain));
     if budget.envelope().is_some() {
         summary.insert("budget".to_string(), budget_value(&budget));
@@ -662,28 +660,16 @@ fn chain_summary_value(chain: &[ChainLink]) -> VmValue {
         .iter()
         .map(|link| {
             let mut dict = BTreeMap::new();
-            dict.insert(
-                "provider".to_string(),
-                VmValue::String(std::sync::Arc::from(link.provider.clone())),
-            );
-            dict.insert(
-                "model".to_string(),
-                VmValue::String(std::sync::Arc::from(link.model.clone())),
-            );
+            dict.put_str("provider", link.provider.clone());
+            dict.put_str("model", link.model.clone());
             if let Some(timeout) = link.timeout_ms {
                 dict.insert("timeout_ms".to_string(), VmValue::Int(timeout as i64));
             }
             if let Some(label) = &link.label {
-                dict.insert(
-                    "label".to_string(),
-                    VmValue::String(std::sync::Arc::from(label.clone())),
-                );
+                dict.put_str("label", label.clone());
             }
             if let Some(region) = &link.region {
-                dict.insert(
-                    "region".to_string(),
-                    VmValue::String(std::sync::Arc::from(region.clone())),
-                );
+                dict.put_str("region", region.clone());
             }
             VmValue::Dict(std::sync::Arc::new(dict))
         })
@@ -739,20 +725,14 @@ fn budget_value(budget: &BudgetRules) -> VmValue {
     if let Some(v) = budget.session_usd {
         dict.insert("session_usd".to_string(), VmValue::Float(v));
     }
-    dict.insert(
-        "on_exceed".to_string(),
-        VmValue::String(std::sync::Arc::from(budget.on_exceed_or_abort().as_str())),
-    );
+    dict.put_str("on_exceed", budget.on_exceed_or_abort().as_str());
     VmValue::Dict(std::sync::Arc::new(dict))
 }
 
 fn observe_value(observe: &ObserveRules) -> VmValue {
     let mut dict = BTreeMap::new();
     if let Some(event) = &observe.emit_event {
-        dict.insert(
-            "emit_event".to_string(),
-            VmValue::String(std::sync::Arc::from(event.clone())),
-        );
+        dict.put_str("emit_event", event.clone());
     }
     VmValue::Dict(std::sync::Arc::new(dict))
 }
@@ -1905,22 +1885,10 @@ pub(crate) fn trace_to_vm_attempts(trace: &RoutingTrace) -> VmValue {
         .map(|attempt| {
             let mut dict = BTreeMap::new();
             dict.insert("index".to_string(), VmValue::Int(attempt.index as i64));
-            dict.insert(
-                "provider".to_string(),
-                VmValue::String(std::sync::Arc::from(attempt.provider.clone())),
-            );
-            dict.insert(
-                "model".to_string(),
-                VmValue::String(std::sync::Arc::from(attempt.model.clone())),
-            );
-            dict.insert(
-                "label".to_string(),
-                VmValue::String(std::sync::Arc::from(attempt.label.clone())),
-            );
-            dict.insert(
-                "status".to_string(),
-                VmValue::String(std::sync::Arc::from(attempt.status.as_str())),
-            );
+            dict.put_str("provider", attempt.provider.clone());
+            dict.put_str("model", attempt.model.clone());
+            dict.put_str("label", attempt.label.clone());
+            dict.put_str("status", attempt.status.as_str());
             dict.insert(
                 "duration_ms".to_string(),
                 VmValue::Int(attempt.duration_ms as i64),
@@ -1936,14 +1904,8 @@ pub(crate) fn trace_to_vm_attempts(trace: &RoutingTrace) -> VmValue {
             }
             if let Some(error) = &attempt.error {
                 let mut err_dict = BTreeMap::new();
-                err_dict.insert(
-                    "category".to_string(),
-                    VmValue::String(std::sync::Arc::from(error.category.clone())),
-                );
-                err_dict.insert(
-                    "message".to_string(),
-                    VmValue::String(std::sync::Arc::from(error.message.clone())),
-                );
+                err_dict.put_str("category", error.category.clone());
+                err_dict.put_str("message", error.message.clone());
                 if let Some(status) = error.status {
                     err_dict.insert("status".to_string(), VmValue::Int(status as i64));
                 }
@@ -1953,10 +1915,7 @@ pub(crate) fn trace_to_vm_attempts(trace: &RoutingTrace) -> VmValue {
                 );
             }
             if let Some(outcome) = attempt.verifier_outcome {
-                dict.insert(
-                    "verifier_outcome".to_string(),
-                    VmValue::String(std::sync::Arc::from(outcome.as_str())),
-                );
+                dict.put_str("verifier_outcome", outcome.as_str());
             }
             if !attempt.verifier_signals.is_empty() {
                 let signals: Vec<VmValue> = attempt
@@ -1964,23 +1923,11 @@ pub(crate) fn trace_to_vm_attempts(trace: &RoutingTrace) -> VmValue {
                     .iter()
                     .map(|signal| {
                         let mut sig_dict = BTreeMap::new();
-                        sig_dict.insert(
-                            "name".to_string(),
-                            VmValue::String(std::sync::Arc::from(signal.name.clone())),
-                        );
-                        sig_dict.insert(
-                            "kind".to_string(),
-                            VmValue::String(std::sync::Arc::from(signal.kind.clone())),
-                        );
-                        sig_dict.insert(
-                            "signal".to_string(),
-                            VmValue::String(std::sync::Arc::from(signal.signal.clone())),
-                        );
+                        sig_dict.put_str("name", signal.name.clone());
+                        sig_dict.put_str("kind", signal.kind.clone());
+                        sig_dict.put_str("signal", signal.signal.clone());
                         if let Some(reason) = &signal.reason {
-                            sig_dict.insert(
-                                "reason".to_string(),
-                                VmValue::String(std::sync::Arc::from(reason.clone())),
-                            );
+                            sig_dict.put_str("reason", reason.clone());
                         }
                         VmValue::Dict(std::sync::Arc::new(sig_dict))
                     })

--- a/crates/harn-vm/src/llm/routing_verifier.rs
+++ b/crates/harn-vm/src/llm/routing_verifier.rs
@@ -15,6 +15,7 @@
 //! construction — type-check / lint stay in-process via harn-parser;
 //! test-run shells out under a per-verifier timeout.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -690,25 +691,19 @@ pub(crate) fn verifiers_summary(verifiers: &[Verifier]) -> VmValue {
         .iter()
         .map(|v| {
             let mut dict = BTreeMap::new();
-            dict.insert(
-                "kind".to_string(),
-                VmValue::String(std::sync::Arc::from(v.kind_label())),
-            );
-            dict.insert(
-                "name".to_string(),
-                VmValue::String(std::sync::Arc::from(v.name().to_string())),
-            );
+            dict.put_str("kind", v.kind_label());
+            dict.put_str("name", v.name());
             let on_fail = match v {
                 Verifier::TypeCheck { on_fail, .. }
                 | Verifier::Lint { on_fail, .. }
                 | Verifier::TestRun { on_fail, .. } => *on_fail,
             };
-            dict.insert(
-                "on_fail".to_string(),
-                VmValue::String(std::sync::Arc::from(match on_fail {
+            dict.put_str(
+                "on_fail",
+                match on_fail {
                     FailMode::Refine => "refine",
                     FailMode::Escalate => "escalate",
-                })),
+                },
             );
             VmValue::Dict(std::sync::Arc::new(dict))
         })

--- a/crates/harn-vm/src/llm/schema_recover.rs
+++ b/crates/harn-vm/src/llm/schema_recover.rs
@@ -43,6 +43,7 @@
 //! prose or that used `output_validation: "off"`, when the caller
 //! wants to recover the schema-shaped payload after the fact.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -583,14 +584,8 @@ async fn run_llm_repair(
 fn build_repair_prompt(raw_text: &str, schema: &VmValue) -> String {
     let schema_text = schema_to_compact_json(schema);
     let mut bindings = BTreeMap::new();
-    bindings.insert(
-        "schema_text".to_string(),
-        VmValue::String(std::sync::Arc::from(schema_text)),
-    );
-    bindings.insert(
-        "raw_text".to_string(),
-        VmValue::String(std::sync::Arc::from(raw_text.to_string())),
-    );
+    bindings.put_str("schema_text", schema_text);
+    bindings.put_str("raw_text", raw_text);
     crate::stdlib::template::render_stdlib_prompt_asset(
         "llm/prompts/schema_recover_repair.harn.prompt",
         Some(&bindings),
@@ -626,10 +621,7 @@ fn merge_repair_options(
         .entry("output_format".to_string())
         .or_insert_with(|| {
             let mut fmt = BTreeMap::new();
-            fmt.insert(
-                "kind".to_string(),
-                VmValue::String(std::sync::Arc::from("json_schema")),
-            );
+            fmt.put_str("kind", "json_schema");
             fmt.insert("schema".to_string(), schema.clone());
             fmt.insert("strict".to_string(), VmValue::Bool(true));
             VmValue::Dict(std::sync::Arc::new(fmt))
@@ -656,20 +648,11 @@ fn envelope_success(
     let mut env = BTreeMap::new();
     env.insert("ok".to_string(), VmValue::Bool(true));
     env.insert("data".to_string(), data);
-    env.insert(
-        "raw_text".to_string(),
-        VmValue::String(std::sync::Arc::from(raw_text)),
-    );
-    env.insert(
-        "error".to_string(),
-        VmValue::String(std::sync::Arc::from("")),
-    );
+    env.put_str("raw_text", raw_text);
+    env.put_str("error", "");
     env.insert("error_category".to_string(), VmValue::Nil);
     env.insert("attempts".to_string(), VmValue::Int(attempts as i64));
-    env.insert(
-        "stage".to_string(),
-        VmValue::String(std::sync::Arc::from(stage)),
-    );
+    env.put_str("stage", stage);
     env.insert("repaired".to_string(), VmValue::Bool(repaired));
     VmValue::Dict(std::sync::Arc::new(env))
 }
@@ -684,23 +667,11 @@ fn envelope_failure(
     let mut env = BTreeMap::new();
     env.insert("ok".to_string(), VmValue::Bool(false));
     env.insert("data".to_string(), VmValue::Nil);
-    env.insert(
-        "raw_text".to_string(),
-        VmValue::String(std::sync::Arc::from(raw_text)),
-    );
-    env.insert(
-        "error".to_string(),
-        VmValue::String(std::sync::Arc::from(error_message)),
-    );
-    env.insert(
-        "error_category".to_string(),
-        VmValue::String(std::sync::Arc::from(error_category)),
-    );
+    env.put_str("raw_text", raw_text);
+    env.put_str("error", error_message);
+    env.put_str("error_category", error_category);
     env.insert("attempts".to_string(), VmValue::Int(attempts as i64));
-    env.insert(
-        "stage".to_string(),
-        VmValue::String(std::sync::Arc::from(stage)),
-    );
+    env.put_str("stage", stage);
     env.insert("repaired".to_string(), VmValue::Bool(false));
     VmValue::Dict(std::sync::Arc::new(env))
 }
@@ -708,23 +679,15 @@ fn envelope_failure(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::value::VmDictExt;
 
     fn person_schema() -> VmValue {
         let mut name = BTreeMap::new();
-        name.insert(
-            "type".to_string(),
-            VmValue::String(std::sync::Arc::from("string")),
-        );
+        name.put_str("type", "string");
         let mut age = BTreeMap::new();
-        age.insert(
-            "type".to_string(),
-            VmValue::String(std::sync::Arc::from("integer")),
-        );
+        age.put_str("type", "integer");
         let mut active = BTreeMap::new();
-        active.insert(
-            "type".to_string(),
-            VmValue::String(std::sync::Arc::from("boolean")),
-        );
+        active.put_str("type", "boolean");
         let mut props = BTreeMap::new();
         props.insert("name".to_string(), VmValue::Dict(std::sync::Arc::new(name)));
         props.insert("age".to_string(), VmValue::Dict(std::sync::Arc::new(age)));
@@ -737,10 +700,7 @@ mod tests {
             VmValue::String(std::sync::Arc::from("age")),
         ]));
         let mut schema = BTreeMap::new();
-        schema.insert(
-            "type".to_string(),
-            VmValue::String(std::sync::Arc::from("object")),
-        );
+        schema.put_str("type", "object");
         schema.insert(
             "properties".to_string(),
             VmValue::Dict(std::sync::Arc::new(props)),
@@ -856,10 +816,7 @@ mod tests {
     #[test]
     fn regex_recover_skips_when_schema_is_not_object() {
         let mut scalar = BTreeMap::new();
-        scalar.insert(
-            "type".to_string(),
-            VmValue::String(std::sync::Arc::from("string")),
-        );
+        scalar.put_str("type", "string");
         let schema = VmValue::Dict(std::sync::Arc::new(scalar));
         let outcome = try_regex_recover("hello", &schema, false).unwrap();
         assert!(outcome.is_none());
@@ -868,10 +825,7 @@ mod tests {
     #[test]
     fn coerce_handles_unquoted_string_with_trailing_punct() {
         let mut field = BTreeMap::new();
-        field.insert(
-            "type".to_string(),
-            VmValue::String(std::sync::Arc::from("string")),
-        );
+        field.put_str("type", "string");
         let v =
             coerce_scalar("Ada,", "string", &VmValue::Dict(std::sync::Arc::new(field))).unwrap();
         assert_eq!(v.display(), "Ada");
@@ -880,10 +834,7 @@ mod tests {
     #[test]
     fn coerce_handles_escaped_quotes_in_string() {
         let mut field = BTreeMap::new();
-        field.insert(
-            "type".to_string(),
-            VmValue::String(std::sync::Arc::from("string")),
-        );
+        field.put_str("type", "string");
         let v = coerce_scalar(
             "he said \\\"hi\\\"",
             "string",
@@ -896,10 +847,7 @@ mod tests {
     #[test]
     fn coerce_rejects_null_for_non_nullable_string() {
         let mut field = BTreeMap::new();
-        field.insert(
-            "type".to_string(),
-            VmValue::String(std::sync::Arc::from("string")),
-        );
+        field.put_str("type", "string");
         let v = coerce_scalar("null", "string", &VmValue::Dict(std::sync::Arc::new(field)));
         assert!(v.is_none());
     }
@@ -921,10 +869,7 @@ mod tests {
     #[test]
     fn parse_repair_config_dict_extracts_overrides() {
         let mut repair = BTreeMap::new();
-        repair.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from("local:fix")),
-        );
+        repair.put_str("model", "local:fix");
         repair.insert("max_tokens".to_string(), VmValue::Int(400));
         let mut opts = BTreeMap::new();
         opts.insert(
@@ -971,15 +916,9 @@ mod tests {
     fn merge_repair_overrides_win_over_base() {
         let schema = person_schema();
         let mut base = BTreeMap::new();
-        base.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from("base:big")),
-        );
+        base.put_str("model", "base:big");
         let mut overrides = BTreeMap::new();
-        overrides.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from("override:small")),
-        );
+        overrides.put_str("model", "override:small");
         let merged = merge_repair_options(Some(&base), &overrides, &schema);
         assert_eq!(
             merged.get("model").map(VmValue::display).as_deref(),

--- a/crates/harn-vm/src/llm/stream_builtins.rs
+++ b/crates/harn-vm/src/llm/stream_builtins.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -65,22 +66,10 @@ fn llm_stream_chunk(
     finish_reason: Option<&str>,
 ) -> VmValue {
     let mut dict = std::collections::BTreeMap::new();
-    dict.insert(
-        "delta".to_string(),
-        VmValue::String(std::sync::Arc::from(delta.to_string())),
-    );
-    dict.insert(
-        "visible_delta".to_string(),
-        VmValue::String(std::sync::Arc::from(visible_delta.to_string())),
-    );
-    dict.insert(
-        "partial".to_string(),
-        VmValue::String(std::sync::Arc::from(partial.to_string())),
-    );
-    dict.insert(
-        "role".to_string(),
-        VmValue::String(std::sync::Arc::from("assistant")),
-    );
+    dict.put_str("delta", delta);
+    dict.put_str("visible_delta", visible_delta);
+    dict.put_str("partial", partial);
+    dict.put_str("role", "assistant");
     dict.insert(
         "finish_reason".to_string(),
         finish_reason
@@ -201,6 +190,7 @@ pub(super) async fn llm_stream_call_impl(args: Vec<VmValue>) -> Result<VmValue, 
 
 #[cfg(test)]
 mod tests {
+    use crate::value::VmDictExt;
     use std::collections::BTreeMap;
     use std::sync::Arc;
     use std::time::Duration;
@@ -268,14 +258,8 @@ mod tests {
 
     fn fake_stream_args() -> Vec<VmValue> {
         let mut options = BTreeMap::new();
-        options.insert(
-            "provider".to_string(),
-            VmValue::String(Arc::from("fake".to_string())),
-        );
-        options.insert(
-            "model".to_string(),
-            VmValue::String(Arc::from("fake".to_string())),
-        );
+        options.put_str("provider", "fake");
+        options.put_str("model", "fake");
         vec![
             VmValue::String(Arc::from("hello".to_string())),
             VmValue::Nil,

--- a/crates/harn-vm/src/llm/structural_experiments.rs
+++ b/crates/harn-vm/src/llm/structural_experiments.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use crate::value::{VmError, VmValue};
@@ -315,14 +316,8 @@ pub(crate) async fn apply_structural_experiment(
                     .map(|value| VmValue::Int(value as i64))
                     .unwrap_or(VmValue::Nil),
             );
-            ctx.insert(
-                "label".to_string(),
-                VmValue::String(std::sync::Arc::from(config.label.as_str())),
-            );
-            ctx.insert(
-                "name".to_string(),
-                VmValue::String(std::sync::Arc::from(config.name.as_str())),
-            );
+            ctx.put_str("label", config.label.as_str());
+            ctx.put_str("name", config.name.as_str());
             ctx.insert(
                 "args".to_string(),
                 crate::stdlib::json_to_vm_value(&config.args),
@@ -446,10 +441,7 @@ fn apply_builtin_experiment(
             if let Some(index) = latest_string_user_message_index(&messages) {
                 if let Some(content) = message_text(&messages[index]).map(str::to_string) {
                     let mut bindings = BTreeMap::new();
-                    bindings.insert(
-                        "content".to_string(),
-                        VmValue::String(std::sync::Arc::from(content)),
-                    );
+                    bindings.put_str("content", content);
                     let rendered = crate::stdlib::template::render_stdlib_prompt_asset(
                         "llm/prompts/structural_chain_of_draft.harn.prompt",
                         Some(&bindings),

--- a/crates/harn-vm/src/llm/structured_envelope.rs
+++ b/crates/harn-vm/src/llm/structured_envelope.rs
@@ -26,6 +26,7 @@
 //! (`auth`, `rate_limit`, `transient_network`, ...) skip repair
 //! since there is no raw text to salvage.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -215,14 +216,8 @@ fn apply_prompt_mode_structured_transport(args: &mut [VmValue]) {
     }
     if let Some(options) = args.get_mut(2) {
         let mut dict = options.as_dict().cloned().unwrap_or_default();
-        dict.insert(
-            "output_format".to_string(),
-            VmValue::String(std::sync::Arc::from("text")),
-        );
-        dict.insert(
-            "response_format".to_string(),
-            VmValue::String(std::sync::Arc::from("text")),
-        );
+        dict.put_str("output_format", "text");
+        dict.put_str("response_format", "text");
         *options = VmValue::Dict(std::sync::Arc::new(dict));
     }
 }
@@ -231,14 +226,8 @@ fn prompt_with_schema_contract(prompt: &str, schema: &VmValue) -> String {
     let schema_json = serde_json::to_string_pretty(&vm_value_to_json(schema))
         .unwrap_or_else(|_| schema.display());
     let mut bindings = BTreeMap::new();
-    bindings.insert(
-        "prompt".to_string(),
-        VmValue::String(std::sync::Arc::from(prompt.to_string())),
-    );
-    bindings.insert(
-        "schema_json".to_string(),
-        VmValue::String(std::sync::Arc::from(schema_json)),
-    );
+    bindings.put_str("prompt", prompt);
+    bindings.put_str("schema_json", schema_json);
     crate::stdlib::template::render_stdlib_prompt_asset(
         "llm/prompts/structured_envelope_schema_contract.harn.prompt",
         Some(&bindings),
@@ -337,14 +326,8 @@ fn build_repair_prompt(raw_text: &str, errors: &[String]) -> String {
         errors.join("; ")
     };
     let mut bindings = BTreeMap::new();
-    bindings.insert(
-        "errors_line".to_string(),
-        VmValue::String(std::sync::Arc::from(errors_line)),
-    );
-    bindings.insert(
-        "raw_text".to_string(),
-        VmValue::String(std::sync::Arc::from(raw_text.to_string())),
-    );
+    bindings.put_str("errors_line", errors_line);
+    bindings.put_str("raw_text", raw_text);
     crate::stdlib::template::render_stdlib_prompt_asset(
         "llm/prompts/structured_envelope_repair.harn.prompt",
         Some(&bindings),
@@ -403,14 +386,8 @@ fn envelope_success(outcome: &SchemaLoopOutcome, repaired: bool) -> VmValue {
     let mut env = BTreeMap::new();
     env.insert("ok".to_string(), VmValue::Bool(true));
     env.insert("data".to_string(), data);
-    env.insert(
-        "raw_text".to_string(),
-        VmValue::String(std::sync::Arc::from(outcome.raw_text.as_str())),
-    );
-    env.insert(
-        "error".to_string(),
-        VmValue::String(std::sync::Arc::from("")),
-    );
+    env.put_str("raw_text", outcome.raw_text.as_str());
+    env.put_str("error", "");
     env.insert("error_category".to_string(), VmValue::Nil);
     env.insert(
         "attempts".to_string(),
@@ -419,14 +396,8 @@ fn envelope_success(outcome: &SchemaLoopOutcome, repaired: bool) -> VmValue {
     env.insert("repaired".to_string(), VmValue::Bool(repaired));
     env.insert("extracted_json".to_string(), VmValue::Bool(extracted_json));
     env.insert("usage".to_string(), usage);
-    env.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(model.as_str())),
-    );
-    env.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(provider.as_str())),
-    );
+    env.put_str("model", model.as_str());
+    env.put_str("provider", provider.as_str());
     VmValue::Dict(std::sync::Arc::new(env))
 }
 
@@ -447,18 +418,9 @@ fn envelope_failure(
     let mut env = BTreeMap::new();
     env.insert("ok".to_string(), VmValue::Bool(false));
     env.insert("data".to_string(), VmValue::Nil);
-    env.insert(
-        "raw_text".to_string(),
-        VmValue::String(std::sync::Arc::from(outcome.raw_text.as_str())),
-    );
-    env.insert(
-        "error".to_string(),
-        VmValue::String(std::sync::Arc::from(message.as_str())),
-    );
-    env.insert(
-        "error_category".to_string(),
-        VmValue::String(std::sync::Arc::from(kind.category())),
-    );
+    env.put_str("raw_text", outcome.raw_text.as_str());
+    env.put_str("error", message.as_str());
+    env.put_str("error_category", kind.category());
     env.insert(
         "attempts".to_string(),
         VmValue::Int(outcome.attempts as i64),
@@ -466,14 +428,8 @@ fn envelope_failure(
     env.insert("repaired".to_string(), VmValue::Bool(repaired));
     env.insert("extracted_json".to_string(), VmValue::Bool(extracted_json));
     env.insert("usage".to_string(), usage);
-    env.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(model.as_str())),
-    );
-    env.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(provider.as_str())),
-    );
+    env.put_str("model", model.as_str());
+    env.put_str("provider", provider.as_str());
     VmValue::Dict(std::sync::Arc::new(env))
 }
 
@@ -491,18 +447,9 @@ fn envelope_from_transport_error(err: &VmError, provider: &str, model: &str) -> 
     let mut env = BTreeMap::new();
     env.insert("ok".to_string(), VmValue::Bool(false));
     env.insert("data".to_string(), VmValue::Nil);
-    env.insert(
-        "raw_text".to_string(),
-        VmValue::String(std::sync::Arc::from("")),
-    );
-    env.insert(
-        "error".to_string(),
-        VmValue::String(std::sync::Arc::from(message.as_str())),
-    );
-    env.insert(
-        "error_category".to_string(),
-        VmValue::String(std::sync::Arc::from(category.as_str())),
-    );
+    env.put_str("raw_text", "");
+    env.put_str("error", message.as_str());
+    env.put_str("error_category", category.as_str());
     env.insert("attempts".to_string(), VmValue::Int(0));
     env.insert("repaired".to_string(), VmValue::Bool(false));
     env.insert("extracted_json".to_string(), VmValue::Bool(false));
@@ -510,14 +457,8 @@ fn envelope_from_transport_error(err: &VmError, provider: &str, model: &str) -> 
         "usage".to_string(),
         VmValue::Dict(std::sync::Arc::new(empty_usage_dict())),
     );
-    env.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(model)),
-    );
-    env.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(provider)),
-    );
+    env.put_str("model", model);
+    env.put_str("provider", provider);
     VmValue::Dict(std::sync::Arc::new(env))
 }
 
@@ -616,6 +557,7 @@ pub(crate) async fn llm_call_structured_result_impl(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::value::VmDictExt;
 
     #[test]
     fn repair_prompt_includes_raw_text_and_errors() {
@@ -651,10 +593,7 @@ mod tests {
         ]));
         // Already prompt-mode text transport -> do NOT re-degrade.
         let mut text_opts = BTreeMap::new();
-        text_opts.insert(
-            "output_format".to_string(),
-            VmValue::String(std::sync::Arc::from("text")),
-        );
+        text_opts.put_str("output_format", "text");
         assert!(!structured_request_uses_response_format(&[
             VmValue::Nil,
             VmValue::Nil,
@@ -662,10 +601,7 @@ mod tests {
         ]));
         // json_object still sends a response_format -> degradable.
         let mut json_object_opts = BTreeMap::new();
-        json_object_opts.insert(
-            "output_format".to_string(),
-            VmValue::String(std::sync::Arc::from("json_object")),
-        );
+        json_object_opts.put_str("output_format", "json_object");
         assert!(structured_request_uses_response_format(&[
             VmValue::Nil,
             VmValue::Nil,
@@ -676,10 +612,7 @@ mod tests {
     #[test]
     fn merge_repair_caps_schema_retries_and_drops_nested_repair() {
         let mut base = BTreeMap::new();
-        base.insert(
-            "provider".to_string(),
-            VmValue::String(std::sync::Arc::from("auto")),
-        );
+        base.put_str("provider", "auto");
         base.insert("schema_retries".to_string(), VmValue::Int(5));
         base.insert(
             "repair".to_string(),
@@ -687,10 +620,7 @@ mod tests {
         );
         let overrides = {
             let mut o = BTreeMap::new();
-            o.insert(
-                "model".to_string(),
-                VmValue::String(std::sync::Arc::from("local:fix")),
-            );
+            o.put_str("model", "local:fix");
             o
         };
         let merged = merge_repair_options(Some(&base), &overrides);

--- a/crates/harn-vm/src/mcp/builtins.rs
+++ b/crates/harn-vm/src/mcp/builtins.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::value::VmDictExt;
 
 pub(crate) fn vm_value_to_serde(val: &VmValue) -> serde_json::Value {
     match val {
@@ -268,10 +269,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
         let mut out = Vec::new();
         for entry in crate::mcp_registry::snapshot_status() {
             let mut dict = BTreeMap::new();
-            dict.insert(
-                "name".to_string(),
-                VmValue::String(std::sync::Arc::from(entry.name.as_str())),
-            );
+            dict.put_str("name", entry.name.as_str());
             dict.insert("lazy".to_string(), VmValue::Bool(entry.lazy));
             dict.insert("active".to_string(), VmValue::Bool(entry.active));
             dict.insert(
@@ -279,10 +277,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
                 VmValue::Int(entry.ref_count as i64),
             );
             if let Some(card) = entry.card {
-                dict.insert(
-                    "card".to_string(),
-                    VmValue::String(std::sync::Arc::from(card.as_str())),
-                );
+                dict.put_str("card", card.as_str());
             }
             out.push(VmValue::Dict(std::sync::Arc::new(dict)));
         }
@@ -439,10 +434,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
         drop(guard);
 
         let mut info = BTreeMap::new();
-        info.insert(
-            "name".to_string(),
-            VmValue::String(std::sync::Arc::from(client.name.as_str())),
-        );
+        info.put_str("name", client.name.as_str());
         info.insert("connected".to_string(), VmValue::Bool(true));
         let initialize = client
             .initialize_result
@@ -461,10 +453,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
                 .and_then(|value| value.as_str())
                 .filter(|value| !value.is_empty())
             {
-                info.insert(
-                    "instructions".to_string(),
-                    VmValue::String(std::sync::Arc::from(instructions)),
-                );
+                info.put_str("instructions", instructions);
             }
             info.insert("initialize".to_string(), json_to_vm_value(&initialize));
         }
@@ -843,10 +832,7 @@ pub(crate) fn register_supervised_mcp_host_builtins(vm: &mut Vm) {
             .into_iter()
             .map(|s| {
                 let mut dict = BTreeMap::new();
-                dict.insert(
-                    "name".to_string(),
-                    VmValue::String(std::sync::Arc::from(s.name)),
-                );
+                dict.put_str("name", s.name);
                 dict.insert("active".to_string(), VmValue::Bool(s.active));
                 dict.insert("lazy".to_string(), VmValue::Bool(s.lazy));
                 dict.insert("ref_count".to_string(), VmValue::Int(s.ref_count as i64));
@@ -858,10 +844,7 @@ pub(crate) fn register_supervised_mcp_host_builtins(vm: &mut Vm) {
                     "consecutive_failures".to_string(),
                     VmValue::Int(s.consecutive_failures as i64),
                 );
-                dict.insert(
-                    "circuit".to_string(),
-                    VmValue::String(std::sync::Arc::from(s.circuit.as_str())),
-                );
+                dict.put_str("circuit", s.circuit.as_str());
                 dict.insert("ejected".to_string(), VmValue::Bool(s.ejected));
                 dict.insert(
                     "cache_entries".to_string(),

--- a/crates/harn-vm/src/mcp_elicit.rs
+++ b/crates/harn-vm/src/mcp_elicit.rs
@@ -17,6 +17,7 @@
 //! See the spec at
 //! <https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation>.
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -218,10 +219,7 @@ pub(crate) fn envelope_from_response(
     }
 
     let mut envelope: BTreeMap<String, VmValue> = BTreeMap::new();
-    envelope.insert(
-        "action".to_string(),
-        VmValue::String(std::sync::Arc::from(action)),
-    );
+    envelope.put_str("action", action);
 
     if action == "accept" {
         let content = result
@@ -317,14 +315,8 @@ pub(crate) async fn dispatch_inbound_elicitation(
     // Includes the originating server name so a single host can route
     // by source, and copies the raw schema through unmodified.
     let mut bridge_params: BTreeMap<String, VmValue> = BTreeMap::new();
-    bridge_params.insert(
-        "server".to_string(),
-        VmValue::String(std::sync::Arc::from(server_name)),
-    );
-    bridge_params.insert(
-        "message".to_string(),
-        VmValue::String(std::sync::Arc::from(message.as_str())),
-    );
+    bridge_params.put_str("server", server_name);
+    bridge_params.put_str("message", message.as_str());
     bridge_params.insert(
         "requestedSchema".to_string(),
         json_to_vm_value(&requested_schema),

--- a/crates/harn-vm/src/mcp_file_upload.rs
+++ b/crates/harn-vm/src/mcp_file_upload.rs
@@ -4,6 +4,7 @@
 //! https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2356.
 //! This should be revisited when the MCP proposal is ratified.
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::io::Read;
@@ -139,14 +140,8 @@ fn status_value() -> VmValue {
             VmValue::Nil
         },
     );
-    file_upload.insert(
-        "proposal_url".to_string(),
-        VmValue::String(std::sync::Arc::from(SPEC_URL)),
-    );
-    file_upload.insert(
-        "wire_format".to_string(),
-        VmValue::String(std::sync::Arc::from("x-mcp-file+rfc2397-data-uri")),
-    );
+    file_upload.put_str("proposal_url", SPEC_URL);
+    file_upload.put_str("wire_format", "x-mcp-file+rfc2397-data-uri");
 
     let mut experimental = BTreeMap::new();
     experimental.insert(
@@ -208,29 +203,17 @@ fn file_input_schema(options: &VmValue) -> Result<VmValue, VmError> {
     }
 
     let mut schema = BTreeMap::new();
-    schema.insert(
-        "type".to_string(),
-        VmValue::String(std::sync::Arc::from("string")),
-    );
-    schema.insert(
-        "format".to_string(),
-        VmValue::String(std::sync::Arc::from("uri")),
-    );
+    schema.put_str("type", "string");
+    schema.put_str("format", "uri");
     schema.insert(
         X_MCP_FILE.to_string(),
         VmValue::Dict(std::sync::Arc::new(descriptor)),
     );
     if let Some(title) = options.and_then(|opts| string_field(opts, "title")) {
-        schema.insert(
-            "title".to_string(),
-            VmValue::String(std::sync::Arc::from(title)),
-        );
+        schema.put_str("title", title);
     }
     if let Some(description) = options.and_then(|opts| string_field(opts, "description")) {
-        schema.insert(
-            "description".to_string(),
-            VmValue::String(std::sync::Arc::from(description)),
-        );
+        schema.put_str("description", description);
     }
     Ok(VmValue::Dict(std::sync::Arc::new(schema)))
 }

--- a/crates/harn-vm/src/mcp_sampling.rs
+++ b/crates/harn-vm/src/mcp_sampling.rs
@@ -18,6 +18,7 @@
 //! See the spec at
 //! <https://modelcontextprotocol.io/specification/2025-11-25/client/sampling>.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use serde_json::{json, Value as JsonValue};
@@ -260,10 +261,7 @@ fn parse_sampling_request(params: &JsonValue) -> Result<SamplingRequest, String>
 ///   return `{provider: "mock"}` without ceremony)
 async fn ask_host_approval(server_name: &str, params: &JsonValue) -> ApprovalDecision {
     let mut bridge_params: BTreeMap<String, VmValue> = BTreeMap::new();
-    bridge_params.insert(
-        "server".to_string(),
-        VmValue::String(std::sync::Arc::from(server_name)),
-    );
+    bridge_params.put_str("server", server_name);
     bridge_params.insert("params".to_string(), json_to_vm_value(params));
 
     let result = dispatch_mock_host_call("mcp", "sample", &bridge_params)
@@ -423,10 +421,7 @@ fn build_llm_call_args(
     }
 
     if let Some(hint) = pick_model_hint(parsed.model_preferences.as_ref()) {
-        options.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from(hint.as_str())),
-        );
+        options.put_str("model", hint.as_str());
     }
 
     if let Some(tools) = parsed.tools.as_ref() {
@@ -445,10 +440,7 @@ fn build_llm_call_args(
         options.insert("metadata".to_string(), json_to_vm_value(metadata));
     }
     if let Some(include_context) = parsed.include_context.as_ref() {
-        options.insert(
-            "include_context".to_string(),
-            VmValue::String(std::sync::Arc::from(include_context.as_str())),
-        );
+        options.put_str("include_context", include_context.as_str());
     }
 
     // Host-bridge overrides win over request-derived defaults so an
@@ -522,6 +514,7 @@ fn build_spec_response(outcome: LlmOutcome, parsed: &SamplingRequest) -> JsonVal
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::value::VmDictExt;
     use std::sync::Arc;
 
     fn minimal_request() -> JsonValue {
@@ -633,15 +626,9 @@ mod tests {
     #[test]
     fn coerce_bridge_response_accept_with_options() {
         let mut dict = BTreeMap::new();
-        dict.insert(
-            "action".to_string(),
-            VmValue::String(std::sync::Arc::from("accept")),
-        );
+        dict.put_str("action", "accept");
         let mut options = BTreeMap::new();
-        options.insert(
-            "provider".to_string(),
-            VmValue::String(std::sync::Arc::from("mock")),
-        );
+        options.put_str("provider", "mock");
         dict.insert(
             "options".to_string(),
             VmValue::Dict(std::sync::Arc::new(options)),
@@ -660,14 +647,8 @@ mod tests {
     #[test]
     fn coerce_bridge_response_decline_with_message() {
         let mut dict = BTreeMap::new();
-        dict.insert(
-            "action".to_string(),
-            VmValue::String(std::sync::Arc::from("decline")),
-        );
-        dict.insert(
-            "message".to_string(),
-            VmValue::String(std::sync::Arc::from("rate limit")),
-        );
+        dict.put_str("action", "decline");
+        dict.put_str("message", "rate limit");
         match coerce_bridge_response(VmValue::Dict(std::sync::Arc::new(dict))) {
             ApprovalDecision::Decline(reason) => assert_eq!(reason, "rate limit"),
             other => panic!("expected decline, got {other:?}"),
@@ -677,10 +658,7 @@ mod tests {
     #[test]
     fn coerce_bridge_response_bare_dict_is_overrides() {
         let mut dict = BTreeMap::new();
-        dict.insert(
-            "provider".to_string(),
-            VmValue::String(std::sync::Arc::from("mock")),
-        );
+        dict.put_str("provider", "mock");
         match coerce_bridge_response(VmValue::Dict(std::sync::Arc::new(dict))) {
             ApprovalDecision::Accept(map) => {
                 assert_eq!(
@@ -782,10 +760,7 @@ mod tests {
         ) -> Result<Option<VmValue>, VmError> {
             if capability == "mcp" && operation == "sample" {
                 let mut envelope: BTreeMap<String, VmValue> = BTreeMap::new();
-                envelope.insert(
-                    "action".to_string(),
-                    VmValue::String(std::sync::Arc::from("accept")),
-                );
+                envelope.put_str("action", "accept");
                 envelope.insert(
                     "options".to_string(),
                     VmValue::Dict(std::sync::Arc::new(self.overrides.clone())),
@@ -828,14 +803,8 @@ mod tests {
         // Install an approving bridge that forces provider=mock so the
         // call resolves through MockProvider deterministically.
         let mut overrides: BTreeMap<String, VmValue> = BTreeMap::new();
-        overrides.insert(
-            "provider".to_string(),
-            VmValue::String(std::sync::Arc::from("mock")),
-        );
-        overrides.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from("mock-model")),
-        );
+        overrides.put_str("provider", "mock");
+        overrides.put_str("model", "mock-model");
         crate::stdlib::host::set_host_call_bridge(Arc::new(ApproveSamplingBridge { overrides }));
 
         let request = json!({

--- a/crates/harn-vm/src/mcp_server/tests.rs
+++ b/crates/harn-vm/src/mcp_server/tests.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -47,14 +48,8 @@ fn test_params_to_json_schema_empty() {
 fn test_params_to_json_schema_with_params() {
     let mut params = BTreeMap::new();
     let mut param_def = BTreeMap::new();
-    param_def.insert(
-        "type".to_string(),
-        VmValue::String(std::sync::Arc::from("string")),
-    );
-    param_def.insert(
-        "description".to_string(),
-        VmValue::String(std::sync::Arc::from("A file path")),
-    );
+    param_def.put_str("type", "string");
+    param_def.put_str("description", "A file path");
     param_def.insert("required".to_string(), VmValue::Bool(true));
     params.insert(
         "path".to_string(),
@@ -84,14 +79,8 @@ fn test_params_to_json_schema_preserves_file_input_descriptor() {
     file_descriptor.insert("maxSize".to_string(), VmValue::Int(64));
 
     let mut param_def = BTreeMap::new();
-    param_def.insert(
-        "type".to_string(),
-        VmValue::String(std::sync::Arc::from("string")),
-    );
-    param_def.insert(
-        "format".to_string(),
-        VmValue::String(std::sync::Arc::from("uri")),
-    );
+    param_def.put_str("type", "string");
+    param_def.put_str("format", "uri");
     param_def.insert(
         "x-mcp-file".to_string(),
         VmValue::Dict(std::sync::Arc::new(file_descriptor)),
@@ -118,10 +107,7 @@ fn test_params_to_json_schema_preserves_file_input_descriptor() {
 #[test]
 fn test_params_to_json_schema_simple_form() {
     let mut params = BTreeMap::new();
-    params.insert(
-        "query".to_string(),
-        VmValue::String(std::sync::Arc::from("string")),
-    );
+    params.put_str("query", "string");
     let schema = params_to_json_schema(Some(&VmValue::Dict(std::sync::Arc::new(params))));
     assert_eq!(
         schema["properties"]["query"]["type"],

--- a/crates/harn-vm/src/metadata.rs
+++ b/crates/harn-vm/src/metadata.rs
@@ -7,6 +7,7 @@
 //! Resolution uses hierarchical inheritance: child directories inherit from
 //! parent directories, with overrides at each level.
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -817,10 +818,7 @@ fn metadata_entries_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue,
             let local = st.local_directory(&dir);
             let resolved = st.resolve(&dir);
             let mut item = BTreeMap::new();
-            item.insert(
-                "dir".to_string(),
-                VmValue::String(std::sync::Arc::from(normalize_directory_key(&dir))),
-            );
+            item.put_str("dir", normalize_directory_key(&dir));
             match &namespace {
                 Some(ns) => {
                     item.insert(
@@ -1209,14 +1207,8 @@ fn path_metadata_entries_impl(args: &[VmValue], _out: &mut String) -> Result<VmV
                     None => directory_metadata_to_vm(meta),
                 };
                 let mut item = BTreeMap::new();
-                item.insert(
-                    "kind".to_string(),
-                    VmValue::String(std::sync::Arc::from("file")),
-                );
-                item.insert(
-                    "path".to_string(),
-                    VmValue::String(std::sync::Arc::from(path.as_str())),
-                );
+                item.put_str("kind", "file");
+                item.put_str("path", path.as_str());
                 item.insert("local".to_string(), local);
                 items.push(VmValue::Dict(std::sync::Arc::new(item)));
             }
@@ -1242,14 +1234,8 @@ fn path_metadata_entries_impl(args: &[VmValue], _out: &mut String) -> Result<VmV
                     None => directory_metadata_to_vm(&resolved),
                 };
                 let mut item = BTreeMap::new();
-                item.insert(
-                    "kind".to_string(),
-                    VmValue::String(std::sync::Arc::from("dir")),
-                );
-                item.insert(
-                    "path".to_string(),
-                    VmValue::String(std::sync::Arc::from(normalize_directory_key(&dir))),
-                );
+                item.put_str("kind", "dir");
+                item.put_str("path", normalize_directory_key(&dir));
                 item.insert("local".to_string(), local_value);
                 item.insert("resolved".to_string(), resolved_value);
                 items.push(VmValue::Dict(std::sync::Arc::new(item)));
@@ -1420,10 +1406,7 @@ fn scan_dir_recursive(
             .map(|d| d.as_secs() as i64)
             .unwrap_or(0);
         let mut m = BTreeMap::new();
-        m.insert(
-            "path".to_string(),
-            VmValue::String(std::sync::Arc::from(rel_path)),
-        );
+        m.put_str("path", rel_path);
         m.insert("size".to_string(), VmValue::Int(meta.len() as i64));
         m.insert("modified".to_string(), VmValue::Int(mtime));
         m.insert("is_dir".to_string(), VmValue::Bool(meta.is_dir()));

--- a/crates/harn-vm/src/orchestration/command_policy.rs
+++ b/crates/harn-vm/src/orchestration/command_policy.rs
@@ -5,6 +5,7 @@
 //! spawns, records deterministic risk labels, and can block or rewrite
 //! constrained request fields without relying on model prompt text.
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Component, Path, PathBuf};
@@ -497,56 +498,26 @@ pub fn blocked_command_response(
     let command_id = format!("cmd_blocked_{}", crate::orchestration::new_id("policy"));
     let now = chrono::Utc::now().to_rfc3339();
     let mut result = BTreeMap::new();
-    result.insert(
-        "command_id".to_string(),
-        VmValue::String(std::sync::Arc::from(command_id.clone())),
-    );
-    result.insert(
-        "status".to_string(),
-        VmValue::String(std::sync::Arc::from(status.to_string())),
-    );
+    result.put_str("command_id", command_id.clone());
+    result.put_str("status", status);
     result.insert("pid".to_string(), VmValue::Nil);
     result.insert("process_group_id".to_string(), VmValue::Nil);
     result.insert("handle_id".to_string(), VmValue::Nil);
-    result.insert(
-        "started_at".to_string(),
-        VmValue::String(std::sync::Arc::from(now.clone())),
-    );
-    result.insert(
-        "ended_at".to_string(),
-        VmValue::String(std::sync::Arc::from(now)),
-    );
+    result.put_str("started_at", now.clone());
+    result.put_str("ended_at", now);
     result.insert("duration_ms".to_string(), VmValue::Int(0));
     result.insert("exit_code".to_string(), VmValue::Int(-1));
     result.insert("signal".to_string(), VmValue::Nil);
     result.insert("timed_out".to_string(), VmValue::Bool(false));
-    result.insert(
-        "stdout".to_string(),
-        VmValue::String(std::sync::Arc::from("")),
-    );
-    result.insert(
-        "stderr".to_string(),
-        VmValue::String(std::sync::Arc::from(message.to_string())),
-    );
-    result.insert(
-        "combined".to_string(),
-        VmValue::String(std::sync::Arc::from(message.to_string())),
-    );
+    result.put_str("stdout", "");
+    result.put_str("stderr", message);
+    result.put_str("combined", message);
     result.insert("exit_status".to_string(), VmValue::Int(-1));
     result.insert("legacy_status".to_string(), VmValue::Int(-1));
     result.insert("success".to_string(), VmValue::Bool(false));
-    result.insert(
-        "error".to_string(),
-        VmValue::String(std::sync::Arc::from("permission_denied")),
-    );
-    result.insert(
-        "reason".to_string(),
-        VmValue::String(std::sync::Arc::from(message.to_string())),
-    );
-    result.insert(
-        "audit_id".to_string(),
-        VmValue::String(std::sync::Arc::from(format!("audit_{command_id}"))),
-    );
+    result.put_str("error", "permission_denied");
+    result.put_str("reason", message);
+    result.put_str("audit_id", format!("audit_{command_id}"));
     result.insert(
         "request".to_string(),
         VmValue::Dict(std::sync::Arc::new(redacted_vm_request(params))),

--- a/crates/harn-vm/src/orchestration/compact_lifecycle.rs
+++ b/crates/harn-vm/src/orchestration/compact_lifecycle.rs
@@ -26,6 +26,7 @@
 //! 10. Emit `AgentEvent::TranscriptCompacted` when the call carries a
 //!     `session_id`.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use serde_json::Value as JsonValue;
@@ -895,10 +896,7 @@ fn build_snapshot_asset(
         );
     }
     if let Some(source) = config.policy.instruction_source() {
-        asset_metadata.insert(
-            "instruction_source".to_string(),
-            VmValue::String(std::sync::Arc::from(source)),
-        );
+        asset_metadata.put_str("instruction_source", source);
     }
     let asset = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
         (
@@ -967,6 +965,7 @@ pub fn transcript_compactable_events(transcript: &BTreeMap<String, VmValue>) -> 
 mod tests {
     use super::*;
     use crate::llm::helpers::{ReminderPropagate, ReminderRoleHint, ReminderSource};
+    use crate::value::VmDictExt;
 
     fn reminder_event_value(body: &str, preserve: bool, ttl: Option<i64>) -> VmValue {
         let reminder = SystemReminder {
@@ -985,14 +984,8 @@ mod tests {
         let reminder_value =
             crate::stdlib::json_to_vm_value(&serde_json::to_value(&reminder).unwrap());
         let mut event = BTreeMap::new();
-        event.insert(
-            "kind".to_string(),
-            VmValue::String(std::sync::Arc::from("system_reminder")),
-        );
-        event.insert(
-            "role".to_string(),
-            VmValue::String(std::sync::Arc::from("system")),
-        );
+        event.put_str("kind", "system_reminder");
+        event.put_str("role", "system");
         event.insert("reminder".to_string(), reminder_value);
         VmValue::Dict(std::sync::Arc::new(event))
     }

--- a/crates/harn-vm/src/orchestration/compaction.rs
+++ b/crates/harn-vm/src/orchestration/compaction.rs
@@ -1,5 +1,6 @@
 //! Auto-compaction — transcript size management strategies.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
@@ -196,22 +197,13 @@ pub fn compaction_policy_option_keys() -> &'static [&'static str] {
 pub fn compaction_policy_to_vm_value(policy: &CompactionPolicy) -> VmValue {
     let mut map = BTreeMap::new();
     if let Some(instructions) = policy.instructions.as_ref() {
-        map.insert(
-            "instructions".to_string(),
-            VmValue::String(std::sync::Arc::from(instructions.clone())),
-        );
+        map.put_str("instructions", instructions.clone());
     }
     if let Some(mode) = policy.mode.as_ref() {
-        map.insert(
-            "mode".to_string(),
-            VmValue::String(std::sync::Arc::from(mode.clone())),
-        );
+        map.put_str("mode", mode.clone());
     }
     if let Some(scope) = policy.scope.as_ref() {
-        map.insert(
-            "scope".to_string(),
-            VmValue::String(std::sync::Arc::from(scope.clone())),
-        );
+        map.put_str("scope", scope.clone());
     }
     map.insert(
         "preserve".to_string(),
@@ -240,10 +232,7 @@ pub fn compaction_policy_to_vm_value(policy: &CompactionPolicy) -> VmValue {
         );
     }
     if let Some(author) = policy.author.as_ref() {
-        map.insert(
-            "author".to_string(),
-            VmValue::String(std::sync::Arc::from(author.clone())),
-        );
+        map.put_str("author", author.clone());
     }
     VmValue::Dict(std::sync::Arc::new(map))
 }
@@ -862,10 +851,7 @@ fn render_llm_compaction_prompt(
         return render_replacement_compaction_prompt(policy, formatted, archived_count);
     }
     let mut bindings = BTreeMap::new();
-    bindings.insert(
-        "formatted_messages".to_string(),
-        VmValue::String(std::sync::Arc::from(formatted.to_string())),
-    );
+    bindings.put_str("formatted_messages", formatted);
     bindings.insert(
         "archived_count".to_string(),
         VmValue::Int(archived_count as i64),
@@ -892,14 +878,8 @@ fn render_replacement_compaction_prompt(
 ) -> Result<String, VmError> {
     let directives = policy.prompt_directives().unwrap_or_default();
     let mut bindings = BTreeMap::new();
-    bindings.insert(
-        "directives".to_string(),
-        VmValue::String(std::sync::Arc::from(directives)),
-    );
-    bindings.insert(
-        "formatted_messages".to_string(),
-        VmValue::String(std::sync::Arc::from(formatted.to_string())),
-    );
+    bindings.put_str("directives", directives);
+    bindings.put_str("formatted_messages", formatted);
     bindings.insert(
         "archived_count".to_string(),
         VmValue::Int(archived_count as i64),

--- a/crates/harn-vm/src/orchestration/policy/mod.rs
+++ b/crates/harn-vm/src/orchestration/policy/mod.rs
@@ -5,6 +5,7 @@ mod effects;
 mod nested_budget;
 mod types;
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::thread_local;
@@ -606,10 +607,7 @@ fn redact_public_message(message: &VmValue) -> Option<VmValue> {
         if public_text.is_empty() {
             redacted.remove("text");
         } else {
-            redacted.insert(
-                "text".to_string(),
-                VmValue::String(std::sync::Arc::from(public_text.join("\n"))),
-            );
+            redacted.put_str("text", public_text.join("\n"));
         }
     }
     Some(VmValue::Dict(std::sync::Arc::new(redacted)))

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -1,5 +1,6 @@
 //! Workflow graph types, normalization, validation, and execution.
 
+use crate::value::VmDictExt;
 use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
@@ -952,16 +953,8 @@ fn workflow_stage_llm_options(
 ) -> BTreeMap<String, VmValue> {
     let mut options = stage_agent_options.llm_options_vm_dict();
     merge_raw_model_policy_options(&mut options, node);
-    options.insert(
-        "session_id".to_string(),
-        VmValue::String(std::sync::Arc::from(stage_session_id.to_string())),
-    );
-    options.insert(
-        "tool_format".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            stage_agent_options.tool_format.clone(),
-        )),
-    );
+    options.put_str("session_id", stage_session_id);
+    options.put_str("tool_format", stage_agent_options.tool_format.clone());
     add_stage_tools_option(&mut options, tools_value, tool_names);
     options
 }
@@ -988,16 +981,10 @@ fn add_workflow_agent_compaction_options(
         options.insert("hard_limit_tokens".to_string(), VmValue::Int(value as i64));
     }
     if let Some(strategy) = node.auto_compact.compact_strategy.as_ref() {
-        options.insert(
-            "compact_strategy".to_string(),
-            VmValue::String(std::sync::Arc::from(strategy.clone())),
-        );
+        options.put_str("compact_strategy", strategy.clone());
     }
     if let Some(strategy) = node.auto_compact.hard_limit_strategy.as_ref() {
-        options.insert(
-            "hard_limit_strategy".to_string(),
-            VmValue::String(std::sync::Arc::from(strategy.clone())),
-        );
+        options.put_str("hard_limit_strategy", strategy.clone());
     }
     if let Some(value) = raw_auto_compact_int(node, "compact_keep_last")
         .or_else(|| raw_auto_compact_int(node, "keep_last"))
@@ -1005,10 +992,7 @@ fn add_workflow_agent_compaction_options(
         options.insert("compact_keep_last".to_string(), VmValue::Int(value as i64));
     }
     if let Some(prompt) = raw_auto_compact_string(node, "summarize_prompt") {
-        options.insert(
-            "summarize_prompt".to_string(),
-            VmValue::String(std::sync::Arc::from(prompt)),
-        );
+        options.put_str("summarize_prompt", prompt);
     }
     if let Some(dict) = raw_auto_compact_dict(node) {
         for key in ["compress_callback", "mask_callback"] {
@@ -1052,16 +1036,8 @@ fn workflow_stage_agent_loop_options(
         .map_err(VmError::Runtime)?;
     insert_json_vm_option(&mut options, "policy", &effective_policy)?;
     insert_json_vm_option(&mut options, "approval_policy", &node.approval_policy)?;
-    options.insert(
-        "session_id".to_string(),
-        VmValue::String(std::sync::Arc::from(stage_session_id.to_string())),
-    );
-    options.insert(
-        "tool_format".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            stage_agent_options.tool_format.clone(),
-        )),
-    );
+    options.put_str("session_id", stage_session_id);
+    options.put_str("tool_format", stage_agent_options.tool_format.clone());
     let stage_label = node
         .id
         .clone()

--- a/crates/harn-vm/src/schema/canonicalize.rs
+++ b/crates/harn-vm/src/schema/canonicalize.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::value::VmValue;
@@ -224,10 +225,7 @@ fn canonicalize_schema_dict(
     match schema.get("type") {
         Some(VmValue::String(type_name)) => {
             let normalized_type = normalize_type_name(type_name);
-            out.insert(
-                "type".to_string(),
-                VmValue::String(std::sync::Arc::from(normalized_type.as_str())),
-            );
+            out.put_str("type", normalized_type.as_str());
         }
         Some(VmValue::List(type_names)) => {
             let union = type_names
@@ -235,10 +233,7 @@ fn canonicalize_schema_dict(
                 .map(|item| {
                     let type_name = normalize_type_name(&item.display());
                     let mut branch = BTreeMap::new();
-                    branch.insert(
-                        "type".to_string(),
-                        VmValue::String(std::sync::Arc::from(type_name.as_str())),
-                    );
+                    branch.put_str("type", type_name.as_str());
                     VmValue::Dict(std::sync::Arc::new(branch))
                 })
                 .collect::<Vec<_>>();
@@ -251,10 +246,7 @@ fn canonicalize_schema_dict(
     }
 
     if out.get("x-harn-type").map(|v| v.display()) == Some("set".to_string()) {
-        out.insert(
-            "type".to_string(),
-            VmValue::String(std::sync::Arc::from("set")),
-        );
+        out.put_str("type", "set");
     }
 
     Ok(out)

--- a/crates/harn-vm/src/schema/result.rs
+++ b/crates/harn-vm/src/schema/result.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use crate::value::VmValue;
@@ -14,14 +15,12 @@ pub(super) fn result_ok_value(value: VmValue) -> VmValue {
 
 pub(super) fn result_err_value(errors: Vec<String>, value: Option<VmValue>) -> VmValue {
     let mut payload = BTreeMap::new();
-    payload.insert(
-        "message".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            errors
-                .first()
-                .cloned()
-                .unwrap_or_else(|| "schema validation failed".to_string()),
-        )),
+    payload.put_str(
+        "message",
+        errors
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "schema validation failed".to_string()),
     );
     payload.insert(
         "errors".to_string(),

--- a/crates/harn-vm/src/security/mod.rs
+++ b/crates/harn-vm/src/security/mod.rs
@@ -29,6 +29,7 @@
 //! trifecta gate only fires where an interactive approval policy is installed,
 //! so non-interactive embedders (headless evals) are unaffected by it.
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -764,10 +765,7 @@ fn policy_from_dict(config: &BTreeMap<String, VmValue>) -> SecurityPolicy {
 
 fn policy_summary(policy: &SecurityPolicy) -> VmValue {
     let mut map = BTreeMap::new();
-    map.insert(
-        "mode".to_string(),
-        VmValue::String(std::sync::Arc::from(policy.mode.as_str())),
-    );
+    map.put_str("mode", policy.mode.as_str());
     map.insert(
         "spotlight_external".to_string(),
         VmValue::Bool(policy.spotlight_external),
@@ -792,10 +790,7 @@ fn policy_summary(policy: &SecurityPolicy) -> VmValue {
         "guard_threshold_percent".to_string(),
         VmValue::Int(i64::from(policy.guard_threshold_percent)),
     );
-    map.insert(
-        "guard_model".to_string(),
-        VmValue::String(std::sync::Arc::from(policy.guard_model.as_str())),
-    );
+    map.put_str("guard_model", policy.guard_model.as_str());
     VmValue::Dict(std::sync::Arc::new(map))
 }
 

--- a/crates/harn-vm/src/shared_state.rs
+++ b/crates/harn-vm/src/shared_state.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -336,27 +337,15 @@ impl VmSharedStateRuntime {
 
 fn handle_value(kind: &str, scoped: &ScopedKey) -> VmValue {
     let mut value = BTreeMap::new();
-    value.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from(kind.to_string())),
-    );
-    value.insert(
-        "scope".to_string(),
-        VmValue::String(std::sync::Arc::from(scoped.scope.clone())),
-    );
-    value.insert(
-        "key".to_string(),
-        VmValue::String(std::sync::Arc::from(scoped.key.clone())),
-    );
+    value.put_str("_type", kind);
+    value.put_str("scope", scoped.scope.clone());
+    value.put_str("key", scoped.key.clone());
     VmValue::Dict(std::sync::Arc::new(value))
 }
 
 fn snapshot_value(value: VmValue, version: u64) -> VmValue {
     let mut snapshot = BTreeMap::new();
-    snapshot.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from("shared_snapshot")),
-    );
+    snapshot.put_str("_type", "shared_snapshot");
     snapshot.insert("value".to_string(), value);
     snapshot.insert("version".to_string(), VmValue::Int(version as i64));
     VmValue::Dict(std::sync::Arc::new(snapshot))
@@ -454,18 +443,9 @@ fn empty_mailbox_metrics() -> VmValue {
 
 fn with_scope_fields(kind: &str, scoped: &ScopedKey, metrics: VmValue) -> VmValue {
     let mut value = metrics.as_dict().cloned().unwrap_or_default();
-    value.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from(kind.to_string())),
-    );
-    value.insert(
-        "scope".to_string(),
-        VmValue::String(std::sync::Arc::from(scoped.scope.clone())),
-    );
-    value.insert(
-        "key".to_string(),
-        VmValue::String(std::sync::Arc::from(scoped.key.clone())),
-    );
+    value.put_str("_type", kind);
+    value.put_str("scope", scoped.scope.clone());
+    value.put_str("key", scoped.key.clone());
     VmValue::Dict(std::sync::Arc::new(value))
 }
 

--- a/crates/harn-vm/src/skills/source.rs
+++ b/crates/harn-vm/src/skills/source.rs
@@ -11,6 +11,7 @@
 //! label so higher-priority layers can shadow lower ones cleanly and
 //! `harn doctor` can report where each skill came from.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -407,30 +408,17 @@ pub fn skill_entry_to_vm(skill: &Skill) -> crate::value::VmValue {
     use crate::value::VmValue;
 
     let mut entry: BTreeMap<String, VmValue> = BTreeMap::new();
-    entry.insert(
-        "name".to_string(),
-        VmValue::String(std::sync::Arc::from(skill.manifest.name.as_str())),
+    entry.put_str("name", skill.manifest.name.as_str());
+    entry.put_str("short", skill.manifest.short.as_str());
+    entry.put_str(
+        "description",
+        if skill.manifest.description.is_empty() {
+            skill.manifest.short.as_str()
+        } else {
+            skill.manifest.description.as_str()
+        },
     );
-    entry.insert(
-        "short".to_string(),
-        VmValue::String(std::sync::Arc::from(skill.manifest.short.as_str())),
-    );
-    entry.insert(
-        "description".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            if skill.manifest.description.is_empty() {
-                skill.manifest.short.as_str()
-            } else {
-                skill.manifest.description.as_str()
-            },
-        )),
-    );
-    if let Some(when) = &skill.manifest.when_to_use {
-        entry.insert(
-            "when_to_use".to_string(),
-            VmValue::String(std::sync::Arc::from(when.as_str())),
-        );
-    }
+    entry.put_opt_str("when_to_use", skill.manifest.when_to_use.as_deref());
     if skill.manifest.disable_model_invocation {
         entry.insert("disable_model_invocation".to_string(), VmValue::Bool(true));
     }
@@ -463,18 +451,8 @@ pub fn skill_entry_to_vm(skill: &Skill) -> crate::value::VmValue {
             )),
         );
     }
-    if let Some(context) = &skill.manifest.context {
-        entry.insert(
-            "context".to_string(),
-            VmValue::String(std::sync::Arc::from(context.as_str())),
-        );
-    }
-    if let Some(agent) = &skill.manifest.agent {
-        entry.insert(
-            "agent".to_string(),
-            VmValue::String(std::sync::Arc::from(agent.as_str())),
-        );
-    }
+    entry.put_opt_str("context", skill.manifest.context.as_deref());
+    entry.put_opt_str("agent", skill.manifest.agent.as_deref());
     if !skill.manifest.hooks.is_empty() {
         let mut hooks: BTreeMap<String, VmValue> = BTreeMap::new();
         for (k, v) in &skill.manifest.hooks {
@@ -485,18 +463,8 @@ pub fn skill_entry_to_vm(skill: &Skill) -> crate::value::VmValue {
             VmValue::Dict(std::sync::Arc::new(hooks)),
         );
     }
-    if let Some(model) = &skill.manifest.model {
-        entry.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from(model.as_str())),
-        );
-    }
-    if let Some(effort) = &skill.manifest.effort {
-        entry.insert(
-            "effort".to_string(),
-            VmValue::String(std::sync::Arc::from(effort.as_str())),
-        );
-    }
+    entry.put_opt_str("model", skill.manifest.model.as_deref());
+    entry.put_opt_str("effort", skill.manifest.effort.as_deref());
     if skill.manifest.require_signature {
         entry.insert("require_signature".to_string(), VmValue::Bool(true));
     }
@@ -513,38 +481,14 @@ pub fn skill_entry_to_vm(skill: &Skill) -> crate::value::VmValue {
             )),
         );
     }
-    if let Some(shell) = &skill.manifest.shell {
-        entry.insert(
-            "shell".to_string(),
-            VmValue::String(std::sync::Arc::from(shell.as_str())),
-        );
-    }
-    if let Some(hint) = &skill.manifest.argument_hint {
-        entry.insert(
-            "argument_hint".to_string(),
-            VmValue::String(std::sync::Arc::from(hint.as_str())),
-        );
-    }
-    entry.insert(
-        "body".to_string(),
-        VmValue::String(std::sync::Arc::from(skill.body.as_str())),
-    );
+    entry.put_opt_str("shell", skill.manifest.shell.as_deref());
+    entry.put_opt_str("argument_hint", skill.manifest.argument_hint.as_deref());
+    entry.put_str("body", skill.body.as_str());
     if let Some(dir) = &skill.skill_dir {
-        entry.insert(
-            "skill_dir".to_string(),
-            VmValue::String(std::sync::Arc::from(dir.display().to_string())),
-        );
+        entry.put_str("skill_dir", dir.display().to_string());
     }
-    entry.insert(
-        "source".to_string(),
-        VmValue::String(std::sync::Arc::from(skill.layer.label())),
-    );
-    if let Some(ns) = &skill.namespace {
-        entry.insert(
-            "namespace".to_string(),
-            VmValue::String(std::sync::Arc::from(ns.as_str())),
-        );
-    }
+    entry.put_str("source", skill.layer.label());
+    entry.put_opt_str("namespace", skill.namespace.as_deref());
     VmValue::Dict(std::sync::Arc::new(entry))
 }
 
@@ -552,30 +496,17 @@ pub fn skill_manifest_ref_to_vm(skill: &SkillManifestRef) -> crate::value::VmVal
     use crate::value::VmValue;
 
     let mut entry: BTreeMap<String, VmValue> = BTreeMap::new();
-    entry.insert(
-        "name".to_string(),
-        VmValue::String(std::sync::Arc::from(skill.manifest.name.as_str())),
+    entry.put_str("name", skill.manifest.name.as_str());
+    entry.put_str("short", skill.manifest.short.as_str());
+    entry.put_str(
+        "description",
+        if skill.manifest.description.is_empty() {
+            skill.manifest.short.as_str()
+        } else {
+            skill.manifest.description.as_str()
+        },
     );
-    entry.insert(
-        "short".to_string(),
-        VmValue::String(std::sync::Arc::from(skill.manifest.short.as_str())),
-    );
-    entry.insert(
-        "description".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            if skill.manifest.description.is_empty() {
-                skill.manifest.short.as_str()
-            } else {
-                skill.manifest.description.as_str()
-            },
-        )),
-    );
-    if let Some(when) = &skill.manifest.when_to_use {
-        entry.insert(
-            "when_to_use".to_string(),
-            VmValue::String(std::sync::Arc::from(when.as_str())),
-        );
-    }
+    entry.put_opt_str("when_to_use", skill.manifest.when_to_use.as_deref());
     if skill.manifest.disable_model_invocation {
         entry.insert("disable_model_invocation".to_string(), VmValue::Bool(true));
     }
@@ -608,18 +539,8 @@ pub fn skill_manifest_ref_to_vm(skill: &SkillManifestRef) -> crate::value::VmVal
             )),
         );
     }
-    if let Some(context) = &skill.manifest.context {
-        entry.insert(
-            "context".to_string(),
-            VmValue::String(std::sync::Arc::from(context.as_str())),
-        );
-    }
-    if let Some(agent) = &skill.manifest.agent {
-        entry.insert(
-            "agent".to_string(),
-            VmValue::String(std::sync::Arc::from(agent.as_str())),
-        );
-    }
+    entry.put_opt_str("context", skill.manifest.context.as_deref());
+    entry.put_opt_str("agent", skill.manifest.agent.as_deref());
     if !skill.manifest.hooks.is_empty() {
         let mut hooks: BTreeMap<String, VmValue> = BTreeMap::new();
         for (key, value) in &skill.manifest.hooks {
@@ -633,40 +554,12 @@ pub fn skill_manifest_ref_to_vm(skill: &SkillManifestRef) -> crate::value::VmVal
             VmValue::Dict(std::sync::Arc::new(hooks)),
         );
     }
-    if let Some(model) = &skill.manifest.model {
-        entry.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from(model.as_str())),
-        );
-    }
-    if let Some(effort) = &skill.manifest.effort {
-        entry.insert(
-            "effort".to_string(),
-            VmValue::String(std::sync::Arc::from(effort.as_str())),
-        );
-    }
-    if let Some(shell) = &skill.manifest.shell {
-        entry.insert(
-            "shell".to_string(),
-            VmValue::String(std::sync::Arc::from(shell.as_str())),
-        );
-    }
-    if let Some(hint) = &skill.manifest.argument_hint {
-        entry.insert(
-            "argument_hint".to_string(),
-            VmValue::String(std::sync::Arc::from(hint.as_str())),
-        );
-    }
-    entry.insert(
-        "source".to_string(),
-        VmValue::String(std::sync::Arc::from(skill.layer.label())),
-    );
-    if let Some(ns) = &skill.namespace {
-        entry.insert(
-            "namespace".to_string(),
-            VmValue::String(std::sync::Arc::from(ns.as_str())),
-        );
-    }
+    entry.put_opt_str("model", skill.manifest.model.as_deref());
+    entry.put_opt_str("effort", skill.manifest.effort.as_deref());
+    entry.put_opt_str("shell", skill.manifest.shell.as_deref());
+    entry.put_opt_str("argument_hint", skill.manifest.argument_hint.as_deref());
+    entry.put_str("source", skill.layer.label());
+    entry.put_opt_str("namespace", skill.namespace.as_deref());
     VmValue::Dict(std::sync::Arc::new(entry))
 }
 

--- a/crates/harn-vm/src/stdlib/agent_sessions.rs
+++ b/crates/harn-vm/src/stdlib/agent_sessions.rs
@@ -5,6 +5,7 @@
 //! store in `crate::agent_sessions`. There is no policy-as-verb
 //! pattern; unknown inputs are hard errors.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
@@ -1164,18 +1165,9 @@ fn agent_session_drain_inbox_builtin(
         .map(|entry| {
             let mut dict = BTreeMap::new();
             dict.insert("sequence".to_string(), VmValue::Int(entry.sequence as i64));
-            dict.insert(
-                "kind".to_string(),
-                VmValue::String(std::sync::Arc::from(entry.kind)),
-            );
-            dict.insert(
-                "content".to_string(),
-                VmValue::String(std::sync::Arc::from(entry.content)),
-            );
-            dict.insert(
-                "source".to_string(),
-                VmValue::String(std::sync::Arc::from(entry.source)),
-            );
+            dict.put_str("kind", entry.kind);
+            dict.put_str("content", entry.content);
+            dict.put_str("source", entry.source);
             dict.insert("ts_ms".to_string(), VmValue::Int(entry.ts_ms));
             VmValue::Dict(std::sync::Arc::new(dict))
         })
@@ -1610,14 +1602,8 @@ async fn cancel_in_flight_tool_call_builtin(
     }
 
     let mut result = BTreeMap::new();
-    result.insert(
-        "status".to_string(),
-        VmValue::String(std::sync::Arc::from(final_status)),
-    );
-    result.insert(
-        "call_id".to_string(),
-        VmValue::String(std::sync::Arc::from(call_id)),
-    );
+    result.put_str("status", final_status);
+    result.put_str("call_id", call_id);
     result.insert(
         "tool".to_string(),
         outcome
@@ -1625,10 +1611,7 @@ async fn cancel_in_flight_tool_call_builtin(
             .map(|name| VmValue::String(std::sync::Arc::from(name)))
             .unwrap_or(VmValue::Nil),
     );
-    result.insert(
-        "reason".to_string(),
-        VmValue::String(std::sync::Arc::from(reason)),
-    );
+    result.put_str("reason", reason);
     Ok(VmValue::Dict(std::sync::Arc::new(result)))
 }
 

--- a/crates/harn-vm/src/stdlib/agent_state.rs
+++ b/crates/harn-vm/src/stdlib/agent_state.rs
@@ -1,5 +1,6 @@
 pub mod backend;
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
@@ -329,32 +330,12 @@ fn handle_value(
     conflict_policy: ConflictPolicy,
 ) -> VmValue {
     let mut handle = BTreeMap::new();
-    handle.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from(HANDLE_TYPE)),
-    );
-    handle.insert(
-        "backend".to_string(),
-        VmValue::String(std::sync::Arc::from(backend.backend_name())),
-    );
-    handle.insert(
-        "root".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            scope.root.to_string_lossy().into_owned(),
-        )),
-    );
-    handle.insert(
-        "session_id".to_string(),
-        VmValue::String(std::sync::Arc::from(scope.namespace.clone())),
-    );
-    handle.insert(
-        "handoff_key".to_string(),
-        VmValue::String(std::sync::Arc::from(HANDOFF_KEY)),
-    );
-    handle.insert(
-        "conflict_policy".to_string(),
-        VmValue::String(std::sync::Arc::from(conflict_policy.as_str())),
-    );
+    handle.put_str("_type", HANDLE_TYPE);
+    handle.put_str("backend", backend.backend_name());
+    handle.put_str("root", scope.root.to_string_lossy());
+    handle.put_str("session_id", scope.namespace.clone());
+    handle.put_str("handoff_key", HANDOFF_KEY);
+    handle.put_str("conflict_policy", conflict_policy.as_str());
     handle.insert("writer".to_string(), writer_vm_value(writer));
     VmValue::Dict(std::sync::Arc::new(handle))
 }

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -12,6 +12,7 @@ mod sub_agent;
 #[path = "workflow/mod.rs"]
 pub(super) mod workflow;
 
+use crate::value::VmDictExt;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -406,10 +407,7 @@ async fn suspend_agent_builtin(
                 let mut summary = worker_summary(&state.lock())?;
                 if let VmValue::Dict(map) = &mut summary {
                     let mut entries = (**map).clone();
-                    entries.insert(
-                        "pre_suspend_denied".to_string(),
-                        VmValue::String(std::sync::Arc::from(block_reason.clone())),
-                    );
+                    entries.put_str("pre_suspend_denied", block_reason.clone());
                     *map = std::sync::Arc::new(entries);
                 }
                 Ok(summary)

--- a/crates/harn-vm/src/stdlib/agents/replay.rs
+++ b/crates/harn-vm/src/stdlib/agents/replay.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -256,10 +257,7 @@ pub(super) fn apply_workflow_replay_config(
     if !carry.artifacts.is_empty() {
         *artifacts = carry.artifacts;
     }
-    options.insert(
-        "parent_worker_id".to_string(),
-        VmValue::String(std::sync::Arc::from(carry.parent_worker_id)),
-    );
+    options.put_str("parent_worker_id", carry.parent_worker_id);
     if let Some(transcript) = carry.transcript {
         options.insert("transcript".to_string(), transcript);
     } else {
@@ -267,10 +265,7 @@ pub(super) fn apply_workflow_replay_config(
     }
     if carry.resume_workflow {
         if let Some(child_run_path) = carry.child_run_path {
-            options.insert(
-                "resume_path".to_string(),
-                VmValue::String(std::sync::Arc::from(child_run_path)),
-            );
+            options.put_str("resume_path", child_run_path);
         }
     } else {
         options.remove("resume_path");
@@ -296,10 +291,7 @@ pub(super) fn apply_sub_agent_replay_config(
     spec.task = next_task.to_string();
     if reset_session {
         spec.session_id = format!("sub_agent_session_{}", uuid::Uuid::now_v7());
-        spec.options.insert(
-            "session_id".to_string(),
-            VmValue::String(std::sync::Arc::from(spec.session_id.clone())),
-        );
+        spec.options.put_str("session_id", spec.session_id.clone());
     }
 }
 

--- a/crates/harn-vm/src/stdlib/agents/resume.rs
+++ b/crates/harn-vm/src/stdlib/agents/resume.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -458,10 +459,7 @@ pub(super) async fn warm_resume_worker(
             let mut summary = worker_summary(&state.lock())?;
             if let VmValue::Dict(map) = &mut summary {
                 let mut entries = (**map).clone();
-                entries.insert(
-                    "pre_resume_denied".to_string(),
-                    VmValue::String(std::sync::Arc::from(reason)),
-                );
+                entries.put_str("pre_resume_denied", reason);
                 *map = std::sync::Arc::new(entries);
             }
             return Ok(summary);

--- a/crates/harn-vm/src/stdlib/agents_daemon.rs
+++ b/crates/harn-vm/src/stdlib/agents_daemon.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, VecDeque};
 use std::future::Future;
@@ -405,18 +406,15 @@ async fn daemon_resume_builtin(
             daemon
                 .options
                 .insert("loop_until_done".to_string(), VmValue::Bool(false));
-            daemon.options.insert(
-                "session_id".to_string(),
-                VmValue::String(std::sync::Arc::from(spec.session_id.clone())),
-            );
-            daemon.options.insert(
-                "persist_path".to_string(),
-                VmValue::String(std::sync::Arc::from(spec.snapshot_path.clone())),
-            );
-            daemon.options.insert(
-                "resume_path".to_string(),
-                VmValue::String(std::sync::Arc::from(spec.snapshot_path.clone())),
-            );
+            daemon
+                .options
+                .put_str("session_id", spec.session_id.clone());
+            daemon
+                .options
+                .put_str("persist_path", spec.snapshot_path.clone());
+            daemon
+                .options
+                .put_str("resume_path", spec.snapshot_path.clone());
             daemon.status = "running".to_string();
             daemon.last_error = None;
             daemon.last_result = None;
@@ -453,18 +451,9 @@ async fn daemon_resume_builtin(
     let mut resume_options = options;
     resume_options.insert("daemon".to_string(), VmValue::Bool(true));
     resume_options.insert("loop_until_done".to_string(), VmValue::Bool(false));
-    resume_options.insert(
-        "session_id".to_string(),
-        VmValue::String(std::sync::Arc::from(spec.session_id.clone())),
-    );
-    resume_options.insert(
-        "persist_path".to_string(),
-        VmValue::String(std::sync::Arc::from(spec.snapshot_path.clone())),
-    );
-    resume_options.insert(
-        "resume_path".to_string(),
-        VmValue::String(std::sync::Arc::from(spec.snapshot_path.clone())),
-    );
+    resume_options.put_str("session_id", spec.session_id.clone());
+    resume_options.put_str("persist_path", spec.snapshot_path.clone());
+    resume_options.put_str("resume_path", spec.snapshot_path.clone());
 
     let state = Arc::new(parking_lot::Mutex::new(DaemonState {
         id: spec.id.clone(),
@@ -578,14 +567,8 @@ fn parse_spawn_spec(
 
     options.insert("daemon".to_string(), VmValue::Bool(true));
     options.insert("loop_until_done".to_string(), VmValue::Bool(false));
-    options.insert(
-        "session_id".to_string(),
-        VmValue::String(std::sync::Arc::from(session_id.clone())),
-    );
-    options.insert(
-        "persist_path".to_string(),
-        VmValue::String(std::sync::Arc::from(paths.snapshot_path.clone())),
-    );
+    options.put_str("session_id", session_id.clone());
+    options.put_str("persist_path", paths.snapshot_path.clone());
     options.remove("resume_path");
 
     Ok(DaemonSpawnSpec {

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use super::agents_workers;
@@ -263,10 +264,7 @@ fn prepare_sub_agent_options(
         .cloned()
         .unwrap_or_default();
     inject_sub_agent_skill_context(&mut options);
-    options.insert(
-        "session_id".to_string(),
-        VmValue::String(std::sync::Arc::from(session_id.to_string())),
-    );
+    options.put_str("session_id", session_id);
     match requested_policy {
         Some(policy) => {
             options.insert("policy".to_string(), super::to_vm(policy)?);
@@ -300,19 +298,10 @@ fn sub_agent_error_dict(
     tool: Option<String>,
 ) -> VmValue {
     let mut error = BTreeMap::new();
-    error.insert(
-        "category".to_string(),
-        VmValue::String(std::sync::Arc::from(category.to_string())),
-    );
-    error.insert(
-        "message".to_string(),
-        VmValue::String(std::sync::Arc::from(message.into())),
-    );
+    error.put_str("category", category);
+    error.put_str("message", message.into());
     if let Some(tool) = tool {
-        error.insert(
-            "tool".to_string(),
-            VmValue::String(std::sync::Arc::from(tool)),
-        );
+        error.put_str("tool", tool);
     }
     VmValue::Dict(std::sync::Arc::new(error))
 }
@@ -327,10 +316,7 @@ fn sub_agent_base_envelope(
 ) -> BTreeMap<String, VmValue> {
     let mut envelope = BTreeMap::new();
     envelope.insert("ok".to_string(), VmValue::Bool(true));
-    envelope.insert(
-        "summary".to_string(),
-        VmValue::String(std::sync::Arc::from(summary)),
-    );
+    envelope.put_str("summary", summary);
     envelope.insert("artifacts".to_string(), artifacts);
     envelope.insert("evidence_added".to_string(), VmValue::Int(evidence_added));
     envelope.insert("tokens_used".to_string(), VmValue::Int(tokens_used));
@@ -340,10 +326,7 @@ fn sub_agent_base_envelope(
     );
     envelope.insert("data".to_string(), VmValue::Nil);
     envelope.insert("error".to_string(), VmValue::Nil);
-    envelope.insert(
-        "session_id".to_string(),
-        VmValue::String(std::sync::Arc::from(session_id.to_string())),
-    );
+    envelope.put_str("session_id", session_id);
     envelope
 }
 
@@ -752,10 +735,7 @@ pub(super) async fn execute_sub_agent(
     );
 
     let mut loop_options = spec.options.clone();
-    loop_options.insert(
-        "session_id".to_string(),
-        VmValue::String(std::sync::Arc::from(spec.session_id.clone())),
-    );
+    loop_options.put_str("session_id", spec.session_id.clone());
     let args = vec![
         VmValue::String(std::sync::Arc::from(spec.task.clone())),
         spec.system

--- a/crates/harn-vm/src/stdlib/agents_workers/execution.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/execution.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -80,10 +81,7 @@ fn ensure_worker_stage_session_id(
         .and_then(|value| value.as_dict())
         .cloned()
         .unwrap_or_default();
-    raw_model_policy.insert(
-        "session_id".to_string(),
-        VmValue::String(std::sync::Arc::from(session_id.clone())),
-    );
+    raw_model_policy.put_str("session_id", session_id.clone());
     node.raw_model_policy = Some(VmValue::Dict(std::sync::Arc::new(raw_model_policy)));
     session_id
 }
@@ -173,10 +171,7 @@ async fn execute_worker_config(
                 options.contains_key("resume_path") || options.contains_key("resume_run");
             if !resumes_existing_run && !options.contains_key("parent_run_id") {
                 if let Some(parent_run_id) = parent_run_id.clone() {
-                    options.insert(
-                        "parent_run_id".to_string(),
-                        VmValue::String(std::sync::Arc::from(parent_run_id)),
-                    );
+                    options.put_str("parent_run_id", parent_run_id);
                 }
             }
             if let Some(parent_worker_id) = options

--- a/crates/harn-vm/src/stdlib/agents_workers/policy.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/policy.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use super::super::parse_context_policy;
@@ -217,18 +218,12 @@ fn fork_worker_transcript(transcript: VmValue) -> VmValue {
     let parent_id = dict.get("id").map(|value| value.display());
     let mut next = dict.clone();
     let new_id = uuid::Uuid::now_v7().to_string();
-    next.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(new_id)),
-    );
+    next.put_str("id", new_id);
     if let Some(parent_id) = parent_id.filter(|value| !value.is_empty()) {
         let metadata = match next.get("metadata") {
             Some(VmValue::Dict(metadata)) => {
                 let mut metadata = metadata.as_ref().clone();
-                metadata.insert(
-                    "parent_transcript_id".to_string(),
-                    VmValue::String(std::sync::Arc::from(parent_id)),
-                );
+                metadata.put_str("parent_transcript_id", parent_id);
                 VmValue::Dict(std::sync::Arc::new(metadata))
             }
             _ => VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
@@ -298,9 +293,6 @@ pub(in super::super) async fn compact_worker_transcript(
         "events".to_string(),
         VmValue::List(std::sync::Arc::new(events)),
     );
-    next.insert(
-        "summary".to_string(),
-        VmValue::String(std::sync::Arc::from(outcome.summary)),
-    );
+    next.put_str("summary", outcome.summary);
     Ok(VmValue::Dict(std::sync::Arc::new(next)))
 }

--- a/crates/harn-vm/src/stdlib/assemble.rs
+++ b/crates/harn-vm/src/stdlib/assemble.rs
@@ -5,6 +5,7 @@
 //! ranker is invoked as a Harn closure, which requires an async-builtin VM
 //! context.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use crate::orchestration::{
@@ -213,14 +214,8 @@ fn assembled_to_vm(assembled: &AssembledContext) -> VmValue {
         .iter()
         .map(|summary| {
             let mut map = BTreeMap::new();
-            map.insert(
-                "artifact_id".to_string(),
-                VmValue::String(std::sync::Arc::from(summary.artifact_id.as_str())),
-            );
-            map.insert(
-                "artifact_kind".to_string(),
-                VmValue::String(std::sync::Arc::from(summary.artifact_kind.as_str())),
-            );
+            map.put_str("artifact_id", summary.artifact_id.as_str());
+            map.put_str("artifact_kind", summary.artifact_kind.as_str());
             map.insert(
                 "chunks_included".to_string(),
                 VmValue::Int(summary.chunks_included as i64),
@@ -242,10 +237,7 @@ fn assembled_to_vm(assembled: &AssembledContext) -> VmValue {
         .iter()
         .map(|exclusion| {
             let mut map = BTreeMap::new();
-            map.insert(
-                "artifact_id".to_string(),
-                VmValue::String(std::sync::Arc::from(exclusion.artifact_id.as_str())),
-            );
+            map.put_str("artifact_id", exclusion.artifact_id.as_str());
             map.insert(
                 "chunk_id".to_string(),
                 exclusion
@@ -254,10 +246,7 @@ fn assembled_to_vm(assembled: &AssembledContext) -> VmValue {
                     .map(|id| VmValue::String(std::sync::Arc::from(id.as_str())))
                     .unwrap_or(VmValue::Nil),
             );
-            map.insert(
-                "reason".to_string(),
-                VmValue::String(std::sync::Arc::from(exclusion.reason)),
-            );
+            map.put_str("reason", exclusion.reason);
             map.insert(
                 "detail".to_string(),
                 exclusion
@@ -275,24 +264,12 @@ fn assembled_to_vm(assembled: &AssembledContext) -> VmValue {
         .iter()
         .map(|reason| {
             let mut map = BTreeMap::new();
-            map.insert(
-                "chunk_id".to_string(),
-                VmValue::String(std::sync::Arc::from(reason.chunk_id.as_str())),
-            );
-            map.insert(
-                "artifact_id".to_string(),
-                VmValue::String(std::sync::Arc::from(reason.artifact_id.as_str())),
-            );
-            map.insert(
-                "strategy".to_string(),
-                VmValue::String(std::sync::Arc::from(reason.strategy)),
-            );
+            map.put_str("chunk_id", reason.chunk_id.as_str());
+            map.put_str("artifact_id", reason.artifact_id.as_str());
+            map.put_str("strategy", reason.strategy);
             map.insert("score".to_string(), VmValue::Float(reason.score));
             map.insert("included".to_string(), VmValue::Bool(reason.included));
-            map.insert(
-                "reason".to_string(),
-                VmValue::String(std::sync::Arc::from(reason.reason)),
-            );
+            map.put_str("reason", reason.reason);
             VmValue::Dict(std::sync::Arc::new(map))
         })
         .collect();
@@ -322,14 +299,8 @@ fn assembled_to_vm(assembled: &AssembledContext) -> VmValue {
         "budget_tokens".to_string(),
         VmValue::Int(assembled.budget_tokens as i64),
     );
-    map.insert(
-        "strategy".to_string(),
-        VmValue::String(std::sync::Arc::from(assembled.strategy.as_str())),
-    );
-    map.insert(
-        "dedup".to_string(),
-        VmValue::String(std::sync::Arc::from(assembled.dedup.as_str())),
-    );
+    map.put_str("strategy", assembled.strategy.as_str());
+    map.put_str("dedup", assembled.dedup.as_str());
     VmValue::Dict(std::sync::Arc::new(map))
 }
 

--- a/crates/harn-vm/src/stdlib/calendar.rs
+++ b/crates/harn-vm/src/stdlib/calendar.rs
@@ -696,15 +696,15 @@ fn calendar_business_window_builtin(
     Ok(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
         ("inside".to_string(), VmValue::Bool(inside)),
         ("business_day".to_string(), VmValue::Bool(business_day)),
-        ("reason".to_string(), string_value(reason)),
+        ("reason".to_string(), VmValue::string(reason)),
         (
             "timezone".to_string(),
-            string_value(calendar.timezone.name()),
+            VmValue::string(calendar.timezone.name()),
         ),
-        ("calendar".to_string(), string_value(&calendar.name)),
+        ("calendar".to_string(), VmValue::string(&calendar.name)),
         (
             "local_date".to_string(),
-            string_value(&date.format("%Y-%m-%d").to_string()),
+            VmValue::string(date.format("%Y-%m-%d").to_string()),
         ),
         (
             "starts_at".to_string(),
@@ -741,7 +741,10 @@ fn parts_dict(dt: DateTime<Tz>) -> BTreeMap<String, VmValue> {
             "quarter".to_string(),
             VmValue::Int(quarter_for_month(dt.month()) as i64),
         ),
-        ("timezone".to_string(), string_value(dt.timezone().name())),
+        (
+            "timezone".to_string(),
+            VmValue::string(dt.timezone().name()),
+        ),
         (
             "offset_seconds".to_string(),
             VmValue::Int(dt.offset().fix().local_minus_utc() as i64),
@@ -750,10 +753,10 @@ fn parts_dict(dt: DateTime<Tz>) -> BTreeMap<String, VmValue> {
             "timestamp".to_string(),
             timestamp_value(dt.with_timezone(&Utc)),
         ),
-        ("iso8601".to_string(), string_value(&dt.to_rfc3339())),
+        ("iso8601".to_string(), VmValue::string(dt.to_rfc3339())),
         (
             "date".to_string(),
-            string_value(&dt.date_naive().format("%Y-%m-%d").to_string()),
+            VmValue::string(dt.date_naive().format("%Y-%m-%d").to_string()),
         ),
     ])
 }
@@ -1001,13 +1004,13 @@ fn country_by_code(raw: &str) -> Option<&'static CountryMeta> {
 
 fn country_value(country: &CountryMeta) -> VmValue {
     let default_timezone = if country.timezones.len() == 1 {
-        string_value(country.timezones[0])
+        VmValue::string(country.timezones[0])
     } else {
         VmValue::Nil
     };
     VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
-        ("code".to_string(), string_value(country.code)),
-        ("name".to_string(), string_value(country.name)),
+        ("code".to_string(), VmValue::string(country.code)),
+        ("name".to_string(), VmValue::string(country.name)),
         (
             "timezones".to_string(),
             string_list_value(country.timezones.iter().copied()),
@@ -1019,11 +1022,11 @@ fn country_value(country: &CountryMeta) -> VmValue {
         ),
         (
             "currency_code".to_string(),
-            string_value(country.currency_code),
+            VmValue::string(country.currency_code),
         ),
         (
             "currency_name".to_string(),
-            string_value(country.currency_name),
+            VmValue::string(country.currency_name),
         ),
         (
             "holiday_calendars".to_string(),
@@ -1034,15 +1037,15 @@ fn country_value(country: &CountryMeta) -> VmValue {
 
 fn holiday_calendar_info(name: &'static str) -> VmValue {
     VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
-        ("name".to_string(), string_value(name)),
-        ("country".to_string(), string_value("US")),
+        ("name".to_string(), VmValue::string(name)),
+        ("country".to_string(), VmValue::string("US")),
         (
             "timezone".to_string(),
-            string_value(DEFAULT_BUSINESS_TIMEZONE),
+            VmValue::string(DEFAULT_BUSINESS_TIMEZONE),
         ),
         (
             "description".to_string(),
-            string_value("United States federal observed holidays"),
+            VmValue::string("United States federal observed holidays"),
         ),
     ])))
 }
@@ -1214,13 +1217,13 @@ fn holiday_value(holiday: &Holiday) -> VmValue {
     VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
         (
             "date".to_string(),
-            string_value(&holiday.date.format("%Y-%m-%d").to_string()),
+            VmValue::string(holiday.date.format("%Y-%m-%d").to_string()),
         ),
         (
             "actual_date".to_string(),
-            string_value(&holiday.actual_date.format("%Y-%m-%d").to_string()),
+            VmValue::string(holiday.actual_date.format("%Y-%m-%d").to_string()),
         ),
-        ("name".to_string(), string_value(holiday.name)),
+        ("name".to_string(), VmValue::string(holiday.name)),
         ("observed".to_string(), VmValue::Bool(holiday.observed)),
     ])))
 }
@@ -1596,12 +1599,8 @@ fn bool_arg(value: Option<&VmValue>, builtin: &str, label: &str) -> Result<Optio
     }
 }
 
-fn string_value(value: &str) -> VmValue {
-    VmValue::String(std::sync::Arc::from(value))
-}
-
 fn string_list_value<'a>(items: impl IntoIterator<Item = &'a str>) -> VmValue {
     VmValue::List(std::sync::Arc::new(
-        items.into_iter().map(string_value).collect(),
+        items.into_iter().map(VmValue::string).collect(),
     ))
 }

--- a/crates/harn-vm/src/stdlib/compaction.rs
+++ b/crates/harn-vm/src/stdlib/compaction.rs
@@ -12,6 +12,7 @@
 //! consumer (TUI, IDE, cloud) and into the runtime so all surfaces see
 //! the same trigger semantics and telemetry shape.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use crate::agent_sessions;
@@ -401,14 +402,8 @@ fn decision_value(
     inherited: bool,
 ) -> VmValue {
     let mut map = BTreeMap::new();
-    map.insert(
-        "action".to_string(),
-        VmValue::String(std::sync::Arc::from(action.as_str())),
-    );
-    map.insert(
-        "session_id".to_string(),
-        VmValue::String(std::sync::Arc::from(session_id.to_string())),
-    );
+    map.put_str("action", action.as_str());
+    map.put_str("session_id", session_id);
     map.insert(
         "estimated_tokens".to_string(),
         VmValue::Int(ctx.estimated_tokens as i64),
@@ -417,19 +412,11 @@ fn decision_value(
         "message_count".to_string(),
         VmValue::Int(ctx.message_count as i64),
     );
-    map.insert(
-        "trigger".to_string(),
-        VmValue::String(std::sync::Arc::from(ctx.trigger_label())),
-    );
-    map.insert(
-        "strategy".to_string(),
-        VmValue::String(std::sync::Arc::from(ctx.strategy.as_str())),
-    );
-    map.insert(
-        "engine_strategy".to_string(),
-        VmValue::String(std::sync::Arc::from(compact_strategy_name(
-            &ctx.strategy.engine_strategy(),
-        ))),
+    map.put_str("trigger", ctx.trigger_label());
+    map.put_str("strategy", ctx.strategy.as_str());
+    map.put_str(
+        "engine_strategy",
+        compact_strategy_name(&ctx.strategy.engine_strategy()),
     );
     if let Some(value) = ctx.token_threshold {
         map.insert("token_threshold".to_string(), VmValue::Int(value as i64));
@@ -448,20 +435,11 @@ fn policy_snapshot_value(
 ) -> VmValue {
     let mut map = BTreeMap::new();
     if let Some(id) = session_id {
-        map.insert(
-            "session_id".to_string(),
-            VmValue::String(std::sync::Arc::from(id.to_string())),
-        );
+        map.put_str("session_id", id);
     } else {
-        map.insert(
-            "session_id".to_string(),
-            VmValue::String(std::sync::Arc::from("")),
-        );
+        map.put_str("session_id", "");
     }
-    map.insert(
-        "strategy".to_string(),
-        VmValue::String(std::sync::Arc::from(policy.strategy.as_str())),
-    );
+    map.put_str("strategy", policy.strategy.as_str());
     if let Some(value) = policy.max_tokens {
         map.insert("max_tokens".to_string(), VmValue::Int(value as i64));
     }
@@ -515,10 +493,7 @@ fn run_result_value(
     transcript: VmValue,
 ) -> VmValue {
     let mut map = BTreeMap::new();
-    map.insert(
-        "session_id".to_string(),
-        VmValue::String(std::sync::Arc::from(session_id.to_string())),
-    );
+    map.put_str("session_id", session_id);
     let compacted = strategy.is_some();
     map.insert("compacted".to_string(), VmValue::Bool(compacted));
     map.insert(
@@ -533,16 +508,11 @@ fn run_result_value(
         "archived_messages".to_string(),
         VmValue::Int(archived as i64),
     );
-    map.insert(
-        "engine_strategy".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            strategy.map(compact_strategy_name).unwrap_or("none"),
-        )),
+    map.put_str(
+        "engine_strategy",
+        strategy.map(compact_strategy_name).unwrap_or("none"),
     );
-    map.insert(
-        "strategy".to_string(),
-        VmValue::String(std::sync::Arc::from(policy.strategy.as_str())),
-    );
+    map.put_str("strategy", policy.strategy.as_str());
     map.insert("latency_ms".to_string(), VmValue::Int(latency_ms as i64));
     if let Some(threshold) = policy.token_threshold() {
         map.insert(

--- a/crates/harn-vm/src/stdlib/compression.rs
+++ b/crates/harn-vm/src/stdlib/compression.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::io::{Cursor, Read, Write};
 
@@ -448,10 +449,7 @@ fn tar_extract_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
         let mut fields = BTreeMap::new();
         fields.insert("content".to_string(), bytes_value(content));
         fields.insert("mode".to_string(), VmValue::Int(mode));
-        fields.insert(
-            "path".to_string(),
-            VmValue::String(std::sync::Arc::from(path)),
-        );
+        fields.put_str("path", path);
         output.push(entry_value(fields));
     }
 
@@ -523,10 +521,7 @@ fn zip_extract_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
 
         let mut fields = BTreeMap::new();
         fields.insert("content".to_string(), bytes_value(content));
-        fields.insert(
-            "path".to_string(),
-            VmValue::String(std::sync::Arc::from(path)),
-        );
+        fields.put_str("path", path);
         output.push(entry_value(fields));
     }
 

--- a/crates/harn-vm/src/stdlib/concurrency.rs
+++ b/crates/harn-vm/src/stdlib/concurrency.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicI64, Ordering};
@@ -89,10 +90,7 @@ fn select_result(index: usize, value: VmValue, channel_name: &str) -> VmValue {
     let mut result = BTreeMap::new();
     result.insert("index".to_string(), VmValue::Int(index as i64));
     result.insert("value".to_string(), value);
-    result.insert(
-        "channel".to_string(),
-        VmValue::String(std::sync::Arc::from(channel_name)),
-    );
+    result.put_str("channel", channel_name);
     VmValue::Dict(std::sync::Arc::new(result))
 }
 
@@ -1623,10 +1621,7 @@ fn timer_start_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
         .unwrap_or_default()
         .as_millis() as i64;
     let mut timer = BTreeMap::new();
-    timer.insert(
-        "name".to_string(),
-        VmValue::String(std::sync::Arc::from(name)),
-    );
+    timer.put_str("name", name);
     timer.insert("start_ms".to_string(), VmValue::Int(now_ms));
     Ok(VmValue::Dict(std::sync::Arc::new(timer)))
 }

--- a/crates/harn-vm/src/stdlib/crypto.rs
+++ b/crates/harn-vm/src/stdlib/crypto.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
@@ -401,10 +402,7 @@ fn verification_result(
 ) -> VmValue {
     let mut result = BTreeMap::new();
     result.insert("valid".to_string(), VmValue::Bool(valid));
-    result.insert(
-        "reason".to_string(),
-        VmValue::String(std::sync::Arc::from(reason)),
-    );
+    result.put_str("reason", reason);
     result.insert(
         "signature_valid".to_string(),
         VmValue::Bool(signature_valid),
@@ -1164,14 +1162,8 @@ fn ed25519_keypair_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue,
     let signing = SigningKey::from_bytes(&bytes);
     let verifying: VerifyingKey = signing.verifying_key();
     let mut dict = std::collections::BTreeMap::new();
-    dict.insert(
-        "private".to_string(),
-        VmValue::String(std::sync::Arc::from(hex::encode(signing.to_bytes()))),
-    );
-    dict.insert(
-        "public".to_string(),
-        VmValue::String(std::sync::Arc::from(hex::encode(verifying.to_bytes()))),
-    );
+    dict.put_str("private", hex::encode(signing.to_bytes()));
+    dict.put_str("public", hex::encode(verifying.to_bytes()));
     Ok(VmValue::Dict(std::sync::Arc::new(dict)))
 }
 
@@ -1255,14 +1247,8 @@ fn x25519_keypair_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, 
     let secret = StaticSecret::from(bytes);
     let public = PublicKey::from(&secret);
     let mut dict = std::collections::BTreeMap::new();
-    dict.insert(
-        "private".to_string(),
-        VmValue::String(std::sync::Arc::from(hex::encode(secret.to_bytes()))),
-    );
-    dict.insert(
-        "public".to_string(),
-        VmValue::String(std::sync::Arc::from(hex::encode(public.to_bytes()))),
-    );
+    dict.put_str("private", hex::encode(secret.to_bytes()));
+    dict.put_str("public", hex::encode(public.to_bytes()));
     Ok(VmValue::Dict(std::sync::Arc::new(dict)))
 }
 

--- a/crates/harn-vm/src/stdlib/datetime.rs
+++ b/crates/harn-vm/src/stdlib/datetime.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use chrono::{
@@ -25,11 +26,9 @@ fn date_now_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
         "timestamp".to_string(),
         VmValue::Float(now.timestamp_millis() as f64 / 1000.0),
     );
-    result.insert(
-        "iso8601".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
-        )),
+    result.put_str(
+        "iso8601",
+        now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
     );
     Ok(VmValue::Dict(std::sync::Arc::new(result)))
 }
@@ -83,10 +82,7 @@ fn date_in_zone_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
     let tz = parse_timezone(&tz_name, "date_in_zone")?;
     let local = dt.with_timezone(&tz);
     let mut result = zoned_datetime_dict(local);
-    result.insert(
-        "zone".to_string(),
-        VmValue::String(std::sync::Arc::from(tz_name)),
-    );
+    result.put_str("zone", tz_name);
     Ok(VmValue::Dict(std::sync::Arc::new(result)))
 }
 
@@ -321,10 +317,7 @@ fn zoned_datetime_dict(dt: DateTime<Tz>) -> BTreeMap<String, VmValue> {
         "timestamp".to_string(),
         timestamp_value(dt.with_timezone(&Utc)),
     );
-    result.insert(
-        "iso8601".to_string(),
-        VmValue::String(std::sync::Arc::from(dt.to_rfc3339())),
-    );
+    result.put_str("iso8601", dt.to_rfc3339());
     result
 }
 

--- a/crates/harn-vm/src/stdlib/fs.rs
+++ b/crates/harn-vm/src/stdlib/fs.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -177,10 +178,7 @@ fn walk_dir_entries(
 
 fn walk_entry_to_vm(entry: WalkDirEntry) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "path".to_string(),
-        VmValue::String(std::sync::Arc::from(entry.path)),
-    );
+    dict.put_str("path", entry.path);
     dict.insert("is_dir".to_string(), VmValue::Bool(entry.is_dir));
     dict.insert("is_file".to_string(), VmValue::Bool(entry.is_file));
     dict.insert("depth".to_string(), VmValue::Int(entry.depth));

--- a/crates/harn-vm/src/stdlib/fs/find_text.rs
+++ b/crates/harn-vm/src/stdlib/fs/find_text.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -267,17 +268,11 @@ fn find_text_matcher(pattern: &str, options: &FindTextOptions) -> Result<RegexMa
 
 fn text_match_to_vm(hit: TextMatch) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "path".to_string(),
-        VmValue::String(std::sync::Arc::from(hit.path)),
-    );
+    dict.put_str("path", hit.path);
     dict.insert("line".to_string(), VmValue::Int(hit.line));
     dict.insert("col".to_string(), VmValue::Int(hit.col));
     dict.insert("column".to_string(), VmValue::Int(hit.col));
-    dict.insert(
-        "text".to_string(),
-        VmValue::String(std::sync::Arc::from(hit.text)),
-    );
+    dict.put_str("text", hit.text);
     VmValue::Dict(std::sync::Arc::new(dict))
 }
 

--- a/crates/harn-vm/src/stdlib/git.rs
+++ b/crates/harn-vm/src/stdlib/git.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -389,10 +390,7 @@ fn register_git_namespace(vm: &mut Vm) {
         ("remove", "git.worktree.remove"),
     ]);
     let mut root = BTreeMap::new();
-    root.insert(
-        "_namespace".to_string(),
-        VmValue::String(std::sync::Arc::from("git")),
-    );
+    root.put_str("_namespace", "git");
     root.insert("repo".to_string(), repo);
     root.insert("worktree".to_string(), worktree);
     for (name, builtin) in [
@@ -582,10 +580,7 @@ const GIT_NONINTERACTIVE_ENV: &[(&str, &str)] = &[
 
 async fn exec_argv(command: &GitCommand) -> Result<VmValue, VmError> {
     let mut params = BTreeMap::new();
-    params.insert(
-        "mode".to_string(),
-        VmValue::String(std::sync::Arc::from("argv")),
-    );
+    params.put_str("mode", "argv");
     params.insert(
         "argv".to_string(),
         VmValue::List(std::sync::Arc::new(
@@ -596,10 +591,7 @@ async fn exec_argv(command: &GitCommand) -> Result<VmValue, VmError> {
                 .collect(),
         )),
     );
-    params.insert(
-        "cwd".to_string(),
-        VmValue::String(std::sync::Arc::from(display_path(&command.cwd))),
-    );
+    params.put_str("cwd", display_path(&command.cwd));
     params.insert("timeout_ms".to_string(), VmValue::Int(120_000));
     params.insert(
         "env_remove".to_string(),
@@ -622,10 +614,7 @@ async fn exec_argv(command: &GitCommand) -> Result<VmValue, VmError> {
         );
     }
     params.insert("env".to_string(), VmValue::Dict(std::sync::Arc::new(env)));
-    params.insert(
-        "env_mode".to_string(),
-        VmValue::String(std::sync::Arc::from("merge")),
-    );
+    params.put_str("env_mode", "merge");
     let caller = json!({
         "surface": "stdlib.git",
         "operation": command.operation,

--- a/crates/harn-vm/src/stdlib/hitl.rs
+++ b/crates/harn-vm/src/stdlib/hitl.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
@@ -624,10 +625,7 @@ pub(crate) async fn request_approval_for_side_effect(
         "detail".to_string(),
         crate::stdlib::json_to_vm_value(&detail),
     );
-    options.insert(
-        "principal".to_string(),
-        VmValue::String(std::sync::Arc::from(principal)),
-    );
+    options.put_str("principal", principal);
     options.insert(
         "reviewers".to_string(),
         VmValue::List(std::sync::Arc::new(
@@ -1400,10 +1398,7 @@ async fn maybe_apply_mock_response(
         .into_iter()
         .map(|(key, value)| (key, crate::stdlib::json_to_vm_value(&value)))
         .collect::<BTreeMap<_, _>>();
-    params.insert(
-        "request_id".to_string(),
-        VmValue::String(std::sync::Arc::from(request_id.to_string())),
-    );
+    params.put_str("request_id", request_id);
     let Some(result) = dispatch_mock_host_call("hitl", kind.as_str(), &params) else {
         return Ok(());
     };

--- a/crates/harn-vm/src/stdlib/hitl_read.rs
+++ b/crates/harn-vm/src/stdlib/hitl_read.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
@@ -193,30 +194,12 @@ fn parse_request_row(
 
 fn pending_row_to_value(row: PendingHitlRow) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "request_id".to_string(),
-        VmValue::String(std::sync::Arc::from(row.request_id)),
-    );
-    dict.insert(
-        "request_kind".to_string(),
-        VmValue::String(std::sync::Arc::from(row.request_kind)),
-    );
-    dict.insert(
-        "agent".to_string(),
-        VmValue::String(std::sync::Arc::from(row.agent)),
-    );
-    dict.insert(
-        "prompt".to_string(),
-        VmValue::String(std::sync::Arc::from(row.prompt)),
-    );
-    dict.insert(
-        "trace_id".to_string(),
-        VmValue::String(std::sync::Arc::from(row.trace_id)),
-    );
-    dict.insert(
-        "timestamp".to_string(),
-        VmValue::String(std::sync::Arc::from(row.timestamp)),
-    );
+    dict.put_str("request_id", row.request_id);
+    dict.put_str("request_kind", row.request_kind);
+    dict.put_str("agent", row.agent);
+    dict.put_str("prompt", row.prompt);
+    dict.put_str("trace_id", row.trace_id);
+    dict.put_str("timestamp", row.timestamp);
     dict.insert(
         "approvers".to_string(),
         VmValue::List(std::sync::Arc::new(

--- a/crates/harn-vm/src/stdlib/host.rs
+++ b/crates/harn-vm/src/stdlib/host.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -231,19 +232,13 @@ fn capability_manifest_with_mocks() -> VmValue {
 
 fn op(name: &str, description: &str) -> (String, VmValue) {
     let mut entry = BTreeMap::new();
-    entry.insert(
-        "description".to_string(),
-        VmValue::String(std::sync::Arc::from(description)),
-    );
+    entry.put_str("description", description);
     (name.to_string(), VmValue::Dict(std::sync::Arc::new(entry)))
 }
 
 fn capability(description: &str, ops: &[(String, VmValue)]) -> VmValue {
     let mut entry = BTreeMap::new();
-    entry.insert(
-        "description".to_string(),
-        VmValue::String(std::sync::Arc::from(description)),
-    );
+    entry.put_str("description", description);
     entry.insert(
         "ops".to_string(),
         VmValue::List(std::sync::Arc::new(
@@ -355,14 +350,8 @@ fn push_host_mock(host_mock: HostMock) {
 
 fn mock_call_value(call: &HostMockCall) -> VmValue {
     let mut item = BTreeMap::new();
-    item.insert(
-        "capability".to_string(),
-        VmValue::String(std::sync::Arc::from(call.capability.clone())),
-    );
-    item.insert(
-        "operation".to_string(),
-        VmValue::String(std::sync::Arc::from(call.operation.clone())),
-    );
+    item.put_str("capability", call.capability.clone());
+    item.put_str("operation", call.operation.clone());
     item.insert(
         "params".to_string(),
         VmValue::Dict(std::sync::Arc::new(call.params.clone())),
@@ -935,18 +924,15 @@ struct ProcessExecResponse<'a> {
 fn process_exec_response(response: ProcessExecResponse<'_>) -> VmValue {
     let combined = format!("{}{}", response.stdout, response.stderr);
     let mut result = BTreeMap::new();
-    result.insert(
-        "command_id".to_string(),
-        VmValue::String(std::sync::Arc::from(format!(
+    result.put_str(
+        "command_id",
+        format!(
             "cmd_{}_{}",
             std::process::id(),
             response.started.elapsed().as_nanos()
-        ))),
+        ),
     );
-    result.insert(
-        "status".to_string(),
-        VmValue::String(std::sync::Arc::from(response.status)),
-    );
+    result.put_str("status", response.status);
     result.insert(
         "pid".to_string(),
         response
@@ -962,15 +948,10 @@ fn process_exec_response(response: ProcessExecResponse<'_>) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     result.insert("handle_id".to_string(), VmValue::Nil);
-    result.insert(
-        "started_at".to_string(),
-        VmValue::String(std::sync::Arc::from(response.started_at)),
-    );
-    result.insert(
-        "ended_at".to_string(),
-        VmValue::String(std::sync::Arc::from(audited_utc_now_rfc3339(
-            "host_call/process.exec.ended_at",
-        ))),
+    result.put_str("started_at", response.started_at);
+    result.put_str(
+        "ended_at",
+        audited_utc_now_rfc3339("host_call/process.exec.ended_at"),
     );
     result.insert(
         "duration_ms".to_string(),
@@ -982,18 +963,9 @@ fn process_exec_response(response: ProcessExecResponse<'_>) -> VmValue {
     );
     result.insert("signal".to_string(), VmValue::Nil);
     result.insert("timed_out".to_string(), VmValue::Bool(response.timed_out));
-    result.insert(
-        "stdout".to_string(),
-        VmValue::String(std::sync::Arc::from(response.stdout.to_string())),
-    );
-    result.insert(
-        "stderr".to_string(),
-        VmValue::String(std::sync::Arc::from(response.stderr.to_string())),
-    );
-    result.insert(
-        "combined".to_string(),
-        VmValue::String(std::sync::Arc::from(combined)),
-    );
+    result.put_str("stdout", response.stdout);
+    result.put_str("stderr", response.stderr);
+    result.put_str("combined", combined);
     result.insert(
         "exit_status".to_string(),
         VmValue::Int(response.exit_code as i64),
@@ -1024,10 +996,7 @@ fn process_exec_argv(params: &BTreeMap<String, VmValue>) -> Result<(String, Vec<
         "shell" => {
             let command = require_param(params, "command")?;
             let mut invocation_params = params.clone();
-            invocation_params.insert(
-                "command".to_string(),
-                VmValue::String(std::sync::Arc::from(command)),
-            );
+            invocation_params.put_str("command", command);
             let invocation =
                 crate::shells::resolve_invocation_from_vm_params(&invocation_params)
                     .map_err(|err| VmError::Runtime(format!("host_call process.exec: {err}")))?;
@@ -1277,6 +1246,7 @@ mod tests {
         dispatch_host_tool_call, dispatch_host_tool_list, dispatch_mock_host_call, push_host_mock,
         reset_host_state, resolve_process_exec_cwd, set_host_call_bridge, HostCallBridge, HostMock,
     };
+    use crate::value::VmDictExt;
     use std::collections::BTreeMap;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
@@ -1354,10 +1324,7 @@ mod tests {
     fn mock_host_call_matches_partial_params_and_overrides_order() {
         reset_host_state();
         let mut exact_params = BTreeMap::new();
-        exact_params.insert(
-            "namespace".to_string(),
-            VmValue::String(std::sync::Arc::from("facts")),
-        );
+        exact_params.put_str("namespace", "facts");
         push_host_mock(HostMock {
             capability: "project".to_string(),
             operation: "metadata_get".to_string(),
@@ -1374,23 +1341,14 @@ mod tests {
         });
 
         let mut call_params = BTreeMap::new();
-        call_params.insert(
-            "dir".to_string(),
-            VmValue::String(std::sync::Arc::from("pkg")),
-        );
-        call_params.insert(
-            "namespace".to_string(),
-            VmValue::String(std::sync::Arc::from("facts")),
-        );
+        call_params.put_str("dir", "pkg");
+        call_params.put_str("namespace", "facts");
         let exact = dispatch_mock_host_call("project", "metadata_get", &call_params)
             .expect("expected exact mock")
             .expect("exact mock should succeed");
         assert_eq!(exact.display(), "facts");
 
-        call_params.insert(
-            "namespace".to_string(),
-            VmValue::String(std::sync::Arc::from("classification")),
-        );
+        call_params.put_str("namespace", "classification");
         let fallback = dispatch_mock_host_call("project", "metadata_get", &call_params)
             .expect("expected fallback mock")
             .expect("fallback mock should succeed");
@@ -1629,10 +1587,7 @@ mod tests {
             ("env".to_string(), env),
         ]);
         if let Some(mode) = env_mode {
-            params.insert(
-                "env_mode".to_string(),
-                VmValue::String(std::sync::Arc::from(mode)),
-            );
+            params.put_str("env_mode", mode);
         }
         let result = super::dispatch_process_exec(&params, serde_json::Value::Null)
             .await

--- a/crates/harn-vm/src/stdlib/http_response.rs
+++ b/crates/harn-vm/src/stdlib/http_response.rs
@@ -19,6 +19,7 @@
 //! code that true streaming will accept; only the on-the-wire timing
 //! differs.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use sha2::{Digest, Sha256};
@@ -57,10 +58,7 @@ fn http_created_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
     let body = args.first().cloned().unwrap_or(VmValue::Nil);
     let mut headers = BTreeMap::new();
     if let Some(location) = args.get(1).and_then(string_or_nil) {
-        headers.insert(
-            "Location".to_string(),
-            VmValue::String(std::sync::Arc::from(location)),
-        );
+        headers.put_str("Location", location);
     }
     Ok(envelope(201, body, BODY_KIND_JSON, headers))
 }
@@ -86,14 +84,8 @@ fn http_error_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
     let details = args.get(3).cloned().unwrap_or(VmValue::Nil);
 
     let mut body = BTreeMap::new();
-    body.insert(
-        "code".to_string(),
-        VmValue::String(std::sync::Arc::from(code)),
-    );
-    body.insert(
-        "message".to_string(),
-        VmValue::String(std::sync::Arc::from(message)),
-    );
+    body.put_str("code", code);
+    body.put_str("message", message);
     if !matches!(details, VmValue::Nil) {
         body.insert("details".to_string(), details);
     }
@@ -150,10 +142,7 @@ async fn http_stream_impl(
 
     let chunks = drain_to_list(source, "http_stream").await?;
     let mut headers = BTreeMap::new();
-    headers.insert(
-        "Content-Type".to_string(),
-        VmValue::String(std::sync::Arc::from(content_type)),
-    );
+    headers.put_str("Content-Type", content_type);
     Ok(envelope(
         200,
         VmValue::List(std::sync::Arc::new(chunks)),
@@ -195,14 +184,8 @@ async fn http_sse_impl(
 
     let events = drain_to_list(source, "http_sse").await?;
     let mut headers = BTreeMap::new();
-    headers.insert(
-        "Content-Type".to_string(),
-        VmValue::String(std::sync::Arc::from("text/event-stream")),
-    );
-    headers.insert(
-        "Cache-Control".to_string(),
-        VmValue::String(std::sync::Arc::from("no-cache")),
-    );
+    headers.put_str("Content-Type", "text/event-stream");
+    headers.put_str("Cache-Control", "no-cache");
     let mut env = envelope_map(
         200,
         VmValue::List(std::sync::Arc::new(events)),
@@ -238,10 +221,7 @@ fn envelope_map(
         VmValue::String(std::sync::Arc::from(HTTP_RESPONSE_TAG_VERSION)),
     );
     map.insert("status".to_string(), VmValue::Int(status));
-    map.insert(
-        "body_kind".to_string(),
-        VmValue::String(std::sync::Arc::from(body_kind)),
-    );
+    map.put_str("body_kind", body_kind);
     map.insert(
         "headers".to_string(),
         VmValue::Dict(std::sync::Arc::new(headers)),
@@ -581,10 +561,7 @@ fn expect_string_list(
 fn http_not_modified_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let mut headers = parse_headers(args.get(1), "http_not_modified")?;
     if let Some(etag) = args.first().and_then(string_or_nil) {
-        headers.insert(
-            "ETag".to_string(),
-            VmValue::String(std::sync::Arc::from(etag)),
-        );
+        headers.put_str("ETag", etag);
     }
     Ok(envelope(304, VmValue::Nil, BODY_KIND_NONE, headers))
 }
@@ -762,19 +739,10 @@ fn http_upgrade_ws_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
         .cloned();
 
     let mut headers = BTreeMap::new();
-    headers.insert(
-        "Upgrade".to_string(),
-        VmValue::String(std::sync::Arc::from("websocket")),
-    );
-    headers.insert(
-        "Connection".to_string(),
-        VmValue::String(std::sync::Arc::from("Upgrade")),
-    );
+    headers.put_str("Upgrade", "websocket");
+    headers.put_str("Connection", "Upgrade");
     if let Some(name) = &negotiated {
-        headers.insert(
-            "Sec-WebSocket-Protocol".to_string(),
-            VmValue::String(std::sync::Arc::from(name.clone())),
-        );
+        headers.put_str("Sec-WebSocket-Protocol", name.clone());
     }
 
     let idle_ping_ms = options
@@ -818,10 +786,7 @@ fn http_upgrade_ws_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
                 map.insert("max_message_bytes".to_string(), VmValue::Int(bytes));
             }
             if let Some(handler) = &on_message {
-                map.insert(
-                    "on_message".to_string(),
-                    VmValue::String(std::sync::Arc::from(handler.clone())),
-                );
+                map.put_str("on_message", handler.clone());
             }
             map
         })),

--- a/crates/harn-vm/src/stdlib/io.rs
+++ b/crates/harn-vm/src/stdlib/io.rs
@@ -1202,6 +1202,7 @@ fn ansi_colorize(text: &str, name: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use crate::value::VmDictExt;
     use std::collections::BTreeMap;
 
     use crate::value::VmValue;
@@ -1228,10 +1229,7 @@ mod tests {
     #[test]
     fn progress_bar_mode_renders_hash_bar() {
         let mut options = BTreeMap::new();
-        options.insert(
-            "mode".to_string(),
-            VmValue::String(std::sync::Arc::from("bar")),
-        );
+        options.put_str("mode", "bar");
         options.insert("current".to_string(), VmValue::Int(3));
         options.insert("total".to_string(), VmValue::Int(5));
         options.insert("width".to_string(), VmValue::Int(10));
@@ -1248,10 +1246,7 @@ mod tests {
     #[test]
     fn progress_spinner_mode_uses_step_to_pick_frame() {
         let mut options = BTreeMap::new();
-        options.insert(
-            "mode".to_string(),
-            VmValue::String(std::sync::Arc::from("spinner")),
-        );
+        options.put_str("mode", "spinner");
         options.insert("step".to_string(), VmValue::Int(2));
 
         let line = render_progress_line(&[
@@ -1272,10 +1267,7 @@ mod tests {
     #[test]
     fn read_line_options_preserve_prompt_whitespace() {
         let mut options = BTreeMap::new();
-        options.insert(
-            "prompt".to_string(),
-            VmValue::String(std::sync::Arc::from("  > ")),
-        );
+        options.put_str("prompt", "  > ");
         options.insert("trim".to_string(), VmValue::Bool(false));
 
         let parsed =
@@ -1288,10 +1280,7 @@ mod tests {
     #[test]
     fn read_line_options_reject_unknown_keys() {
         let mut options = BTreeMap::new();
-        options.insert(
-            "promtp".to_string(),
-            VmValue::String(std::sync::Arc::from("> ")),
-        );
+        options.put_str("promtp", "> ");
 
         let err = super::parse_read_line_options(&[VmValue::Dict(std::sync::Arc::new(options))])
             .unwrap_err();

--- a/crates/harn-vm/src/stdlib/io.rs
+++ b/crates/harn-vm/src/stdlib/io.rs
@@ -260,36 +260,32 @@ fn normalize_read_line_value(mut line: String, trim: bool) -> String {
     }
 }
 
-fn vm_string(value: impl Into<String>) -> VmValue {
-    VmValue::String(std::sync::Arc::from(value.into()))
-}
-
 fn read_line_result(outcome: ReadLineOutcome) -> VmValue {
     let mut out = BTreeMap::new();
     match outcome {
         ReadLineOutcome::Ok(value) => {
             out.insert("ok".to_string(), VmValue::Bool(true));
-            out.insert("status".to_string(), vm_string("ok"));
-            out.insert("value".to_string(), vm_string(value));
+            out.insert("status".to_string(), VmValue::string("ok"));
+            out.insert("value".to_string(), VmValue::string(value));
         }
         ReadLineOutcome::Eof => {
             out.insert("ok".to_string(), VmValue::Bool(false));
-            out.insert("status".to_string(), vm_string("eof"));
+            out.insert("status".to_string(), VmValue::string("eof"));
         }
         #[cfg(unix)]
         ReadLineOutcome::Timeout => {
             out.insert("ok".to_string(), VmValue::Bool(false));
-            out.insert("status".to_string(), vm_string("timeout"));
+            out.insert("status".to_string(), VmValue::string("timeout"));
         }
         #[cfg(unix)]
         ReadLineOutcome::Interrupt => {
             out.insert("ok".to_string(), VmValue::Bool(false));
-            out.insert("status".to_string(), vm_string("interrupt"));
+            out.insert("status".to_string(), VmValue::string("interrupt"));
         }
         ReadLineOutcome::Error(error) => {
             out.insert("ok".to_string(), VmValue::Bool(false));
-            out.insert("status".to_string(), vm_string("error"));
-            out.insert("error".to_string(), vm_string(error));
+            out.insert("status".to_string(), VmValue::string("error"));
+            out.insert("error".to_string(), VmValue::string(error));
         }
     }
     VmValue::Dict(std::sync::Arc::new(out))

--- a/crates/harn-vm/src/stdlib/json_stream.rs
+++ b/crates/harn-vm/src/stdlib/json_stream.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::{Cell, RefCell};
 use std::collections::BTreeMap;
 
@@ -766,30 +767,15 @@ fn verdict_value(status: &JsonStreamStatus) -> VmValue {
     let mut dict = BTreeMap::new();
     match status {
         JsonStreamStatus::Pending => {
-            dict.insert(
-                "verdict".to_string(),
-                VmValue::String(std::sync::Arc::from("pending")),
-            );
+            dict.put_str("verdict", "pending");
         }
         JsonStreamStatus::Valid => {
-            dict.insert(
-                "verdict".to_string(),
-                VmValue::String(std::sync::Arc::from("valid")),
-            );
+            dict.put_str("verdict", "valid");
         }
         JsonStreamStatus::Invalid { reason, path } => {
-            dict.insert(
-                "verdict".to_string(),
-                VmValue::String(std::sync::Arc::from("invalid")),
-            );
-            dict.insert(
-                "reason".to_string(),
-                VmValue::String(std::sync::Arc::from(reason.as_str())),
-            );
-            dict.insert(
-                "path".to_string(),
-                VmValue::String(std::sync::Arc::from(path.as_str())),
-            );
+            dict.put_str("verdict", "invalid");
+            dict.put_str("reason", reason.as_str());
+            dict.put_str("path", path.as_str());
         }
     }
     VmValue::Dict(std::sync::Arc::new(dict))

--- a/crates/harn-vm/src/stdlib/jsonrpc.rs
+++ b/crates/harn-vm/src/stdlib/jsonrpc.rs
@@ -21,6 +21,7 @@
 //! mock plumbing, and the egress allowlist apply identically to RPC
 //! traffic.
 
+use crate::value::VmDictExt;
 use std::cell::Cell;
 use std::collections::BTreeMap;
 
@@ -159,14 +160,8 @@ fn build_request_options(
     options: Option<&BTreeMap<String, VmValue>>,
 ) -> BTreeMap<String, VmValue> {
     let mut headers = BTreeMap::new();
-    headers.insert(
-        "Content-Type".to_string(),
-        VmValue::String(std::sync::Arc::from("application/json")),
-    );
-    headers.insert(
-        "Accept".to_string(),
-        VmValue::String(std::sync::Arc::from("application/json")),
-    );
+    headers.put_str("Content-Type", "application/json");
+    headers.put_str("Accept", "application/json");
     if let Some(extra) = options
         .and_then(|d| d.get("headers"))
         .and_then(VmValue::as_dict)
@@ -180,10 +175,7 @@ fn build_request_options(
         }
     }
     let mut request_options = BTreeMap::new();
-    request_options.insert(
-        "body".to_string(),
-        VmValue::String(std::sync::Arc::from(body)),
-    );
+    request_options.put_str("body", body);
     request_options.insert(
         "headers".to_string(),
         VmValue::Dict(std::sync::Arc::new(headers)),
@@ -222,14 +214,8 @@ fn next_id_value() -> VmValue {
 
 fn build_envelope(method: &str, params: &VmValue, id: &VmValue, notify: bool) -> VmValue {
     let mut m = BTreeMap::new();
-    m.insert(
-        "jsonrpc".to_string(),
-        VmValue::String(std::sync::Arc::from("2.0")),
-    );
-    m.insert(
-        "method".to_string(),
-        VmValue::String(std::sync::Arc::from(method)),
-    );
+    m.put_str("jsonrpc", "2.0");
+    m.put_str("method", method);
     if !matches!(params, VmValue::Nil) {
         m.insert("params".to_string(), params.clone());
     }
@@ -306,10 +292,7 @@ fn unwrap_batch_response(response: VmValue, slots: &[BatchSlot]) -> Result<VmVal
             let mut err_dict = BTreeMap::new();
             err_dict.insert("jsonrpc_error".to_string(), VmValue::Bool(true));
             err_dict.insert("code".to_string(), VmValue::Int(0));
-            err_dict.insert(
-                "message".to_string(),
-                VmValue::String(std::sync::Arc::from("missing response for call")),
-            );
+            err_dict.put_str("message", "missing response for call");
             out.push(VmValue::Dict(std::sync::Arc::new(err_dict)));
             continue;
         };
@@ -365,10 +348,7 @@ fn error_to_dict(err: &serde_json::Value) -> BTreeMap<String, VmValue> {
     let mut error_dict = BTreeMap::new();
     error_dict.insert("jsonrpc_error".to_string(), VmValue::Bool(true));
     error_dict.insert("code".to_string(), VmValue::Int(code));
-    error_dict.insert(
-        "message".to_string(),
-        VmValue::String(std::sync::Arc::from(message.to_string())),
-    );
+    error_dict.put_str("message", message);
     if let Some(data) = err.get("data") {
         error_dict.insert("data".to_string(), crate::schema::json_to_vm_value(data));
     }
@@ -396,6 +376,7 @@ fn canonical_id_key_from_vm(id: &VmValue) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::value::VmDictExt;
 
     #[test]
     fn envelope_includes_id_when_not_notify() {
@@ -440,10 +421,7 @@ mod tests {
         let body = serde_json::json!({"jsonrpc":"2.0","result":{"ok":true},"id":1});
         let mut response = BTreeMap::new();
         response.insert("status".to_string(), VmValue::Int(200));
-        response.insert(
-            "body".to_string(),
-            VmValue::String(std::sync::Arc::from(body.to_string())),
-        );
+        response.put_str("body", body.to_string());
         let result = unwrap_jsonrpc_response(VmValue::Dict(std::sync::Arc::new(response))).unwrap();
         let dict = result.as_dict().unwrap();
         match dict.get("ok") {
@@ -461,10 +439,7 @@ mod tests {
         });
         let mut response = BTreeMap::new();
         response.insert("status".to_string(), VmValue::Int(200));
-        response.insert(
-            "body".to_string(),
-            VmValue::String(std::sync::Arc::from(body.to_string())),
-        );
+        response.put_str("body", body.to_string());
         let err =
             unwrap_jsonrpc_response(VmValue::Dict(std::sync::Arc::new(response))).unwrap_err();
         match err {
@@ -482,10 +457,7 @@ mod tests {
     #[test]
     fn build_request_options_case_insensitive_override() {
         let mut user_headers = BTreeMap::new();
-        user_headers.insert(
-            "content-type".to_string(),
-            VmValue::String(std::sync::Arc::from("application/x-test")),
-        );
+        user_headers.put_str("content-type", "application/x-test");
         let mut opts = BTreeMap::new();
         opts.insert(
             "headers".to_string(),
@@ -518,10 +490,7 @@ mod tests {
         ]);
         let mut response = BTreeMap::new();
         response.insert("status".to_string(), VmValue::Int(200));
-        response.insert(
-            "body".to_string(),
-            VmValue::String(std::sync::Arc::from(body.to_string())),
-        );
+        response.put_str("body", body.to_string());
         let slots = vec![
             BatchSlot {
                 id: VmValue::Int(1),
@@ -550,10 +519,7 @@ mod tests {
         ]);
         let mut response = BTreeMap::new();
         response.insert("status".to_string(), VmValue::Int(200));
-        response.insert(
-            "body".to_string(),
-            VmValue::String(std::sync::Arc::from(body.to_string())),
-        );
+        response.put_str("body", body.to_string());
         let slots = vec![
             BatchSlot {
                 id: VmValue::Int(1),

--- a/crates/harn-vm/src/stdlib/junit.rs
+++ b/crates/harn-vm/src/stdlib/junit.rs
@@ -13,6 +13,7 @@
 //! deliberately independent — the format is small and stable, and consoli-
 //! dating later is straightforward if drift becomes a real problem.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::time::Duration;
 
@@ -97,14 +98,8 @@ fn parse_junit_xml_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
 
 fn record_to_value(record: TestRecord) -> VmValue {
     let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
-    map.insert(
-        "name".to_string(),
-        VmValue::String(std::sync::Arc::from(record.name.as_str())),
-    );
-    map.insert(
-        "status".to_string(),
-        VmValue::String(std::sync::Arc::from(record.status.as_str())),
-    );
+    map.put_str("name", record.name.as_str());
+    map.put_str("status", record.status.as_str());
     map.insert(
         "duration_ms".to_string(),
         VmValue::Int(record.duration_ms as i64),

--- a/crates/harn-vm/src/stdlib/lifecycle_receipts.rs
+++ b/crates/harn-vm/src/stdlib/lifecycle_receipts.rs
@@ -6,6 +6,7 @@
 //! between record and replay runs, that cached resume inputs survive a
 //! re-run, and that the signed timestamps reject tampered receipts.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use serde_json::Value as JsonValue;
@@ -197,10 +198,7 @@ fn lifecycle_replay_drain_decision_impl(
         Ok(action) => Ok(VmValue::Dict(std::sync::Arc::new({
             let mut map = BTreeMap::new();
             map.insert("ok".to_string(), VmValue::Bool(true));
-            map.insert(
-                "action".to_string(),
-                VmValue::String(std::sync::Arc::from(drain_action_str(action))),
-            );
+            map.put_str("action", drain_action_str(action));
             map
         }))),
         Err(error) => Ok(error_value(error)),
@@ -479,10 +477,7 @@ fn verification_value(result: Result<(), LifecycleReceiptError>) -> VmValue {
         }
         Err(error) => {
             map.insert("verified".to_string(), VmValue::Bool(false));
-            map.insert(
-                "error".to_string(),
-                VmValue::String(std::sync::Arc::from(error.to_string())),
-            );
+            map.put_str("error", error.to_string());
         }
     }
     VmValue::Dict(std::sync::Arc::new(map))
@@ -491,10 +486,7 @@ fn verification_value(result: Result<(), LifecycleReceiptError>) -> VmValue {
 fn error_value(error: LifecycleReceiptError) -> VmValue {
     let mut map = BTreeMap::new();
     map.insert("ok".to_string(), VmValue::Bool(false));
-    map.insert(
-        "error".to_string(),
-        VmValue::String(std::sync::Arc::from(error.to_string())),
-    );
+    map.put_str("error", error.to_string());
     let code = match &error {
         LifecycleReceiptError::ResumeInputHashMismatch { .. } => "HARN-SUS-011",
         LifecycleReceiptError::DrainDecisionPromptHashMismatch { .. } => "HARN-SUS-012",
@@ -503,10 +495,7 @@ fn error_value(error: LifecycleReceiptError) -> VmValue {
         | LifecycleReceiptError::SignatureKeyMismatch { .. } => "HARN-SUS-013",
         LifecycleReceiptError::Persistence(_) => "HARN-SUS-013",
     };
-    map.insert(
-        "code".to_string(),
-        VmValue::String(std::sync::Arc::from(code)),
-    );
+    map.put_str("code", code);
     VmValue::Dict(std::sync::Arc::new(map))
 }
 

--- a/crates/harn-vm/src/stdlib/long_running.rs
+++ b/crates/harn-vm/src/stdlib/long_running.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, OnceLock};
@@ -24,28 +25,13 @@ pub(crate) struct OperationHandleInfo {
 impl OperationHandleInfo {
     pub(crate) fn into_vm_value(self) -> VmValue {
         let mut dict = BTreeMap::new();
-        dict.insert(
-            "handle_id".to_string(),
-            VmValue::String(std::sync::Arc::from(self.handle_id)),
-        );
-        dict.insert(
-            "started_at".to_string(),
-            VmValue::String(std::sync::Arc::from(self.started_at)),
-        );
+        dict.put_str("handle_id", self.handle_id);
+        dict.put_str("started_at", self.started_at);
         dict.insert("ended_at".to_string(), VmValue::Nil);
         dict.insert("duration_ms".to_string(), VmValue::Int(0));
-        dict.insert(
-            "status".to_string(),
-            VmValue::String(std::sync::Arc::from("running")),
-        );
-        dict.insert(
-            "operation".to_string(),
-            VmValue::String(std::sync::Arc::from(self.operation)),
-        );
-        dict.insert(
-            "command_or_op_descriptor".to_string(),
-            VmValue::String(std::sync::Arc::from(self.descriptor)),
-        );
+        dict.put_str("status", "running");
+        dict.put_str("operation", self.operation);
+        dict.put_str("command_or_op_descriptor", self.descriptor);
         VmValue::Dict(std::sync::Arc::new(dict))
     }
 }

--- a/crates/harn-vm/src/stdlib/memory.rs
+++ b/crates/harn-vm/src/stdlib/memory.rs
@@ -12,6 +12,7 @@
 //! responsible for the model choice, rate limiting, and cost accounting.
 //! See `docs/src/host-boundary.md` and `docs/src/memory.md`.
 
+use crate::value::VmDictExt;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::{self, OpenOptions};
@@ -920,14 +921,8 @@ async fn ensure_embedding(
         return Ok(cached.vector);
     }
     let mut params = BTreeMap::new();
-    params.insert(
-        "text".to_string(),
-        VmValue::String(std::sync::Arc::from(text)),
-    );
-    params.insert(
-        "model_hint".to_string(),
-        VmValue::String(std::sync::Arc::from(hint.to_string())),
-    );
+    params.put_str("text", text);
+    params.put_str("model_hint", hint);
     let result = dispatch_host_operation("memory", "embed", &params).await?;
     let cached = parse_embedding_response(result, hint)?;
     write_cached_embedding(&path, &cached)?;
@@ -1277,30 +1272,15 @@ fn values_as_strings(value: &VmValue) -> Vec<String> {
 
 fn memory_record_to_vm(record: &MemoryRecord, score: Option<f64>) -> VmValue {
     let mut map = BTreeMap::new();
-    map.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from(MEMORY_TYPE)),
-    );
-    map.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(record.id.as_str())),
-    );
-    map.insert(
-        "namespace".to_string(),
-        VmValue::String(std::sync::Arc::from(record.namespace.as_str())),
-    );
-    map.insert(
-        "key".to_string(),
-        VmValue::String(std::sync::Arc::from(record.key.as_str())),
-    );
+    map.put_str("_type", MEMORY_TYPE);
+    map.put_str("id", record.id.as_str());
+    map.put_str("namespace", record.namespace.as_str());
+    map.put_str("key", record.key.as_str());
     map.insert(
         "value".to_string(),
         crate::stdlib::json_to_vm_value(&record.value),
     );
-    map.insert(
-        "text".to_string(),
-        VmValue::String(std::sync::Arc::from(record.text.as_str())),
-    );
+    map.put_str("text", record.text.as_str());
     map.insert(
         "tags".to_string(),
         VmValue::List(std::sync::Arc::new(
@@ -1311,10 +1291,7 @@ fn memory_record_to_vm(record: &MemoryRecord, score: Option<f64>) -> VmValue {
                 .collect(),
         )),
     );
-    map.insert(
-        "stored_at".to_string(),
-        VmValue::String(std::sync::Arc::from(record.stored_at.as_str())),
-    );
+    map.put_str("stored_at", record.stored_at.as_str());
     map.insert(
         "provenance".to_string(),
         record
@@ -1344,19 +1321,10 @@ fn summary_to_vm(namespace: &str, records: Vec<MemoryRecord>) -> VmValue {
         text.push_str(&line);
     }
     let mut map = BTreeMap::new();
-    map.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from("memory_summary")),
-    );
-    map.insert(
-        "namespace".to_string(),
-        VmValue::String(std::sync::Arc::from(namespace.to_string())),
-    );
+    map.put_str("_type", "memory_summary");
+    map.put_str("namespace", namespace);
     map.insert("count".to_string(), VmValue::Int(records.len() as i64));
-    map.insert(
-        "text".to_string(),
-        VmValue::String(std::sync::Arc::from(text)),
-    );
+    map.put_str("text", text);
     map.insert(
         "records".to_string(),
         VmValue::List(std::sync::Arc::new(
@@ -1371,18 +1339,9 @@ fn summary_to_vm(namespace: &str, records: Vec<MemoryRecord>) -> VmValue {
 
 fn forget_result_to_vm(event: &ForgetEvent) -> VmValue {
     let mut map = BTreeMap::new();
-    map.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from("memory_forget")),
-    );
-    map.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(event.id.as_str())),
-    );
-    map.insert(
-        "namespace".to_string(),
-        VmValue::String(std::sync::Arc::from(event.namespace.as_str())),
-    );
+    map.put_str("_type", "memory_forget");
+    map.put_str("id", event.id.as_str());
+    map.put_str("namespace", event.namespace.as_str());
     map.insert(
         "forgotten".to_string(),
         VmValue::Int(event.forgotten_ids.len() as i64),
@@ -1397,36 +1356,21 @@ fn forget_result_to_vm(event: &ForgetEvent) -> VmValue {
                 .collect(),
         )),
     );
-    map.insert(
-        "forgotten_at".to_string(),
-        VmValue::String(std::sync::Arc::from(event.forgotten_at.as_str())),
-    );
+    map.put_str("forgotten_at", event.forgotten_at.as_str());
     VmValue::Dict(std::sync::Arc::new(map))
 }
 
 fn memory_open_to_vm(event: &OpenEvent) -> VmValue {
     let mut map = BTreeMap::new();
-    map.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from("memory_open")),
-    );
-    map.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(event.id.as_str())),
-    );
-    map.insert(
-        "namespace".to_string(),
-        VmValue::String(std::sync::Arc::from(event.namespace.as_str())),
-    );
+    map.put_str("_type", "memory_open");
+    map.put_str("id", event.id.as_str());
+    map.put_str("namespace", event.namespace.as_str());
     let backend = match event.backend {
         MemoryBackend::Bm25 => "bm25",
         MemoryBackend::Vector => "vector",
         MemoryBackend::Hybrid => "hybrid",
     };
-    map.insert(
-        "backend".to_string(),
-        VmValue::String(std::sync::Arc::from(backend)),
-    );
+    map.put_str("backend", backend);
     map.insert(
         "embed_model_hint".to_string(),
         event
@@ -1456,10 +1400,7 @@ fn memory_open_to_vm(event: &OpenEvent) -> VmValue {
             .map(VmValue::Float)
             .unwrap_or(VmValue::Nil),
     );
-    map.insert(
-        "opened_at".to_string(),
-        VmValue::String(std::sync::Arc::from(event.opened_at.as_str())),
-    );
+    map.put_str("opened_at", event.opened_at.as_str());
     VmValue::Dict(std::sync::Arc::new(map))
 }
 
@@ -1474,6 +1415,7 @@ fn now_rfc3339() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::value::VmDictExt;
 
     fn temp_root(name: &str) -> PathBuf {
         let root =
@@ -1624,10 +1566,7 @@ mod tests {
             ])),
         );
         dict.insert("dim".to_string(), VmValue::Int(3));
-        dict.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from("test-model")),
-        );
+        dict.put_str("model", "test-model");
         let value = VmValue::Dict(std::sync::Arc::new(dict));
         let parsed = parse_embedding_response(value, "fallback").unwrap();
         assert_eq!(parsed.dim, 3);

--- a/crates/harn-vm/src/stdlib/multipart.rs
+++ b/crates/harn-vm/src/stdlib/multipart.rs
@@ -32,10 +32,6 @@ fn builtin_error(builtin: &str, message: impl std::fmt::Display) -> VmError {
     VmError::Runtime(format!("{builtin}: {message}"))
 }
 
-fn string_value(value: impl Into<String>) -> VmValue {
-    VmValue::String(std::sync::Arc::from(value.into()))
-}
-
 fn bytes_value(bytes: Vec<u8>) -> VmValue {
     VmValue::Bytes(std::sync::Arc::new(bytes))
 }
@@ -49,7 +45,7 @@ fn list_value(items: Vec<VmValue>) -> VmValue {
 }
 
 fn nil_or_string(value: Option<String>) -> VmValue {
-    value.map(string_value).unwrap_or(VmValue::Nil)
+    value.map(VmValue::string).unwrap_or(VmValue::Nil)
 }
 
 fn expect_string<'a>(args: &'a [VmValue], index: usize, builtin: &str) -> Result<&'a str, VmError> {
@@ -432,18 +428,18 @@ fn parse_multipart_body(
 fn headers_value(headers: &BTreeMap<String, String>) -> VmValue {
     let map = headers
         .iter()
-        .map(|(key, value)| (key.clone(), string_value(value)))
+        .map(|(key, value)| (key.clone(), VmValue::string(value)))
         .collect();
     dict_value(map)
 }
 
 fn parsed_field_value(field: ParsedField) -> VmValue {
     let text = match std::str::from_utf8(&field.bytes) {
-        Ok(text) => string_value(text),
+        Ok(text) => VmValue::string(text),
         Err(_) => VmValue::Nil,
     };
     let mut map = BTreeMap::new();
-    map.insert("name".to_string(), string_value(field.name));
+    map.insert("name".to_string(), VmValue::string(field.name));
     map.insert("filename".to_string(), nil_or_string(field.filename));
     map.insert(
         "content_type".to_string(),
@@ -470,7 +466,7 @@ fn multipart_parse_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValu
     let field_count = fields.len() as i64;
 
     let mut result = BTreeMap::new();
-    result.insert("boundary".to_string(), string_value(boundary));
+    result.insert("boundary".to_string(), VmValue::string(boundary));
     result.insert(
         "fields".to_string(),
         list_value(fields.into_iter().map(parsed_field_value).collect()),
@@ -532,7 +528,7 @@ fn multipart_field_text_builtin(args: &[VmValue], _out: &mut String) -> Result<V
     };
     let text =
         std::str::from_utf8(bytes).map_err(|error| builtin_error("multipart_field_text", error))?;
-    Ok(string_value(text))
+    Ok(VmValue::string(text))
 }
 
 fn field_input_string(
@@ -760,8 +756,8 @@ fn multipart_form_data_builtin(args: &[VmValue], _out: &mut String) -> Result<Vm
 fn form_data_result(boundary: String, body: Vec<u8>) -> Result<VmValue, VmError> {
     let content_type = format!("multipart/form-data; boundary={boundary}");
     let mut result = BTreeMap::new();
-    result.insert("boundary".to_string(), string_value(boundary));
-    result.insert("content_type".to_string(), string_value(content_type));
+    result.insert("boundary".to_string(), VmValue::string(boundary));
+    result.insert("content_type".to_string(), VmValue::string(content_type));
     result.insert("body".to_string(), bytes_value(body));
     Ok(dict_value(result))
 }
@@ -784,7 +780,7 @@ mod tests {
     use super::*;
 
     fn s(value: &str) -> VmValue {
-        string_value(value)
+        VmValue::string(value)
     }
 
     fn b(value: &[u8]) -> VmValue {

--- a/crates/harn-vm/src/stdlib/oauth_dynreg.rs
+++ b/crates/harn-vm/src/stdlib/oauth_dynreg.rs
@@ -239,13 +239,12 @@ fn next_store_id() -> String {
 
 fn store_handle(id: &str) -> VmValue {
     let mut fields = BTreeMap::new();
-    fields.insert(HANDLE_KEY_KIND.to_string(), string_value(KIND_DYNREG_STORE));
-    fields.insert(HANDLE_KEY_ID.to_string(), string_value(id));
+    fields.insert(
+        HANDLE_KEY_KIND.to_string(),
+        VmValue::string(KIND_DYNREG_STORE),
+    );
+    fields.insert(HANDLE_KEY_ID.to_string(), VmValue::string(id));
     VmValue::Dict(std::sync::Arc::new(fields))
-}
-
-fn string_value(value: &str) -> VmValue {
-    VmValue::String(std::sync::Arc::from(value))
 }
 
 fn handle_id(handle: &BTreeMap<String, VmValue>) -> Result<String, VmError> {
@@ -287,7 +286,7 @@ fn validate_metadata_value(metadata: &BTreeMap<String, VmValue>) -> VmValue {
     out.insert(
         "errors".to_string(),
         VmValue::List(std::sync::Arc::new(
-            errors.iter().map(|e| string_value(e)).collect::<Vec<_>>(),
+            errors.iter().map(VmValue::string).collect::<Vec<_>>(),
         )),
     );
     VmValue::Dict(std::sync::Arc::new(out))
@@ -562,14 +561,14 @@ fn build_client_metadata_value(metadata: &BTreeMap<String, VmValue>) -> Result<V
     // token_endpoint_auth_method defaults to `client_secret_basic`.
     let mut out: BTreeMap<String, VmValue> = metadata.clone();
     out.entry("response_types".to_string())
-        .or_insert_with(|| VmValue::List(std::sync::Arc::new(vec![string_value("code")])));
+        .or_insert_with(|| VmValue::List(std::sync::Arc::new(vec![VmValue::string("code")])));
     out.entry("grant_types".to_string()).or_insert_with(|| {
-        VmValue::List(std::sync::Arc::new(vec![string_value(
+        VmValue::List(std::sync::Arc::new(vec![VmValue::string(
             "authorization_code",
         )]))
     });
     out.entry("token_endpoint_auth_method".to_string())
-        .or_insert_with(|| string_value("client_secret_basic"));
+        .or_insert_with(|| VmValue::string("client_secret_basic"));
     Ok(VmValue::Dict(std::sync::Arc::new(out)))
 }
 
@@ -582,53 +581,56 @@ fn build_authorization_server_metadata_value(
     let issuer = derive_issuer(&auth_url)?;
 
     let mut out: BTreeMap<String, VmValue> = BTreeMap::new();
-    out.insert("issuer".to_string(), string_value(&issuer));
+    out.insert("issuer".to_string(), VmValue::string(&issuer));
     out.insert(
         "authorization_endpoint".to_string(),
-        string_value(&auth_url),
+        VmValue::string(&auth_url),
     );
-    out.insert("token_endpoint".to_string(), string_value(&token_url));
+    out.insert("token_endpoint".to_string(), VmValue::string(&token_url));
     if let Some(VmValue::String(s)) = provider.get("device_code_url") {
         out.insert(
             "device_authorization_endpoint".to_string(),
-            string_value(s.as_ref()),
+            VmValue::string(s.as_ref()),
         );
     }
     if let Some(VmValue::String(s)) = provider.get("revoke_url") {
-        out.insert("revocation_endpoint".to_string(), string_value(s.as_ref()));
+        out.insert(
+            "revocation_endpoint".to_string(),
+            VmValue::string(s.as_ref()),
+        );
     }
     if let Some(VmValue::String(s)) = provider.get("userinfo_url") {
-        out.insert("userinfo_endpoint".to_string(), string_value(s.as_ref()));
+        out.insert("userinfo_endpoint".to_string(), VmValue::string(s.as_ref()));
     }
     out.insert(
         "response_types_supported".to_string(),
-        VmValue::List(std::sync::Arc::new(vec![string_value("code")])),
+        VmValue::List(std::sync::Arc::new(vec![VmValue::string("code")])),
     );
     out.insert(
         "grant_types_supported".to_string(),
         VmValue::List(std::sync::Arc::new(vec![
-            string_value("authorization_code"),
-            string_value("refresh_token"),
-            string_value("urn:ietf:params:oauth:grant-type:device_code"),
+            VmValue::string("authorization_code"),
+            VmValue::string("refresh_token"),
+            VmValue::string("urn:ietf:params:oauth:grant-type:device_code"),
         ])),
     );
     out.insert(
         "token_endpoint_auth_methods_supported".to_string(),
         VmValue::List(std::sync::Arc::new(vec![
-            string_value("client_secret_basic"),
-            string_value("client_secret_post"),
-            string_value("none"),
+            VmValue::string("client_secret_basic"),
+            VmValue::string("client_secret_post"),
+            VmValue::string("none"),
         ])),
     );
     if let Some(VmValue::Bool(true)) | Some(VmValue::Bool(false)) = provider.get("pkce_required") {
         out.insert(
             "code_challenge_methods_supported".to_string(),
-            VmValue::List(std::sync::Arc::new(vec![string_value("S256")])),
+            VmValue::List(std::sync::Arc::new(vec![VmValue::string("S256")])),
         );
     } else {
         out.insert(
             "code_challenge_methods_supported".to_string(),
-            VmValue::List(std::sync::Arc::new(vec![string_value("S256")])),
+            VmValue::List(std::sync::Arc::new(vec![VmValue::string("S256")])),
         );
     }
     if let Some(VmValue::List(scopes)) = provider.get("default_scopes") {
@@ -687,17 +689,17 @@ fn register_client_value(
     let mut canonical = metadata.clone();
     canonical
         .entry("response_types".to_string())
-        .or_insert_with(|| VmValue::List(std::sync::Arc::new(vec![string_value("code")])));
+        .or_insert_with(|| VmValue::List(std::sync::Arc::new(vec![VmValue::string("code")])));
     canonical
         .entry("grant_types".to_string())
         .or_insert_with(|| {
-            VmValue::List(std::sync::Arc::new(vec![string_value(
+            VmValue::List(std::sync::Arc::new(vec![VmValue::string(
                 "authorization_code",
             )]))
         });
     canonical
         .entry("token_endpoint_auth_method".to_string())
-        .or_insert_with(|| string_value("client_secret_basic"));
+        .or_insert_with(|| VmValue::string("client_secret_basic"));
 
     let canonical_dict = VmValue::Dict(std::sync::Arc::new(canonical.clone()));
     let canonical_json = vm_value_to_json(&canonical_dict);
@@ -720,8 +722,8 @@ fn register_client_value(
 
     // Build the response dict — full RFC 7591 §3.2.1 success body.
     let mut response: BTreeMap<String, VmValue> = canonical;
-    response.insert("client_id".to_string(), string_value(&client_id));
-    response.insert("client_secret".to_string(), string_value(&client_secret));
+    response.insert("client_id".to_string(), VmValue::string(&client_id));
+    response.insert("client_secret".to_string(), VmValue::string(&client_secret));
     response.insert("client_id_issued_at".to_string(), VmValue::Int(issued_at));
     // Per RFC 7591 §3.2.1, `client_secret_expires_at: 0` means non-expiring.
     response.insert("client_secret_expires_at".to_string(), VmValue::Int(0));
@@ -750,7 +752,7 @@ fn get_client_value(handle: &BTreeMap<String, VmValue>, client_id: &str) -> VmVa
             VmValue::Dict(dict) => dict.as_ref().clone(),
             _ => BTreeMap::new(),
         };
-        response.insert("client_id".to_string(), string_value(&client.client_id));
+        response.insert("client_id".to_string(), VmValue::string(&client.client_id));
         response.insert(
             "client_id_issued_at".to_string(),
             VmValue::Int(client.client_id_issued_at),
@@ -773,7 +775,7 @@ fn list_clients_value(handle: &BTreeMap<String, VmValue>) -> VmValue {
         let ids: Vec<VmValue> = store
             .clients
             .keys()
-            .map(|id| string_value(id.as_str()))
+            .map(|id| VmValue::string(id.as_str()))
             .collect();
         VmValue::List(std::sync::Arc::new(ids))
     })
@@ -888,7 +890,7 @@ mod tests {
         let mut m = BTreeMap::new();
         m.insert(
             "redirect_uris".to_string(),
-            VmValue::List(std::sync::Arc::new(vec![string_value(uri)])),
+            VmValue::List(std::sync::Arc::new(vec![VmValue::string(uri)])),
         );
         m
     }
@@ -969,7 +971,7 @@ mod tests {
         let mut m = metadata_with_redirect("https://app.example/cb");
         m.insert(
             "grant_types".to_string(),
-            VmValue::List(std::sync::Arc::new(vec![string_value("password")])),
+            VmValue::List(std::sync::Arc::new(vec![VmValue::string("password")])),
         );
         let mut errors = Vec::new();
         validate_metadata(&m, &mut errors);
@@ -993,11 +995,11 @@ mod tests {
         let mut provider = BTreeMap::new();
         provider.insert(
             "auth_url".to_string(),
-            string_value("https://idp.example/authorize"),
+            VmValue::string("https://idp.example/authorize"),
         );
         provider.insert(
             "token_url".to_string(),
-            string_value("https://idp.example/token"),
+            VmValue::string("https://idp.example/token"),
         );
         let built = build_authorization_server_metadata_value(&provider, None).expect("ok");
         let VmValue::Dict(dict) = built else {
@@ -1030,8 +1032,8 @@ mod tests {
                 .insert(id.clone(), DynregStore::default());
         });
         let mut handle = BTreeMap::new();
-        handle.insert("kind".to_string(), string_value(KIND_DYNREG_STORE));
-        handle.insert("id".to_string(), string_value(&id));
+        handle.insert("kind".to_string(), VmValue::string(KIND_DYNREG_STORE));
+        handle.insert("id".to_string(), VmValue::string(&id));
         let m = metadata_with_redirect("https://app.example/cb");
         let response = register_client_value(&handle, &m).expect("registration ok");
         let VmValue::Dict(dict) = response else {
@@ -1063,8 +1065,8 @@ mod tests {
                 .insert(id.clone(), DynregStore::default());
         });
         let mut handle = BTreeMap::new();
-        handle.insert("kind".to_string(), string_value(KIND_DYNREG_STORE));
-        handle.insert("id".to_string(), string_value(&id));
+        handle.insert("kind".to_string(), VmValue::string(KIND_DYNREG_STORE));
+        handle.insert("id".to_string(), VmValue::string(&id));
         let m = metadata_with_redirect("http://attacker.example/cb");
         let err = register_client_value(&handle, &m).unwrap_err();
         let VmError::Runtime(text) = err else {

--- a/crates/harn-vm/src/stdlib/oauth_storage.rs
+++ b/crates/harn-vm/src/stdlib/oauth_storage.rs
@@ -210,8 +210,8 @@ fn memory_handle() -> VmValue {
         format!("memory-{}", *guard)
     };
     let mut fields = BTreeMap::new();
-    fields.insert(HANDLE_KEY_KIND.to_string(), string_value(KIND_MEMORY));
-    fields.insert(HANDLE_KEY_ID.to_string(), string_value(&id));
+    fields.insert(HANDLE_KEY_KIND.to_string(), VmValue::string(KIND_MEMORY));
+    fields.insert(HANDLE_KEY_ID.to_string(), VmValue::string(&id));
     VmValue::Dict(std::sync::Arc::new(fields))
 }
 
@@ -226,9 +226,9 @@ fn file_handle(path: &str, secret: &[u8]) -> VmValue {
         secrets.borrow_mut().insert(id.clone(), secret.to_vec());
     });
     let mut fields = BTreeMap::new();
-    fields.insert(HANDLE_KEY_KIND.to_string(), string_value(KIND_FILE));
-    fields.insert(HANDLE_KEY_ID.to_string(), string_value(&id));
-    fields.insert(HANDLE_KEY_PATH.to_string(), string_value(path));
+    fields.insert(HANDLE_KEY_KIND.to_string(), VmValue::string(KIND_FILE));
+    fields.insert(HANDLE_KEY_ID.to_string(), VmValue::string(&id));
+    fields.insert(HANDLE_KEY_PATH.to_string(), VmValue::string(path));
     VmValue::Dict(std::sync::Arc::new(fields))
 }
 
@@ -239,14 +239,10 @@ fn cloud_handle(kind: &'static str) -> VmValue {
         "session"
     };
     let mut fields = BTreeMap::new();
-    fields.insert(HANDLE_KEY_KIND.to_string(), string_value(kind));
-    fields.insert(HANDLE_KEY_ID.to_string(), string_value(kind));
-    fields.insert(HANDLE_KEY_SCOPE.to_string(), string_value(scope));
+    fields.insert(HANDLE_KEY_KIND.to_string(), VmValue::string(kind));
+    fields.insert(HANDLE_KEY_ID.to_string(), VmValue::string(kind));
+    fields.insert(HANDLE_KEY_SCOPE.to_string(), VmValue::string(scope));
     VmValue::Dict(std::sync::Arc::new(fields))
-}
-
-fn string_value(value: &str) -> VmValue {
-    VmValue::String(std::sync::Arc::from(value))
 }
 
 fn handle_kind(handle: &BTreeMap<String, VmValue>) -> Result<String, VmError> {
@@ -608,8 +604,8 @@ fn cloud_scope(handle: &BTreeMap<String, VmValue>) -> Result<String, VmError> {
 async fn cloud_get(handle: &BTreeMap<String, VmValue>, key: &str) -> Result<VmValue, VmError> {
     let scope = cloud_scope(handle)?;
     let mut params = BTreeMap::new();
-    params.insert("scope".to_string(), string_value(&scope));
-    params.insert("key".to_string(), string_value(key));
+    params.insert("scope".to_string(), VmValue::string(&scope));
+    params.insert("key".to_string(), VmValue::string(key));
     dispatch_host_operation("oauth_storage", "cloud_get", &params).await
 }
 
@@ -621,8 +617,8 @@ async fn cloud_set(
 ) -> Result<(), VmError> {
     let scope = cloud_scope(handle)?;
     let mut params = BTreeMap::new();
-    params.insert("scope".to_string(), string_value(&scope));
-    params.insert("key".to_string(), string_value(key));
+    params.insert("scope".to_string(), VmValue::string(&scope));
+    params.insert("key".to_string(), VmValue::string(key));
     params.insert("token".to_string(), json_to_vm_dict(&token));
     if let Some(ttl) = ttl_seconds {
         params.insert("ttl_seconds".to_string(), VmValue::Int(ttl));
@@ -634,8 +630,8 @@ async fn cloud_set(
 async fn cloud_delete(handle: &BTreeMap<String, VmValue>, key: &str) -> Result<(), VmError> {
     let scope = cloud_scope(handle)?;
     let mut params = BTreeMap::new();
-    params.insert("scope".to_string(), string_value(&scope));
-    params.insert("key".to_string(), string_value(key));
+    params.insert("scope".to_string(), VmValue::string(&scope));
+    params.insert("key".to_string(), VmValue::string(key));
     dispatch_host_operation("oauth_storage", "cloud_delete", &params).await?;
     Ok(())
 }
@@ -755,7 +751,7 @@ mod tests {
 
     fn token_dict(access: &str) -> BTreeMap<String, VmValue> {
         let mut dict = BTreeMap::new();
-        dict.insert("access_token".to_string(), string_value(access));
+        dict.insert("access_token".to_string(), VmValue::string(access));
         dict
     }
 
@@ -772,7 +768,7 @@ mod tests {
             .get("access_token")
             .unwrap_or_else(|| panic!("missing access_token field"));
         assert!(
-            values_equal(access, &string_value(expected)),
+            values_equal(access, &VmValue::string(expected)),
             "expected access_token=`{expected}`, got {access:?}"
         );
     }

--- a/crates/harn-vm/src/stdlib/observability.rs
+++ b/crates/harn-vm/src/stdlib/observability.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::sync::atomic::Ordering;
@@ -501,18 +502,9 @@ fn field_string(value: Option<&VmValue>, key: &str) -> Option<String> {
 
 fn span_to_vm_value(span: &ObsSpan) -> VmValue {
     let mut out = BTreeMap::new();
-    out.insert(
-        "trace_id".to_string(),
-        VmValue::String(std::sync::Arc::from(span.trace_id.as_str())),
-    );
-    out.insert(
-        "span_id".to_string(),
-        VmValue::String(std::sync::Arc::from(span.id.as_str())),
-    );
-    out.insert(
-        "name".to_string(),
-        VmValue::String(std::sync::Arc::from(span.name.as_str())),
-    );
+    out.put_str("trace_id", span.trace_id.as_str());
+    out.put_str("span_id", span.id.as_str());
+    out.put_str("name", span.name.as_str());
     out.insert(
         "attrs".to_string(),
         json_to_vm_value(&serde_json::Value::Object(span.attrs.clone())),

--- a/crates/harn-vm/src/stdlib/pool/mod.rs
+++ b/crates/harn-vm/src/stdlib/pool/mod.rs
@@ -16,6 +16,7 @@
 //!   the API level so user code is portable; today they fail with a clear
 //!   diagnostic until an embedding host wires a tenant/org pool backend.
 
+use crate::value::VmDictExt;
 use std::any::Any;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::future::Future;
@@ -901,36 +902,21 @@ fn pool_snapshot_value(pool: &PoolEntry) -> VmValue {
         }
     }
     let mut snapshot = BTreeMap::new();
-    snapshot.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from(POOL_TYPE)),
-    );
-    snapshot.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(pool.id.as_str())),
-    );
-    snapshot.insert(
-        "name".to_string(),
-        VmValue::String(std::sync::Arc::from(pool.name.as_str())),
-    );
+    snapshot.put_str("_type", POOL_TYPE);
+    snapshot.put_str("id", pool.id.as_str());
+    snapshot.put_str("name", pool.name.as_str());
     snapshot.insert(
         "max_concurrent".to_string(),
         VmValue::Int(pool.max_concurrent as i64),
     );
-    snapshot.insert(
-        "created_at".to_string(),
-        VmValue::String(std::sync::Arc::from(pool.created_at.as_str())),
-    );
+    snapshot.put_str("created_at", pool.created_at.as_str());
     snapshot.insert("active".to_string(), VmValue::Int(active));
     snapshot.insert("queued".to_string(), VmValue::Int(queued));
     snapshot.insert("completed".to_string(), VmValue::Int(completed));
     snapshot.insert("failed".to_string(), VmValue::Int(failed));
     snapshot.insert("rejected".to_string(), VmValue::Int(rejected));
     snapshot.insert("total".to_string(), VmValue::Int(pool.tasks.len() as i64));
-    snapshot.insert(
-        "queue_strategy".to_string(),
-        VmValue::String(std::sync::Arc::from(pool.queue_strategy.name())),
-    );
+    snapshot.put_str("queue_strategy", pool.queue_strategy.name());
     snapshot.insert(
         "backpressure".to_string(),
         backpressure_snapshot_value(&pool.backpressure),
@@ -943,15 +929,9 @@ fn pool_snapshot_value(pool: &PoolEntry) -> VmValue {
         "tasks".to_string(),
         VmValue::List(std::sync::Arc::new(tasks)),
     );
-    snapshot.insert(
-        "scope".to_string(),
-        VmValue::String(std::sync::Arc::from(pool.scope.as_str())),
-    );
+    snapshot.put_str("scope", pool.scope.as_str());
     if !pool.scope_id.is_empty() {
-        snapshot.insert(
-            "scope_id".to_string(),
-            VmValue::String(std::sync::Arc::from(pool.scope_id.as_str())),
-        );
+        snapshot.put_str("scope_id", pool.scope_id.as_str());
     }
     snapshot.insert("durable".to_string(), VmValue::Bool(pool.store.is_some()));
     snapshot.insert(
@@ -969,22 +949,13 @@ fn pool_snapshot_value(pool: &PoolEntry) -> VmValue {
 
 fn backpressure_snapshot_value(backpressure: &BackpressureStrategy) -> VmValue {
     let mut value = BTreeMap::new();
-    value.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from("backpressure")),
-    );
-    value.insert(
-        "kind".to_string(),
-        VmValue::String(std::sync::Arc::from(backpressure.name())),
-    );
+    value.put_str("_type", "backpressure");
+    value.put_str("kind", backpressure.name());
     if let Some(max_depth) = backpressure.max_depth() {
         value.insert("max_depth".to_string(), VmValue::Int(max_depth as i64));
     }
     if let BackpressureStrategy::Queue { on_full, .. } = backpressure {
-        value.insert(
-            "on_full".to_string(),
-            VmValue::String(std::sync::Arc::from(on_full.as_str())),
-        );
+        value.put_str("on_full", on_full.as_str());
     }
     VmValue::Dict(std::sync::Arc::new(value))
 }
@@ -1001,123 +972,37 @@ fn task_sort_key(task: &VmValue) -> String {
 
 fn task_snapshot_value(task: &TaskState) -> VmValue {
     let mut entry = BTreeMap::new();
-    entry.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from(POOL_TASK_TYPE)),
-    );
-    entry.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(task.id.as_str())),
-    );
-    entry.insert(
-        "pool_id".to_string(),
-        VmValue::String(std::sync::Arc::from(task.pool_id.as_str())),
-    );
-    entry.insert(
-        "pool".to_string(),
-        VmValue::String(std::sync::Arc::from(task.pool_name.as_str())),
-    );
-    entry.insert(
-        "status".to_string(),
-        VmValue::String(std::sync::Arc::from(task.status.as_str())),
-    );
+    entry.put_str("_type", POOL_TASK_TYPE);
+    entry.put_str("id", task.id.as_str());
+    entry.put_str("pool_id", task.pool_id.as_str());
+    entry.put_str("pool", task.pool_name.as_str());
+    entry.put_str("status", task.status.as_str());
     entry.insert("priority".to_string(), VmValue::Int(task.priority));
-    entry.insert(
-        "submitted_at".to_string(),
-        VmValue::String(std::sync::Arc::from(task.submitted_at.as_str())),
-    );
-    if let Some(key) = &task.key {
-        entry.insert(
-            "key".to_string(),
-            VmValue::String(std::sync::Arc::from(key.as_str())),
-        );
-    }
-    if let Some(started_at) = &task.started_at {
-        entry.insert(
-            "started_at".to_string(),
-            VmValue::String(std::sync::Arc::from(started_at.as_str())),
-        );
-    }
-    if let Some(finished_at) = &task.finished_at {
-        entry.insert(
-            "finished_at".to_string(),
-            VmValue::String(std::sync::Arc::from(finished_at.as_str())),
-        );
-    }
+    entry.put_str("submitted_at", task.submitted_at.as_str());
+    entry.put_opt_str("key", task.key.as_deref());
+    entry.put_opt_str("started_at", task.started_at.as_deref());
+    entry.put_opt_str("finished_at", task.finished_at.as_deref());
     if let Some(result) = &task.result {
         entry.insert("result".to_string(), result.clone());
     }
-    if let Some(error) = &task.error {
-        entry.insert(
-            "error".to_string(),
-            VmValue::String(std::sync::Arc::from(error.as_str())),
-        );
-    }
-    if let Some(reason) = &task.rejection_reason {
-        entry.insert(
-            "rejection_reason".to_string(),
-            VmValue::String(std::sync::Arc::from(reason.as_str())),
-        );
-    }
-    if let Some(policy) = &task.rejection_policy {
-        entry.insert(
-            "rejection_policy".to_string(),
-            VmValue::String(std::sync::Arc::from(policy.as_str())),
-        );
-    }
+    entry.put_opt_str("error", task.error.as_deref());
+    entry.put_opt_str("rejection_reason", task.rejection_reason.as_deref());
+    entry.put_opt_str("rejection_policy", task.rejection_policy.as_deref());
     VmValue::Dict(std::sync::Arc::new(entry))
 }
 
 fn task_handle_value(task: &TaskState) -> VmValue {
     let mut handle = BTreeMap::new();
-    handle.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from(POOL_TASK_TYPE)),
-    );
-    handle.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(task.id.as_str())),
-    );
-    handle.insert(
-        "pool_id".to_string(),
-        VmValue::String(std::sync::Arc::from(task.pool_id.as_str())),
-    );
-    handle.insert(
-        "pool".to_string(),
-        VmValue::String(std::sync::Arc::from(task.pool_name.as_str())),
-    );
-    handle.insert(
-        "submitted_at".to_string(),
-        VmValue::String(std::sync::Arc::from(task.submitted_at.as_str())),
-    );
-    handle.insert(
-        "status".to_string(),
-        VmValue::String(std::sync::Arc::from(task.status.as_str())),
-    );
-    if let Some(key) = &task.key {
-        handle.insert(
-            "key".to_string(),
-            VmValue::String(std::sync::Arc::from(key.as_str())),
-        );
-    }
-    if let Some(error) = &task.error {
-        handle.insert(
-            "error".to_string(),
-            VmValue::String(std::sync::Arc::from(error.as_str())),
-        );
-    }
-    if let Some(reason) = &task.rejection_reason {
-        handle.insert(
-            "rejection_reason".to_string(),
-            VmValue::String(std::sync::Arc::from(reason.as_str())),
-        );
-    }
-    if let Some(policy) = &task.rejection_policy {
-        handle.insert(
-            "rejection_policy".to_string(),
-            VmValue::String(std::sync::Arc::from(policy.as_str())),
-        );
-    }
+    handle.put_str("_type", POOL_TASK_TYPE);
+    handle.put_str("id", task.id.as_str());
+    handle.put_str("pool_id", task.pool_id.as_str());
+    handle.put_str("pool", task.pool_name.as_str());
+    handle.put_str("submitted_at", task.submitted_at.as_str());
+    handle.put_str("status", task.status.as_str());
+    handle.put_opt_str("key", task.key.as_deref());
+    handle.put_opt_str("error", task.error.as_deref());
+    handle.put_opt_str("rejection_reason", task.rejection_reason.as_deref());
+    handle.put_opt_str("rejection_policy", task.rejection_policy.as_deref());
     VmValue::Dict(std::sync::Arc::new(handle))
 }
 

--- a/crates/harn-vm/src/stdlib/postgres/introspect.rs
+++ b/crates/harn-vm/src/stdlib/postgres/introspect.rs
@@ -38,6 +38,7 @@
 //! `run_maintenance` equivalent: it pre-creates the next N day/hour
 //! partitions so inserts never hit the DEFAULT partition.
 
+use crate::value::VmDictExt;
 use std::collections::{BTreeMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
@@ -217,10 +218,7 @@ async fn pg_pool_stats_impl(
         "statement_cache_capacity".to_string(),
         VmValue::Int(record.statement_cache_capacity as i64),
     );
-    dict.insert(
-        "read_routing_policy".to_string(),
-        VmValue::String(std::sync::Arc::from(record.read_routing_policy.as_str())),
-    );
+    dict.put_str("read_routing_policy", record.read_routing_policy.as_str());
     dict.insert(
         "replicas".to_string(),
         VmValue::Int(record.replicas.len() as i64),
@@ -242,10 +240,7 @@ async fn pg_pool_stats_impl(
         );
     }
     let circuit_state = record.circuit.snapshot();
-    dict.insert(
-        "circuit_state".to_string(),
-        VmValue::String(std::sync::Arc::from(circuit_state.state)),
-    );
+    dict.put_str("circuit_state", circuit_state.state);
     dict.insert(
         "circuit_failures".to_string(),
         VmValue::Int(circuit_state.failures as i64),

--- a/crates/harn-vm/src/stdlib/postgres/listen.rs
+++ b/crates/harn-vm/src/stdlib/postgres/listen.rs
@@ -32,6 +32,7 @@
 //! only worth it for long-running consumers that already manage their
 //! own lifecycle.
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -176,14 +177,8 @@ async fn pg_listener_recv_impl(
     let channel = notification.channel().to_string();
     let payload = notification.payload().to_string();
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "channel".to_string(),
-        VmValue::String(std::sync::Arc::from(channel.clone())),
-    );
-    dict.insert(
-        "payload".to_string(),
-        VmValue::String(std::sync::Arc::from(payload.clone())),
-    );
+    dict.put_str("channel", channel.clone());
+    dict.put_str("payload", payload.clone());
     dict.insert(
         "process_id".to_string(),
         VmValue::Int(i64::from(notification.process_id())),

--- a/crates/harn-vm/src/stdlib/postgres/migrate.rs
+++ b/crates/harn-vm/src/stdlib/postgres/migrate.rs
@@ -15,6 +15,7 @@
 //!   mutually exclude. This lets Harn apply an existing SQLx migration
 //!   history idempotently without forking it.
 
+use crate::value::VmDictExt;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -431,7 +432,7 @@ fn build_response(
     response.insert("available".to_string(), str_list(available));
     response.insert("dry_run".to_string(), VmValue::Bool(dry_run));
     response.insert("duration_ms".to_string(), VmValue::Int(duration_ms));
-    response.insert("table".to_string(), VmValue::String(Arc::from(table_name)));
+    response.put_str("table", table_name);
     VmValue::Dict(Arc::new(response))
 }
 

--- a/crates/harn-vm/src/stdlib/postgres/mod.rs
+++ b/crates/harn-vm/src/stdlib/postgres/mod.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::ops::Bound;
@@ -760,15 +761,9 @@ fn register_local_pool_handle(
         "statement_cache_capacity".to_string(),
         VmValue::Int(record.statement_cache_capacity as i64),
     );
-    meta.insert(
-        "read_routing_policy".to_string(),
-        VmValue::String(Arc::from(record.read_routing_policy.as_str())),
-    );
+    meta.put_str("read_routing_policy", record.read_routing_policy.as_str());
     if let Some(application_name) = application_name {
-        meta.insert(
-            "application_name".to_string(),
-            VmValue::String(std::sync::Arc::from(application_name)),
-        );
+        meta.put_str("application_name", application_name);
     }
     POOLS.with(|pools| {
         pools.borrow_mut().insert(id.clone(), record);
@@ -2043,14 +2038,8 @@ pub(super) fn unregister_tx(id: &str) {
 }
 
 pub(super) fn handle_value(kind: &str, id: &str, mut extra: BTreeMap<String, VmValue>) -> VmValue {
-    extra.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from(kind)),
-    );
-    extra.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(id.to_string())),
-    );
+    extra.put_str("_type", kind);
+    extra.put_str("id", id);
     VmValue::Dict(std::sync::Arc::new(extra))
 }
 

--- a/crates/harn-vm/src/stdlib/process.rs
+++ b/crates/harn-vm/src/stdlib/process.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::io::Write as _;
@@ -360,41 +361,19 @@ fn asset_root_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
 fn runtime_paths_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let runtime_base = runtime_root_base();
     let mut paths = BTreeMap::new();
-    paths.insert(
-        "execution_root".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            execution_root_path().to_string_lossy().into_owned(),
-        )),
+    paths.put_str("execution_root", execution_root_path().to_string_lossy());
+    paths.put_str("asset_root", asset_root_path().to_string_lossy());
+    paths.put_str(
+        "state_root",
+        crate::runtime_paths::state_root(&runtime_base).to_string_lossy(),
     );
-    paths.insert(
-        "asset_root".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            asset_root_path().to_string_lossy().into_owned(),
-        )),
+    paths.put_str(
+        "run_root",
+        crate::runtime_paths::run_root(&runtime_base).to_string_lossy(),
     );
-    paths.insert(
-        "state_root".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            crate::runtime_paths::state_root(&runtime_base)
-                .to_string_lossy()
-                .into_owned(),
-        )),
-    );
-    paths.insert(
-        "run_root".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            crate::runtime_paths::run_root(&runtime_base)
-                .to_string_lossy()
-                .into_owned(),
-        )),
-    );
-    paths.insert(
-        "worktree_root".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            crate::runtime_paths::worktree_root(&runtime_base)
-                .to_string_lossy()
-                .into_owned(),
-        )),
+    paths.put_str(
+        "worktree_root",
+        crate::runtime_paths::worktree_root(&runtime_base).to_string_lossy(),
     );
     Ok(VmValue::Dict(std::sync::Arc::new(paths)))
 }
@@ -541,18 +520,8 @@ pub(crate) fn spawn_captured_value(args: &[VmValue]) -> Result<VmValue, VmError>
     };
     let mut result = BTreeMap::new();
     result.insert("exit_code".to_string(), VmValue::Int(exit_code));
-    result.insert(
-        "stdout".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            String::from_utf8_lossy(&output.stdout).as_ref(),
-        )),
-    );
-    result.insert(
-        "stderr".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            String::from_utf8_lossy(&output.stderr).as_ref(),
-        )),
-    );
+    result.put_str("stdout", String::from_utf8_lossy(&output.stdout).as_ref());
+    result.put_str("stderr", String::from_utf8_lossy(&output.stderr).as_ref());
     result.insert("duration_ms".to_string(), VmValue::Int(duration_ms));
     result.insert("success".to_string(), VmValue::Bool(success));
     result.insert("timed_out".to_string(), VmValue::Bool(timed_out));
@@ -784,17 +753,13 @@ fn captured_run_to_value(run: &CapturedRun) -> VmValue {
     };
     let success = !run.timed_out && run.output.status.success();
     let mut result = BTreeMap::new();
-    result.insert(
-        "stdout".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            String::from_utf8_lossy(&run.output.stdout).as_ref(),
-        )),
+    result.put_str(
+        "stdout",
+        String::from_utf8_lossy(&run.output.stdout).as_ref(),
     );
-    result.insert(
-        "stderr".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            String::from_utf8_lossy(&run.output.stderr).as_ref(),
-        )),
+    result.put_str(
+        "stderr",
+        String::from_utf8_lossy(&run.output.stderr).as_ref(),
     );
     result.insert("status".to_string(), VmValue::Int(status));
     result.insert("success".to_string(), VmValue::Bool(success));
@@ -929,18 +894,8 @@ const PATH_BUILTINS: &[&VmBuiltinDef] = &[&SOURCE_DIR_IMPL_DEF, &PROJECT_ROOT_IM
 
 fn vm_output_to_value(output: std::process::Output) -> VmValue {
     let mut result = BTreeMap::new();
-    result.insert(
-        "stdout".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            String::from_utf8_lossy(&output.stdout).as_ref(),
-        )),
-    );
-    result.insert(
-        "stderr".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            String::from_utf8_lossy(&output.stderr).as_ref(),
-        )),
-    );
+    result.put_str("stdout", String::from_utf8_lossy(&output.stdout).as_ref());
+    result.put_str("stderr", String::from_utf8_lossy(&output.stderr).as_ref());
     result.insert(
         "status".to_string(),
         VmValue::Int(output.status.code().unwrap_or(-1) as i64),

--- a/crates/harn-vm/src/stdlib/process_spawn.rs
+++ b/crates/harn-vm/src/stdlib/process_spawn.rs
@@ -24,6 +24,7 @@
 //! it kills the child first. `kill_on_drop(true)` on the command is a
 //! second backstop so a dropped `Child` does not outlive the registry.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
@@ -267,26 +268,14 @@ async fn spawn(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
     }
 
     let mut result = BTreeMap::new();
-    result.insert(
-        "handle_id".to_string(),
-        VmValue::String(std::sync::Arc::from(handle_id)),
-    );
+    result.put_str("handle_id", handle_id);
     result.insert(
         "pid".to_string(),
         pid.map(|p| VmValue::Int(p as i64)).unwrap_or(VmValue::Nil),
     );
-    result.insert(
-        "started_at".to_string(),
-        VmValue::String(std::sync::Arc::from(started_at)),
-    );
-    result.insert(
-        "command".to_string(),
-        VmValue::String(std::sync::Arc::from(command_display)),
-    );
-    result.insert(
-        "status".to_string(),
-        VmValue::String(std::sync::Arc::from("running")),
-    );
+    result.put_str("started_at", started_at);
+    result.put_str("command", command_display);
+    result.put_str("status", "running");
     Ok(VmValue::Dict(std::sync::Arc::new(result)))
 }
 
@@ -413,23 +402,11 @@ fn poll(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
     let running = status == SpawnStatus::Running;
 
     let mut result = BTreeMap::new();
-    result.insert(
-        "handle_id".to_string(),
-        VmValue::String(std::sync::Arc::from(entry.handle_id.clone())),
-    );
-    result.insert(
-        "status".to_string(),
-        VmValue::String(std::sync::Arc::from(status.as_str())),
-    );
+    result.put_str("handle_id", entry.handle_id.clone());
+    result.put_str("status", status.as_str());
     result.insert("running".to_string(), VmValue::Bool(running));
-    result.insert(
-        "command".to_string(),
-        VmValue::String(std::sync::Arc::from(entry.command_display.clone())),
-    );
-    result.insert(
-        "started_at".to_string(),
-        VmValue::String(std::sync::Arc::from(entry.started_at.clone())),
-    );
+    result.put_str("command", entry.command_display.clone());
+    result.put_str("started_at", entry.started_at.clone());
     result.insert(
         "pid".to_string(),
         entry
@@ -444,18 +421,8 @@ fn poll(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
             .map(|c| VmValue::Int(c as i64))
             .unwrap_or(VmValue::Nil),
     );
-    result.insert(
-        "stdout".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            String::from_utf8_lossy(&state.stdout).into_owned(),
-        )),
-    );
-    result.insert(
-        "stderr".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            String::from_utf8_lossy(&state.stderr).into_owned(),
-        )),
-    );
+    result.put_str("stdout", String::from_utf8_lossy(&state.stdout));
+    result.put_str("stderr", String::from_utf8_lossy(&state.stderr));
     Ok(VmValue::Dict(std::sync::Arc::new(result)))
 }
 
@@ -485,10 +452,7 @@ async fn wait(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
                     let mut result = BTreeMap::new();
                     result.insert("timed_out".to_string(), VmValue::Bool(true));
                     result.insert("running".to_string(), VmValue::Bool(true));
-                    result.insert(
-                        "status".to_string(),
-                        VmValue::String(std::sync::Arc::from("running")),
-                    );
+                    result.put_str("status", "running");
                     return Ok(VmValue::Dict(std::sync::Arc::new(result)));
                 }
             }
@@ -501,10 +465,7 @@ async fn wait(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
     let state = entry.state.lock().expect("spawn state poisoned");
     let status = state.status.unwrap_or(SpawnStatus::Running);
     let mut result = BTreeMap::new();
-    result.insert(
-        "status".to_string(),
-        VmValue::String(std::sync::Arc::from(status.as_str())),
-    );
+    result.put_str("status", status.as_str());
     result.insert(
         "exit_code".to_string(),
         state
@@ -512,18 +473,8 @@ async fn wait(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
             .map(|c| VmValue::Int(c as i64))
             .unwrap_or(VmValue::Nil),
     );
-    result.insert(
-        "stdout".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            String::from_utf8_lossy(&state.stdout).into_owned(),
-        )),
-    );
-    result.insert(
-        "stderr".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            String::from_utf8_lossy(&state.stderr).into_owned(),
-        )),
-    );
+    result.put_str("stdout", String::from_utf8_lossy(&state.stdout));
+    result.put_str("stderr", String::from_utf8_lossy(&state.stderr));
     result.insert(
         "timed_out".to_string(),
         VmValue::Bool(status == SpawnStatus::TimedOut),
@@ -567,10 +518,7 @@ async fn kill(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
 fn kill_result(success: bool, status: SpawnStatus) -> VmValue {
     let mut result = BTreeMap::new();
     result.insert("success".to_string(), VmValue::Bool(success));
-    result.insert(
-        "status".to_string(),
-        VmValue::String(std::sync::Arc::from(status.as_str())),
-    );
+    result.put_str("status", status.as_str());
     VmValue::Dict(std::sync::Arc::new(result))
 }
 

--- a/crates/harn-vm/src/stdlib/project.rs
+++ b/crates/harn-vm/src/stdlib/project.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
@@ -204,10 +205,7 @@ struct ProjectFingerprint {
 impl ProjectFingerprint {
     fn into_vm_value(self) -> VmValue {
         let mut value = BTreeMap::new();
-        value.insert(
-            "primary_language".to_string(),
-            VmValue::String(std::sync::Arc::from(self.primary_language)),
-        );
+        value.put_str("primary_language", self.primary_language);
         value.insert(
             "languages".to_string(),
             VmValue::List(std::sync::Arc::new(
@@ -346,22 +344,10 @@ struct ProjectTreeEntry {
 impl ProjectTreeEntry {
     fn into_vm_value(self) -> VmValue {
         let mut value = BTreeMap::new();
-        value.insert(
-            "path".to_string(),
-            VmValue::String(std::sync::Arc::from(self.relative_path)),
-        );
-        value.insert(
-            "dir".to_string(),
-            VmValue::String(std::sync::Arc::from(self.metadata_path)),
-        );
-        value.insert(
-            "structure_hash".to_string(),
-            VmValue::String(std::sync::Arc::from(self.structure_hash)),
-        );
-        value.insert(
-            "content_hash".to_string(),
-            VmValue::String(std::sync::Arc::from(self.content_hash)),
-        );
+        value.put_str("path", self.relative_path);
+        value.put_str("dir", self.metadata_path);
+        value.put_str("structure_hash", self.structure_hash);
+        value.put_str("content_hash", self.content_hash);
         VmValue::Dict(std::sync::Arc::new(value))
     }
 }
@@ -387,12 +373,7 @@ impl ProjectEvidence {
     fn into_vm_value(self) -> VmValue {
         let confidence = confidence_value(&self);
         let mut result = BTreeMap::new();
-        result.insert(
-            "path".to_string(),
-            VmValue::String(std::sync::Arc::from(
-                self.path.to_string_lossy().into_owned(),
-            )),
-        );
+        result.put_str("path", self.path.to_string_lossy());
         result.insert(
             "languages".to_string(),
             VmValue::List(std::sync::Arc::new(
@@ -635,12 +616,7 @@ impl ContextProfileResolution {
             "schema_version".to_string(),
             VmValue::Int(CONTEXT_PROFILE_SCHEMA_VERSION),
         );
-        out.insert(
-            "path".to_string(),
-            VmValue::String(std::sync::Arc::from(
-                self.path.to_string_lossy().into_owned(),
-            )),
-        );
+        out.put_str("path", self.path.to_string_lossy());
         out.insert("signals".to_string(), self.signals.into_vm_value());
         out.insert("profile_ids".to_string(), string_list_value(profile_ids));
         out.insert(
@@ -2918,10 +2894,7 @@ fn push_unique(values: &mut Vec<String>, value: String) {
 
 fn catalog_entry_value(entry: &ProjectCatalogEntry) -> VmValue {
     let mut value = BTreeMap::new();
-    value.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(entry.id.to_string())),
-    );
+    value.put_str("id", entry.id);
     value.insert(
         "languages".to_string(),
         VmValue::List(std::sync::Arc::new(

--- a/crates/harn-vm/src/stdlib/project.rs
+++ b/crates/harn-vm/src/stdlib/project.rs
@@ -656,7 +656,7 @@ impl ContextProfileResolution {
 impl ContextSignals {
     fn into_vm_value(self) -> VmValue {
         let mut out = BTreeMap::new();
-        out.insert("source".to_string(), string_value(self.source));
+        out.insert("source".to_string(), VmValue::string(self.source));
         out.insert("fingerprint".to_string(), self.fingerprint.into_vm_value());
         out.insert(
             "remote".to_string(),
@@ -675,13 +675,13 @@ impl ContextSignals {
 impl GitRemoteSignal {
     fn into_vm_value(self) -> VmValue {
         let mut out = BTreeMap::new();
-        out.insert("name".to_string(), string_value(self.name));
-        out.insert("host".to_string(), string_value(self.host));
+        out.insert("name".to_string(), VmValue::string(self.name));
+        out.insert("host".to_string(), VmValue::string(self.host));
         out.insert(
             "slug".to_string(),
-            self.slug.map(string_value).unwrap_or(VmValue::Nil),
+            self.slug.map(VmValue::string).unwrap_or(VmValue::Nil),
         );
-        out.insert("url".to_string(), string_value(self.redacted_url));
+        out.insert("url".to_string(), VmValue::string(self.redacted_url));
         VmValue::Dict(std::sync::Arc::new(out))
     }
 }
@@ -689,9 +689,9 @@ impl GitRemoteSignal {
 impl ContextProfileFragment {
     fn into_vm_value(self) -> VmValue {
         let mut out = BTreeMap::new();
-        out.insert("id".to_string(), string_value(self.id));
-        out.insert("source".to_string(), string_value(self.source));
-        out.insert("body".to_string(), string_value(self.body));
+        out.insert("id".to_string(), VmValue::string(self.id));
+        out.insert("source".to_string(), VmValue::string(self.source));
+        out.insert("body".to_string(), VmValue::string(self.body));
         out.insert(
             "requires_caps".to_string(),
             string_list_value(self.requires_caps),
@@ -703,8 +703,8 @@ impl ContextProfileFragment {
 impl McpPresetCandidate {
     fn into_vm_value(self) -> VmValue {
         let mut out = BTreeMap::new();
-        out.insert("id".to_string(), string_value(self.id));
-        out.insert("status".to_string(), string_value(self.status));
+        out.insert("id".to_string(), VmValue::string(self.id));
+        out.insert("status".to_string(), VmValue::string(self.status));
         out.insert(
             "missing_credentials".to_string(),
             string_list_value(self.missing_credentials),
@@ -716,8 +716,8 @@ impl McpPresetCandidate {
 impl ContextProfileActivation {
     fn into_vm_value(self) -> VmValue {
         let mut out = BTreeMap::new();
-        out.insert("id".to_string(), string_value(self.id));
-        out.insert("reason".to_string(), string_value(self.reason));
+        out.insert("id".to_string(), VmValue::string(self.id));
+        out.insert("reason".to_string(), VmValue::string(self.reason));
         out.insert("caps".to_string(), string_list_value(self.caps));
         out.insert("skills".to_string(), string_list_value(self.skills));
         out.insert(
@@ -1530,13 +1530,9 @@ fn value_as_string(value: &VmValue) -> Option<String> {
     }
 }
 
-fn string_value(value: impl Into<String>) -> VmValue {
-    VmValue::String(std::sync::Arc::from(value.into()))
-}
-
 fn string_list_value(values: Vec<String>) -> VmValue {
     VmValue::List(std::sync::Arc::new(
-        values.into_iter().map(string_value).collect(),
+        values.into_iter().map(VmValue::string).collect(),
     ))
 }
 
@@ -3240,7 +3236,7 @@ mod tests {
         let mut signals = BTreeMap::new();
         signals.insert(
             "remote".to_string(),
-            string_value("https://github.com/burin-labs/harn.git"),
+            VmValue::string("https://github.com/burin-labs/harn.git"),
         );
         let mut raw_options = BTreeMap::new();
         raw_options.insert("include_env_credentials".to_string(), VmValue::Bool(false));

--- a/crates/harn-vm/src/stdlib/project_enrich.rs
+++ b/crates/harn-vm/src/stdlib/project_enrich.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -1484,24 +1485,15 @@ fn enrichment_bindings(
     files: &[RelevantFile],
 ) -> BTreeMap<String, VmValue> {
     let mut bindings = BTreeMap::new();
-    bindings.insert(
-        "path".to_string(),
-        VmValue::String(std::sync::Arc::from(root.to_string_lossy().into_owned())),
-    );
+    bindings.put_str("path", root.to_string_lossy());
     bindings.insert("base_evidence".to_string(), base_evidence.clone());
     bindings.insert("evidence".to_string(), base_evidence.clone());
     let file_values = files
         .iter()
         .map(|file| {
             let mut value = BTreeMap::new();
-            value.insert(
-                "path".to_string(),
-                VmValue::String(std::sync::Arc::from(file.rel_path.clone())),
-            );
-            value.insert(
-                "content".to_string(),
-                VmValue::String(std::sync::Arc::from(file.content.clone())),
-            );
+            value.put_str("path", file.rel_path.clone());
+            value.put_str("content", file.content.clone());
             value.insert("truncated".to_string(), VmValue::Bool(file.truncated));
             VmValue::Dict(std::sync::Arc::new(value))
         })
@@ -1520,30 +1512,18 @@ fn enrichment_bindings(
 
 fn llm_options_value(options: &ProjectEnrichOptions, rendered_prompt: &str) -> VmValue {
     let mut llm_options = BTreeMap::new();
-    llm_options.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(options.provider.clone())),
-    );
-    llm_options.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(options.model.clone())),
-    );
+    llm_options.put_str("provider", options.provider.clone());
+    llm_options.put_str("model", options.model.clone());
     if let Some(temperature) = options.temperature {
         llm_options.insert("temperature".to_string(), VmValue::Float(temperature));
     }
     llm_options.insert("output_schema".to_string(), options.schema.clone());
-    llm_options.insert(
-        "output_validation".to_string(),
-        VmValue::String(std::sync::Arc::from("error")),
-    );
+    llm_options.put_str("output_validation", "error");
     llm_options.insert(
         "schema_retries".to_string(),
         VmValue::Int(options.schema_retries as i64),
     );
-    llm_options.insert(
-        "response_format".to_string(),
-        VmValue::String(std::sync::Arc::from("json")),
-    );
+    llm_options.put_str("response_format", "json");
     llm_options.insert(
         "messages".to_string(),
         VmValue::List(std::sync::Arc::new(vec![json_to_vm_value(
@@ -1565,10 +1545,7 @@ fn validation_envelope(
 ) -> VmValue {
     let mut dict = BTreeMap::new();
     dict.insert("base_evidence".to_string(), base_evidence.clone());
-    dict.insert(
-        "validation_error".to_string(),
-        VmValue::String(std::sync::Arc::from(message)),
-    );
+    dict.put_str("validation_error", message);
     dict.insert(
         "_provenance".to_string(),
         provenance_value(model, input_tokens, output_tokens, false),

--- a/crates/harn-vm/src/stdlib/records.rs
+++ b/crates/harn-vm/src/stdlib/records.rs
@@ -1,5 +1,6 @@
 //! Artifact and run-record builtins.
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 
@@ -1371,10 +1372,7 @@ fn eval_metrics_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
         .iter()
         .map(|metric| {
             let mut dict = BTreeMap::new();
-            dict.insert(
-                "name".to_string(),
-                VmValue::String(std::sync::Arc::from(metric.name.as_str())),
-            );
+            dict.put_str("name", metric.name.as_str());
             dict.insert(
                 "value".to_string(),
                 crate::stdlib::json_to_vm_value(&metric.value),

--- a/crates/harn-vm/src/stdlib/regex.rs
+++ b/crates/harn-vm/src/stdlib/regex.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::rc::Rc;
@@ -186,10 +187,7 @@ fn regex_captures_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
     for caps in re.captures_iter(&text) {
         let mut dict = BTreeMap::new();
 
-        dict.insert(
-            "match".to_string(),
-            VmValue::String(std::sync::Arc::from(caps.get(0).map_or("", |m| m.as_str()))),
-        );
+        dict.put_str("match", caps.get(0).map_or("", |m| m.as_str()));
 
         let groups: Vec<VmValue> = (1..caps.len())
             .map(|i| match caps.get(i) {

--- a/crates/harn-vm/src/stdlib/skills.rs
+++ b/crates/harn-vm/src/stdlib/skills.rs
@@ -21,6 +21,7 @@
 //!
 //! Registries mirror the tool-registry shape: `{ _type: "skill_registry", skills: [ ... ] }`.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
@@ -81,18 +82,9 @@ fn vm_skill_catalog_entries(skills: &[VmValue]) -> Vec<VmValue> {
             .map(|v| v.display())
             .unwrap_or_default();
         let mut rendered = BTreeMap::new();
-        rendered.insert(
-            "name".to_string(),
-            VmValue::String(std::sync::Arc::from(id.as_str())),
-        );
-        rendered.insert(
-            "description".to_string(),
-            VmValue::String(std::sync::Arc::from(description.as_str())),
-        );
-        rendered.insert(
-            "when_to_use".to_string(),
-            VmValue::String(std::sync::Arc::from(when_to_use.as_str())),
-        );
+        rendered.put_str("name", id.as_str());
+        rendered.put_str("description", description.as_str());
+        rendered.put_str("when_to_use", when_to_use.as_str());
         catalog.push((id, VmValue::Dict(std::sync::Arc::new(rendered))));
     }
     catalog.sort_by(|a, b| a.0.cmp(&b.0));
@@ -132,10 +124,7 @@ fn who_signed_entry(entry: &BTreeMap<String, VmValue>) -> VmValue {
         Some(provenance) => provenance.clone(),
         None => BTreeMap::new(),
     };
-    out.insert(
-        "skill_id".to_string(),
-        VmValue::String(std::sync::Arc::from(vm_skill_entry_id(entry).as_str())),
-    );
+    out.put_str("skill_id", vm_skill_entry_id(entry).as_str());
     out.entry("signed".to_string())
         .or_insert(VmValue::Bool(false));
     out.entry("trusted".to_string())
@@ -257,10 +246,7 @@ pub(crate) fn register_skill_builtins(vm: &mut Vm) {
 #[harn_builtin(sig = "skill_registry() -> dict", category = "skills")]
 fn skill_registry_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let mut registry = BTreeMap::new();
-    registry.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from("skill_registry")),
-    );
+    registry.put_str("_type", "skill_registry");
     registry.insert(
         "skills".to_string(),
         VmValue::List(std::sync::Arc::new(Vec::new())),
@@ -360,10 +346,7 @@ fn skill_define_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
     }
 
     let mut entry = BTreeMap::new();
-    entry.insert(
-        "name".to_string(),
-        VmValue::String(std::sync::Arc::from(name.as_str())),
-    );
+    entry.put_str("name", name.as_str());
     // Keep `description` at the top level even if missing (empty string)
     // so `skill_describe` / transcript surfaces have a stable shape.
     if !config.contains_key("description") {
@@ -371,15 +354,9 @@ fn skill_define_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
             .get("short")
             .map(|value| value.display())
             .unwrap_or_default();
-        entry.insert(
-            "description".to_string(),
-            VmValue::String(std::sync::Arc::from("")),
-        );
+        entry.put_str("description", "");
         if !fallback.is_empty() {
-            entry.insert(
-                "description".to_string(),
-                VmValue::String(std::sync::Arc::from(fallback.as_str())),
-            );
+            entry.put_str("description", fallback.as_str());
         }
     }
     for (k, v) in config.iter() {

--- a/crates/harn-vm/src/stdlib/sqlite/mod.rs
+++ b/crates/harn-vm/src/stdlib/sqlite/mod.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -401,10 +402,7 @@ fn open_db(path: &str, options: Option<&BTreeMap<String, VmValue>>) -> Result<Vm
     meta.insert("read_only".to_string(), VmValue::Bool(read_only));
     meta.insert("memory".to_string(), VmValue::Bool(is_memory));
     if let Some(path) = &stored_path {
-        meta.insert(
-            "path".to_string(),
-            VmValue::String(Arc::from(path.to_string_lossy().into_owned())),
-        );
+        meta.put_str("path", path.to_string_lossy());
     }
     let record = Arc::new(DbRecord {
         conn: Arc::new(Mutex::new(conn)),
@@ -654,7 +652,7 @@ async fn migrate(args: Vec<VmValue>) -> Result<VmValue, VmError> {
         string_list(entries.iter().map(|entry| entry.name.clone()).collect()),
     );
     response.insert("dry_run".to_string(), VmValue::Bool(dry_run));
-    response.insert("table".to_string(), VmValue::String(Arc::from(table)));
+    response.put_str("table", table);
     Ok(VmValue::Dict(Arc::new(response)))
 }
 
@@ -961,8 +959,8 @@ fn unregister_tx(id: &str) {
 }
 
 fn handle_value(kind: &str, id: &str, mut extra: BTreeMap<String, VmValue>) -> VmValue {
-    extra.insert("_type".to_string(), VmValue::String(Arc::from(kind)));
-    extra.insert("id".to_string(), VmValue::String(Arc::from(id.to_string())));
+    extra.put_str("_type", kind);
+    extra.put_str("id", id);
     VmValue::Dict(Arc::new(extra))
 }
 

--- a/crates/harn-vm/src/stdlib/strings.rs
+++ b/crates/harn-vm/src/stdlib/strings.rs
@@ -1,4 +1,5 @@
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
+use crate::value::VmDictExt;
 use crate::value::{values_equal, VmError, VmValue};
 use crate::vm::Vm;
 use unicode_normalization::UnicodeNormalization;
@@ -165,18 +166,9 @@ fn provenance_result_dict(
 ) -> VmValue {
     let spans_list: Vec<VmValue> = spans.iter().map(span_to_vm_dict).collect();
     let mut out = std::collections::BTreeMap::new();
-    out.insert(
-        "text".to_string(),
-        VmValue::String(std::sync::Arc::from(rendered)),
-    );
-    out.insert(
-        "template_uri".to_string(),
-        VmValue::String(std::sync::Arc::from(template_uri)),
-    );
-    out.insert(
-        "prompt_id".to_string(),
-        VmValue::String(std::sync::Arc::from(prompt_id)),
-    );
+    out.put_str("text", rendered);
+    out.put_str("template_uri", template_uri);
+    out.put_str("prompt_id", prompt_id);
     out.insert(
         "spans".to_string(),
         VmValue::List(std::sync::Arc::new(spans_list)),

--- a/crates/harn-vm/src/stdlib/supervisor.rs
+++ b/crates/harn-vm/src/stdlib/supervisor.rs
@@ -971,21 +971,21 @@ fn next_supervisor_id() -> String {
 
 fn supervisor_handle_value(state: &SupervisorState) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert("_type".to_string(), string_value("supervisor"));
-    dict.insert("id".to_string(), string_value(&state.id));
-    dict.insert("name".to_string(), string_value(&state.name));
+    dict.insert("_type".to_string(), VmValue::string("supervisor"));
+    dict.insert("id".to_string(), VmValue::string(&state.id));
+    dict.insert("name".to_string(), VmValue::string(&state.name));
     VmValue::Dict(std::sync::Arc::new(dict))
 }
 
 fn supervisor_state_value(state: &SupervisorState) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert("_type".to_string(), string_value("supervisor_state"));
-    dict.insert("id".to_string(), string_value(&state.id));
-    dict.insert("name".to_string(), string_value(&state.name));
-    dict.insert("status".to_string(), string_value(&state.status));
+    dict.insert("_type".to_string(), VmValue::string("supervisor_state"));
+    dict.insert("id".to_string(), VmValue::string(&state.id));
+    dict.insert("name".to_string(), VmValue::string(&state.name));
+    dict.insert("status".to_string(), VmValue::string(&state.status));
     dict.insert(
         "strategy".to_string(),
-        string_value(strategy_name(state.strategy)),
+        VmValue::string(strategy_name(state.strategy)),
     );
     dict.insert("metrics".to_string(), metrics_value(state));
     dict.insert(
@@ -999,9 +999,9 @@ fn supervisor_state_value(state: &SupervisorState) -> VmValue {
 
 fn child_state_value(child: &ChildSlot) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert("name".to_string(), string_value(&child.spec.name));
-    dict.insert("kind".to_string(), string_value(&child.spec.kind));
-    dict.insert("status".to_string(), string_value(&child.status));
+    dict.insert("name".to_string(), VmValue::string(&child.spec.name));
+    dict.insert("kind".to_string(), VmValue::string(&child.spec.kind));
+    dict.insert("status".to_string(), VmValue::string(&child.status));
     dict.insert(
         "restart_count".to_string(),
         VmValue::Int(child.restart_count as i64),
@@ -1011,7 +1011,7 @@ fn child_state_value(child: &ChildSlot) -> VmValue {
         child
             .last_error
             .as_deref()
-            .map(string_value)
+            .map(VmValue::string)
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
@@ -1019,7 +1019,7 @@ fn child_state_value(child: &ChildSlot) -> VmValue {
         child
             .current_wait_reason
             .as_deref()
-            .map(string_value)
+            .map(VmValue::string)
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
@@ -1028,7 +1028,7 @@ fn child_state_value(child: &ChildSlot) -> VmValue {
             .spec
             .active_lease
             .as_deref()
-            .map(string_value)
+            .map(VmValue::string)
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
@@ -1103,23 +1103,23 @@ fn event_value(event: &SupervisorEvent) -> VmValue {
     dict.insert("at_ms".to_string(), VmValue::Int(event.at_ms));
     dict.insert(
         "supervisor_id".to_string(),
-        string_value(&event.supervisor_id),
+        VmValue::string(&event.supervisor_id),
     );
     dict.insert(
         "child".to_string(),
         event
             .child
             .as_deref()
-            .map(string_value)
+            .map(VmValue::string)
             .unwrap_or(VmValue::Nil),
     );
-    dict.insert("kind".to_string(), string_value(&event.kind));
+    dict.insert("kind".to_string(), VmValue::string(&event.kind));
     dict.insert(
         "message".to_string(),
         event
             .message
             .as_deref()
-            .map(string_value)
+            .map(VmValue::string)
             .unwrap_or(VmValue::Nil),
     );
     VmValue::Dict(std::sync::Arc::new(dict))
@@ -1127,9 +1127,9 @@ fn event_value(event: &SupervisorEvent) -> VmValue {
 
 fn child_context_value(supervisor_id: &str, spec: &ChildSpec, generation: u64) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert("supervisor_id".to_string(), string_value(supervisor_id));
-    dict.insert("child_name".to_string(), string_value(&spec.name));
-    dict.insert("child_kind".to_string(), string_value(&spec.kind));
+    dict.insert("supervisor_id".to_string(), VmValue::string(supervisor_id));
+    dict.insert("child_name".to_string(), VmValue::string(&spec.name));
+    dict.insert("child_kind".to_string(), VmValue::string(&spec.kind));
     dict.insert("attempt".to_string(), VmValue::Int(generation as i64 + 1));
     dict.insert("restart_count".to_string(), VmValue::Int(generation as i64));
     VmValue::Dict(std::sync::Arc::new(dict))
@@ -1171,10 +1171,6 @@ fn emit_event_log(event: &SupervisorEvent) {
     tokio::task::spawn_local(async move {
         let _ = log.append(&topic, log_event).await;
     });
-}
-
-fn string_value(value: &str) -> VmValue {
-    VmValue::String(std::sync::Arc::from(value))
 }
 
 fn duration_ms(value: &VmValue) -> Option<u64> {
@@ -1252,13 +1248,13 @@ mod tests {
     fn parses_restart_policy_aliases() {
         let policy =
             parse_restart_policy(Some(&VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
-                ("mode".to_string(), string_value("on-failure")),
+                ("mode".to_string(), VmValue::string("on-failure")),
                 ("max".to_string(), VmValue::Int(2)),
                 ("window".to_string(), VmValue::Duration(500)),
-                ("backoff".to_string(), string_value("10ms")),
+                ("backoff".to_string(), VmValue::string("10ms")),
                 ("factor".to_string(), VmValue::Float(3.0)),
                 ("jitter".to_string(), VmValue::Int(4)),
-                ("circuit_open".to_string(), string_value("1s")),
+                ("circuit_open".to_string(), VmValue::string("1s")),
             ])))))
             .unwrap();
 

--- a/crates/harn-vm/src/stdlib/template/llm_context.rs
+++ b/crates/harn-vm/src/stdlib/template/llm_context.rs
@@ -22,6 +22,7 @@
 //! push/pop pairs (e.g. an inner `llm_call` from a middleware handler)
 //! shadow the outer frame for the duration of the inner render.
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 
@@ -59,18 +60,9 @@ impl LlmRenderContext {
     /// `{provider, model, family, capabilities: <provider_capabilities dict>}`.
     pub fn to_vm_value(&self) -> VmValue {
         let mut dict = BTreeMap::new();
-        dict.insert(
-            "provider".to_string(),
-            VmValue::String(std::sync::Arc::from(self.provider.as_str())),
-        );
-        dict.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from(self.model.as_str())),
-        );
-        dict.insert(
-            "family".to_string(),
-            VmValue::String(std::sync::Arc::from(self.family.as_str())),
-        );
+        dict.put_str("provider", self.provider.as_str());
+        dict.put_str("model", self.model.as_str());
+        dict.put_str("family", self.family.as_str());
         dict.insert("capabilities".to_string(), self.capabilities.clone());
         VmValue::Dict(std::sync::Arc::new(dict))
     }

--- a/crates/harn-vm/src/stdlib/testbench.rs
+++ b/crates/harn-vm/src/stdlib/testbench.rs
@@ -6,6 +6,7 @@
 //! `harn test-bench` CLI. They're no-ops when no testbench session is
 //! active, so they're always safe to call.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
@@ -40,10 +41,7 @@ fn testbench_fs_diff_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValu
         .into_iter()
         .map(|entry| {
             let mut d = BTreeMap::new();
-            d.insert(
-                "path".to_string(),
-                VmValue::String(std::sync::Arc::from(entry.path.to_string_lossy().as_ref())),
-            );
+            d.put_str("path", entry.path.to_string_lossy().as_ref());
             let (kind_str, content_val) = match entry.kind {
                 DiffKind::Added { content } => (
                     "added",
@@ -59,10 +57,7 @@ fn testbench_fs_diff_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValu
                 ),
                 DiffKind::Deleted => ("deleted", VmValue::Nil),
             };
-            d.insert(
-                "kind".to_string(),
-                VmValue::String(std::sync::Arc::from(kind_str)),
-            );
+            d.put_str("kind", kind_str);
             d.insert("content".to_string(), content_val);
             VmValue::Dict(std::sync::Arc::new(d))
         })
@@ -83,10 +78,7 @@ fn testbench_clock_leaks_impl(_args: &[VmValue], _out: &mut String) -> Result<Vm
         .into_iter()
         .map(|leak| {
             let mut d = BTreeMap::new();
-            d.insert(
-                "capability".to_string(),
-                VmValue::String(std::sync::Arc::from(leak.capability_id)),
-            );
+            d.put_str("capability", leak.capability_id);
             d.insert("count".to_string(), VmValue::Int(leak.count as i64));
             VmValue::Dict(std::sync::Arc::new(d))
         })

--- a/crates/harn-vm/src/stdlib/testing.rs
+++ b/crates/harn-vm/src/stdlib/testing.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
@@ -161,14 +162,8 @@ fn throw_error_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
         .unwrap_or(ErrorCategory::Generic);
 
     let mut err_dict = BTreeMap::new();
-    err_dict.insert(
-        "message".to_string(),
-        VmValue::String(std::sync::Arc::from(message.as_str())),
-    );
-    err_dict.insert(
-        "category".to_string(),
-        VmValue::String(std::sync::Arc::from(category.as_str())),
-    );
+    err_dict.put_str("message", message.as_str());
+    err_dict.put_str("category", category.as_str());
     Err(VmError::Thrown(VmValue::Dict(std::sync::Arc::new(
         err_dict,
     ))))

--- a/crates/harn-vm/src/stdlib/timing.rs
+++ b/crates/harn-vm/src/stdlib/timing.rs
@@ -23,6 +23,7 @@
 //! stack — and missing handles surface as a typed thrown error so
 //! callers never silently drop work.
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::sync::OnceLock;
@@ -87,15 +88,9 @@ fn timing_start_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
         crate::tracing::span_start_user_timing(name.clone(), attrs_btree);
 
     let mut handle = BTreeMap::new();
-    handle.insert(
-        "name".to_string(),
-        VmValue::String(std::sync::Arc::from(name.as_str())),
-    );
+    handle.put_str("name", name.as_str());
     handle.insert("span_id".to_string(), VmValue::Int(span_id as i64));
-    handle.insert(
-        "trace_id".to_string(),
-        VmValue::String(std::sync::Arc::from(trace_id.as_str())),
-    );
+    handle.put_str("trace_id", trace_id.as_str());
     handle.insert(
         "parent_span_id".to_string(),
         parent_id
@@ -114,12 +109,7 @@ fn timing_start_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
         "attributes".to_string(),
         json_to_vm_value(&serde_json::Value::Object(attrs)),
     );
-    handle.insert(
-        "kind".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            crate::tracing::SpanKind::UserTiming.as_str(),
-        )),
-    );
+    handle.put_str("kind", crate::tracing::SpanKind::UserTiming.as_str());
 
     Ok(VmValue::Dict(std::sync::Arc::new(handle)))
 }

--- a/crates/harn-vm/src/stdlib/token_redaction.rs
+++ b/crates/harn-vm/src/stdlib/token_redaction.rs
@@ -13,6 +13,7 @@
 //! optional process-wide async forwarder that appends events to the
 //! `audit.token_redaction` event-log topic.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::sync::Once;
@@ -242,14 +243,8 @@ fn token_redaction_drain_audit_impl(
         .into_iter()
         .map(|event| {
             let mut entry: BTreeMap<String, VmValue> = BTreeMap::new();
-            entry.insert(
-                "code".to_string(),
-                VmValue::String(std::sync::Arc::from(TOKEN_REDACTION_DIAGNOSTIC)),
-            );
-            entry.insert(
-                "pattern".to_string(),
-                VmValue::String(std::sync::Arc::from(event.pattern_name.as_str())),
-            );
+            entry.put_str("code", TOKEN_REDACTION_DIAGNOSTIC);
+            entry.put_str("pattern", event.pattern_name.as_str());
             entry.insert(
                 "match_count".to_string(),
                 VmValue::Int(event.match_count as i64),

--- a/crates/harn-vm/src/stdlib/tool_hooks.rs
+++ b/crates/harn-vm/src/stdlib/tool_hooks.rs
@@ -36,6 +36,7 @@
 //! handling, and the matching engine runs as a single linear sweep over
 //! catalogues × rules (TH-01 acceptance criterion).
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 
@@ -229,14 +230,8 @@ fn validate_rule_dict(
     let _ = optional_int_field(config, "priority", builtin)?;
 
     let mut rule = BTreeMap::new();
-    rule.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from(TOOL_RULE_TYPE)),
-    );
-    rule.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(id.as_str())),
-    );
+    rule.put_str("_type", TOOL_RULE_TYPE);
+    rule.put_str("id", id.as_str());
     rule.insert("pattern".to_string(), pattern.clone());
     rule.insert(
         "applies_to".to_string(),
@@ -247,10 +242,7 @@ fn validate_rule_dict(
                 .collect(),
         )),
     );
-    rule.insert(
-        "severity".to_string(),
-        VmValue::String(std::sync::Arc::from(severity.as_str())),
-    );
+    rule.put_str("severity", severity.as_str());
     rule.insert(
         "rewrite".to_string(),
         config.get("rewrite").cloned().unwrap_or(VmValue::Nil),
@@ -338,26 +330,11 @@ fn build_catalogue(config: &BTreeMap<String, VmValue>) -> Result<VmValue, VmErro
     let rules = extract_rules(config.get("rules"), builtin)?;
 
     let mut catalogue = BTreeMap::new();
-    catalogue.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from(CATALOGUE_TYPE)),
-    );
-    catalogue.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(id.as_str())),
-    );
-    catalogue.insert(
-        "stack".to_string(),
-        VmValue::String(std::sync::Arc::from(stack.as_str())),
-    );
-    catalogue.insert(
-        "version".to_string(),
-        VmValue::String(std::sync::Arc::from(version.as_str())),
-    );
-    catalogue.insert(
-        "source".to_string(),
-        VmValue::String(std::sync::Arc::from(source.as_str())),
-    );
+    catalogue.put_str("_type", CATALOGUE_TYPE);
+    catalogue.put_str("id", id.as_str());
+    catalogue.put_str("stack", stack.as_str());
+    catalogue.put_str("version", version.as_str());
+    catalogue.put_str("source", source.as_str());
     catalogue.insert("priority".to_string(), VmValue::Int(priority));
     catalogue.insert(
         "rules".to_string(),
@@ -497,14 +474,8 @@ fn make_match_record(
     let mut out = BTreeMap::new();
     out.insert("catalogue_id".to_string(), catalogue_id);
     out.insert("stack".to_string(), stack);
-    out.insert(
-        "rule_id".to_string(),
-        VmValue::String(std::sync::Arc::from(rule_id(rule).as_str())),
-    );
-    out.insert(
-        "severity".to_string(),
-        VmValue::String(std::sync::Arc::from(rule_severity(rule).as_str())),
-    );
+    out.put_str("rule_id", rule_id(rule).as_str());
+    out.put_str("severity", rule_severity(rule).as_str());
     out.insert(
         "explanation".to_string(),
         rule.get("explanation")
@@ -561,10 +532,7 @@ fn catalogue_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
 #[harn_builtin(sig = "tool_hooks_registry() -> dict", category = "tool_hooks")]
 fn tool_hooks_registry_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let mut registry = BTreeMap::new();
-    registry.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from(REGISTRY_TYPE)),
-    );
+    registry.put_str("_type", REGISTRY_TYPE);
     registry.insert(
         "catalogues".to_string(),
         VmValue::List(std::sync::Arc::new(Vec::new())),
@@ -989,10 +957,7 @@ fn tool_hooks_inject_reminder_impl(
     crate::orchestration::record_lifecycle_audit("tool_hooks.reminder_injected", audit_payload);
 
     let mut out = BTreeMap::new();
-    out.insert(
-        "reminder_id".to_string(),
-        VmValue::String(std::sync::Arc::from(reminder_id.as_str())),
-    );
+    out.put_str("reminder_id", reminder_id.as_str());
     out.insert("deduped_count".to_string(), VmValue::Int(deduped_count));
     out.insert(
         "session_attached".to_string(),
@@ -1157,6 +1122,7 @@ fn classifier_cache_clear() {
 mod tests {
     use super::*;
     use crate::stdlib::register_vm_stdlib;
+    use crate::value::VmDictExt;
 
     fn vm_with_stdlib() -> Vm {
         let mut vm = Vm::new();
@@ -1172,51 +1138,28 @@ mod tests {
 
     fn sample_rule_config() -> VmValue {
         let mut config: BTreeMap<String, VmValue> = BTreeMap::new();
-        config.insert(
-            "id".to_string(),
-            VmValue::String(std::sync::Arc::from("rust.cargo.target_dir_conflict")),
-        );
-        config.insert(
-            "pattern".to_string(),
-            VmValue::String(std::sync::Arc::from(r"^cargo (build|test)\b")),
-        );
+        config.put_str("id", "rust.cargo.target_dir_conflict");
+        config.put_str("pattern", r"^cargo (build|test)\b");
         config.insert(
             "applies_to".to_string(),
             VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                 std::sync::Arc::from("rust"),
             )])),
         );
-        config.insert(
-            "severity".to_string(),
-            VmValue::String(std::sync::Arc::from("warning")),
-        );
-        config.insert(
-            "explanation".to_string(),
-            VmValue::String(std::sync::Arc::from(
-                "Concurrent cargo runs without --target-dir thrash the lockfile",
-            )),
+        config.put_str("severity", "warning");
+        config.put_str(
+            "explanation",
+            "Concurrent cargo runs without --target-dir thrash the lockfile",
         );
         VmValue::Dict(std::sync::Arc::new(config))
     }
 
     fn sample_catalogue_config(rule: VmValue) -> VmValue {
         let mut config: BTreeMap<String, VmValue> = BTreeMap::new();
-        config.insert(
-            "id".to_string(),
-            VmValue::String(std::sync::Arc::from("harn-canon/rust")),
-        );
-        config.insert(
-            "stack".to_string(),
-            VmValue::String(std::sync::Arc::from("rust")),
-        );
-        config.insert(
-            "version".to_string(),
-            VmValue::String(std::sync::Arc::from("0.1.0")),
-        );
-        config.insert(
-            "source".to_string(),
-            VmValue::String(std::sync::Arc::from("harn-canon")),
-        );
+        config.put_str("id", "harn-canon/rust");
+        config.put_str("stack", "rust");
+        config.put_str("version", "0.1.0");
+        config.put_str("source", "harn-canon");
         config.insert(
             "rules".to_string(),
             VmValue::List(std::sync::Arc::new(vec![rule])),
@@ -1242,15 +1185,9 @@ mod tests {
     fn tool_rule_rejects_bad_severity() {
         let vm = vm_with_stdlib();
         let mut config: BTreeMap<String, VmValue> = BTreeMap::new();
-        config.insert("id".to_string(), VmValue::String(std::sync::Arc::from("r")));
-        config.insert(
-            "pattern".to_string(),
-            VmValue::String(std::sync::Arc::from(".")),
-        );
-        config.insert(
-            "severity".to_string(),
-            VmValue::String(std::sync::Arc::from("catastrophic")),
-        );
+        config.put_str("id", "r");
+        config.put_str("pattern", ".");
+        config.put_str("severity", "catastrophic");
         let result = call_sync(
             &vm,
             "tool_rule",
@@ -1263,11 +1200,8 @@ mod tests {
     fn tool_rule_rejects_invalid_regex() {
         let vm = vm_with_stdlib();
         let mut config: BTreeMap<String, VmValue> = BTreeMap::new();
-        config.insert("id".to_string(), VmValue::String(std::sync::Arc::from("r")));
-        config.insert(
-            "pattern".to_string(),
-            VmValue::String(std::sync::Arc::from("[invalid")),
-        );
+        config.put_str("id", "r");
+        config.put_str("pattern", "[invalid");
         let result = call_sync(
             &vm,
             "tool_rule",
@@ -1385,10 +1319,7 @@ mod tests {
         let rust_cat =
             call_sync(&vm, "catalogue", &[sample_catalogue_config(rule.clone())]).expect("cat");
         let mut shell_cfg: BTreeMap<String, VmValue> = BTreeMap::new();
-        shell_cfg.insert(
-            "id".to_string(),
-            VmValue::String(std::sync::Arc::from("harn-canon/shell")),
-        );
+        shell_cfg.put_str("id", "harn-canon/shell");
         // Stackless catalogue: matches every requested stack — universal rules.
         shell_cfg.insert(
             "rules".to_string(),
@@ -1401,14 +1332,8 @@ mod tests {
         )
         .expect("cat");
         let mut python_cfg: BTreeMap<String, VmValue> = BTreeMap::new();
-        python_cfg.insert(
-            "id".to_string(),
-            VmValue::String(std::sync::Arc::from("harn-canon/python")),
-        );
-        python_cfg.insert(
-            "stack".to_string(),
-            VmValue::String(std::sync::Arc::from("python")),
-        );
+        python_cfg.put_str("id", "harn-canon/python");
+        python_cfg.put_str("stack", "python");
         python_cfg.insert(
             "rules".to_string(),
             VmValue::List(std::sync::Arc::new(vec![rule])),
@@ -1491,23 +1416,14 @@ mod tests {
 
     fn audit_payload(rule_id: &str, command: &str) -> VmValue {
         let mut payload: BTreeMap<String, VmValue> = BTreeMap::new();
-        payload.insert(
-            "rule_id".to_string(),
-            VmValue::String(std::sync::Arc::from(rule_id)),
-        );
-        payload.insert(
-            "command".to_string(),
-            VmValue::String(std::sync::Arc::from(command)),
-        );
+        payload.put_str("rule_id", rule_id);
+        payload.put_str("command", command);
         VmValue::Dict(std::sync::Arc::new(payload))
     }
 
     fn reminder_options(body: &str, tag: &str, ttl: i64) -> VmValue {
         let mut options: BTreeMap<String, VmValue> = BTreeMap::new();
-        options.insert(
-            "body".to_string(),
-            VmValue::String(std::sync::Arc::from(body)),
-        );
+        options.put_str("body", body);
         options.insert(
             "tags".to_string(),
             VmValue::List(std::sync::Arc::new(vec![VmValue::String(
@@ -1616,10 +1532,7 @@ mod tests {
 
     fn verdict_value(kind: &str) -> VmValue {
         let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
-        dict.insert(
-            "kind".to_string(),
-            VmValue::String(std::sync::Arc::from(kind)),
-        );
+        dict.put_str("kind", kind);
         dict.insert("confidence".to_string(), VmValue::Float(0.9));
         VmValue::Dict(std::sync::Arc::new(dict))
     }

--- a/crates/harn-vm/src/stdlib/tools.rs
+++ b/crates/harn-vm/src/stdlib/tools.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -203,10 +204,7 @@ fn plan_entries_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
 )]
 fn tool_registry_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let mut registry = BTreeMap::new();
-    registry.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from("tool_registry")),
-    );
+    registry.put_str("_type", "tool_registry");
     registry.insert(
         "tools".to_string(),
         VmValue::List(std::sync::Arc::new(Vec::new())),
@@ -485,14 +483,8 @@ fn tool_schema_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
                 vm_build_output_schema(entry.get("outputSchema"), components.as_ref());
 
             let mut tool_def = BTreeMap::new();
-            tool_def.insert(
-                "name".to_string(),
-                VmValue::String(std::sync::Arc::from(name)),
-            );
-            tool_def.insert(
-                "description".to_string(),
-                VmValue::String(std::sync::Arc::from(description)),
-            );
+            tool_def.put_str("name", name);
+            tool_def.put_str("description", description);
             tool_def.insert("inputSchema".to_string(), input_schema);
             if let Some(output_schema) = output_schema {
                 tool_def.insert("outputSchema".to_string(), output_schema);
@@ -502,10 +494,7 @@ fn tool_schema_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
     }
 
     let mut schema = BTreeMap::new();
-    schema.insert(
-        "schema_version".to_string(),
-        VmValue::String(std::sync::Arc::from("harn-tools/1.0")),
-    );
+    schema.put_str("schema_version", "harn-tools/1.0");
 
     if let Some(comps) = &components {
         let mut comp_wrapper = BTreeMap::new();
@@ -765,22 +754,13 @@ fn tool_define_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
     let output_schema = config.get("returns").cloned().unwrap_or(VmValue::Nil);
 
     let mut tool_entry = BTreeMap::new();
-    tool_entry.insert(
-        "name".to_string(),
-        VmValue::String(std::sync::Arc::from(name.as_str())),
-    );
-    tool_entry.insert(
-        "description".to_string(),
-        VmValue::String(std::sync::Arc::from(description)),
-    );
+    tool_entry.put_str("name", name.as_str());
+    tool_entry.put_str("description", description);
     tool_entry.insert("handler".to_string(), handler);
     tool_entry.insert("parameters".to_string(), parameters);
     // Store the canonical executor as a plain string; wire
     // serialization is handled by the ACP adapter.
-    tool_entry.insert(
-        "executor".to_string(),
-        VmValue::String(std::sync::Arc::from(resolved_executor)),
-    );
+    tool_entry.put_str("executor", resolved_executor);
     if !matches!(output_schema, VmValue::Nil) {
         tool_entry.insert("outputSchema".to_string(), output_schema);
     }
@@ -1310,26 +1290,11 @@ fn is_optional_param(schema: &VmValue) -> bool {
 
 fn synthesized_tool_dry_run_result(spec: &SynthesizedToolSpec, call_args: VmValue) -> VmValue {
     let mut result = BTreeMap::new();
-    result.insert(
-        "_type".to_string(),
-        VmValue::String(std::sync::Arc::from("synthesized_tool_result")),
-    );
-    result.insert(
-        "status".to_string(),
-        VmValue::String(std::sync::Arc::from("dry_run")),
-    );
-    result.insert(
-        "tool_id".to_string(),
-        VmValue::String(std::sync::Arc::from(spec.id.as_str())),
-    );
-    result.insert(
-        "name".to_string(),
-        VmValue::String(std::sync::Arc::from(spec.name.as_str())),
-    );
-    result.insert(
-        "description".to_string(),
-        VmValue::String(std::sync::Arc::from(spec.description.as_str())),
-    );
+    result.put_str("_type", "synthesized_tool_result");
+    result.put_str("status", "dry_run");
+    result.put_str("tool_id", spec.id.as_str());
+    result.put_str("name", spec.name.as_str());
+    result.put_str("description", spec.description.as_str());
     result.insert("args".to_string(), call_args);
     result.insert(
         "capabilities".to_string(),
@@ -1340,34 +1305,20 @@ fn synthesized_tool_dry_run_result(spec: &SynthesizedToolSpec, call_args: VmValu
                 .collect(),
         )),
     );
-    result.insert(
-        "side_effect_level".to_string(),
-        VmValue::String(std::sync::Arc::from(spec.side_effect_level.as_str())),
-    );
-    result.insert(
-        "message".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            "synthesized tool is pinned and validated, but executor is dry_run; \
+    result.put_str("side_effect_level", spec.side_effect_level.as_str());
+    result.put_str(
+        "message",
+        "synthesized tool is pinned and validated, but executor is dry_run; \
              set executor: \"host_bridge\" or \"mcp_server\" to dispatch",
-        )),
     );
     VmValue::Dict(std::sync::Arc::new(result))
 }
 
 fn synthesized_tool_spec_value(spec: &SynthesizedToolSpec) -> VmValue {
     let mut value = BTreeMap::new();
-    value.insert(
-        "id".to_string(),
-        VmValue::String(std::sync::Arc::from(spec.id.as_str())),
-    );
-    value.insert(
-        "name".to_string(),
-        VmValue::String(std::sync::Arc::from(spec.name.as_str())),
-    );
-    value.insert(
-        "description".to_string(),
-        VmValue::String(std::sync::Arc::from(spec.description.as_str())),
-    );
+    value.put_str("id", spec.id.as_str());
+    value.put_str("name", spec.name.as_str());
+    value.put_str("description", spec.description.as_str());
     value.insert("parameters".to_string(), spec.parameters.clone());
     value.insert("return_type".to_string(), spec.return_type.clone());
     value.insert(
@@ -1379,45 +1330,24 @@ fn synthesized_tool_spec_value(spec: &SynthesizedToolSpec) -> VmValue {
                 .collect(),
         )),
     );
-    value.insert(
-        "side_effect_level".to_string(),
-        VmValue::String(std::sync::Arc::from(spec.side_effect_level.as_str())),
-    );
+    value.put_str("side_effect_level", spec.side_effect_level.as_str());
     match &spec.executor {
         SynthesizedToolExecutor::DryRun => {
-            value.insert(
-                "executor".to_string(),
-                VmValue::String(std::sync::Arc::from("dry_run")),
-            );
+            value.put_str("executor", "dry_run");
         }
         SynthesizedToolExecutor::HostBridge { host_tool } => {
-            value.insert(
-                "executor".to_string(),
-                VmValue::String(std::sync::Arc::from("host_bridge")),
-            );
-            value.insert(
-                "host_tool".to_string(),
-                VmValue::String(std::sync::Arc::from(host_tool.as_str())),
-            );
+            value.put_str("executor", "host_bridge");
+            value.put_str("host_tool", host_tool.as_str());
         }
         SynthesizedToolExecutor::McpServer {
             tool_name,
             server_name,
             ..
         } => {
-            value.insert(
-                "executor".to_string(),
-                VmValue::String(std::sync::Arc::from("mcp_server")),
-            );
-            value.insert(
-                "mcp_tool".to_string(),
-                VmValue::String(std::sync::Arc::from(tool_name.as_str())),
-            );
+            value.put_str("executor", "mcp_server");
+            value.put_str("mcp_tool", tool_name.as_str());
             if let Some(server_name) = server_name {
-                value.insert(
-                    "mcp_server".to_string(),
-                    VmValue::String(std::sync::Arc::from(server_name.as_str())),
-                );
+                value.put_str("mcp_server", server_name.as_str());
             }
         }
     }
@@ -1630,10 +1560,7 @@ fn vm_format_schema(schema: Option<&VmValue>) -> String {
 
 fn vm_build_empty_schema() -> BTreeMap<String, VmValue> {
     let mut schema = BTreeMap::new();
-    schema.insert(
-        "schema_version".to_string(),
-        VmValue::String(std::sync::Arc::from("harn-tools/1.0")),
-    );
+    schema.put_str("schema_version", "harn-tools/1.0");
     schema.insert(
         "tools".to_string(),
         VmValue::List(std::sync::Arc::new(Vec::new())),
@@ -1646,10 +1573,7 @@ fn vm_build_input_schema(
     components: Option<&BTreeMap<String, VmValue>>,
 ) -> VmValue {
     let mut schema = BTreeMap::new();
-    schema.insert(
-        "type".to_string(),
-        VmValue::String(std::sync::Arc::from("object")),
-    );
+    schema.put_str("type", "object");
 
     let params_map = match params {
         Some(VmValue::Dict(map)) if !map.is_empty() => map,
@@ -1698,10 +1622,7 @@ fn vm_resolve_param_type(val: &VmValue, components: Option<&BTreeMap<String, VmV
         VmValue::String(type_name) => {
             let json_type = vm_harn_type_to_json_schema(type_name);
             let mut prop = BTreeMap::new();
-            prop.insert(
-                "type".to_string(),
-                VmValue::String(std::sync::Arc::from(json_type)),
-            );
+            prop.put_str("type", json_type);
             VmValue::Dict(std::sync::Arc::new(prop))
         }
         VmValue::Dict(map) => {
@@ -1712,12 +1633,7 @@ fn vm_resolve_param_type(val: &VmValue, components: Option<&BTreeMap<String, VmV
                     }
                 }
                 let mut prop = BTreeMap::new();
-                prop.insert(
-                    "$ref".to_string(),
-                    VmValue::String(std::sync::Arc::from(
-                        format!("#/components/schemas/{ref_name}").as_str(),
-                    )),
-                );
+                prop.put_str("$ref", format!("#/components/schemas/{ref_name}").as_str());
                 VmValue::Dict(std::sync::Arc::new(prop))
             } else {
                 VmValue::Dict(std::sync::Arc::new((**map).clone()))
@@ -1725,10 +1641,7 @@ fn vm_resolve_param_type(val: &VmValue, components: Option<&BTreeMap<String, VmV
         }
         _ => {
             let mut prop = BTreeMap::new();
-            prop.insert(
-                "type".to_string(),
-                VmValue::String(std::sync::Arc::from("string")),
-            );
+            prop.put_str("type", "string");
             VmValue::Dict(std::sync::Arc::new(prop))
         }
     }

--- a/crates/harn-vm/src/stdlib/tracing.rs
+++ b/crates/harn-vm/src/stdlib/tracing.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::sync::atomic::Ordering;
 
@@ -95,18 +96,9 @@ fn trace_start_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
     });
 
     let mut span = BTreeMap::new();
-    span.insert(
-        "trace_id".to_string(),
-        VmValue::String(std::sync::Arc::from(trace_id)),
-    );
-    span.insert(
-        "span_id".to_string(),
-        VmValue::String(std::sync::Arc::from(span_id)),
-    );
-    span.insert(
-        "name".to_string(),
-        VmValue::String(std::sync::Arc::from(name)),
-    );
+    span.put_str("trace_id", trace_id);
+    span.put_str("span_id", span_id);
+    span.put_str("name", name);
     span.insert("start_ms".to_string(), VmValue::Int(start_ms));
     Ok(VmValue::Dict(std::sync::Arc::new(span)))
 }
@@ -117,18 +109,9 @@ fn trace_end_impl(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError
     let level_num = 1_u8;
     if level_num >= VM_MIN_LOG_LEVEL.load(Ordering::Relaxed) {
         let mut fields = BTreeMap::new();
-        fields.insert(
-            "trace_id".to_string(),
-            VmValue::String(std::sync::Arc::from(trace_id)),
-        );
-        fields.insert(
-            "span_id".to_string(),
-            VmValue::String(std::sync::Arc::from(span_id)),
-        );
-        fields.insert(
-            "name".to_string(),
-            VmValue::String(std::sync::Arc::from(name)),
-        );
+        fields.put_str("trace_id", trace_id);
+        fields.put_str("span_id", span_id);
+        fields.put_str("name", name);
         fields.insert("duration_ms".to_string(), VmValue::Int(duration_ms));
         let line = vm_build_log_line("info", "span_end", Some(&fields));
         out.push_str(&line);
@@ -156,14 +139,8 @@ fn llm_info_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
     };
     let api_key_set = crate::llm_config::provider_key_available(&provider);
     let mut info = BTreeMap::new();
-    info.insert(
-        "provider".to_string(),
-        VmValue::String(std::sync::Arc::from(provider)),
-    );
-    info.insert(
-        "model".to_string(),
-        VmValue::String(std::sync::Arc::from(model)),
-    );
+    info.put_str("provider", provider);
+    info.put_str("model", model);
     info.insert("api_key_set".to_string(), VmValue::Bool(api_key_set));
     Ok(VmValue::Dict(std::sync::Arc::new(info)))
 }

--- a/crates/harn-vm/src/stdlib/transcript_project.rs
+++ b/crates/harn-vm/src/stdlib/transcript_project.rs
@@ -14,6 +14,7 @@
 //! conflict through the projection event's `provider_safety_blocked`
 //! flag and pass the original message through.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use serde_json::Value as JsonValue;
@@ -1474,18 +1475,9 @@ fn canonical_json(value: &JsonValue) -> String {
 
 pub(crate) fn result_to_vm(result: &ProjectionResult, policy: &ProjectionPolicy) -> VmValue {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "policy".to_string(),
-        VmValue::String(std::sync::Arc::from(policy.kind.as_str())),
-    );
-    dict.insert(
-        "reason".to_string(),
-        VmValue::String(std::sync::Arc::from(result.reason.clone())),
-    );
-    dict.insert(
-        "prefix_hash".to_string(),
-        VmValue::String(std::sync::Arc::from(result.prefix_hash.clone())),
-    );
+    dict.put_str("policy", policy.kind.as_str());
+    dict.put_str("reason", result.reason.clone());
+    dict.put_str("prefix_hash", result.prefix_hash.clone());
     dict.insert(
         "messages".to_string(),
         VmValue::List(std::sync::Arc::new(

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::time::Duration;
@@ -1532,10 +1533,7 @@ pub(crate) async fn register_auto_resume_trigger(
     };
 
     let mut normalized = trigger_config.as_ref().clone();
-    normalized.insert(
-        "handler".to_string(),
-        VmValue::String(std::sync::Arc::from("worker://__resume_auto_resume__")),
-    );
+    normalized.put_str("handler", "worker://__resume_auto_resume__");
     let mut spec = parse_trigger_config(&normalized).map_err(|error| {
         suspend_diagnostic_error(
             Code::ResumeTriggerRegistrationFailed,

--- a/crates/harn-vm/src/stdlib/tui.rs
+++ b/crates/harn-vm/src/stdlib/tui.rs
@@ -1,5 +1,6 @@
 //! Terminal UI builtins backing the Harn `std/tui` module.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::io::{ErrorKind, Write};
 use std::process::{Command, Stdio};
@@ -301,10 +302,7 @@ fn page_result(ok: bool, paged: bool, error: Option<String>) -> VmValue {
         ("paged".to_string(), VmValue::Bool(paged)),
     ]);
     if let Some(error) = error {
-        result.insert(
-            "error".to_string(),
-            VmValue::String(std::sync::Arc::from(error)),
-        );
+        result.put_str("error", error);
     }
     VmValue::Dict(std::sync::Arc::new(result))
 }

--- a/crates/harn-vm/src/stdlib/url_parse.rs
+++ b/crates/harn-vm/src/stdlib/url_parse.rs
@@ -1,6 +1,7 @@
 //! URL parse / build / query builtins. The module is named `url_parse`
 //! rather than `url` to avoid colliding with the `url` crate.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use url::Url;
@@ -38,10 +39,7 @@ fn url_parse_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
         ))))
     })?;
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "scheme".to_string(),
-        VmValue::String(std::sync::Arc::from(parsed.scheme())),
-    );
+    dict.put_str("scheme", parsed.scheme());
     dict.insert(
         "host".to_string(),
         parsed
@@ -56,10 +54,7 @@ fn url_parse_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
             .map(|p| VmValue::Int(p as i64))
             .unwrap_or(VmValue::Nil),
     );
-    dict.insert(
-        "path".to_string(),
-        VmValue::String(std::sync::Arc::from(parsed.path())),
-    );
+    dict.put_str("path", parsed.path());
     dict.insert(
         "query".to_string(),
         parsed
@@ -171,14 +166,8 @@ fn query_parse_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
     let pairs: Vec<VmValue> = url::form_urlencoded::parse(trimmed.as_bytes())
         .map(|(k, v)| {
             let mut row = BTreeMap::new();
-            row.insert(
-                "key".to_string(),
-                VmValue::String(std::sync::Arc::from(k.into_owned())),
-            );
-            row.insert(
-                "value".to_string(),
-                VmValue::String(std::sync::Arc::from(v.into_owned())),
-            );
+            row.put_str("key", &k);
+            row.put_str("value", &v);
             VmValue::Dict(std::sync::Arc::new(row))
         })
         .collect();

--- a/crates/harn-vm/src/stdlib/workflow/hooks.rs
+++ b/crates/harn-vm/src/stdlib/workflow/hooks.rs
@@ -1,5 +1,6 @@
 //! Tool, persona, and step hook registration builtins for workflow execution.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -617,42 +618,21 @@ pub(super) async fn fire_session_hook_builtin(
     let mut out: BTreeMap<String, VmValue> = BTreeMap::new();
     match control {
         crate::orchestration::HookControl::Allow => {
-            out.insert(
-                "control".to_string(),
-                VmValue::String(std::sync::Arc::from("allow")),
-            );
+            out.put_str("control", "allow");
         }
         crate::orchestration::HookControl::Block { reason } => {
-            out.insert(
-                "control".to_string(),
-                VmValue::String(std::sync::Arc::from("block")),
-            );
-            out.insert(
-                "reason".to_string(),
-                VmValue::String(std::sync::Arc::from(reason)),
-            );
+            out.put_str("control", "block");
+            out.put_str("reason", reason);
         }
         crate::orchestration::HookControl::Decision { kind, reason } => {
-            out.insert(
-                "control".to_string(),
-                VmValue::String(std::sync::Arc::from("decision")),
-            );
-            out.insert(
-                "decision".to_string(),
-                VmValue::String(std::sync::Arc::from(kind)),
-            );
+            out.put_str("control", "decision");
+            out.put_str("decision", kind);
             if let Some(reason) = reason {
-                out.insert(
-                    "reason".to_string(),
-                    VmValue::String(std::sync::Arc::from(reason)),
-                );
+                out.put_str("reason", reason);
             }
         }
         crate::orchestration::HookControl::Modify { payload: modified } => {
-            out.insert(
-                "control".to_string(),
-                VmValue::String(std::sync::Arc::from("modify")),
-            );
+            out.put_str("control", "modify");
             out.insert(
                 "modify".to_string(),
                 crate::stdlib::json_to_vm_value(&modified),

--- a/crates/harn-vm/src/stdlib/workflow/state.rs
+++ b/crates/harn-vm/src/stdlib/workflow/state.rs
@@ -1,5 +1,6 @@
 //! Workflow run state machine and stage-lifecycle helpers.
 
+use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
@@ -164,14 +165,8 @@ pub(super) fn workflow_control_to_vm(
     include_graph: bool,
 ) -> Result<VmValue, VmError> {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "state_id".to_string(),
-        VmValue::String(std::sync::Arc::from(state.state_id.as_str())),
-    );
-    dict.insert(
-        "run_id".to_string(),
-        VmValue::String(std::sync::Arc::from(state.run.id.as_str())),
-    );
+    dict.put_str("state_id", state.state_id.as_str());
+    dict.put_str("run_id", state.run.id.as_str());
     dict.insert(
         "ready_nodes".to_string(),
         string_list_to_vm(&state.ready_nodes),
@@ -266,10 +261,7 @@ fn validate_workflow_skill_registry(value: VmValue) -> Option<VmValue> {
         }
         VmValue::List(list) => {
             let mut dict = BTreeMap::new();
-            dict.insert(
-                "_type".to_string(),
-                VmValue::String(std::sync::Arc::from("skill_registry")),
-            );
+            dict.put_str("_type", "skill_registry");
             dict.insert("skills".to_string(), VmValue::List(list.clone()));
             Some(VmValue::Dict(std::sync::Arc::new(dict)))
         }
@@ -666,10 +658,7 @@ fn stage_metadata(
 
 fn workflow_stage_plan_to_vm(scope: &StageExecutionScope) -> Result<VmValue, VmError> {
     let mut dict = BTreeMap::new();
-    dict.insert(
-        "kind".to_string(),
-        VmValue::String(std::sync::Arc::from(scope.node.kind.as_str())),
-    );
+    dict.put_str("kind", scope.node.kind.as_str());
     match &scope.execution {
         StageExecution::Precomputed(executed) => {
             dict.insert(
@@ -684,10 +673,7 @@ fn workflow_stage_plan_to_vm(scope: &StageExecutionScope) -> Result<VmValue, VmE
                     crate::stdlib::json_to_vm_value(result),
                 );
             } else {
-                dict.insert(
-                    "prompt".to_string(),
-                    VmValue::String(std::sync::Arc::from(prepared.prompt.as_str())),
-                );
+                dict.put_str("prompt", prepared.prompt.as_str());
                 dict.insert(
                     "system".to_string(),
                     prepared
@@ -1060,10 +1046,7 @@ pub(super) async fn prepare_workflow_stage_state(
             .map(|artifact| artifact.id.clone())
             .collect::<Vec<_>>();
         let mut map_options = BTreeMap::new();
-        map_options.insert(
-            "task".to_string(),
-            VmValue::String(std::sync::Arc::from(state.run.task.clone())),
-        );
+        map_options.put_str("task", state.run.task.clone());
         if let Some(transcript) = transcript.clone() {
             map_options.insert("transcript".to_string(), transcript);
         }

--- a/crates/harn-vm/src/stdlib/xml.rs
+++ b/crates/harn-vm/src/stdlib/xml.rs
@@ -30,6 +30,7 @@
 //! prefixes are preserved verbatim in tag names; they are not
 //! resolved.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 
 use base64::engine::general_purpose::STANDARD as BASE64;
@@ -639,10 +640,7 @@ fn finalize_element(
         );
     }
     if !trimmed.is_empty() {
-        out.insert(
-            "@text".to_string(),
-            VmValue::String(std::sync::Arc::from(trimmed.to_string())),
-        );
+        out.put_str("@text", trimmed);
     }
     VmValue::Dict(std::sync::Arc::new(out))
 }

--- a/crates/harn-vm/src/step_runtime.rs
+++ b/crates/harn-vm/src/step_runtime.rs
@@ -14,6 +14,7 @@
 //! `crates/harn-vm/src/llm/`, `crates/harn-vm/src/vm/`, and the compiler
 //! stay focused.
 
+use crate::value::VmDictExt;
 use std::cell::{Cell, RefCell};
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -856,30 +857,12 @@ fn budget_exhausted_error(
     consumed_cost_usd: f64,
 ) -> VmError {
     let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
-    dict.insert(
-        "category".to_string(),
-        VmValue::String(std::sync::Arc::from("budget_exceeded")),
-    );
-    dict.insert(
-        "kind".to_string(),
-        VmValue::String(std::sync::Arc::from("budget_exhausted")),
-    );
-    dict.insert(
-        "reason".to_string(),
-        VmValue::String(std::sync::Arc::from("step_budget_exhausted")),
-    );
-    dict.insert(
-        "step".to_string(),
-        VmValue::String(std::sync::Arc::from(definition.name.clone())),
-    );
-    dict.insert(
-        "function".to_string(),
-        VmValue::String(std::sync::Arc::from(definition.function.clone())),
-    );
-    dict.insert(
-        "limit".to_string(),
-        VmValue::String(std::sync::Arc::from(limit.to_string())),
-    );
+    dict.put_str("category", "budget_exceeded");
+    dict.put_str("kind", "budget_exhausted");
+    dict.put_str("reason", "step_budget_exhausted");
+    dict.put_str("step", definition.name.clone());
+    dict.put_str("function", definition.function.clone());
+    dict.put_str("limit", limit);
     dict.insert("limit_value".to_string(), VmValue::Float(limit_value));
     dict.insert(
         "consumed_tokens".to_string(),
@@ -889,21 +872,19 @@ fn budget_exhausted_error(
         "consumed_cost_usd".to_string(),
         VmValue::Float(consumed_cost_usd),
     );
-    dict.insert(
-        "error_boundary".to_string(),
-        VmValue::String(std::sync::Arc::from(
-            definition
-                .error_boundary
-                .clone()
-                .unwrap_or_else(|| "fail".to_string()),
-        )),
+    dict.put_str(
+        "error_boundary",
+        definition
+            .error_boundary
+            .clone()
+            .unwrap_or_else(|| "fail".to_string()),
     );
-    dict.insert(
-        "message".to_string(),
-        VmValue::String(std::sync::Arc::from(format!(
+    dict.put_str(
+        "message",
+        format!(
             "step `{}` exceeded {} budget ({} > {})",
             definition.name, limit, consumed_tokens as i64, limit_value as i64
-        ))),
+        ),
     );
     VmError::Thrown(VmValue::Dict(std::sync::Arc::new(dict)))
 }
@@ -940,10 +921,7 @@ pub fn mark_escalated(err: VmError, step_name: Option<&str>, function: Option<&s
     };
     let mut next = (*dict).clone();
     next.insert("escalated".to_string(), VmValue::Bool(true));
-    next.insert(
-        "category".to_string(),
-        VmValue::String(std::sync::Arc::from("handoff_escalation")),
-    );
+    next.put_str("category", "handoff_escalation");
     if let Some(step) = step_name {
         next.entry("step".to_string())
             .or_insert_with(|| VmValue::String(std::sync::Arc::from(step.to_string())));
@@ -999,6 +977,7 @@ fn __register_persona(args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::value::VmDictExt;
 
     fn fresh_state() {
         reset_thread_local_state();
@@ -1011,18 +990,9 @@ mod tests {
         budget.insert("max_tokens".to_string(), VmValue::Int(100));
         budget.insert("max_usd".to_string(), VmValue::Float(0.05));
         let mut meta: BTreeMap<String, VmValue> = BTreeMap::new();
-        meta.insert(
-            "name".to_string(),
-            VmValue::String(std::sync::Arc::from("plan")),
-        );
-        meta.insert(
-            "model".to_string(),
-            VmValue::String(std::sync::Arc::from("claude-haiku-4-5")),
-        );
-        meta.insert(
-            "error_boundary".to_string(),
-            VmValue::String(std::sync::Arc::from("continue")),
-        );
+        meta.put_str("name", "plan");
+        meta.put_str("model", "claude-haiku-4-5");
+        meta.put_str("error_boundary", "continue");
         meta.insert(
             "budget".to_string(),
             VmValue::Dict(std::sync::Arc::new(budget)),
@@ -1102,10 +1072,7 @@ mod tests {
     fn stage_policy_narrows_but_does_not_widen_parent_policy() {
         fresh_state();
         let mut meta: BTreeMap<String, VmValue> = BTreeMap::new();
-        meta.insert(
-            "name".to_string(),
-            VmValue::String(std::sync::Arc::from("research")),
-        );
+        meta.put_str("name", "research");
         register_step_from_dict(vec![
             VmValue::String(std::sync::Arc::from("research_step")),
             VmValue::Dict(std::sync::Arc::new(meta)),
@@ -1113,10 +1080,7 @@ mod tests {
         .expect("step registration");
 
         let mut stage_dict: BTreeMap<String, VmValue> = BTreeMap::new();
-        stage_dict.insert(
-            "name".to_string(),
-            VmValue::String(std::sync::Arc::from("research")),
-        );
+        stage_dict.put_str("name", "research");
         // Stage tries to add `edit` on top of a parent that only allowed `read`.
         stage_dict.insert(
             "allowed_tools".to_string(),
@@ -1126,10 +1090,7 @@ mod tests {
             ])),
         );
         let mut persona_meta: BTreeMap<String, VmValue> = BTreeMap::new();
-        persona_meta.insert(
-            "name".to_string(),
-            VmValue::String(std::sync::Arc::from("scoped")),
-        );
+        persona_meta.put_str("name", "scoped");
         persona_meta.insert(
             "stages".to_string(),
             VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
@@ -1161,10 +1122,7 @@ mod tests {
     fn stage_policy_is_pushed_and_popped_around_step() {
         fresh_state();
         let mut meta: BTreeMap<String, VmValue> = BTreeMap::new();
-        meta.insert(
-            "name".to_string(),
-            VmValue::String(std::sync::Arc::from("research")),
-        );
+        meta.put_str("name", "research");
         register_step_from_dict(vec![
             VmValue::String(std::sync::Arc::from("research_step")),
             VmValue::Dict(std::sync::Arc::new(meta)),
@@ -1172,10 +1130,7 @@ mod tests {
         .expect("step registration succeeds");
 
         let mut stage_dict: BTreeMap<String, VmValue> = BTreeMap::new();
-        stage_dict.insert(
-            "name".to_string(),
-            VmValue::String(std::sync::Arc::from("research")),
-        );
+        stage_dict.put_str("name", "research");
         stage_dict.insert(
             "allowed_tools".to_string(),
             VmValue::List(std::sync::Arc::new(vec![VmValue::String(
@@ -1183,10 +1138,7 @@ mod tests {
             )])),
         );
         let mut persona_meta: BTreeMap<String, VmValue> = BTreeMap::new();
-        persona_meta.insert(
-            "name".to_string(),
-            VmValue::String(std::sync::Arc::from("scoped")),
-        );
+        persona_meta.put_str("name", "scoped");
         persona_meta.insert(
             "stages".to_string(),
             VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(

--- a/crates/harn-vm/src/synchronization.rs
+++ b/crates/harn-vm/src/synchronization.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -297,14 +298,8 @@ impl VmSyncPrimitive {
             .expect("sync metrics mutex poisoned")
             .clone();
         let mut dict = BTreeMap::new();
-        dict.insert(
-            "kind".to_string(),
-            VmValue::String(std::sync::Arc::from(self.kind.as_str())),
-        );
-        dict.insert(
-            "key".to_string(),
-            VmValue::String(std::sync::Arc::from(self.key.as_str())),
-        );
+        dict.put_str("kind", self.kind.as_str());
+        dict.put_str("key", self.key.as_str());
         dict.insert("capacity".to_string(), VmValue::Int(self.capacity as i64));
         dict.insert(
             "acquisition_count".to_string(),

--- a/crates/harn-vm/src/value/build.rs
+++ b/crates/harn-vm/src/value/build.rs
@@ -1,0 +1,98 @@
+//! Ergonomic builders for the `BTreeMap<String, VmValue>` that backs
+//! `VmValue::Dict`.
+//!
+//! Harn builtins assemble result dicts by hand, and the raw
+//! `map.insert("key".to_string(), VmValue::String(std::sync::Arc::from(v)))`
+//! spelling is both verbose and — once rustfmt wraps it — four lines per
+//! field. [`VmDictExt`] collapses each field to a single call while keeping
+//! the receiver, so the common shapes read as `dict.put_str("key", v)` /
+//! `dict.put_opt_str("key", maybe.as_deref())`. There is no behavioural
+//! change: every method is a thin wrapper over `BTreeMap::insert`.
+
+use std::collections::BTreeMap;
+
+use super::VmValue;
+
+/// Field-insertion helpers for a `VmValue::Dict` backing map.
+///
+/// Implemented for the concrete `BTreeMap<String, VmValue>` only, so the
+/// methods are unavailable on unrelated maps and cannot be applied by mistake.
+pub trait VmDictExt {
+    /// Inserts `value` under `key` (owning the key as a `String`).
+    fn put(&mut self, key: &str, value: VmValue);
+    /// Inserts a string value built via [`VmValue::string`].
+    fn put_str(&mut self, key: &str, value: impl AsRef<str>);
+    /// Inserts a string value only when `value` is `Some`.
+    fn put_opt_str(&mut self, key: &str, value: Option<impl AsRef<str>>);
+    /// Inserts a `VmValue` only when `value` is `Some`.
+    fn put_opt(&mut self, key: &str, value: Option<VmValue>);
+    /// Inserts a boolean value.
+    fn put_bool(&mut self, key: &str, value: bool);
+    /// Inserts an integer value.
+    fn put_int(&mut self, key: &str, value: i64);
+}
+
+impl VmDictExt for BTreeMap<String, VmValue> {
+    fn put(&mut self, key: &str, value: VmValue) {
+        self.insert(key.to_string(), value);
+    }
+
+    fn put_str(&mut self, key: &str, value: impl AsRef<str>) {
+        self.insert(key.to_string(), VmValue::string(value));
+    }
+
+    fn put_opt_str(&mut self, key: &str, value: Option<impl AsRef<str>>) {
+        if let Some(value) = value {
+            self.insert(key.to_string(), VmValue::string(value));
+        }
+    }
+
+    fn put_opt(&mut self, key: &str, value: Option<VmValue>) {
+        if let Some(value) = value {
+            self.insert(key.to_string(), value);
+        }
+    }
+
+    fn put_bool(&mut self, key: &str, value: bool) {
+        self.insert(key.to_string(), VmValue::Bool(value));
+    }
+
+    fn put_int(&mut self, key: &str, value: i64) {
+        self.insert(key.to_string(), VmValue::Int(value));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn put_str_matches_manual_construction() {
+        let mut dict = BTreeMap::new();
+        dict.put_str("k", "v");
+        match dict.get("k") {
+            Some(VmValue::String(s)) => assert_eq!(s.as_ref(), "v"),
+            other => panic!("expected string value, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn put_opt_str_skips_none_and_inserts_some() {
+        let mut dict = BTreeMap::new();
+        dict.put_opt_str("present", Some("v"));
+        dict.put_opt_str("absent", None::<&str>);
+        assert!(dict.contains_key("present"));
+        assert!(!dict.contains_key("absent"));
+    }
+
+    #[test]
+    fn put_handles_scalars() {
+        let mut dict = BTreeMap::new();
+        dict.put_bool("b", true);
+        dict.put_int("n", 7);
+        dict.put("nil", VmValue::Nil);
+        assert!(matches!(dict.get("b"), Some(VmValue::Bool(true))));
+        assert!(matches!(dict.get("n"), Some(VmValue::Int(7))));
+        assert!(matches!(dict.get("nil"), Some(VmValue::Nil)));
+    }
+}

--- a/crates/harn-vm/src/value/core.rs
+++ b/crates/harn-vm/src/value/core.rs
@@ -180,6 +180,17 @@ static ASCII_CHAR_STRINGS: std::sync::LazyLock<[Arc<str>; 128]> = std::sync::Laz
 });
 
 impl VmValue {
+    /// Canonical `VmValue::String` constructor from anything string-like.
+    ///
+    /// Collapses the ubiquitous `VmValue::String(std::sync::Arc::from(..))`
+    /// spelling to a single call and performs exactly one allocation via
+    /// `Arc::<str>::from(&str)` regardless of whether the input is a `&str`,
+    /// `String`, `&String`, or `Cow<str>`. Prefer this over hand-writing the
+    /// `Arc::from` at call sites.
+    pub fn string(value: impl AsRef<str>) -> Self {
+        VmValue::String(Arc::from(value.as_ref()))
+    }
+
     /// Builds a `VmValue::String` holding a single character, reusing the
     /// interned ASCII table (see [`ASCII_CHAR_STRINGS`]) so the common ASCII
     /// path does not allocate.

--- a/crates/harn-vm/src/value/mod.rs
+++ b/crates/harn-vm/src/value/mod.rs
@@ -1,3 +1,4 @@
+mod build;
 mod core;
 mod env;
 mod error;
@@ -6,6 +7,7 @@ mod structural;
 
 pub type VmMutex<T> = parking_lot::Mutex<T>;
 
+pub use build::VmDictExt;
 pub use core::{
     struct_fields_to_map, StructLayout, VmAsyncBuiltinFn, VmBuiltinFn, VmEnumVariant, VmValue,
 };

--- a/crates/harn-vm/src/vm/methods/harness.rs
+++ b/crates/harn-vm/src/vm/methods/harness.rs
@@ -7,6 +7,7 @@
 //! attribute the error to the active capability profile rather than an
 //! opaque tool rejection.
 
+use crate::value::VmDictExt;
 use std::collections::BTreeMap;
 use std::time::Duration;
 
@@ -1020,10 +1021,7 @@ impl crate::vm::Vm {
                 }
                 if !(matches!(args.get(1), Some(VmValue::Dict(_))) && args.get(2).is_none()) {
                     if let Some(body) = args.get(1) {
-                        options.insert(
-                            "body".to_string(),
-                            VmValue::String(std::sync::Arc::from(body.display())),
-                        );
+                        options.put_str("body", body.display());
                     }
                 }
             } else if let Some(VmValue::Dict(d)) = args.get(1) {
@@ -1798,10 +1796,7 @@ fn tag_egress_dict(
     ) {
         return std::sync::Arc::new(next);
     }
-    next.insert(
-        "code".to_string(),
-        VmValue::String(std::sync::Arc::from(HARN_CAP_201_CODE)),
-    );
+    next.put_str("code", HARN_CAP_201_CODE);
     std::sync::Arc::new(next)
 }
 
@@ -1966,14 +1961,8 @@ fn mock_read_line_value(state: &crate::harness::MockHarnessState, args: &[VmValu
             if structured {
                 let mut out = std::collections::BTreeMap::new();
                 out.insert("ok".to_string(), VmValue::Bool(true));
-                out.insert(
-                    "status".to_string(),
-                    VmValue::String(std::sync::Arc::from("ok")),
-                );
-                out.insert(
-                    "value".to_string(),
-                    VmValue::String(std::sync::Arc::from(line)),
-                );
+                out.put_str("status", "ok");
+                out.put_str("value", line);
                 VmValue::Dict(std::sync::Arc::new(out))
             } else {
                 VmValue::String(std::sync::Arc::from(line))
@@ -1983,10 +1972,7 @@ fn mock_read_line_value(state: &crate::harness::MockHarnessState, args: &[VmValu
             if structured {
                 let mut out = std::collections::BTreeMap::new();
                 out.insert("ok".to_string(), VmValue::Bool(false));
-                out.insert(
-                    "status".to_string(),
-                    VmValue::String(std::sync::Arc::from("eof")),
-                );
+                out.put_str("status", "eof");
                 VmValue::Dict(std::sync::Arc::new(out))
             } else {
                 VmValue::Nil

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -1,3 +1,4 @@
+use crate::value::VmDictExt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -56,34 +57,22 @@ impl super::super::Vm {
         output: Option<VmValue>,
     ) -> VmValue {
         let mut step = std::collections::BTreeMap::new();
-        step.insert(
-            "name".to_string(),
-            VmValue::String(std::sync::Arc::from(step_name)),
-        );
-        step.insert(
-            "function".to_string(),
-            VmValue::String(std::sync::Arc::from(function_name)),
-        );
+        step.put_str("name", step_name);
+        step.put_str("function", function_name);
         step.insert(
             "args".to_string(),
             VmValue::List(std::sync::Arc::new(args.to_vec())),
         );
         let mut payload = std::collections::BTreeMap::new();
-        payload.insert(
-            "event".to_string(),
-            VmValue::String(std::sync::Arc::from(event.as_str())),
-        );
-        payload.insert(
-            "target".to_string(),
-            VmValue::String(std::sync::Arc::from(match persona {
+        payload.put_str("event", event.as_str());
+        payload.put_str(
+            "target",
+            match persona {
                 Some(persona) if !persona.is_empty() => format!("{persona}.{step_name}"),
                 _ => step_name.to_string(),
-            })),
+            },
         );
-        payload.insert(
-            "persona".to_string(),
-            VmValue::String(std::sync::Arc::from(persona.unwrap_or(""))),
-        );
+        payload.put_str("persona", persona.unwrap_or(""));
         payload.insert("step".to_string(), VmValue::Dict(std::sync::Arc::new(step)));
         if let Some(output) = output {
             payload.insert("output".to_string(), output);


### PR DESCRIPTION
## Summary

A DRY / simplification sweep that removes **~2,750 lines** across the workspace
with **zero capability or behaviour change**. The unifying idea is one canonical
way to build VM string-dicts, plus a few self-contained structural collapses.

Net: **152 files changed, ~1,600 insertions, ~4,360 deletions**.

## The six areas

1. **`VmValue::string` + `VmDictExt` foundation** (`value/build.rs`, `value/core.rs`)
   - `VmValue::string(impl AsRef<str>)` — one canonical, single-allocation string
     constructor (replaces hand-written `VmValue::String(std::sync::Arc::from(..))`).
   - `VmDictExt` extension trait on `BTreeMap<String, VmValue>`:
     `put` / `put_str` / `put_opt_str` / `put_opt` / `put_bool` / `put_int`.
   - Unit-tested; the trait is the vehicle for the sweep below.

2. **Dict-insert codemod across `harn-vm`** — collapsed **933** multi-line
   `recv.insert("k".to_string(), VmValue::String(Arc::from(v)))` blocks (4–6 lines
   each) into single `recv.put_str("k", v)` / `put_opt_str(..)` calls across 123
   files, then `clippy --fix` removed the now-redundant `.to_string()`/
   `.into_owned()`/`&` at the collapsed sites. **−2,587 net.**

3. **Folded 8 file-local `string_value`/`vm_string` constructors** into
   `VmValue::string` (supervisor, oauth_dynreg/storage, multipart, project,
   calendar, io, http) — one constructor instead of nine ad-hoc copies.

4. **`ProviderDefaults` overlay/fill** (`llm/capabilities.rs`) — the two 12-field
   merge methods + `has_any_field` are now driven by a single field-roster
   macro + generic `overlay_opt`/`fill_opt` helpers. The field list lives in
   exactly one place.

5. **Extended the dict-insert codemod to `harn-hostlib`, `harn-serve`,
   `harn-cli`, `harn-dap`** (they import `harn_vm::VmDictExt`). ~35 more sites.

6. **`harn-serve` api.rs** — collapsed 11 identical 7-line invalid-JSON-body
   guards into a single `invalid_json_response()` helper.

## Why this is safe

`put_str(x)` is `VmValue::String(Arc::from(x.as_ref()))` — byte-for-byte the same
value the old spelling produced, with one allocation instead of two on the
`&str` path. The codemod only ever matched `VmValue::String(Arc::from(..))`
values (so the receiver is provably a `BTreeMap<String, VmValue>`); every
non-matching site was left untouched. No public Harn primitive, builtin, or
language surface changed — purely internal Rust ergonomics.

## Verification (all green locally)

- `cargo clippy --workspace --all-targets -- -D warnings` → clean (exit 0)
- `cargo fmt --check` → clean
- `HARN_LLM_CALLS_DISABLED=1 cargo nextest run --workspace` → **7394 passed, 0 failed, 2 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
