### PR TITLE
feat(stdlib): expose workspace snapshot/restore to .harn pipelines

### DIFF
--- a/changelog.d/fs-snapshot-builtins.added.md
+++ b/changelog.d/fs-snapshot-builtins.added.md
@@ -1,0 +1,6 @@
+- `std/fs` gains `fs_snapshot(paths, opts?)`, `fs_restore(snapshot_id, paths?, opts?)`, `fs_list_snapshots(opts?)`, and
+  `fs_drop_snapshot(snapshot_id, opts?)` — thin pipeline-facing wrappers over the existing host
+  `hostlib_fs_*` snapshot builtins. Pipelines can now checkpoint the workspace and roll a mutation back between
+  independent retry attempts (the substrate for a verify-gated best-of-N agent loop). Snapshots are session-scoped:
+  the session id defaults to the active agent session (`agent_session_current_id()`) so each conversation's snapshots
+  stay isolated and are cleaned up on session close.

--- a/conformance/tests/harness/real_fs_snapshot_roundtrip.expected
+++ b/conformance/tests/harness/real_fs_snapshot_roundtrip.expected
@@ -1,0 +1,9 @@
+attempt-1
+1
+1
+clobbered
+1
+original
+true
+false
+0

--- a/conformance/tests/harness/real_fs_snapshot_roundtrip.harn
+++ b/conformance/tests/harness/real_fs_snapshot_roundtrip.harn
@@ -1,0 +1,32 @@
+import { fs_drop_snapshot, fs_list_snapshots, fs_restore, fs_snapshot } from "std/fs"
+
+/**
+ * Pipeline-facing workspace snapshot/restore: capture a file's pre-image,
+ * clobber it, then roll the change back. This is the substrate the best-of-N
+ * agent loop uses to retry from a clean workspace. Snapshots are
+ * session-scoped; an explicit `session_id` keeps the fixture hermetic.
+ */
+fn main(harness: Harness) {
+  let session = "conformance-snapshot-session"
+  let path = harness.fs.path_join(harness.fs.temp_dir(), "harn_fs_snapshot.txt")
+  if harness.fs.exists(path) {
+    harness.fs.delete(path)
+  }
+  harness.fs.write_text(path, "original")
+  let snap = fs_snapshot([path], {session_id: session, snapshot_id: "attempt-1"})
+  harness.stdio.println(snap.snapshot_id)
+  harness.stdio.println(len(snap.captured_paths))
+  // List sees exactly the one snapshot we took.
+  harness.stdio.println(len(fs_list_snapshots({session_id: session})))
+  // Mutate the workspace, then restore the captured pre-image.
+  harness.fs.write_text(path, "clobbered")
+  harness.stdio.println(harness.fs.read_text(path))
+  let restored = fs_restore(snap.snapshot_id, [], {session_id: session})
+  harness.stdio.println(len(restored.restored_paths))
+  harness.stdio.println(harness.fs.read_text(path))
+  // Drop releases the checkpoint and is idempotent.
+  harness.stdio.println(fs_drop_snapshot(snap.snapshot_id, {session_id: session}).dropped)
+  harness.stdio.println(fs_drop_snapshot(snap.snapshot_id, {session_id: session}).dropped)
+  harness.stdio.println(len(fs_list_snapshots({session_id: session})))
+  harness.fs.delete(path)
+}

--- a/crates/harn-stdlib/src/stdlib/stdlib_fs.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_fs.harn
@@ -274,3 +274,92 @@ pub fn file_size(path: string) {
   }
   return nil
 }
+
+/**
+ * Workspace snapshots — thin pipeline-facing wrappers over the host
+ * `hostlib_fs_*` snapshot builtins (crates/harn-hostlib/src/fs_snapshot.rs).
+ * They capture the pre-image of explicit paths so a pipeline can checkpoint
+ * the workspace and roll it back between independent retry attempts — the
+ * substrate for a verify-gated best-of-N agent loop.
+ *
+ * Snapshots are session-scoped: the session id defaults to the active agent
+ * session (`agent_session_current_id()`), so each conversation's snapshots
+ * stay isolated and are cleaned up when the host closes the session. Callers
+ * outside an agent session must pass an explicit `session_id`. This helper
+ * resolves and validates that session id.
+ *
+ * @effects: [host]
+ * @errors: []
+ */
+fn __fs_snapshot_session(opts) -> string {
+  let session = opts?.session_id ?? agent_session_current_id()
+  if session == nil || session == "" {
+    throw "fs_snapshot: no active agent session; pass an explicit `session_id`"
+  }
+  return session
+}
+
+/**
+ * Capture a workspace snapshot of `paths`, returning `{snapshot_id,
+ * captured_paths, byte_count}`.
+ *
+ * `opts.session_id` defaults to the active agent session. `opts.snapshot_id`
+ * defaults to a fresh `snapshot-<uuid>` id so independent attempts never
+ * collide. `paths` are captured immediately; restoring later reinstates
+ * their pre-image (including deleting paths that were absent at capture).
+ *
+ * @effects: [host, fs]
+ * @errors: [backend]
+ * @api_stability: experimental
+ * @example: let snap = fs_snapshot(["src/lib.rs"]); fs_restore(snap.snapshot_id)
+ */
+pub fn fs_snapshot(paths: list<string> = [], opts = {}) -> dict {
+  let session = __fs_snapshot_session(opts)
+  let scope = opts?.snapshot_id ?? ("snapshot-" + uuid_v7())
+  return hostlib_fs_snapshot({session_id: session, scope_id: scope, paths: paths ?? [], root: opts?.root})
+}
+
+/**
+ * Restore a previously-captured snapshot, returning `{snapshot_id,
+ * restored_paths, skipped_paths_with_reasons}`. With an empty `paths` every
+ * captured path is restored; otherwise only the listed subset.
+ *
+ * @effects: [host, fs]
+ * @errors: [backend]
+ * @api_stability: experimental
+ * @example: fs_restore(snap.snapshot_id)
+ */
+pub fn fs_restore(snapshot_id: string, paths: list<string> = [], opts = {}) -> dict {
+  let session = __fs_snapshot_session(opts)
+  return hostlib_fs_restore({session_id: session, snapshot_id: snapshot_id, paths: paths ?? []})
+}
+
+/**
+ * List the snapshots registered for the session, oldest first. Each entry is
+ * `{snapshot_id, scope_id, taken_at_ms, captured_paths, byte_count}`.
+ *
+ * @effects: [host]
+ * @errors: [backend]
+ * @api_stability: experimental
+ * @example: for snap in fs_list_snapshots() { log(snap.snapshot_id) }
+ */
+pub fn fs_list_snapshots(opts = {}) -> list<dict> {
+  let session = __fs_snapshot_session(opts)
+  let result = hostlib_fs_list_snapshots({session_id: session})
+  return result?.snapshots ?? []
+}
+
+/**
+ * Drop a snapshot's in-memory and on-disk state, returning `{snapshot_id,
+ * dropped}`. Idempotent: dropping an unknown id reports `dropped: false`.
+ * The best-of-N loop calls this to release each attempt's checkpoint.
+ *
+ * @effects: [host, fs]
+ * @errors: [backend]
+ * @api_stability: experimental
+ * @example: fs_drop_snapshot(snap.snapshot_id)
+ */
+pub fn fs_drop_snapshot(snapshot_id: string, opts = {}) -> dict {
+  let session = __fs_snapshot_session(opts)
+  return hostlib_fs_drop_snapshot({session_id: session, snapshot_id: snapshot_id})
+}


### PR DESCRIPTION
## What

Adds four `std/fs` functions — `fs_snapshot`, `fs_restore`, `fs_list_snapshots`, `fs_drop_snapshot` — that wrap the existing host `hostlib_fs_*` snapshot builtins (`crates/harn-hostlib/src/fs_snapshot.rs`).

## Why

The filesystem snapshot/restore primitive already existed in Rust and was registered on the VM via `harn_hostlib::install_default`, but only harn-serve's ACP checkpoint machinery consumed it — there was **no pipeline-facing surface**. A `.harn` pipeline could not snapshot/restore the workspace.

These thin wrappers let a pipeline checkpoint the workspace and roll a mutation back between independent retry attempts — the keystone substrate for a **verify-gated best-of-N agent loop** (independent fresh attempts, the statistically-sound lever for flaky cheap-model coding cells). A separate Burin follow-up will consume `fs_snapshot`/`fs_restore`.

## Design

- **No Rust changes.** The wrappers call the already-registered builtins by name (`hostlib_fs_snapshot`, etc.), matching the established `stdlib_command.harn` / `stdlib_edit.harn` convention of `pub fn`s over `hostlib_*` builtins. The primitive is reused faithfully, not reimplemented.
- **Session-scoped + auto-cleanup.** Session id defaults to the active agent session via `agent_session_current_id()` so each conversation's snapshots stay isolated and are cleaned up by the host on session close. Callers outside a session pass an explicit `session_id`. Per-snapshot cleanup is exposed via `fs_drop_snapshot` (the underlying `drop_session_snapshots` handles whole-session teardown on close).
- `fs_snapshot` generates a fresh `snapshot-<uuid_v7>` id by default so independent attempts never collide; callers can pin an explicit `snapshot_id`.

## API

```
fs_snapshot(paths: list<string> = [], opts = {}) -> dict        // {snapshot_id, captured_paths, byte_count}
fs_restore(snapshot_id: string, paths: list<string> = [], opts = {}) -> dict  // {snapshot_id, restored_paths, skipped_paths_with_reasons}
fs_list_snapshots(opts = {}) -> list<dict>
fs_drop_snapshot(snapshot_id: string, opts = {}) -> dict        // {snapshot_id, dropped}
```
`opts` accepts `session_id`, `snapshot_id` (snapshot only), and `root`.

## Tests / verification (deterministic only)

- New `conformance/tests/harness/real_fs_snapshot_roundtrip.harn` exercises snapshot -> mutate -> restore -> drop end to end.
- `make conformance` — 1618 passed, 0 failed.
- `cargo nextest run -p harn-hostlib -p harn-stdlib` — 602 passed (incl. all 10 `fs_snapshot` Rust tests + registration + smoke).
- `make check-generated-registry`, `make check-highlight`, `make lint-harn`, markdownlint — all green.
- `cargo build --bin harn` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)