### PR TITLE
Optimize VM hot dispatch paths

### DIFF
--- a/changelog.d/3295.changed.md
+++ b/changelog.d/3295.changed.md
@@ -1,0 +1,4 @@
+- **VM hot paths.** Local property and subscript assignment now compile to
+  slot-addressed bytecode, builtin ID dispatch uses a hash-indexed side table,
+  and ASCII string `len` / `count` paths avoid unnecessary scalar iteration
+  while preserving Unicode behavior (#3295).

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -649,7 +649,8 @@ fn op_stack_delta(op: Op, count: u16) -> Option<i32> {
         // Consume one value (into a binding / property / discard). `SetVar`,
         // `SetProperty` and the local-slot stores read their target by name
         // or slot index, so they only pop the value being stored.
-        DefLet | DefVar | SetVar | DefLocalSlot | SetLocalSlot | SetProperty | Pop => -1,
+        DefLet | DefVar | SetVar | DefLocalSlot | SetLocalSlot | SetProperty
+        | SetLocalSlotProperty | Pop => -1,
         // Value-preserving: unary ops, by-name lookups/checks, and scope /
         // iterator / exception-handler bookkeeping (the last three touch
         // side stacks, not the operand stack).
@@ -665,8 +666,9 @@ fn op_stack_delta(op: Op, count: u16) -> Option<i32> {
         // `IterInit` consumes the iterable and pushes nothing (the iterator
         // lives on a side stack).
         IterInit => -1,
-        // Pop three (or two values + a by-name target), push one.
-        Slice | SetSubscript => -2,
+        // Net -2: `Slice` pops object/start/end and pushes one value;
+        // subscript stores pop value/index and read the target from bytecode.
+        Slice | SetSubscript | SetLocalSlotSubscript => -2,
         // Variadic whose arity is the emit argument: pop `count`, push one.
         BuildList | Concat | CallBuiltin => 1 - count,
         BuildDict => 1 - 2 * count,
@@ -775,6 +777,23 @@ impl Chunk {
         }
         if op_reads_outer_name(op) {
             self.references_outer_names = true;
+        }
+    }
+
+    /// Emit a local-slot property assignment:
+    /// opcode + u16 property constant index + u16 local slot index.
+    pub fn emit_set_local_slot_property(&mut self, prop_idx: u16, slot: u16, line: u32) {
+        #[cfg(debug_assertions)]
+        self.note_balance(Op::SetLocalSlotProperty, 0);
+        let col = self.current_col;
+        self.code.push(Op::SetLocalSlotProperty as u8);
+        self.code.push((prop_idx >> 8) as u8);
+        self.code.push((prop_idx & 0xFF) as u8);
+        self.code.push((slot >> 8) as u8);
+        self.code.push((slot & 0xFF) as u8);
+        for _ in 0..5 {
+            self.lines.push(line);
+            self.columns.push(col);
         }
     }
 
@@ -1290,6 +1309,21 @@ pub(crate) fn disasm_local_slot_u16(chunk: &Chunk, ip: &mut usize, label: &str) 
     let slot = chunk.read_u16(*ip);
     *ip += 2;
     let mut out = format!("{label} {slot:>4}");
+    if let Some(info) = chunk.local_slots.get(slot as usize) {
+        out.push_str(&format!(" ({})", info.name));
+    }
+    out
+}
+
+pub(crate) fn disasm_const_pool_local_slot(chunk: &Chunk, ip: &mut usize, label: &str) -> String {
+    let prop = chunk.read_u16(*ip);
+    *ip += 2;
+    let slot = chunk.read_u16(*ip);
+    *ip += 2;
+    let mut out = format!(
+        "{label} prop {prop:>4} ({}) slot {slot:>4}",
+        chunk.constants[prop as usize]
+    );
     if let Some(info) = chunk.local_slots.get(slot as usize) {
         out.push_str(&format!(" ({})", info.name));
     }

--- a/crates/harn-vm/src/compiler/statements.rs
+++ b/crates/harn-vm/src/compiler/statements.rs
@@ -76,9 +76,8 @@ impl Compiler {
             }
         } else if let Node::PropertyAccess { object, property } = &target.node {
             if let Node::Identifier(var_name) = &object.node {
-                // Single-level `x.prop (op)= value` — SetProperty reads the
-                // variable, sets the property, and writes it back.
-                let var_idx = self.string_constant(var_name);
+                // Single-level `x.prop (op)= value` can store straight into
+                // a resolved local slot; non-locals keep the env-aware opcode.
                 let prop_idx = self.string_constant(property);
                 if let Some(op) = op {
                     self.compile_node(target)?;
@@ -87,16 +86,22 @@ impl Compiler {
                 } else {
                     self.compile_node(value)?;
                 }
-                // The variable name index is encoded as a second u16.
-                self.chunk.emit_u16(Op::SetProperty, prop_idx, self.line);
-                let hi = (var_idx >> 8) as u8;
-                let lo = var_idx as u8;
-                self.chunk.code.push(hi);
-                self.chunk.code.push(lo);
-                self.chunk.lines.push(self.line);
-                self.chunk.columns.push(self.column);
-                self.chunk.lines.push(self.line);
-                self.chunk.columns.push(self.column);
+                if let Some(binding) = self.resolve_local_slot(var_name) {
+                    self.chunk
+                        .emit_set_local_slot_property(prop_idx, binding.slot, self.line);
+                } else {
+                    // The variable name index is encoded as a second u16.
+                    let var_idx = self.string_constant(var_name);
+                    self.chunk.emit_u16(Op::SetProperty, prop_idx, self.line);
+                    let hi = (var_idx >> 8) as u8;
+                    let lo = var_idx as u8;
+                    self.chunk.code.push(hi);
+                    self.chunk.code.push(lo);
+                    self.chunk.lines.push(self.line);
+                    self.chunk.columns.push(self.column);
+                    self.chunk.lines.push(self.line);
+                    self.chunk.columns.push(self.column);
+                }
             } else {
                 self.compile_path_assignment(target, value, op)?;
             }
@@ -109,7 +114,6 @@ impl Compiler {
                 if op.is_some() && !Self::is_effect_free_index(index) {
                     self.compile_path_assignment(target, value, op)?;
                 } else {
-                    let var_idx = self.string_constant(var_name);
                     if let Some(op) = op {
                         self.compile_node(target)?;
                         self.compile_node(value)?;
@@ -118,7 +122,13 @@ impl Compiler {
                         self.compile_node(value)?;
                     }
                     self.compile_node(index)?;
-                    self.chunk.emit_u16(Op::SetSubscript, var_idx, self.line);
+                    if let Some(binding) = self.resolve_local_slot(var_name) {
+                        self.chunk
+                            .emit_u16(Op::SetLocalSlotSubscript, binding.slot, self.line);
+                    } else {
+                        let var_idx = self.string_constant(var_name);
+                        self.chunk.emit_u16(Op::SetSubscript, var_idx, self.line);
+                    }
                 }
             } else {
                 self.compile_path_assignment(target, value, op)?;

--- a/crates/harn-vm/src/compiler/tests.rs
+++ b/crates/harn-vm/src/compiler/tests.rs
@@ -777,3 +777,48 @@ fn inplace_concat_skips_scalar_compound_assign() {
         "scalar assign should emit a single store, not the in-place doubling:\n{d}"
     );
 }
+
+#[test]
+fn local_property_assignment_uses_slot_opcode() {
+    let chunk = compile_source("pipeline t(task) {\n  var out = {}\n  out.a = 1\n}");
+    let d = chunk.disassemble("t");
+    let opcodes = disasm_opcodes(&d);
+    assert!(
+        opcodes.contains(&"SET_LOCAL_SLOT_PROPERTY"),
+        "local property assignment should store by slot:\n{d}"
+    );
+    assert!(
+        !opcodes.contains(&"SET_PROPERTY"),
+        "slot-resolved local property assignment should skip by-name store:\n{d}"
+    );
+}
+
+#[test]
+fn local_subscript_assignment_uses_slot_opcode() {
+    let chunk = compile_source("pipeline t(task) {\n  var out = {}\n  out[\"a\"] = 1\n}");
+    let d = chunk.disassemble("t");
+    let opcodes = disasm_opcodes(&d);
+    assert!(
+        opcodes.contains(&"SET_LOCAL_SLOT_SUBSCRIPT"),
+        "local subscript assignment should store by slot:\n{d}"
+    );
+    assert!(
+        !opcodes.contains(&"SET_SUBSCRIPT"),
+        "slot-resolved local subscript assignment should skip by-name store:\n{d}"
+    );
+}
+
+#[test]
+fn nonlocal_subscript_assignment_keeps_by_name_opcode() {
+    let chunk = compile_source("var out = {}\npipeline t(task) {\n  out[\"a\"] = 1\n}");
+    let d = chunk.disassemble("t");
+    let opcodes = disasm_opcodes(&d);
+    assert!(
+        opcodes.contains(&"SET_SUBSCRIPT"),
+        "non-local subscript assignment must keep env-aware store:\n{d}"
+    );
+    assert!(
+        !opcodes.contains(&"SET_LOCAL_SLOT_SUBSCRIPT"),
+        "non-local assignment cannot be lowered to a frame-local slot:\n{d}"
+    );
+}

--- a/crates/harn-vm/src/stdlib/json_query.rs
+++ b/crates/harn-vm/src/stdlib/json_query.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use crate::value::{values_equal, VmValue};
+use crate::value::{string_char_count, values_equal, VmValue};
 
 pub(crate) fn eval_jq(input: &VmValue, source: &str) -> Result<Vec<VmValue>, String> {
     let mut parser = Parser::new(source);
@@ -246,7 +246,7 @@ fn collect_recursive(value: &VmValue, out: &mut Vec<VmValue>) {
 fn eval_builtin(builtin: Builtin, input: &VmValue) -> VmValue {
     match builtin {
         Builtin::Length => VmValue::Int(match input {
-            VmValue::String(s) => s.chars().count() as i64,
+            VmValue::String(s) => string_char_count(s) as i64,
             VmValue::Bytes(bytes) => bytes.len() as i64,
             VmValue::List(items) | VmValue::Set(items) => items.len() as i64,
             VmValue::Dict(map) => map.len() as i64,

--- a/crates/harn-vm/src/stdlib/strings.rs
+++ b/crates/harn-vm/src/stdlib/strings.rs
@@ -1,6 +1,6 @@
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
 use crate::value::VmDictExt;
-use crate::value::{values_equal, VmError, VmValue};
+use crate::value::{string_char_count, values_equal, VmError, VmValue};
 use crate::vm::Vm;
 use unicode_normalization::UnicodeNormalization;
 use unicode_segmentation::UnicodeSegmentation;
@@ -487,7 +487,7 @@ fn join_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
 /// of the string. This matches the documented spec `substring(start, end?)`,
 /// the `s[a:b]` slice operator, `list.slice`, and `bytes_slice`.
 pub(crate) fn char_substring(s: &str, start: i64, end: Option<i64>) -> String {
-    let len = s.chars().count() as i64;
+    let len = string_char_count(s) as i64;
     let start = start.clamp(0, len);
     let end = end.unwrap_or(len).clamp(0, len).max(start);
     s.chars()

--- a/crates/harn-vm/src/stdlib/template/filters.rs
+++ b/crates/harn-vm/src/stdlib/template/filters.rs
@@ -1,4 +1,4 @@
-use crate::value::VmValue;
+use crate::value::{string_char_count, VmValue};
 
 use super::error::TemplateError;
 use super::render::{display_value, truthy};
@@ -76,7 +76,7 @@ pub(super) fn apply_filter(
         "length" => {
             need(0, args)?;
             let n: i64 = match v {
-                VmValue::String(s) => s.chars().count() as i64,
+                VmValue::String(s) => string_char_count(s) as i64,
                 VmValue::List(items) => items.len() as i64,
                 VmValue::Set(items) => items.len() as i64,
                 VmValue::Dict(d) => d.len() as i64,

--- a/crates/harn-vm/src/stdlib/types.rs
+++ b/crates/harn-vm/src/stdlib/types.rs
@@ -1,5 +1,5 @@
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
-use crate::value::{VmError, VmValue};
+use crate::value::{string_char_count, VmError, VmValue};
 use crate::vm::Vm;
 
 const I64_FLOAT_UPPER_BOUND_EXCLUSIVE: f64 = 9_223_372_036_854_775_808.0;
@@ -161,7 +161,7 @@ fn to_list_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError>
 )]
 fn len_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     match args.first().unwrap_or(&VmValue::Nil) {
-        VmValue::String(s) => Ok(VmValue::Int(s.chars().count() as i64)),
+        VmValue::String(s) => Ok(VmValue::Int(string_char_count(s) as i64)),
         VmValue::Bytes(bytes) => Ok(VmValue::Int(bytes.len() as i64)),
         VmValue::List(items) => Ok(VmValue::Int(items.len() as i64)),
         VmValue::Dict(map) => Ok(VmValue::Int(map.len() as i64)),

--- a/crates/harn-vm/src/value/core.rs
+++ b/crates/harn-vm/src/value/core.rs
@@ -29,6 +29,19 @@ pub type VmAsyncBuiltinFn = Arc<
 
 type Shared<T> = Arc<T>;
 
+/// Character count with a byte-length fast path for ASCII text.
+///
+/// Harn exposes string lengths as Unicode scalar counts. ASCII is one byte per
+/// scalar, so cached string `count` / `len` paths can avoid a full iterator
+/// scan without changing behavior for non-ASCII text.
+pub fn string_char_count(text: &str) -> usize {
+    if text.is_ascii() {
+        text.len()
+    } else {
+        text.chars().count()
+    }
+}
+
 /// Indexed runtime layout for a Harn struct instance.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructLayout {

--- a/crates/harn-vm/src/value/mod.rs
+++ b/crates/harn-vm/src/value/mod.rs
@@ -9,7 +9,8 @@ pub type VmMutex<T> = parking_lot::Mutex<T>;
 
 pub use build::VmDictExt;
 pub use core::{
-    struct_fields_to_map, StructLayout, VmAsyncBuiltinFn, VmBuiltinFn, VmEnumVariant, VmValue,
+    string_char_count, struct_fields_to_map, StructLayout, VmAsyncBuiltinFn, VmBuiltinFn,
+    VmEnumVariant, VmValue,
 };
 pub use env::{closest_match, ModuleFunctionRegistry, ModuleState, VmClosure, VmEnv};
 pub use error::{

--- a/crates/harn-vm/src/vm/methods/string.rs
+++ b/crates/harn-vm/src/vm/methods/string.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::value::{VmError, VmValue};
+use crate::value::{string_char_count, VmError, VmValue};
 
 impl crate::vm::Vm {
     pub(super) fn call_string_method(
@@ -9,7 +9,7 @@ impl crate::vm::Vm {
         args: &[VmValue],
     ) -> Result<VmValue, VmError> {
         match method {
-            "count" => Ok(VmValue::Int(s.chars().count() as i64)),
+            "count" => Ok(VmValue::Int(string_char_count(s) as i64)),
             "empty" => Ok(VmValue::Bool(s.is_empty())),
             "contains" => Ok(VmValue::Bool(
                 s.contains(&*args.first().map(|a| a.as_str_cow()).unwrap_or_default()),
@@ -68,7 +68,7 @@ impl crate::vm::Vm {
                     .map(|a| a.display())
                     .and_then(|s| s.chars().next())
                     .unwrap_or(' ');
-                let current_len = s.chars().count();
+                let current_len = string_char_count(s);
                 if current_len >= width {
                     Ok(VmValue::String(Arc::clone(s)))
                 } else {
@@ -115,7 +115,7 @@ impl crate::vm::Vm {
             }
             "lower" | "to_lower" => Ok(VmValue::String(std::sync::Arc::from(s.to_lowercase()))),
             "upper" | "to_upper" => Ok(VmValue::String(std::sync::Arc::from(s.to_uppercase()))),
-            "len" => Ok(VmValue::Int(s.chars().count() as i64)),
+            "len" => Ok(VmValue::Int(string_char_count(s) as i64)),
             _ => Err(VmError::Runtime(format!("string has no method `{method}`"))),
         }
     }

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 use crate::chunk::{DirectCallState, DirectCallTarget, InlineCacheEntry, MethodCacheTarget};
 use crate::orchestration::HookEvent;
 use crate::value::{
-    values_equal, DeadlockError, VmClosure, VmError, VmJoinHandle, VmTaskHandle, VmValue,
+    string_char_count, values_equal, DeadlockError, VmClosure, VmError, VmJoinHandle, VmTaskHandle,
+    VmValue,
 };
 use crate::BuiltinId;
 
@@ -376,7 +377,7 @@ impl super::super::Vm {
                 Some(VmValue::Bool(items.iter().any(|v| values_equal(v, needle))))
             }
             (MethodCacheTarget::StringCount, VmValue::String(s)) => {
-                Some(VmValue::Int(s.chars().count() as i64))
+                Some(VmValue::Int(string_char_count(s) as i64))
             }
             (MethodCacheTarget::StringEmpty, VmValue::String(s)) => {
                 Some(VmValue::Bool(s.is_empty()))

--- a/crates/harn-vm/src/vm/ops/collections.rs
+++ b/crates/harn-vm/src/vm/ops/collections.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::chunk::{InlineCacheEntry, PropertyCacheTarget};
-use crate::value::{VmError, VmValue};
+use crate::value::{string_char_count, VmError, VmValue};
 
 /// Resolve a (possibly negative) list-assignment index against `len`, erroring
 /// if it falls outside the list. A negative index counts from the end (`-1` is
@@ -121,7 +121,7 @@ impl super::super::Vm {
                 Some(items.last().cloned().unwrap_or(VmValue::Nil))
             }
             (PropertyCacheTarget::StringCount, VmValue::String(s)) => {
-                Some(VmValue::Int(s.chars().count() as i64))
+                Some(VmValue::Int(string_char_count(s) as i64))
             }
             (PropertyCacheTarget::StringEmpty, VmValue::String(s)) => {
                 Some(VmValue::Bool(s.is_empty()))
@@ -195,7 +195,7 @@ impl super::super::Vm {
                 _ => VmValue::Nil,
             },
             VmValue::String(s) => match name {
-                "count" => VmValue::Int(s.chars().count() as i64),
+                "count" => VmValue::Int(string_char_count(s) as i64),
                 "empty" => VmValue::Bool(s.is_empty()),
                 _ => VmValue::Nil,
             },
@@ -368,7 +368,7 @@ impl super::super::Vm {
                 }
             }
             VmValue::String(s) => {
-                let char_count = s.chars().count() as i64;
+                let char_count = string_char_count(s) as i64;
                 let start = match &start_val {
                     VmValue::Nil => 0i64,
                     VmValue::Int(i) => {
@@ -585,6 +585,106 @@ impl super::super::Vm {
             }
         }
         Ok(())
+    }
+
+    pub(super) fn execute_set_local_slot_property(&mut self) -> Result<(), VmError> {
+        let (chunk, prop_idx, slot_idx) = {
+            let frame = self.frames.last_mut().unwrap();
+            let prop_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            let slot_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            (Arc::clone(&frame.chunk), prop_idx, slot_idx)
+        };
+        let prop_name = Self::const_str(&chunk.constants[prop_idx])?;
+        let new_value = self.pop()?;
+
+        let frame = self.frames.last_mut().unwrap();
+        let Some(info) = frame.chunk.local_slots.get(slot_idx) else {
+            return Err(VmError::Runtime(format!(
+                "Invalid local slot index: {slot_idx}"
+            )));
+        };
+        if !info.mutable {
+            return Err(VmError::ImmutableAssignment(info.name.clone()));
+        }
+        let Some(slot) = frame.local_slots.get_mut(slot_idx) else {
+            return Err(VmError::Runtime(format!(
+                "Invalid local slot index: {slot_idx}"
+            )));
+        };
+        if !slot.initialized {
+            return Err(VmError::UndefinedVariable(info.name.clone()));
+        }
+
+        if let VmValue::Dict(map) = &mut slot.value {
+            Arc::make_mut(map).insert(prop_name.to_string(), new_value);
+            slot.synced = false;
+            return Ok(());
+        }
+
+        if matches!(slot.value, VmValue::StructInstance { .. }) {
+            let next = slot
+                .value
+                .struct_instance_with_property(prop_name, new_value)
+                .expect("struct instance matched above");
+            slot.value = next;
+            slot.synced = false;
+            return Ok(());
+        }
+
+        Err(VmError::TypeError(format!(
+            "cannot set property `{prop_name}` on {}",
+            slot.value.type_name()
+        )))
+    }
+
+    pub(super) fn execute_set_local_slot_subscript(&mut self) -> Result<(), VmError> {
+        let slot_idx = {
+            let frame = self.frames.last_mut().unwrap();
+            let slot_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            slot_idx
+        };
+        let index = self.pop()?;
+        let new_value = self.pop()?;
+
+        let frame = self.frames.last_mut().unwrap();
+        let Some(info) = frame.chunk.local_slots.get(slot_idx) else {
+            return Err(VmError::Runtime(format!(
+                "Invalid local slot index: {slot_idx}"
+            )));
+        };
+        if !info.mutable {
+            return Err(VmError::ImmutableAssignment(info.name.clone()));
+        }
+        let Some(slot) = frame.local_slots.get_mut(slot_idx) else {
+            return Err(VmError::Runtime(format!(
+                "Invalid local slot index: {slot_idx}"
+            )));
+        };
+        if !slot.initialized {
+            return Err(VmError::UndefinedVariable(info.name.clone()));
+        }
+
+        match &mut slot.value {
+            VmValue::List(items) => {
+                let Some(i) = index.as_int() else {
+                    return Err(Self::list_index_type_error(&index));
+                };
+                let idx = resolve_list_assign_index(i, items.len())?;
+                Arc::make_mut(items)[idx] = new_value;
+                slot.synced = false;
+                Ok(())
+            }
+            VmValue::Dict(map) => {
+                let key = index.display();
+                Arc::make_mut(map).insert(key, new_value);
+                slot.synced = false;
+                Ok(())
+            }
+            other => Err(Self::subscript_assign_type_error(other)),
+        }
     }
 
     /// Index-assignment on a list requires an int index — mirrors the read

--- a/crates/harn-vm/src/vm/ops/mod.rs
+++ b/crates/harn-vm/src/vm/ops/mod.rs
@@ -92,6 +92,8 @@ harn_opcode_macros::define_opcodes! {
     GetPropertyOpt { sync(self.execute_get_property(true)), disasm: const_pool_u16("GET_PROPERTY_OPT") };
     SetProperty { sync(self.execute_set_property()), disasm: const_pool_u16("SET_PROPERTY") };
     SetSubscript { sync(self.execute_set_subscript()), disasm: const_pool_u16("SET_SUBSCRIPT") };
+    SetLocalSlotProperty { sync(self.execute_set_local_slot_property()), disasm: const_pool_local_slot("SET_LOCAL_SLOT_PROPERTY") };
+    SetLocalSlotSubscript { sync(self.execute_set_local_slot_subscript()), disasm: local_slot_u16("SET_LOCAL_SLOT_SUBSCRIPT") };
     MethodCall { split(self.execute_method_call_sync(false), self.execute_method_call(false).await), disasm: method_call("METHOD_CALL") };
     MethodCallOpt { split(self.execute_method_call_sync(true), self.execute_method_call(true).await), disasm: method_call("METHOD_CALL_OPT") };
 

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -163,7 +163,7 @@ pub struct Vm {
     pub(crate) builtin_metadata: Arc<BTreeMap<String, VmBuiltinMetadata>>,
     /// Numeric side index for builtins. Name-keyed maps remain authoritative;
     /// this index is the hot path for direct builtin bytecode and callback refs.
-    pub(crate) builtins_by_id: Arc<BTreeMap<BuiltinId, VmBuiltinEntry>>,
+    pub(crate) builtins_by_id: Arc<HashMap<BuiltinId, VmBuiltinEntry>>,
     /// IDs with detected name collisions. Collided names safely fall back to
     /// the authoritative name-keyed lookup path.
     pub(crate) builtin_id_collisions: Arc<HashSet<BuiltinId>>,
@@ -293,7 +293,7 @@ pub struct VmBaseline {
     builtins: Arc<BTreeMap<String, VmBuiltinFn>>,
     async_builtins: Arc<BTreeMap<String, VmAsyncBuiltinFn>>,
     builtin_metadata: Arc<BTreeMap<String, VmBuiltinMetadata>>,
-    builtins_by_id: Arc<BTreeMap<BuiltinId, VmBuiltinEntry>>,
+    builtins_by_id: Arc<HashMap<BuiltinId, VmBuiltinEntry>>,
     builtin_id_collisions: Arc<HashSet<BuiltinId>>,
     source_dir: Option<std::path::PathBuf>,
     source_file: Option<String>,
@@ -516,9 +516,9 @@ impl Vm {
     }
 
     /// Returns the slot index of an initialized active local with the given
-    /// name, walking from innermost to outermost scope. Used by hot paths
-    /// (subscript-store, etc.) that want to mutate the slot value in place
-    /// without paying a defensive `VmValue::clone` first.
+    /// name, walking from innermost to outermost scope. Used by legacy by-name
+    /// hot paths that still want to mutate the slot value in place without
+    /// paying a defensive `VmValue::clone` first.
     pub(crate) fn active_local_slot_index(&self, name: &str) -> Option<usize> {
         let frame = self.frames.last()?;
         for (idx, info) in frame.chunk.local_slots.iter().enumerate().rev() {
@@ -566,7 +566,7 @@ impl Vm {
             builtins: Arc::new(BTreeMap::new()),
             async_builtins: Arc::new(BTreeMap::new()),
             builtin_metadata: Arc::new(BTreeMap::new()),
-            builtins_by_id: Arc::new(BTreeMap::new()),
+            builtins_by_id: Arc::new(HashMap::new()),
             builtin_id_collisions: Arc::new(HashSet::new()),
             iterators: Vec::new(),
             frames: Vec::new(),

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -686,6 +686,20 @@ log("hello".substring(1, 3)) }"#,
 }
 
 #[test]
+fn test_string_length_fast_paths_keep_unicode_scalar_semantics() {
+    let out = run_output(
+        r#"pipeline t(task) {
+log(len("abcd"))
+log(len("é🙂"))
+log("é🙂".count)
+log("é🙂".count())
+log("é🙂".len())
+}"#,
+    );
+    assert_eq!(out, "[harn] 4\n[harn] 2\n[harn] 2\n[harn] 2\n[harn] 2");
+}
+
+#[test]
 fn test_list_properties() {
     let out = run_output(
         "pipeline t(task) { let list = [1, 2, 3]\nlog(list.count)\nlog(list.empty)\nlog(list.first)\nlog(list.last) }",
@@ -1292,6 +1306,21 @@ log(d.count)
 }",
     );
     assert_eq!(out, "[harn] 3");
+}
+
+#[test]
+fn test_slot_subscript_assignment_updates_slot_value() {
+    let out = run_output(
+        r#"pipeline t(task) {
+var d = {}
+d["a"] = 1
+d["b"] = 2
+var xs = [0, 0]
+xs[1] = 3
+log(d.a + d["b"] + xs[1])
+}"#,
+    );
+    assert_eq!(out, "[harn] 6");
 }
 
 // --- Error handling tests ---

--- a/perf/vm/bench_vm_hot_paths.rs
+++ b/perf/vm/bench_vm_hot_paths.rs
@@ -384,6 +384,28 @@ pipeline default(task) {
             runtime,
         ),
         VmHotPathFixture::new(
+            "local_collection_assignment",
+            r#"
+pipeline default(task) {
+  var dict = {}
+  var list = [0, 0, 0, 0]
+  var i = 0
+  var total = 0
+  while i < 2500 {
+    dict["a"] = i
+    dict.b = i + 1
+    list[2] = i
+    total = total + dict["a"] + dict.b + list[2]
+    i = i + 1
+  }
+  if total < 0 {
+    log("unreachable")
+  }
+}
+"#,
+            runtime,
+        ),
+        VmHotPathFixture::new(
             "string_interpolation_many_parts",
             r#"
 pipeline default(task) {


### PR DESCRIPTION
## Summary
- Add slot-addressed VM opcodes for local property and subscript assignment, and lower compiler-resolved locals to them.
- Move the private builtin-id dispatch side table from `BTreeMap` to `HashMap` while keeping name-keyed builtin maps authoritative.
- Add a shared ASCII fast path for Unicode scalar counts used by string `len` / `count` paths, plus a direct local collection assignment microbenchmark.

## Verification
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-perf-toolchain-check cargo check -p harn-vm -p harn-vm-perf`
- `CARGO_TARGET_DIR=/tmp/harn-perf-toolchain-check cargo test -p harn-vm --lib` (3700 passed)
- `CARGO_TARGET_DIR=/tmp/harn-perf-toolchain-target CARGO_PROFILE_BENCH_LTO=false CARGO_PROFILE_BENCH_CODEGEN_UNITS=16 ./scripts/bench_vm_micro.sh --target-dir /tmp/harn-perf-toolchain-target`

## Bench Notes
- First before/after Criterion pass against the original branch state showed `dict_helper_builtins` improving from about 4.20 ms to 3.19 ms and `builtin_reference_lookup` from about 4.70 ms to 1.99 ms. Broader fixtures also moved, so I am treating those broad deltas as directional rather than exact.
- Final warmed run keeps `dict_helper_builtins` near 3.20 ms and records the new `local_collection_assignment` fixture at about 1.09 ms with 7,584 allocations per iteration.
