### PR TITLE
feat(agent): best_of_n_candidates — generic best-of-N selection + spec-contract gate (#3281)

### DIFF
--- a/changelog.d/3281.added.md
+++ b/changelog.d/3281.added.md
@@ -1,0 +1,6 @@
+- `std/agent/best_of_n` adds `best_of_n_candidates(opts)` — a generic best-of-N candidate selector with an optional
+  pre-generation spec-contract gate. The host supplies `generate` / `select_callback` / `spec_contract_callback`
+  closures (it owns candidate generation, including any workspace reset, and the selection signal); Harn owns the
+  advance / fallthrough policy. Host-callback errors degrade gracefully — a non-true spec contract aborts to a single
+  candidate, a failing `generate` skips it, and a nil/out-of-range/erroring `select_callback` falls through to a
+  deterministic candidate — so best-of-N is a safe overlay over plain single-attempt behavior.

--- a/conformance/tests/stdlib/agent_best_of_n.expected
+++ b/conformance/tests/stdlib/agent_best_of_n.expected
@@ -1,0 +1,8 @@
+selected idx=1 id=1 n=3
+fallthrough_no_winner idx=2
+fallthrough_no_winner idx=2
+fallthrough_contract idx=0 n=1 contract=false
+selected idx=0 contract=true
+selected idx=0 n=1
+no_generate
+selected n=2 id=0

--- a/conformance/tests/stdlib/agent_best_of_n.harn
+++ b/conformance/tests/stdlib/agent_best_of_n.harn
@@ -1,0 +1,42 @@
+import "std/agent/best_of_n"
+
+pipeline default() {
+  let gen = { i -> {id: i} }
+  // 1. host signal selects a winner.
+  let r1 = best_of_n_candidates({k: 3, generate: gen, select_callback: { c -> 1 }})
+  __io_println("${r1.reason} idx=${r1.selected_index} id=${r1.candidate.id} n=${len(r1.candidates)}")
+  // 2. nil winner -> deterministic fallthrough to the last candidate.
+  let r2 = best_of_n_candidates({k: 3, generate: gen, select_callback: { c -> nil }})
+  __io_println("${r2.reason} idx=${r2.selected_index}")
+  // 3. out-of-range winner -> fallthrough.
+  let r3 = best_of_n_candidates({k: 3, generate: gen, select_callback: { c -> 99 }})
+  __io_println("${r3.reason} idx=${r3.selected_index}")
+  // 4. spec_contract false -> abort to single-candidate path (one generated).
+  let r4 = best_of_n_candidates(
+    {k: 3, generate: gen, select_callback: { c -> 1 }, spec_contract_callback: { -> false }},
+  )
+  __io_println(
+    "${r4.reason} idx=${r4.selected_index} n=${len(r4.candidates)} contract=${r4.contract_ok}",
+  )
+  // 5. spec_contract true -> normal best-of-N.
+  let r5 = best_of_n_candidates(
+    {k: 2, generate: gen, select_callback: { c -> 0 }, spec_contract_callback: { -> true }},
+  )
+  __io_println("${r5.reason} idx=${r5.selected_index} contract=${r5.contract_ok}")
+  // 6. k=1 short-circuits to a single candidate, no select needed.
+  let r6 = best_of_n_candidates({k: 1, generate: gen})
+  __io_println("${r6.reason} idx=${r6.selected_index} n=${len(r6.candidates)}")
+  // 7. missing generate callback.
+  let r7 = best_of_n_candidates({k: 3})
+  __io_println(r7.reason)
+  // 8. a failing candidate is skipped, not fatal.
+  let gen_flaky = { i ->
+    if i == 1 {
+      assert(false, "boom")
+    } else {
+      {id: i}
+    }
+  }
+  let r8 = best_of_n_candidates({k: 3, generate: gen_flaky, select_callback: { c -> 0 }})
+  __io_println("${r8.reason} n=${len(r8.candidates)} id=${r8.candidate.id}")
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -406,6 +406,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/agent/control.harn"),
     },
     StdlibSource {
+        module: "agent/best_of_n",
+        source: include_str!("stdlib/agent/best_of_n.harn"),
+    },
+    StdlibSource {
         module: "agent/loop",
         source: include_str!("stdlib/agent/loop.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/agent/best_of_n.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/best_of_n.harn
@@ -1,0 +1,162 @@
+/**
+ * agent/best_of_n.harn
+ *
+ * Generic best-of-N candidate selection with an optional pre-generation
+ * spec-contract gate — the reusable "callback contract" half of an agent_loop
+ * best-of-N strategy. Harn owns the advance/stop + fallthrough POLICY; the host
+ * owns candidate GENERATION (including any workspace reset) and the selection
+ * SIGNAL, both supplied as callbacks. A host (e.g. an eval driver) wires its own
+ * candidate generator + an oracle-independent scorer in, without this module
+ * knowing how candidates are produced or scored.
+ *
+ * Host-callback errors never hard-fail the run: a non-true/erroring
+ * spec_contract_callback aborts to the single-candidate path, a failing
+ * generate skips that candidate, and a nil/out-of-range/erroring
+ * select_callback falls through to a deterministic candidate. Best-of-N is thus
+ * a safe overlay that degrades to plain single-attempt behavior.
+ */
+fn __bon_clamp_int(value, lo, hi) {
+  let n = if type_of(value) == "int" {
+    value
+  } else {
+    lo
+  }
+  if n < lo {
+    return lo
+  }
+  if n > hi {
+    return hi
+  }
+  return n
+}
+
+/**
+ * Run best-of-N candidate selection with an optional spec-contract gate.
+ *
+ * opts:
+ *   k: int                            candidate count (clamped to [1, 64])
+ *   generate: closure(index) -> any   REQUIRED — produce candidate `index` (0-based)
+ *   select_callback: closure(candidates) -> int?  pick the winning index;
+ *                                       nil/out-of-range/error -> fallthrough
+ *   spec_contract_callback: closure() -> bool?  optional pre-generation gate; a
+ *                                       non-true or erroring return ABORTS to the
+ *                                       single-candidate path
+ *   fallthrough_index: int            winner when select yields none (default: last candidate)
+ *   on_candidate: closure({index, candidate}) -> nil  optional progress hook
+ *
+ * Returns `{reason, selected_index, candidate, candidates, contract_ok}` where
+ * `reason` is one of: `selected`, `fallthrough_no_winner`, `fallthrough_contract`,
+ * `no_candidates`, `no_generate`.
+ *
+ * @effects: []
+ * @errors: []
+ */
+pub fn best_of_n_candidates(opts) {
+  let o = if type_of(opts) == "dict" {
+    opts
+  } else {
+    {}
+  }
+  let generate = o?.generate
+  if generate == nil {
+    return {reason: "no_generate", selected_index: nil, candidate: nil, candidates: [], contract_ok: false}
+  }
+  let k = __bon_clamp_int(o?.k ?? 1, 1, 64)
+  let select_callback = o?.select_callback
+  let spec_contract_callback = o?.spec_contract_callback
+  let on_candidate = o?.on_candidate
+  // Pre-generation spec-contract gate. A non-true or erroring contract aborts
+  // best-of-N to a single-candidate run (never a hard failure).
+  var contract_ok = true
+  if spec_contract_callback != nil {
+    contract_ok = false
+    let cr = try {
+      spec_contract_callback()
+    }
+    if is_ok(cr) {
+      let verdict = unwrap(cr)
+      // Only a boolean true proceeds; nil / non-bool / false all abort.
+      contract_ok = type_of(verdict) == "bool" && verdict
+    }
+  }
+  let target = if contract_ok {
+    k
+  } else {
+    1
+  }
+  // Host-driven candidate generation; a failing candidate is simply skipped.
+  var candidates = []
+  var idx = 0
+  while idx < target {
+    let gr = try {
+      generate(idx)
+    }
+    if is_ok(gr) {
+      let cand = unwrap(gr)
+      candidates = candidates.push(cand)
+      if on_candidate != nil {
+        let _ = try {
+          on_candidate({index: idx, candidate: cand})
+        }
+      }
+    }
+    idx = idx + 1
+  }
+  if len(candidates) == 0 {
+    return {
+      reason: "no_candidates",
+      selected_index: nil,
+      candidate: nil,
+      candidates: [],
+      contract_ok: contract_ok,
+    }
+  }
+  if !contract_ok {
+    return {
+      reason: "fallthrough_contract",
+      selected_index: 0,
+      candidate: candidates[0],
+      candidates: candidates,
+      contract_ok: false,
+    }
+  }
+  if len(candidates) == 1 {
+    return {
+      reason: "selected",
+      selected_index: 0,
+      candidate: candidates[0],
+      candidates: candidates,
+      contract_ok: true,
+    }
+  }
+  // Host selection signal. nil / out-of-range / error -> deterministic fallthrough.
+  var winner = nil
+  if select_callback != nil {
+    let sr = try {
+      select_callback(candidates)
+    }
+    if is_ok(sr) {
+      let w = unwrap(sr)
+      if type_of(w) == "int" && w >= 0 && w < len(candidates) {
+        winner = w
+      }
+    }
+  }
+  if winner == nil {
+    let fallback_idx = __bon_clamp_int(o?.fallthrough_index ?? (len(candidates) - 1), 0, len(candidates) - 1)
+    return {
+      reason: "fallthrough_no_winner",
+      selected_index: fallback_idx,
+      candidate: candidates[fallback_idx],
+      candidates: candidates,
+      contract_ok: true,
+    }
+  }
+  return {
+    reason: "selected",
+    selected_index: winner,
+    candidate: candidates[winner],
+    candidates: candidates,
+    contract_ok: true,
+  }
+}


### PR DESCRIPTION
Closes #3281.

## What

Adds `std/agent/best_of_n::best_of_n_candidates(opts)` — a generic best-of-N candidate selector with an optional pre-generation **spec-contract gate**. It encodes the **callback contract** of an agent_loop best-of-N strategy:

- **Harn owns** the advance/stop + fallthrough policy.
- **The host owns** candidate generation (incl. any workspace reset) and the selection signal, supplied as closures: `generate(index)`, `select_callback(candidates) -> int?`, optional `spec_contract_callback() -> bool?`.

Returns `{reason, selected_index, candidate, candidates, contract_ok}` with `reason ∈ {selected, fallthrough_no_winner, fallthrough_contract, no_candidates, no_generate}`.

**Graceful degradation (best-of-N as a safe overlay):**
- a non-true / erroring `spec_contract_callback` → abort to a single candidate;
- a failing `generate(i)` → that candidate is skipped, not fatal;
- a nil / out-of-range / erroring `select_callback` → deterministic fallthrough (default: last candidate);
- `k=1` short-circuits to a single candidate.

## Why this shape

The full end-state (Harn driving N internal `agent_loop` sessions) is a larger core change. `#3252` (process.spawn, landed) unblocks host-side candidate isolation, and this ships the **contract decoupled from the core** so a downstream host can drive candidates externally today and adopt an internal driver later without an API change.

## Tests

`conformance/tests/stdlib/agent_best_of_n.harn` (+ `.expected`) covers: select-by-signal, nil/out-of-range fallthrough, spec-contract abort to single candidate, `k=1` short-circuit, missing-`generate`, and failing-candidate skip. `harn test conformance --filter agent_best_of_n` → 1 passed; `harn lint`/`fmt --check` clean; `clippy -p harn-stdlib` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
