### PR TITLE
fix(stdlib): trim cookie name/value in parse_set_cookie before validation

### DIFF
--- a/changelog.d/3297.fixed.md
+++ b/changelog.d/3297.fixed.md
@@ -1,0 +1,5 @@
+- **`parse_set_cookie` now trims whitespace around the cookie name and value
+  before validation (#3297).** A `Set-Cookie: name = value` header was
+  previously dropped entirely (the un-trimmed `name ` failed `valid_cookie_name`)
+  and parsed values kept a stray leading space, diverging from the
+  `Cookie`-header parser, which already trims both sides.

--- a/crates/harn-vm/src/stdlib/cookies.rs
+++ b/crates/harn-vm/src/stdlib/cookies.rs
@@ -786,8 +786,8 @@ mod tests {
     fn parse_set_cookie_trims_name_before_validation() {
         // Whitespace around the name (`name = value`) must not cause the whole
         // Set-Cookie to be dropped, matching `parse_cookie_header_value`.
-        let (name, value, delete) =
-            parse_set_cookie("sid = abc; Path=/").expect("whitespace around name should still parse");
+        let (name, value, delete) = parse_set_cookie("sid = abc; Path=/")
+            .expect("whitespace around name should still parse");
         assert_eq!(name, "sid");
         assert_eq!(value, "abc");
         assert!(!delete);
@@ -795,8 +795,7 @@ mod tests {
 
     #[test]
     fn parse_set_cookie_flags_expired_max_age_as_delete() {
-        let (name, _value, delete) =
-            parse_set_cookie("sid=abc; Max-Age=0").expect("should parse");
+        let (name, _value, delete) = parse_set_cookie("sid=abc; Max-Age=0").expect("should parse");
         assert_eq!(name, "sid");
         assert!(delete);
     }

--- a/crates/harn-vm/src/stdlib/cookies.rs
+++ b/crates/harn-vm/src/stdlib/cookies.rs
@@ -603,6 +603,12 @@ fn parse_set_cookie(header: &str) -> Option<(String, String, bool)> {
     let mut segments = header.split(';');
     let first = segments.next()?.trim_matches(|ch| ch == ' ' || ch == '\t');
     let (name, value) = first.split_once('=')?;
+    // Trim optional whitespace around the name/value, the same way
+    // `parse_cookie_header_value` does — `valid_cookie_name` rejects spaces, so
+    // without this a `name = value` pair would be dropped entirely (and the
+    // value would keep a stray leading space).
+    let name = name.trim_matches(|ch| ch == ' ' || ch == '\t');
+    let value = value.trim_matches(|ch| ch == ' ' || ch == '\t');
     if !valid_cookie_name(name) {
         return None;
     }
@@ -771,3 +777,27 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
     &SESSION_FROM_COOKIES_IMPL_DEF,
     &COOKIE_ROUND_TRIP_IMPL_DEF,
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::parse_set_cookie;
+
+    #[test]
+    fn parse_set_cookie_trims_name_before_validation() {
+        // Whitespace around the name (`name = value`) must not cause the whole
+        // Set-Cookie to be dropped, matching `parse_cookie_header_value`.
+        let (name, value, delete) =
+            parse_set_cookie("sid = abc; Path=/").expect("whitespace around name should still parse");
+        assert_eq!(name, "sid");
+        assert_eq!(value, "abc");
+        assert!(!delete);
+    }
+
+    #[test]
+    fn parse_set_cookie_flags_expired_max_age_as_delete() {
+        let (name, _value, delete) =
+            parse_set_cookie("sid=abc; Max-Age=0").expect("should parse");
+        assert_eq!(name, "sid");
+        assert!(delete);
+    }
+}


### PR DESCRIPTION
Part of a cross-repo bug-fix pass (companion: burin-labs/burin-code#2319).

## Fix
`parse_set_cookie` split the first `Set-Cookie` segment on `=` but, unlike its sibling `parse_cookie_header_value`, never trimmed the resulting name/value:

```rust
let (name, value) = first.split_once('=')?;
if !valid_cookie_name(name) { return None; }   // name may be "sid " → rejected
```

Because `valid_cookie_name` rejects spaces, a `name = value` Set-Cookie was **dropped entirely**, and a successfully-parsed value kept a stray leading space. `parse_cookie_header_value` already trims both sides before validating — this aligns `parse_set_cookie` with that contract.

## Change
- Trim leading/trailing spaces/tabs from both `name` and `value` before validation (matching the sibling parser).
- Added unit tests covering the whitespace-around-name case and the expired `Max-Age` delete case (`cargo test -p harn-vm --lib stdlib::cookies` — both pass).

No behavior change for well-formed headers (the existing conformance `Set-Cookie` strings have no whitespace around `=`).

https://claude.ai/code/session_014ArWvbEcYZNCi3YfVusjHL

---
_Generated by [Claude Code](https://claude.ai/code/session_014ArWvbEcYZNCi3YfVusjHL)_