### PR TITLE
fix(agent): retry errored/tool-call-less generations instead of nagging — stop advancing the loop on a broken turn

### DIFF
--- a/changelog.d/retry-errored-actionless-generation.fixed.md
+++ b/changelog.d/retry-errored-actionless-generation.fixed.md
@@ -1,0 +1,17 @@
+- **Errored / tool-call-less generations are retried instead of advancing the
+  loop on a broken turn.** A cheap model sometimes returns a generation that
+  ends with a provider error (`stop_reason == "error"`) after only *narrating*
+  an intended tool call in its text/reasoning (e.g. "We need to make edit to
+  create tests/...test.cpp...") while emitting ZERO parsed tool calls. The agent
+  loop used to advance on that turn and reply with a generic
+  `no_progress`/`stall_diagnostics` nag that never told the model its turn
+  errored, so after a few such turns the model gave up having written nothing.
+  This is distinct from the zero-token empty-completion retry (those have
+  non-zero reasoning tokens, so the zero-token predicate misses them).
+  `observed_llm_call` now treats an errored-but-actionless `Ok` generation as a
+  transient provider hiccup and retries it within the same bounded
+  empty-completion budget (no change to the global retry default). When the
+  budget is exhausted and the loop does advance, the stall detector emits
+  cause-specific feedback ("your previous turn ended with a provider error and
+  emitted no tool call — re-emit the intended tool call") instead of the generic
+  no-progress nag, while genuine no-tool-intent stalls keep the existing nag.

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -2648,6 +2648,7 @@ fn __agent_loop_run(message, session, initial_opts) {
         visible_text,
         had_parse_errors,
         stall_prev_turn_made_edit,
+        llm_result?.stop_reason ?? "",
       )
       stall_state = stall_observation.state
       stall_enabled_seen = stall_enabled_seen || stall_observation.enabled

--- a/crates/harn-stdlib/src/stdlib/agent/stall.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/stall.harn
@@ -585,6 +585,10 @@ fn __agent_stall_feedback_text(warning: AgentStallWarning) -> string {
     "the action `" + warning.tool_name + "` failed with the same error " + count + " times in a row"
   } else if pattern == "no_progress_monologue" {
     count + " consecutive assistant messages made no progress (no tool call)"
+  } else if pattern == "errored_no_tool_call" {
+    "your previous turn ended with a provider error and emitted no tool call ("
+      + count
+      + " in a row) — re-emit the intended tool call"
   } else if pattern == "ping_pong" {
     "the loop is ping-ponging between two actions (" + count + " cycles)"
   } else if pattern == "repeated_context_window_error" {
@@ -740,6 +744,7 @@ fn __agent_stall_observe_no_progress(
   config: AgentStallConfig,
   state: AgentStallState,
   defer_feedback: bool,
+  turn_stop_reason = "",
 ) -> AgentStallObservation {
   // An agent message breaks any action-repeat / ping-pong run.
   var next_state = __agent_stall_reset_action(state)
@@ -756,12 +761,22 @@ fn __agent_stall_observe_no_progress(
     }
   }
   next_state = __agent_stall_register_trip(next_state, config)
+  // A turn that ended with a provider error (stop_reason=error) but emitted no
+  // tool call narrated its intent without landing an action — the cheap-model
+  // eval-meter failure class. Give it cause-specific feedback instead of the
+  // generic "made no progress" nag, so the model knows its turn errored and to
+  // re-emit the intended tool call.
+  let pattern = if to_string(turn_stop_reason) == "error" {
+    "errored_no_tool_call"
+  } else {
+    "no_progress_monologue"
+  }
   let warning = __agent_stall_warning_record(
     iteration,
     "",
     {},
     "",
-    "no_progress_monologue",
+    pattern,
     next_state.no_progress_streak,
     next_state.consecutive_trips,
     next_state.hard_stop,
@@ -965,6 +980,7 @@ fn __agent_stall_observe_core(
   prev_dispatch = nil,
   turn_text = "",
   had_parse_errors = false,
+  turn_stop_reason = "",
 ) -> AgentStallObservation {
   let config = __agent_stall_config(raw_config)
   if !config.enabled {
@@ -1004,7 +1020,14 @@ fn __agent_stall_observe_core(
     // no-progress monologue candidate; a fully empty turn resets the action
     // stream.
     if to_string(turn_text) != "" || len(tool_calls) > 0 {
-      return __agent_stall_observe_no_progress(session_id, iteration, config, state, defer_feedback)
+      return __agent_stall_observe_no_progress(
+        session_id,
+        iteration,
+        config,
+        state,
+        defer_feedback,
+        turn_stop_reason,
+      )
     }
     return {
       state: __agent_stall_register_recovery(__agent_stall_reset_action(state)),
@@ -1155,6 +1178,7 @@ pub fn agent_stall_observe_tool_calls(
   turn_text = "",
   had_parse_errors = false,
   turn_made_edit = false,
+  turn_stop_reason = "",
 ) -> AgentStallObservation {
   let observation = __agent_stall_observe_core(
     session_id,
@@ -1166,6 +1190,7 @@ pub fn agent_stall_observe_tool_calls(
     prev_dispatch,
     turn_text,
     had_parse_errors,
+    turn_stop_reason,
   )
   if !observation.enabled {
     return observation

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -235,6 +235,49 @@ fn is_zero_token_empty_completion(result: &super::api::LlmResult) -> bool {
         && !has_tool_search_block
 }
 
+/// A wire-level "success" whose `stop_reason` reports a provider *error* yet
+/// carries no dispatchable action. Observed live (cheap-model eval meter):
+/// a generation comes back with `stop_reason == "error"` after only narrating
+/// an intended tool call in its text/thinking ("We need to make edit to create
+/// tests/...test.cpp...") but with ZERO parsed tool calls. Unlike
+/// [`is_zero_token_empty_completion`], the reasoning channel is non-empty, so
+/// the zero-token predicate misses it — yet the loop still has no action to run
+/// and would otherwise advance on a broken turn (and reply with a generic
+/// no-progress nag that never tells the model its turn errored). Treated as a
+/// transient provider hiccup and retried in [`observed_llm_call`].
+///
+/// Token-cap truncations are excluded for the same reason as the zero-token
+/// path: a deterministic cap would just re-truncate on every retry. A turn that
+/// errored but still dispatched a tool call, or carried a server-side
+/// tool-search block, is NOT actionless — the loop has real work and is left
+/// untouched.
+fn is_errored_actionless_completion(result: &super::api::LlmResult) -> bool {
+    let stop = result
+        .stop_reason
+        .as_deref()
+        .map(str::to_ascii_lowercase)
+        .unwrap_or_default();
+    if stop != "error" {
+        return false;
+    }
+    let has_tool_search_block = result.blocks.iter().any(|block| {
+        matches!(
+            block.get("type").and_then(|value| value.as_str()),
+            Some("tool_search_query") | Some("tool_search_result")
+        )
+    });
+    result.tool_calls.is_empty() && !has_tool_search_block
+}
+
+/// Unproductive `Ok` generations the agent loop should retry rather than
+/// advance on: the zero-token empty completion (provider stall) and the
+/// errored-but-actionless completion (`stop_reason == "error"` with no
+/// dispatchable tool call). Both leave the loop with no action to run, so
+/// advancing burns an iteration on a broken turn.
+fn is_retryable_unproductive_completion(result: &super::api::LlmResult) -> bool {
+    is_zero_token_empty_completion(result) || is_errored_actionless_completion(result)
+}
+
 /// Extract retry-after delay from an error message if present.
 ///
 /// Supports both forms defined by RFC 7231 §7.1.3:
@@ -1142,23 +1185,36 @@ pub(crate) async fn observed_llm_call(
 
         match llm_result {
             Ok(result) => {
-                // Zero-token empty "success" (no content, no thinking, no tool
-                // calls): a provider hiccup, not an answer. Retry within the
-                // empty-completion budget; once exhausted, fall through and
-                // return the result unchanged so callers see today's shape
+                // An unproductive "success" the loop has no action to run on —
+                // either a zero-token empty completion (provider stall) or an
+                // errored-but-actionless turn (`stop_reason == "error"` that
+                // narrated an intended tool call but emitted none). Both are
+                // provider hiccups, not answers: retry within the
+                // empty-completion budget rather than advancing the loop on a
+                // broken turn (which would only reply with a generic
+                // no-progress nag). Once the budget is exhausted, fall through
+                // and return the result unchanged so callers see today's shape
                 // rather than a novel error.
-                if is_zero_token_empty_completion(&result)
+                if is_retryable_unproductive_completion(&result)
                     && attempt < empty_completion_retry_budget(retry_config, &opts.provider)
                 {
+                    let errored_actionless = is_errored_actionless_completion(&result);
                     annotate_current_span(&[
                         ("status", serde_json::json!("retrying")),
                         ("retry_reason", serde_json::json!("empty_completion")),
                         ("attempt", serde_json::json!(attempt)),
                     ]);
-                    let detail = format!(
-                        "provider {} model {} returned a zero-token empty completion (no content, thinking, or tool calls)",
-                        opts.provider, opts.model
-                    );
+                    let detail = if errored_actionless {
+                        format!(
+                            "provider {} model {} ended with a provider error (stop_reason=error) and emitted no tool call (the intended action went only to the reasoning channel)",
+                            opts.provider, opts.model
+                        )
+                    } else {
+                        format!(
+                            "provider {} model {} returned a zero-token empty completion (no content, thinking, or tool calls)",
+                            opts.provider, opts.model
+                        )
+                    };
                     append_llm_observability_entry(
                         "empty_completion_retry",
                         serde_json::Map::from_iter([
@@ -1860,6 +1916,17 @@ mod empty_completion_retry_tests {
         FakeLlmTurn::stream(vec![FakeLlmEvent::Done(FakeStopReason::EndTurn)])
     }
 
+    /// The live cheap-model failure: the turn narrates an intended tool call in
+    /// its text but finishes with a provider error (`stop_reason == "error"`)
+    /// and emits ZERO tool calls. Non-empty text means the zero-token predicate
+    /// misses it, yet the loop has no action to run.
+    fn errored_actionless_turn() -> FakeLlmTurn {
+        FakeLlmTurn::stream(vec![
+            FakeLlmEvent::Token("We need to make edit to create tests/foo_test.cpp".into()),
+            FakeLlmEvent::Done(FakeStopReason::Custom("error".into())),
+        ])
+    }
+
     fn retry_config(retries: usize) -> LlmRetryConfig {
         LlmRetryConfig {
             retries,
@@ -1905,6 +1972,81 @@ mod empty_completion_retry_tests {
             );
             reset_agent_trace_state();
             // _guard drop asserts both scripted turns were consumed.
+        });
+    }
+
+    #[test]
+    fn errored_actionless_completion_retries_then_succeeds() {
+        // An errored turn that narrated intent but emitted no tool call must be
+        // RETRIED (not advanced on); the next good turn proceeds.
+        current_thread_runtime().block_on(async {
+            reset_agent_trace_state();
+            let _guard =
+                install_fake_llm_script(FakeLlmScript::new().push(errored_actionless_turn()).push(
+                    FakeLlmTurn::stream(vec![
+                        FakeLlmEvent::Token("recovered".into()),
+                        FakeLlmEvent::Done(FakeStopReason::EndTurn),
+                    ]),
+                ));
+            let result = observed_llm_call(
+                &fake_opts(),
+                None,
+                None,
+                &retry_config(1),
+                None,
+                false,
+                false,
+                None,
+            )
+            .await
+            .expect("errored-actionless retry should recover");
+            assert_eq!(result.text, "recovered");
+
+            let retries: Vec<usize> = peek_agent_trace()
+                .iter()
+                .filter_map(|event| match event {
+                    AgentTraceEvent::EmptyCompletionRetry { attempt, .. } => Some(*attempt),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(retries, vec![1], "expected exactly one retry trace event");
+            reset_agent_trace_state();
+            // _guard drop asserts both scripted turns were consumed.
+        });
+    }
+
+    #[test]
+    fn errored_actionless_completion_returns_unchanged_after_budget_exhausted() {
+        // Retries stay bounded: once the budget is spent, the errored turn is
+        // returned unchanged (callers see today's shape, not a novel error).
+        current_thread_runtime().block_on(async {
+            reset_agent_trace_state();
+            let _guard = install_fake_llm_script(
+                FakeLlmScript::new()
+                    .push(errored_actionless_turn())
+                    .push(errored_actionless_turn()),
+            );
+            let result = observed_llm_call(
+                &fake_opts(),
+                None,
+                None,
+                &retry_config(1),
+                None,
+                false,
+                false,
+                None,
+            )
+            .await
+            .expect("exhausted retries must return Ok, not a new error");
+            assert!(result.tool_calls.is_empty());
+            assert_eq!(result.stop_reason.as_deref(), Some("error"));
+
+            let retries = peek_agent_trace()
+                .iter()
+                .filter(|event| matches!(event, AgentTraceEvent::EmptyCompletionRetry { .. }))
+                .count();
+            assert_eq!(retries, 1, "exactly one retry before the budget is spent");
+            reset_agent_trace_state();
         });
     }
 
@@ -2090,6 +2232,48 @@ mod empty_completion_retry_tests {
         let mut with_tool_search = empty_result();
         with_tool_search.blocks = vec![serde_json::json!({"type": "tool_search_query"})];
         assert!(!is_zero_token_empty_completion(&with_tool_search));
+    }
+
+    #[test]
+    fn errored_actionless_completion_predicate_edges() {
+        // The live failure shape: stop_reason=error, the model narrated an
+        // intended tool call in its text but emitted ZERO tool calls. The
+        // zero-token predicate misses it (non-empty text), but it IS retryable.
+        let mut narrated = empty_result();
+        narrated.stop_reason = Some("error".to_string());
+        narrated.text = "We need to make edit to create tests/foo_test.cpp".to_string();
+        narrated.output_tokens = 42;
+        assert!(is_errored_actionless_completion(&narrated));
+        assert!(!is_zero_token_empty_completion(&narrated));
+        assert!(is_retryable_unproductive_completion(&narrated));
+
+        // Case-insensitive on the stop reason.
+        let mut upper = narrated.clone();
+        upper.stop_reason = Some("ERROR".to_string());
+        assert!(is_errored_actionless_completion(&upper));
+
+        // A clean finish is not the errored-actionless case (it may still be a
+        // genuine answer or a billed-noncommittal parse error — not ours).
+        let mut clean = narrated.clone();
+        clean.stop_reason = Some("stop".to_string());
+        assert!(!is_errored_actionless_completion(&clean));
+
+        // An errored turn that STILL dispatched a tool call has real work — the
+        // loop must not treat it as actionless.
+        let mut errored_with_call = narrated.clone();
+        errored_with_call.tool_calls = vec![serde_json::json!({"id": "t1", "name": "edit"})];
+        assert!(!is_errored_actionless_completion(&errored_with_call));
+
+        // An errored turn whose only activity was a server-side tool search is
+        // not actionless either (no dispatchable call, but the search counts).
+        let mut errored_with_search = narrated;
+        errored_with_search.blocks = vec![serde_json::json!({"type": "tool_search_query"})];
+        assert!(errored_with_search.tool_calls.is_empty());
+        assert!(!is_errored_actionless_completion(&errored_with_search));
+
+        // The zero-token empty completion still flows through the unified
+        // predicate.
+        assert!(is_retryable_unproductive_completion(&empty_result()));
     }
 }
 

--- a/tests/agent/stall_test.harn
+++ b/tests/agent/stall_test.harn
@@ -116,6 +116,38 @@ pipeline test_parse_error_turn_is_not_no_progress(task) {
   assert(o3.state.no_progress_streak == 0)
 }
 
+fn _observe_errored_no_call(state, iteration) {
+  // 0 tool calls + narration text, turn ended with a PROVIDER ERROR
+  // (turn_stop_reason = "error"): the cheap-model eval-meter failure class.
+  return agent_stall_observe_tool_calls(
+    "unit",
+    [],
+    iteration,
+    CONFIG,
+    state,
+    true,
+    nil,
+    "We need to make edit to create tests/foo_test.cpp",
+    false,
+    false,
+    "error",
+  )
+}
+
+pipeline test_errored_no_tool_call_gets_cause_specific_feedback(task) {
+  // A turn that ended with a provider error and emitted no tool call gets the
+  // cause-specific `errored_no_tool_call` warning (so the model is told its
+  // turn errored and to re-emit the intended call), NOT the generic
+  // no_progress_monologue nag.
+  let o1 = _observe_errored_no_call(agent_stall_initial_state(), 1)
+  assert(o1.warning == nil)
+  let o2 = _observe_errored_no_call(o1.state, 2)
+  assert(o2.warning == nil)
+  let o3 = _observe_errored_no_call(o2.state, 3)
+  assert(o3.warning != nil)
+  assert(o3.warning.pattern == "errored_no_tool_call")
+}
+
 pipeline test_text_only_turn_without_parse_errors_still_trips(task) {
   // Control: the SAME 0-call + text turn WITHOUT parse errors is a real
   // no-progress monologue and must still trip at the threshold. Guards against


### PR DESCRIPTION
## Problem

A forensic agent traced a generalizable eval-failure class (explains cpp-storage 3/5; contributes to scala/php flakiness). The cheap model sometimes emits a generation that ends with a provider error (`stop_reason == "error"`) and **narrates** an intended tool call in its text/reasoning (e.g. "We need to make edit to create tests/...test.cpp...") while emitting **zero** parsed tool calls.

The agent loop did **not** retry these — it advanced and replied with a generic `<runtime_feedback kind="stall_diagnostics">` / `no_progress_streak` nag that never told the model its turn errored or failed to land a tool call. After a few of these the model gave up INCOMPLETE having written nothing (cpp-storage t3: 5 such errors in 11 responses → quit at 25s of a 300s budget).

This is **distinct** from the zero-token empty-completion retry (commit f2889410 / #3219): those generations have non-zero reasoning tokens, so the zero-token predicate (`output_tokens == 0 && text empty && thinking empty`) misses them. This is **not** a model-capability weakness — it's the harness advancing the loop on a broken generation instead of retrying.

## Fix (generalizable, language-agnostic, minimal)

**1. Retry the errored/actionless generation** (`crates/harn-vm/src/llm/agent_observe.rs`)
- New `is_errored_actionless_completion(result)`: `stop_reason == "error"` (case-insensitive) AND zero dispatchable tool calls AND no server-side tool-search block. Non-empty text/reasoning is allowed (that's the narration), which is exactly why the zero-token predicate misses it.
- Both predicates fold into `is_retryable_unproductive_completion`, the single check at the `Ok(result)` arm of `observed_llm_call`.
- The errored turn is retried within the **same** bounded `empty_completion_retry_budget` the zero-token path uses (built-in floor of 1 for real providers; mock/fake honor only an explicit opt-in). **No change to the global retry default** (`DEFAULT_LLM_CALL_RETRIES` stays `0`); agent resilience continues to come from `agent/options.harn` `llm_retries` + the proactive rate limiter. The retry's detail line is cause-specific for the provider-error case.

**2. Cause-specific feedback when the loop does advance** (`crates/harn-stdlib/src/stdlib/agent/`)
- `agent_stall_observe_tool_calls` now takes an optional `turn_stop_reason` (defaulted — every existing caller stays arity-compatible); `loop.harn` threads `llm_result?.stop_reason`.
- When a no-tool-call turn that ended with `stop_reason == "error"` crosses the no-progress threshold, the stall detector emits a new `errored_no_tool_call` warning — "your previous turn ended with a provider error and emitted no tool call — re-emit the intended tool call" — instead of the generic "made no progress" nag. Genuine no-tool-intent stalls keep the existing `no_progress_monologue` nag.

## Tests (deterministic, no paid evals)

Rust (`harn-vm`), mirroring the existing empty-completion retry family driven through `FakeLlmProvider`:
- `errored_actionless_completion_predicate_edges` — predicate truth table (errored+narration+no-call → true; clean finish, errored-with-call, errored-with-tool-search → false; case-insensitive).
- `errored_actionless_completion_retries_then_succeeds` — an errored turn (narration + `Done(Custom("error"))`, zero calls) is retried; the next good turn proceeds. Exactly one retry trace event.
- `errored_actionless_completion_returns_unchanged_after_budget_exhausted` — retries stay bounded; the errored result is returned unchanged once spent.

Harn (`tests/agent/stall_test.harn`):
- `test_errored_no_tool_call_gets_cause_specific_feedback` — an errored no-call turn trips with `pattern == "errored_no_tool_call"`, not `no_progress_monologue`.

## Local checks (all green)

- `cargo nextest run -p harn-vm` — **3815 passed, 0 failed**
- `make conformance` (`harn test conformance`) — **1617 passed, 0 failed, 0 skipped**
- `harn test tests/agent/` (`make test-agent-scripts`) — **32 passed**
- `cargo clippy -p harn-vm --all-targets` — clean
- `make fmt-harn`, `harn lint` (touched files), `lint_test_patterns.sh`, `check-generated-registry` — all OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)