### PR TITLE
chore(stdlib): remove dead codepaths (unused store helpers, dup hex_encode, adapter_shim stub)

### DIFF
--- a/changelog.d/dead-codepaths.removed.md
+++ b/changelog.d/dead-codepaths.removed.md
@@ -1,0 +1,4 @@
+- Removed three dead codepaths: the unused `std/collections` helpers `store_stale` / `store_refresh` (zero call
+  sites), and the dead `"adapter_shim"` `callsite_strategy` branch in `std/edit`'s `add_parameter` (it only ever
+  returned "not yet supported"). Internal: `harn-cli`'s bundle signer now uses `hex::encode` instead of a duplicate
+  local `hex_encode` helper.

--- a/crates/harn-cli/src/commands/pack.rs
+++ b/crates/harn-cli/src/commands/pack.rs
@@ -748,20 +748,12 @@ fn sign_bundle(
     let signature = signing_key.sign(bundle_hash.as_bytes());
     bundle.signature = Some(Ed25519Signature {
         key_id: Some(skill_provenance::fingerprint_for_key(&verifying_key)),
-        public_key: hex_encode(&verifying_key.to_bytes()),
-        signature: hex_encode(&signature.to_bytes()),
+        public_key: hex::encode(verifying_key.to_bytes()),
+        signature: hex::encode(signature.to_bytes()),
         manifest_hash_blake3: bundle_hash,
         algorithm: "ed25519".to_string(),
     });
     Ok(())
-}
-
-fn hex_encode(bytes: &[u8]) -> String {
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        out.push_str(&format!("{byte:02x}"));
-    }
-    out
 }
 
 fn emit_release_trust_record(

--- a/crates/harn-stdlib/src/stdlib/stdlib_collections.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_collections.harn
@@ -91,30 +91,3 @@ pub fn index_by<V>(items: list<V>, key_fn) -> dict<string, V> {
   }
   return __dict_from_pairs(pairs)
 }
-
-// Check if a store key is stale (older than max_age_seconds).
-// Uses store_get/store_set convention: timestamps stored as key + "_ts".
-/**
- * store_stale.
- *
- * @effects: [time, store.read]
- * @errors: []
- */
-pub fn store_stale(key, max_age_seconds) {
-  let ts = store_get(key + "_ts")
-  if ts == nil {
-    return true
-  }
-  return harness.clock.timestamp() - ts > max_age_seconds
-}
-
-// Refresh a store key's timestamp to now.
-/**
- * store_refresh.
- *
- * @effects: [time, store.write]
- * @errors: []
- */
-pub fn store_refresh(key) {
-  store_set(key + "_ts", harness.clock.timestamp())
-}

--- a/crates/harn-stdlib/src/stdlib/stdlib_edit.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_edit.harn
@@ -2529,10 +2529,7 @@ fn __refactor_def_op(spec, path, fn_name, new_inner) {
  * - `"manual"` — rewrite the definition only and report the untouched call
  *   sites in `warnings` for the agent to fix.
  *
- * `adapter_shim` from the epic is not yet supported (it needs the old
- * signature + a delegating body); use `add_parameter` / `reorder_parameters`
- * for the structured cases instead. Languages: rust, python, typescript,
- * tsx, javascript, jsx, go.
+ * Languages: rust, python, typescript, tsx, javascript, jsx, go.
  *
  * @effects: [host, fs]
  * @errors: [backend]
@@ -2636,7 +2633,6 @@ pub fn edit_change_signature(params) {
  * - `"default_fill"` (default) — insert `default` (required) at the same
  *   index in every call's argument list.
  * - `"strict"` — refuse with `result: "conflict"` when call sites exist.
- * - `"adapter_shim"` — not yet supported.
  *
  * `param` is the full declaration text (e.g. `"c: i64"`, `"c"`, `"c int"`).
  * Languages: rust, python, typescript, tsx, javascript, jsx, go.
@@ -2697,13 +2693,6 @@ pub fn edit_add_parameter(params) {
           call_count: calls.count,
         },
       ],
-    )
-  }
-  if strategy == "adapter_shim" {
-    return __refactor_unsupported(
-      "add_parameter",
-      language,
-      "adapter_shim is not yet supported; use default_fill (with `default`) or strict",
     )
   }
   let default_val = p?.default


### PR DESCRIPTION
## What

Three verified dead-codepath removals (no users yet → no back-compat to preserve):

1. **`std/collections`** — drop `store_stale` / `store_refresh`. Zero call sites anywhere (only their own docstrings referenced the names).
2. **`harn-cli` `pack.rs`** — replace the local `hex_encode` helper with `hex::encode` (the `hex` crate is already a dependency). Identical output, two call sites in the bundle signer.
3. **`std/edit`** — remove the dead `callsite_strategy == "adapter_shim"` branch in `add_parameter` (it only ever returned "not yet supported") plus its doc references. `__refactor_unsupported` stays (12 other call sites use it).

## Verification

- `harn check` + `harn lint` clean on both `.harn` files.
- `cargo check -p harn-cli` clean (the `hex::encode` swap compiles).
- Grep confirms **no conformance test or Rust test** references any removed symbol; `__refactor_unsupported` retains 12 live call sites.
- Pre-commit clippy on `harn-cli` + `harn-stdlib` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
