### PR TITLE
docs: fix broken trust-boundary link and clarify installer dir selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ curl -fsSL https://harnlang.com/install.sh | sh
 Detects OS/CPU, downloads the matching signed binary for the current
 [GitHub release](https://github.com/burin-labs/harn/releases),
 verifies it against the release's `SHA256SUMS` manifest, and installs
-`harn`, `harn-dap`, and `harn-lsp` into the first writable directory
-among `$HARN_INSTALL_DIR`, `$XDG_BIN_DIR`, `$HOME/bin`,
-`$HOME/.local/bin`, or `$HOME/.harn/bin`. macOS binaries are notarized.
+`harn`, `harn-dap`, and `harn-lsp`. It honors `$HARN_INSTALL_DIR` or
+`$XDG_BIN_DIR` when set, otherwise uses `$HOME/bin` or `$HOME/.local/bin`
+when one already exists and is on `PATH`, and falls back to creating
+`$HOME/.harn/bin`. macOS binaries are notarized.
 To upgrade later: `harn upgrade`.
 
 With Cargo:

--- a/crates/harn-hostlib/README.md
+++ b/crates/harn-hostlib/README.md
@@ -183,7 +183,7 @@ ask for it.
 Conversely, the work that *does* belong in `harn-vm` — orchestration,
 transcript lifecycle, replay/eval, mutation session audit metadata —
 stays there. See
-[`AGENTS.md`](../../CLAUDE.md#trust-boundary) for the canonical trust
+[`AGENTS.md`](../../AGENTS.md#trust-boundary) for the canonical trust
 boundary.
 
 ## Scanner host capability


### PR DESCRIPTION
Two small, verified documentation fixes.

## `crates/harn-hostlib/README.md` — broken trust-boundary link
The link rendered as `AGENTS.md` but pointed at `../../CLAUDE.md#trust-boundary`. `CLAUDE.md` is only a redirect stub (`Use AGENTS.md as the canonical repo guidance`) and has no `## Trust boundary` section, so the anchor went nowhere. `AGENTS.md` is the canonical file and contains that section. Repointed the link to `../../AGENTS.md#trust-boundary`.

## `README.md` — installer directory selection
The README said the installer drops binaries into "the first writable directory among `$HARN_INSTALL_DIR`, `$XDG_BIN_DIR`, `$HOME/bin`, `$HOME/.local/bin`, or `$HOME/.harn/bin`." That mis-describes `install.sh`: `$HOME/bin` and `$HOME/.local/bin` are only chosen when they **already exist and are on `PATH`** (writability isn't the gate); otherwise it falls back to creating `$HOME/.harn/bin`. Reworded to match the actual logic.

## Verification
`npx markdownlint-cli2@0.22.1` on both changed files: 0 errors.

https://claude.ai/code/session_01KNGgEjq7vSaaV1LWnH3hgD

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNGgEjq7vSaaV1LWnH3hgD)_