### PR TITLE
feat(llm): add Moonshot, DeepInfra, and SambaNova providers

### DIFF
--- a/changelog.d/moonshot-deepinfra-sambanova.added.md
+++ b/changelog.d/moonshot-deepinfra-sambanova.added.md
@@ -1,0 +1,5 @@
+- Added three OpenAI-compatible LLM providers to the bundled catalog:
+  `moonshot` (first-party Kimi K2 host), `deepinfra` (open-weight host), and
+  `sambanova` (fast RDU inference). Each ships catalog rows, capability matrix
+  entries, and short aliases (`kimi-direct`/`moonshot-kimi-k2.7-code`,
+  `deepinfra-deepseek`/`deepinfra-qwen3.6`, `sambanova-deepseek`/`sambanova-llama`).

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -174,6 +174,15 @@ top_k_supported = false
 [provider_defaults.xai]
 top_k_supported = false
 
+[provider_defaults.moonshot]
+top_k_supported = false
+
+[provider_defaults.deepinfra]
+top_k_supported = false
+
+[provider_defaults.sambanova]
+top_k_supported = false
+
 # --- source: 20-providers/00-anthropic.toml ---
 # ---------- Anthropic (Claude) ------------------------------------------------
 
@@ -2000,6 +2009,158 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
+
+# --- source: 20-providers/35-moonshot.toml ---
+# ---------- Moonshot AI — direct Kimi K2 (OpenAI-compatible /v1) -------------
+# Moonshot's first-party API serves the Kimi K2 family with reliable native
+# tool calls, an inline thinking mode, prompt caching, and multimodal input.
+# K2.7 Code additionally accepts video. Catalog keys are `moonshot/<wire>`
+# (e.g. `moonshot/kimi-k2.6`), so the patterns match the `*kimi*` substring
+# to cover both the prefixed catalog key and the bare wire id.
+
+[[provider.moonshot]]
+model_match = "*kimi-k2.7-code*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+vision = true
+vision_supported = true
+video_supported = true
+prompt_caching = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.moonshot]]
+model_match = "*kimi*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+vision = true
+vision_supported = true
+prompt_caching = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+# --- source: 20-providers/36-deepinfra.toml ---
+# ---------- DeepInfra — open-weight OpenAI-compatible host -------------------
+# DeepInfra serves open weights (DeepSeek, Qwen, Llama, Kimi, GPT-OSS) on a
+# standard OpenAI chat-completions surface with native tool calls. Reasoning
+# families expose an inline thinking trace; DeepSeek routes honor prompt
+# caching. Catalog keys are `deepinfra/<hf-id>`, so patterns match the
+# family substring.
+
+[[provider.deepinfra]]
+model_match = "*deepseek*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+prompt_caching = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.deepinfra]]
+model_match = "*qwen3.6*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+vision = true
+vision_supported = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.deepinfra]]
+model_match = "*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "none"
+
+# --- source: 20-providers/37-sambanova.toml ---
+# ---------- SambaNova Cloud — fast RDU OpenAI-compatible inference -----------
+# SambaNova serves large open weights (DeepSeek, Llama 4, Qwen) at high
+# throughput on an OpenAI chat-completions surface with native tool calls.
+# DeepSeek reasoning routes expose an inline thinking trace; Llama 4 routes
+# are non-thinking multimodal. Catalog keys are `sambanova/<wire>`.
+
+[[provider.sambanova]]
+model_match = "*deepseek*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.sambanova]]
+model_match = "*llama*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+vision = true
+vision_supported = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "none"
+
+[[provider.sambanova]]
+model_match = "*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "none"
 
 # --- source: 20-providers/40-deepseek-reasoning.toml ---
 # ---------- DeepSeek reasoning (across host providers) -----------------------

--- a/crates/harn-vm/src/llm/capability_sources/10-defaults/provider-defaults.toml
+++ b/crates/harn-vm/src/llm/capability_sources/10-defaults/provider-defaults.toml
@@ -43,3 +43,12 @@ top_k_supported = false
 [provider_defaults.xai]
 top_k_supported = false
 
+[provider_defaults.moonshot]
+top_k_supported = false
+
+[provider_defaults.deepinfra]
+top_k_supported = false
+
+[provider_defaults.sambanova]
+top_k_supported = false
+

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/35-moonshot.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/35-moonshot.toml
@@ -1,0 +1,43 @@
+# ---------- Moonshot AI — direct Kimi K2 (OpenAI-compatible /v1) -------------
+# Moonshot's first-party API serves the Kimi K2 family with reliable native
+# tool calls, an inline thinking mode, prompt caching, and multimodal input.
+# K2.7 Code additionally accepts video. Catalog keys are `moonshot/<wire>`
+# (e.g. `moonshot/kimi-k2.6`), so the patterns match the `*kimi*` substring
+# to cover both the prefixed catalog key and the bare wire id.
+
+[[provider.moonshot]]
+model_match = "*kimi-k2.7-code*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+vision = true
+vision_supported = true
+video_supported = true
+prompt_caching = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.moonshot]]
+model_match = "*kimi*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+vision = true
+vision_supported = true
+prompt_caching = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/36-deepinfra.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/36-deepinfra.toml
@@ -1,0 +1,53 @@
+# ---------- DeepInfra — open-weight OpenAI-compatible host -------------------
+# DeepInfra serves open weights (DeepSeek, Qwen, Llama, Kimi, GPT-OSS) on a
+# standard OpenAI chat-completions surface with native tool calls. Reasoning
+# families expose an inline thinking trace; DeepSeek routes honor prompt
+# caching. Catalog keys are `deepinfra/<hf-id>`, so patterns match the
+# family substring.
+
+[[provider.deepinfra]]
+model_match = "*deepseek*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+prompt_caching = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.deepinfra]]
+model_match = "*qwen3.6*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+vision = true
+vision_supported = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.deepinfra]]
+model_match = "*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "none"

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/37-sambanova.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/37-sambanova.toml
@@ -1,0 +1,50 @@
+# ---------- SambaNova Cloud — fast RDU OpenAI-compatible inference -----------
+# SambaNova serves large open weights (DeepSeek, Llama 4, Qwen) at high
+# throughput on an OpenAI chat-completions surface with native tool calls.
+# DeepSeek reasoning routes expose an inline thinking trace; Llama 4 routes
+# are non-thinking multimodal. Catalog keys are `sambanova/<wire>`.
+
+[[provider.sambanova]]
+model_match = "*deepseek*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["enabled"]
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "inline"
+
+[[provider.sambanova]]
+model_match = "*llama*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+vision = true
+vision_supported = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "none"
+
+[[provider.sambanova]]
+model_match = "*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "none"

--- a/crates/harn-vm/src/llm/catalog_sources/10-providers/all.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/10-providers/all.toml
@@ -285,6 +285,72 @@ latency_p50_ms = 1900
 method = "GET"
 path = "/models"
 
+# Moonshot AI — first-party host of the Kimi K2 family. OpenAI-compatible
+# `/v1/chat/completions`; the same models were previously only reachable
+# through OpenRouter/Together aggregator routes. Moonshot also exposes an
+# Anthropic-compatible `/anthropic` surface, but Harn dials the
+# OpenAI-compatible endpoint so the shared openai_chat_completions wire
+# format Just Works. Use the `.cn` base via MOONSHOT_BASE_URL for the
+# China region.
+[providers.moonshot]
+base_url = "https://api.moonshot.ai/v1"
+base_url_env = "MOONSHOT_BASE_URL"
+auth_style = "bearer"
+auth_env = ["MOONSHOT_API_KEY", "KIMI_API_KEY"]
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+cost_per_1k_in = 0.0006
+cost_per_1k_out = 0.0025
+latency_p50_ms = 1900
+features = ["native_tools", "reasoning", "prompt_caching"]
+
+[providers.moonshot.healthcheck]
+method = "GET"
+path = "/models"
+
+# DeepInfra — OpenAI-compatible host for open-weight models (DeepSeek,
+# Qwen, Llama, Kimi, GPT-OSS, Gemma). The compat surface lives under the
+# `/v1/openai` path prefix, so the base_url carries it and chat_endpoint
+# stays the standard `/chat/completions`. Catalog rows are keyed with a
+# `deepinfra/<hf-id>` prefix and carry `wire_model` so they stay
+# collision-free with the bare/openrouter ids for the same weights.
+[providers.deepinfra]
+base_url = "https://api.deepinfra.com/v1/openai"
+base_url_env = "DEEPINFRA_BASE_URL"
+auth_style = "bearer"
+auth_env = ["DEEPINFRA_API_KEY", "DEEPINFRA_TOKEN"]
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+cost_per_1k_in = 0.0002
+cost_per_1k_out = 0.0006
+latency_p50_ms = 1500
+features = ["native_tools"]
+
+[providers.deepinfra.healthcheck]
+method = "GET"
+path = "/models"
+
+# SambaNova Cloud — OpenAI-compatible RDU-hosted inference with very high
+# token throughput on large open-weight models (DeepSeek, Llama 4, Qwen).
+# A latency-budgeted executor target alongside Groq/Cerebras with a
+# different model mix. Catalog rows use a `sambanova/<wire-id>` prefix +
+# `wire_model` so they don't collide with other hosts of the same weights.
+[providers.sambanova]
+base_url = "https://api.sambanova.ai/v1"
+base_url_env = "SAMBANOVA_BASE_URL"
+auth_style = "bearer"
+auth_env = "SAMBANOVA_API_KEY"
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+cost_per_1k_in = 0.0006
+cost_per_1k_out = 0.0012
+latency_p50_ms = 350
+features = ["native_tools"]
+
+[providers.sambanova.healthcheck]
+method = "GET"
+path = "/models"
+
 # AWS Bedrock — resolves credentials through env, profile, container, or
 # EC2 instance roles, then signs Converse API calls with SigV4.
 [providers.bedrock]

--- a/crates/harn-vm/src/llm/catalog_sources/30-aliases/aliases.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/30-aliases/aliases.toml
@@ -125,6 +125,45 @@ provider = "openrouter"
 id = "moonshotai/kimi-k2.7-code"
 provider = "openrouter"
 
+# Kimi via Moonshot's first-party API. Native tool calls are reliable on
+# the direct route, so pin `native`.
+[aliases."kimi-direct"]
+id = "moonshot/kimi-k2.6"
+provider = "moonshot"
+tool_format = "native"
+
+[aliases."moonshot-kimi"]
+id = "moonshot/kimi-k2.6"
+provider = "moonshot"
+tool_format = "native"
+
+[aliases."moonshot-kimi-k2.7-code"]
+id = "moonshot/kimi-k2.7-code"
+provider = "moonshot"
+tool_format = "native"
+
+# DeepInfra — open-weight OpenAI-compatible host.
+[aliases."deepinfra-deepseek"]
+id = "deepinfra/deepseek-ai/DeepSeek-V4-Pro"
+provider = "deepinfra"
+tool_format = "native"
+
+[aliases."deepinfra-qwen3.6"]
+id = "deepinfra/Qwen/Qwen3.6-35B-A3B"
+provider = "deepinfra"
+tool_format = "native"
+
+# SambaNova Cloud — fast RDU inference.
+[aliases."sambanova-deepseek"]
+id = "sambanova/DeepSeek-V4-Pro"
+provider = "sambanova"
+tool_format = "native"
+
+[aliases."sambanova-llama"]
+id = "sambanova/Llama-4-Maverick"
+provider = "sambanova"
+tool_format = "native"
+
 # Qwen 3.7 via OpenRouter/Together. Keep bare aliases on OpenRouter because it
 # exposes both Max and Plus; Together currently serves only Max.
 [aliases."qwen3.7"]

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/95-moonshot-deepinfra-sambanova.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/95-moonshot-deepinfra-sambanova.toml
@@ -1,0 +1,112 @@
+# Direct first-party / fast-inference routes for models that were
+# previously only reachable through aggregator providers.
+#
+# Each row is keyed by a `provider/<wire-id>` selector so it stays
+# collision-free with the same weights hosted elsewhere (e.g. the
+# OpenRouter/Together `moonshotai/kimi-k2.6` rows). `normalize_model_id`
+# strips the leading known-provider segment, and `wire_model` records the
+# exact id sent on the wire for clarity.
+#
+# Structure note: this fragment opens with a `[models.X]` header (not a
+# bare defaults block) so it does not collide with the trailing defaults
+# block of the preceding fragment. Each model's `tier`/`open_weight`/
+# `strengths`/`complementary_with` defaults trail its own table.
+
+# ---------- Moonshot AI — direct Kimi K2 routes -------------------------------
+[models."moonshot/kimi-k2.6"]
+name = "Kimi K2.6 (Moonshot direct)"
+provider = "moonshot"
+wire_model = "kimi-k2.6"
+logical_model = "moonshot-kimi-k2.6"
+equivalence_group = "moonshot-kimi-k2.6"
+served_variant = "moonshot-direct"
+api_dialect = "openai_chat"
+context_window = 262144
+capabilities = ["tools", "vision", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.60, output_per_mtok = 2.50, cache_read_per_mtok = 0.15 }
+tier = "frontier"
+open_weight = true
+strengths = ["coding", "agentic", "long_context", "tool_use", "reasoning", "vision"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "deepseek"]
+
+[models."moonshot/kimi-k2.7-code"]
+name = "Kimi K2.7 Code (Moonshot direct)"
+provider = "moonshot"
+wire_model = "kimi-k2.7-code"
+logical_model = "moonshot-kimi-k2.7-code"
+equivalence_group = "moonshot-kimi-k2.7-code"
+served_variant = "moonshot-direct"
+api_dialect = "openai_chat"
+context_window = 262144
+capabilities = ["tools", "vision", "video", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.80, output_per_mtok = 3.20, cache_read_per_mtok = 0.20 }
+tier = "frontier"
+open_weight = true
+strengths = ["coding", "agentic", "long_context", "tool_use", "reasoning", "vision"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "deepseek"]
+
+# ---------- DeepInfra — open-weight OpenAI-compatible host --------------------
+[models."deepinfra/deepseek-ai/DeepSeek-V4-Pro"]
+name = "DeepSeek V4 Pro (DeepInfra)"
+provider = "deepinfra"
+wire_model = "deepseek-ai/DeepSeek-V4-Pro"
+logical_model = "deepseek-v4-pro"
+equivalence_group = "deepseek-v4-pro"
+served_variant = "deepinfra"
+api_dialect = "openai_chat"
+context_window = 163840
+capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.50, output_per_mtok = 1.50 }
+tier = "frontier"
+open_weight = true
+strengths = ["reasoning", "coding", "tool_use", "long_context", "cheap"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "kimi"]
+
+[models."deepinfra/Qwen/Qwen3.6-35B-A3B"]
+name = "Qwen3.6 35B A3B (DeepInfra)"
+provider = "deepinfra"
+wire_model = "Qwen/Qwen3.6-35B-A3B"
+logical_model = "qwen3.6-35b-a3b"
+equivalence_group = "qwen3.6-35b-a3b"
+served_variant = "deepinfra"
+api_dialect = "openai_chat"
+context_window = 262144
+capabilities = ["tools", "vision", "streaming", "thinking"]
+pricing = { input_per_mtok = 0.10, output_per_mtok = 0.30 }
+tier = "mid"
+open_weight = true
+strengths = ["coding", "agentic", "tool_use", "long_context", "cheap", "vision"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "deepseek", "kimi"]
+
+# ---------- SambaNova Cloud — fast RDU inference ------------------------------
+[models."sambanova/DeepSeek-V4-Pro"]
+name = "DeepSeek V4 Pro (SambaNova)"
+provider = "sambanova"
+wire_model = "DeepSeek-V4-Pro"
+logical_model = "deepseek-v4-pro"
+equivalence_group = "deepseek-v4-pro"
+served_variant = "sambanova-rdu"
+api_dialect = "openai_chat"
+context_window = 163840
+capabilities = ["tools", "streaming", "thinking"]
+pricing = { input_per_mtok = 0.60, output_per_mtok = 1.20 }
+tier = "frontier"
+open_weight = true
+strengths = ["speed", "reasoning", "coding", "tool_use", "long_context"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "kimi"]
+
+[models."sambanova/Llama-4-Maverick"]
+name = "Llama 4 Maverick (SambaNova)"
+provider = "sambanova"
+wire_model = "Llama-4-Maverick-17B-128E-Instruct"
+logical_model = "llama-4-maverick"
+equivalence_group = "llama-4-maverick"
+served_variant = "sambanova-rdu"
+api_dialect = "openai_chat"
+context_window = 131072
+capabilities = ["tools", "vision", "streaming"]
+pricing = { input_per_mtok = 0.63, output_per_mtok = 1.80 }
+tier = "mid"
+open_weight = true
+strengths = ["speed", "vision", "tool_use", "long_context", "cheap"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "deepseek", "kimi"]

--- a/crates/harn-vm/src/llm/provider.rs
+++ b/crates/harn-vm/src/llm/provider.rs
@@ -208,6 +208,9 @@ pub(crate) fn register_default_providers() {
             "dashscope",
             "minimax",
             "zai",
+            "moonshot",
+            "deepinfra",
+            "sambanova",
         ] {
             names.insert(name.to_string());
         }

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -316,6 +316,72 @@ latency_p50_ms = 1900
 method = "GET"
 path = "/models"
 
+# Moonshot AI — first-party host of the Kimi K2 family. OpenAI-compatible
+# `/v1/chat/completions`; the same models were previously only reachable
+# through OpenRouter/Together aggregator routes. Moonshot also exposes an
+# Anthropic-compatible `/anthropic` surface, but Harn dials the
+# OpenAI-compatible endpoint so the shared openai_chat_completions wire
+# format Just Works. Use the `.cn` base via MOONSHOT_BASE_URL for the
+# China region.
+[providers.moonshot]
+base_url = "https://api.moonshot.ai/v1"
+base_url_env = "MOONSHOT_BASE_URL"
+auth_style = "bearer"
+auth_env = ["MOONSHOT_API_KEY", "KIMI_API_KEY"]
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+cost_per_1k_in = 0.0006
+cost_per_1k_out = 0.0025
+latency_p50_ms = 1900
+features = ["native_tools", "reasoning", "prompt_caching"]
+
+[providers.moonshot.healthcheck]
+method = "GET"
+path = "/models"
+
+# DeepInfra — OpenAI-compatible host for open-weight models (DeepSeek,
+# Qwen, Llama, Kimi, GPT-OSS, Gemma). The compat surface lives under the
+# `/v1/openai` path prefix, so the base_url carries it and chat_endpoint
+# stays the standard `/chat/completions`. Catalog rows are keyed with a
+# `deepinfra/<hf-id>` prefix and carry `wire_model` so they stay
+# collision-free with the bare/openrouter ids for the same weights.
+[providers.deepinfra]
+base_url = "https://api.deepinfra.com/v1/openai"
+base_url_env = "DEEPINFRA_BASE_URL"
+auth_style = "bearer"
+auth_env = ["DEEPINFRA_API_KEY", "DEEPINFRA_TOKEN"]
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+cost_per_1k_in = 0.0002
+cost_per_1k_out = 0.0006
+latency_p50_ms = 1500
+features = ["native_tools"]
+
+[providers.deepinfra.healthcheck]
+method = "GET"
+path = "/models"
+
+# SambaNova Cloud — OpenAI-compatible RDU-hosted inference with very high
+# token throughput on large open-weight models (DeepSeek, Llama 4, Qwen).
+# A latency-budgeted executor target alongside Groq/Cerebras with a
+# different model mix. Catalog rows use a `sambanova/<wire-id>` prefix +
+# `wire_model` so they don't collide with other hosts of the same weights.
+[providers.sambanova]
+base_url = "https://api.sambanova.ai/v1"
+base_url_env = "SAMBANOVA_BASE_URL"
+auth_style = "bearer"
+auth_env = "SAMBANOVA_API_KEY"
+chat_endpoint = "/chat/completions"
+completion_endpoint = "/completions"
+cost_per_1k_in = 0.0006
+cost_per_1k_out = 0.0012
+latency_p50_ms = 350
+features = ["native_tools"]
+
+[providers.sambanova.healthcheck]
+method = "GET"
+path = "/models"
+
 # AWS Bedrock — resolves credentials through env, profile, container, or
 # EC2 instance roles, then signs Converse API calls with SigV4.
 [providers.bedrock]
@@ -722,6 +788,45 @@ provider = "openrouter"
 [aliases."openrouter-kimi-k2.7-code"]
 id = "moonshotai/kimi-k2.7-code"
 provider = "openrouter"
+
+# Kimi via Moonshot's first-party API. Native tool calls are reliable on
+# the direct route, so pin `native`.
+[aliases."kimi-direct"]
+id = "moonshot/kimi-k2.6"
+provider = "moonshot"
+tool_format = "native"
+
+[aliases."moonshot-kimi"]
+id = "moonshot/kimi-k2.6"
+provider = "moonshot"
+tool_format = "native"
+
+[aliases."moonshot-kimi-k2.7-code"]
+id = "moonshot/kimi-k2.7-code"
+provider = "moonshot"
+tool_format = "native"
+
+# DeepInfra — open-weight OpenAI-compatible host.
+[aliases."deepinfra-deepseek"]
+id = "deepinfra/deepseek-ai/DeepSeek-V4-Pro"
+provider = "deepinfra"
+tool_format = "native"
+
+[aliases."deepinfra-qwen3.6"]
+id = "deepinfra/Qwen/Qwen3.6-35B-A3B"
+provider = "deepinfra"
+tool_format = "native"
+
+# SambaNova Cloud — fast RDU inference.
+[aliases."sambanova-deepseek"]
+id = "sambanova/DeepSeek-V4-Pro"
+provider = "sambanova"
+tool_format = "native"
+
+[aliases."sambanova-llama"]
+id = "sambanova/Llama-4-Maverick"
+provider = "sambanova"
+tool_format = "native"
 
 # Qwen 3.7 via OpenRouter/Together. Keep bare aliases on OpenRouter because it
 # exposes both Max and Plus; Together currently serves only Max.
@@ -2227,3 +2332,117 @@ rate_limits = { rpm = 1800, tpm = 10000000, tier = "us-east-1", source_url = "ht
 tier = "frontier"
 open_weight = false
 strengths = ["coding", "agentic", "tool_use", "reasoning", "vision"]
+
+# --- source: 60-models/95-moonshot-deepinfra-sambanova.toml ---
+# Direct first-party / fast-inference routes for models that were
+# previously only reachable through aggregator providers.
+#
+# Each row is keyed by a `provider/<wire-id>` selector so it stays
+# collision-free with the same weights hosted elsewhere (e.g. the
+# OpenRouter/Together `moonshotai/kimi-k2.6` rows). `normalize_model_id`
+# strips the leading known-provider segment, and `wire_model` records the
+# exact id sent on the wire for clarity.
+#
+# Structure note: this fragment opens with a `[models.X]` header (not a
+# bare defaults block) so it does not collide with the trailing defaults
+# block of the preceding fragment. Each model's `tier`/`open_weight`/
+# `strengths`/`complementary_with` defaults trail its own table.
+
+# ---------- Moonshot AI — direct Kimi K2 routes -------------------------------
+[models."moonshot/kimi-k2.6"]
+name = "Kimi K2.6 (Moonshot direct)"
+provider = "moonshot"
+wire_model = "kimi-k2.6"
+logical_model = "moonshot-kimi-k2.6"
+equivalence_group = "moonshot-kimi-k2.6"
+served_variant = "moonshot-direct"
+api_dialect = "openai_chat"
+context_window = 262144
+capabilities = ["tools", "vision", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.60, output_per_mtok = 2.50, cache_read_per_mtok = 0.15 }
+tier = "frontier"
+open_weight = true
+strengths = ["coding", "agentic", "long_context", "tool_use", "reasoning", "vision"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "deepseek"]
+
+[models."moonshot/kimi-k2.7-code"]
+name = "Kimi K2.7 Code (Moonshot direct)"
+provider = "moonshot"
+wire_model = "kimi-k2.7-code"
+logical_model = "moonshot-kimi-k2.7-code"
+equivalence_group = "moonshot-kimi-k2.7-code"
+served_variant = "moonshot-direct"
+api_dialect = "openai_chat"
+context_window = 262144
+capabilities = ["tools", "vision", "video", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.80, output_per_mtok = 3.20, cache_read_per_mtok = 0.20 }
+tier = "frontier"
+open_weight = true
+strengths = ["coding", "agentic", "long_context", "tool_use", "reasoning", "vision"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "deepseek"]
+
+# ---------- DeepInfra — open-weight OpenAI-compatible host --------------------
+[models."deepinfra/deepseek-ai/DeepSeek-V4-Pro"]
+name = "DeepSeek V4 Pro (DeepInfra)"
+provider = "deepinfra"
+wire_model = "deepseek-ai/DeepSeek-V4-Pro"
+logical_model = "deepseek-v4-pro"
+equivalence_group = "deepseek-v4-pro"
+served_variant = "deepinfra"
+api_dialect = "openai_chat"
+context_window = 163840
+capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
+pricing = { input_per_mtok = 0.50, output_per_mtok = 1.50 }
+tier = "frontier"
+open_weight = true
+strengths = ["reasoning", "coding", "tool_use", "long_context", "cheap"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "kimi"]
+
+[models."deepinfra/Qwen/Qwen3.6-35B-A3B"]
+name = "Qwen3.6 35B A3B (DeepInfra)"
+provider = "deepinfra"
+wire_model = "Qwen/Qwen3.6-35B-A3B"
+logical_model = "qwen3.6-35b-a3b"
+equivalence_group = "qwen3.6-35b-a3b"
+served_variant = "deepinfra"
+api_dialect = "openai_chat"
+context_window = 262144
+capabilities = ["tools", "vision", "streaming", "thinking"]
+pricing = { input_per_mtok = 0.10, output_per_mtok = 0.30 }
+tier = "mid"
+open_weight = true
+strengths = ["coding", "agentic", "tool_use", "long_context", "cheap", "vision"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "deepseek", "kimi"]
+
+# ---------- SambaNova Cloud — fast RDU inference ------------------------------
+[models."sambanova/DeepSeek-V4-Pro"]
+name = "DeepSeek V4 Pro (SambaNova)"
+provider = "sambanova"
+wire_model = "DeepSeek-V4-Pro"
+logical_model = "deepseek-v4-pro"
+equivalence_group = "deepseek-v4-pro"
+served_variant = "sambanova-rdu"
+api_dialect = "openai_chat"
+context_window = 163840
+capabilities = ["tools", "streaming", "thinking"]
+pricing = { input_per_mtok = 0.60, output_per_mtok = 1.20 }
+tier = "frontier"
+open_weight = true
+strengths = ["speed", "reasoning", "coding", "tool_use", "long_context"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "qwen", "kimi"]
+
+[models."sambanova/Llama-4-Maverick"]
+name = "Llama 4 Maverick (SambaNova)"
+provider = "sambanova"
+wire_model = "Llama-4-Maverick-17B-128E-Instruct"
+logical_model = "llama-4-maverick"
+equivalence_group = "llama-4-maverick"
+served_variant = "sambanova-rdu"
+api_dialect = "openai_chat"
+context_window = 131072
+capabilities = ["tools", "vision", "streaming"]
+pricing = { input_per_mtok = 0.63, output_per_mtok = 1.80 }
+tier = "mid"
+open_weight = true
+strengths = ["speed", "vision", "tool_use", "long_context", "cheap"]
+complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "deepseek", "kimi"]

--- a/docs/provider-support.json
+++ b/docs/provider-support.json
@@ -330,6 +330,59 @@
       "local_setup_notes": []
     },
     {
+      "id": "deepinfra",
+      "display_name": "Deepinfra",
+      "catalog_provider": "deepinfra",
+      "endpoint_style": "OpenAI-compatible chat completions",
+      "classification": "hosted",
+      "auth_env": [
+        "DEEPINFRA_API_KEY",
+        "DEEPINFRA_TOKEN"
+      ],
+      "recommended": {
+        "selector": "deepinfra:deepinfra/Qwen/Qwen3.6-35B-A3B",
+        "provider": "deepinfra",
+        "model": "deepinfra/Qwen/Qwen3.6-35B-A3B",
+        "display_name": "Qwen3.6 35B A3B (DeepInfra)",
+        "tool_format": "native",
+        "harn_options": [
+          "provider = \"deepinfra\"",
+          "model = \"deepinfra/Qwen/Qwen3.6-35B-A3B\"",
+          "tool_format = \"native\"",
+          "structured_output_mode = \"native_json\""
+        ]
+      },
+      "capabilities": {
+        "native_tools": true,
+        "text_tools": true,
+        "preferred_tool_format": "native",
+        "tool_mode_parity": "unknown",
+        "structured_output_transport": "native",
+        "structured_output_mode": "native_json",
+        "streaming": true,
+        "reasoning_knobs": [
+          "enabled"
+        ],
+        "prompt_or_context_cache": false,
+        "usage_accounting_confidence": "high"
+      },
+      "empirical": {
+        "status": "not_recorded",
+        "sources": [],
+        "total_runs": 0,
+        "passed_runs": 0,
+        "failed_runs": 0,
+        "skipped_runs": 0,
+        "best_tool_format": null,
+        "native_text_parity": null,
+        "evidence": []
+      },
+      "notes": [],
+      "caveats": [],
+      "mcp_notes": [],
+      "local_setup_notes": []
+    },
+    {
       "id": "deepseek",
       "display_name": "Deepseek",
       "catalog_provider": "deepseek",
@@ -878,6 +931,59 @@
       ]
     },
     {
+      "id": "moonshot",
+      "display_name": "Moonshot",
+      "catalog_provider": "moonshot",
+      "endpoint_style": "OpenAI-compatible chat completions",
+      "classification": "hosted",
+      "auth_env": [
+        "MOONSHOT_API_KEY",
+        "KIMI_API_KEY"
+      ],
+      "recommended": {
+        "selector": "moonshot:moonshot/kimi-k2.6",
+        "provider": "moonshot",
+        "model": "moonshot/kimi-k2.6",
+        "display_name": "Kimi K2.6 (Moonshot direct)",
+        "tool_format": "native",
+        "harn_options": [
+          "provider = \"moonshot\"",
+          "model = \"moonshot/kimi-k2.6\"",
+          "tool_format = \"native\"",
+          "structured_output_mode = \"native_json\""
+        ]
+      },
+      "capabilities": {
+        "native_tools": true,
+        "text_tools": true,
+        "preferred_tool_format": "native",
+        "tool_mode_parity": "unknown",
+        "structured_output_transport": "native",
+        "structured_output_mode": "native_json",
+        "streaming": true,
+        "reasoning_knobs": [
+          "enabled"
+        ],
+        "prompt_or_context_cache": true,
+        "usage_accounting_confidence": "high"
+      },
+      "empirical": {
+        "status": "not_recorded",
+        "sources": [],
+        "total_runs": 0,
+        "passed_runs": 0,
+        "failed_runs": 0,
+        "skipped_runs": 0,
+        "best_tool_format": null,
+        "native_text_parity": null,
+        "evidence": []
+      },
+      "notes": [],
+      "caveats": [],
+      "mcp_notes": [],
+      "local_setup_notes": []
+    },
+    {
       "id": "ollama",
       "display_name": "Ollama",
       "catalog_provider": "ollama",
@@ -1026,6 +1132,58 @@
           "enabled"
         ],
         "prompt_or_context_cache": true,
+        "usage_accounting_confidence": "high"
+      },
+      "empirical": {
+        "status": "not_recorded",
+        "sources": [],
+        "total_runs": 0,
+        "passed_runs": 0,
+        "failed_runs": 0,
+        "skipped_runs": 0,
+        "best_tool_format": null,
+        "native_text_parity": null,
+        "evidence": []
+      },
+      "notes": [],
+      "caveats": [],
+      "mcp_notes": [],
+      "local_setup_notes": []
+    },
+    {
+      "id": "sambanova",
+      "display_name": "Sambanova",
+      "catalog_provider": "sambanova",
+      "endpoint_style": "OpenAI-compatible chat completions",
+      "classification": "hosted",
+      "auth_env": [
+        "SAMBANOVA_API_KEY"
+      ],
+      "recommended": {
+        "selector": "sambanova:sambanova/DeepSeek-V4-Pro",
+        "provider": "sambanova",
+        "model": "sambanova/DeepSeek-V4-Pro",
+        "display_name": "DeepSeek V4 Pro (SambaNova)",
+        "tool_format": "native",
+        "harn_options": [
+          "provider = \"sambanova\"",
+          "model = \"sambanova/DeepSeek-V4-Pro\"",
+          "tool_format = \"native\"",
+          "structured_output_mode = \"native_json\""
+        ]
+      },
+      "capabilities": {
+        "native_tools": true,
+        "text_tools": true,
+        "preferred_tool_format": "native",
+        "tool_mode_parity": "unknown",
+        "structured_output_transport": "native",
+        "structured_output_mode": "native_json",
+        "streaming": true,
+        "reasoning_knobs": [
+          "enabled"
+        ],
+        "prompt_or_context_cache": false,
         "usage_accounting_confidence": "high"
       },
       "empirical": {

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -47,6 +47,9 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `cohere` | `command-*` | `any` | `adaptive` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
 | `dashscope` | `qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `dashscope` | `qwen*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `deepinfra` | `*deepseek*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `deepinfra` | `*qwen3.6*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `deepinfra` | `*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `deepseek` | `deepseek-v4-pro*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `deepseek` | `deepseek-v4-flash*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `deepseek` | `deepseek-chat*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | yes |
@@ -82,6 +85,8 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `mistral` | `devstral-*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `mlx` | `*qwen3.6*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `mlx` | `*qwen3*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `moonshot` | `*kimi-k2.7-code*` | `any` | `enabled` | yes | no | no | yes | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `moonshot` | `*kimi*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `ollama` | `llava*` | `any` | no | yes | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | `json` | no | yes | `text_only` | yes | no |
 | `ollama` | `bakllava*` | `any` | no | yes | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | `json` | no | yes | `text_only` | yes | no |
 | `ollama` | `llama3.2-vision*` | `any` | no | yes | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `none` | `json` | no | yes | `text_only` | yes | no |
@@ -143,6 +148,9 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `openrouter` | `z-ai/glm-5*` | `any` | no | no | no | no | no | yes | no | `native` | `plain` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `kwaipilot/kat-coder-pro-v2` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `interchangeable` | yes | yes |
 | `openrouter` | `stepfun/step-3.7-flash` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `interchangeable` | yes | yes |
+| `sambanova` | `*deepseek*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `sambanova` | `*llama*` | `any` | no | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `sambanova` | `*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `together` | `Qwen/Qwen3.7-Max` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `together` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `together` | `qwen/qwen3-coder*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
@@ -185,6 +193,8 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `cerebras` | `llama-3.3-70b` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `cerebras` | `zai-glm-4.7` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `cohere` | `command-a-plus-05-2026` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `deepinfra` | `deepinfra/Qwen/Qwen3.6-35B-A3B` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `deepinfra` | `deepinfra/deepseek-ai/DeepSeek-V4-Pro` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `deepseek` | `deepseek-chat` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `deepseek` | `deepseek-reasoner` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `deepseek` | `deepseek-v4-flash` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
@@ -214,6 +224,8 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `mistral` | `mistral-large-2512` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `mistral` | `mistral-small-2603` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `mlx` | `unsloth/Qwen3.6-27B-UD-MLX-4bit` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `moonshot` | `moonshot/kimi-k2.6` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `moonshot` | `moonshot/kimi-k2.7-code` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `ollama` | `devstral-small-2:24b` | `json` | `text_only` | - | - | - | - | - | `data not yet collected` |
 | `ollama` | `gemma4:12b-mlx` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
 | `ollama` | `gemma4:12b-mxfp8` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
@@ -254,6 +266,8 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `openrouter` | `z-ai/glm-5` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `z-ai/glm-5.1` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `z-ai/glm-5v-turbo` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `sambanova` | `sambanova/DeepSeek-V4-Pro` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `sambanova` | `sambanova/Llama-4-Maverick` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `together` | `MiniMaxAI/MiniMax-M2.7` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `together` | `Qwen/Qwen3-Coder-Next-FP8` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `together` | `Qwen/Qwen3.7-Max` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |

--- a/docs/src/provider-support.md
+++ b/docs/src/provider-support.md
@@ -17,6 +17,7 @@ No benchmark summary is baked into this checked-in page. To layer local empirica
 | `Cerebras` | OpenAI-compatible chat completions | `cerebras/gpt-oss-120b` | `native` | yes | yes | `native` / `native_json` | `effort,reasoning_effort` | no | `high` | `not_recorded` |
 | `Cohere` | OpenAI-compatible chat completions | `cohere:command-a-plus-05-2026` | `native` | yes | yes | `native` / `native_json` | `adaptive` | no | `high` | `not_recorded` |
 | `Dashscope` | OpenAI-compatible chat completions | `dashscope:qwen3.6*` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `provider_default` | `not_recorded` |
+| `Deepinfra` | OpenAI-compatible chat completions | `deepinfra:deepinfra/Qwen/Qwen3.6-35B-A3B` | `native` | yes | yes | `native` / `native_json` | `enabled` | no | `high` | `not_recorded` |
 | `Deepseek` | OpenAI-compatible chat completions | `deepseek:deepseek-v4-flash` | `native` | yes | yes | `native` / `native_json` | `enabled` | yes | `high` | `not_recorded` |
 | `Fireworks` | OpenAI-compatible chat completions | `fireworks:*qwen3.6*` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `provider_default` | `not_recorded` |
 | `Gemini API` | Gemini generateContent | `gemini:gemini-2.5-flash` | `native` | yes | yes | `native` / `native_json` | `adaptive,effort,enabled` | yes | `medium` | `not_recorded` |
@@ -27,9 +28,11 @@ No benchmark summary is baked into this checked-in page. To layer local empirica
 | `Minimax` | OpenAI-compatible chat completions | `minimax:MiniMax-M2.5-highspeed` | `native` | yes | yes | `delimited` / `delimited` | `enabled` | yes | `high` | `not_recorded` |
 | `Mistral via OpenRouter` | OpenAI-compatible chat completions through OpenRouter | `openrouter:mistralai/mistral-small-2603` | `native` | yes | yes | `native` / `native_json` | none | yes | `medium` | `not_recorded` |
 | `MLX OpenAI-compatible server` | OpenAI-compatible MLX server | `mlx-qwen3.6-27b` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `medium` | `not_recorded` |
+| `Moonshot` | OpenAI-compatible chat completions | `moonshot:moonshot/kimi-k2.6` | `native` | yes | yes | `native` / `native_json` | `enabled` | yes | `high` | `not_recorded` |
 | `Ollama` | Ollama native chat API | `devstral-small-2` | `text` | no | yes | `format_kw` / `delimited` | none | no | `high` | `not_recorded` |
 | `OpenAI` | OpenAI chat completions / Responses-compatible routes | `mid` | `native` | yes | yes | `native` / `native_json` | none | no | `high` | `not_recorded` |
 | `Openrouter` | OpenAI-compatible chat completions | `openrouter:google/gemini-2.5-flash` | `native` | yes | yes | `native` / `native_json` | `effort,enabled` | yes | `high` | `not_recorded` |
+| `Sambanova` | OpenAI-compatible chat completions | `sambanova:sambanova/DeepSeek-V4-Pro` | `native` | yes | yes | `native` / `native_json` | `enabled` | no | `high` | `not_recorded` |
 | `Tgi` | OpenAI-compatible chat completions | `tgi` | `text` | no | yes | `none` / `none` | none | no | `local_zero_cost` | `not_recorded` |
 | `Together` | OpenAI-compatible chat completions | `together:Qwen/Qwen3-Coder-Next-FP8` | `native` | yes | yes | `native` / `delimited` | none | no | `high` | `not_recorded` |
 | `Vertex` | Gemini generateContent | `vertex:gemini-*` | `native` | yes | yes | `none` / `native_json` | none | no | `provider_default` | `not_recorded` |

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -679,6 +679,33 @@ public let harnProviderCatalogJSON = #"""
       "latency_p50_ms": 1600
     },
     {
+      "id": "deepinfra",
+      "display_name": "Deepinfra",
+      "classification": "hosted",
+      "endpoint": {
+        "base_url": "https://api.deepinfra.com/v1/openai",
+        "base_url_env": "DEEPINFRA_BASE_URL",
+        "chat_endpoint": "/chat/completions",
+        "completion_endpoint": "/completions"
+      },
+      "auth": {
+        "style": "bearer",
+        "env": [
+          "DEEPINFRA_API_KEY",
+          "DEEPINFRA_TOKEN"
+        ],
+        "required": true
+      },
+      "protocols": [
+        "openai_chat_completions"
+      ],
+      "features": [
+        "native_tools"
+      ],
+      "caveats": [],
+      "latency_p50_ms": 1500
+    },
+    {
       "id": "deepseek",
       "display_name": "Deepseek",
       "classification": "hosted",
@@ -959,6 +986,35 @@ public let harnProviderCatalogJSON = #"""
       "latency_p50_ms": 900
     },
     {
+      "id": "moonshot",
+      "display_name": "Moonshot",
+      "classification": "hosted",
+      "endpoint": {
+        "base_url": "https://api.moonshot.ai/v1",
+        "base_url_env": "MOONSHOT_BASE_URL",
+        "chat_endpoint": "/chat/completions",
+        "completion_endpoint": "/completions"
+      },
+      "auth": {
+        "style": "bearer",
+        "env": [
+          "MOONSHOT_API_KEY",
+          "KIMI_API_KEY"
+        ],
+        "required": true
+      },
+      "protocols": [
+        "openai_chat_completions"
+      ],
+      "features": [
+        "native_tools",
+        "reasoning",
+        "prompt_caching"
+      ],
+      "caveats": [],
+      "latency_p50_ms": 1900
+    },
+    {
       "id": "ollama",
       "display_name": "Ollama",
       "classification": "local",
@@ -1036,6 +1092,32 @@ public let harnProviderCatalogJSON = #"""
       "features": [],
       "caveats": [],
       "latency_p50_ms": 2200
+    },
+    {
+      "id": "sambanova",
+      "display_name": "Sambanova",
+      "classification": "hosted",
+      "endpoint": {
+        "base_url": "https://api.sambanova.ai/v1",
+        "base_url_env": "SAMBANOVA_BASE_URL",
+        "chat_endpoint": "/chat/completions",
+        "completion_endpoint": "/completions"
+      },
+      "auth": {
+        "style": "bearer",
+        "env": [
+          "SAMBANOVA_API_KEY"
+        ],
+        "required": true
+      },
+      "protocols": [
+        "openai_chat_completions"
+      ],
+      "features": [
+        "native_tools"
+      ],
+      "caveats": [],
+      "latency_p50_ms": 350
     },
     {
       "id": "tgi",
@@ -2840,6 +2922,178 @@ public let harnProviderCatalogJSON = #"""
         "reasoning",
         "multilingual",
         "vision"
+      ]
+    },
+    {
+      "id": "deepinfra/Qwen/Qwen3.6-35B-A3B",
+      "name": "Qwen3.6 35B A3B (DeepInfra)",
+      "provider": "deepinfra",
+      "aliases": [
+        "deepinfra-qwen3.6"
+      ],
+      "context_window": 262144,
+      "logical_model": "qwen3.6-35b-a3b",
+      "equivalence_group": "qwen3.6-35b-a3b",
+      "served_variant": "deepinfra",
+      "wire_model": "Qwen/Qwen3.6-35B-A3B",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.1,
+        "output_per_mtok": 0.3,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "qwen",
+      "lineage": "qwen3",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "coding",
+        "agentic",
+        "tool_use",
+        "long_context",
+        "cheap",
+        "vision"
+      ]
+    },
+    {
+      "id": "deepinfra/deepseek-ai/DeepSeek-V4-Pro",
+      "name": "DeepSeek V4 Pro (DeepInfra)",
+      "provider": "deepinfra",
+      "aliases": [
+        "deepinfra-deepseek"
+      ],
+      "context_window": 163840,
+      "logical_model": "deepseek-v4-pro",
+      "equivalence_group": "deepseek-v4-pro",
+      "served_variant": "deepinfra",
+      "wire_model": "deepseek-ai/DeepSeek-V4-Pro",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.5,
+        "output_per_mtok": 1.5,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "deepseek",
+      "lineage": "deepseek",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "reasoning",
+        "coding",
+        "tool_use",
+        "long_context",
+        "cheap"
       ]
     },
     {
@@ -4969,6 +5223,185 @@ public let harnProviderCatalogJSON = #"""
       "open_weight": true,
       "strengths": [
         "coding",
+        "vision"
+      ]
+    },
+    {
+      "id": "moonshot/kimi-k2.6",
+      "name": "Kimi K2.6 (Moonshot direct)",
+      "provider": "moonshot",
+      "aliases": [
+        "kimi-direct",
+        "moonshot-kimi"
+      ],
+      "context_window": 262144,
+      "logical_model": "moonshot-kimi-k2.6",
+      "equivalence_group": "moonshot-kimi-k2.6",
+      "served_variant": "moonshot-direct",
+      "wire_model": "kimi-k2.6",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.6,
+        "output_per_mtok": 2.5,
+        "cache_read_per_mtok": 0.15,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "kimi",
+      "lineage": "kimi",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "coding",
+        "agentic",
+        "long_context",
+        "tool_use",
+        "reasoning",
+        "vision"
+      ]
+    },
+    {
+      "id": "moonshot/kimi-k2.7-code",
+      "name": "Kimi K2.7 Code (Moonshot direct)",
+      "provider": "moonshot",
+      "aliases": [
+        "moonshot-kimi-k2.7-code"
+      ],
+      "context_window": 262144,
+      "logical_model": "moonshot-kimi-k2.7-code",
+      "equivalence_group": "moonshot-kimi-k2.7-code",
+      "served_variant": "moonshot-direct",
+      "wire_model": "kimi-k2.7-code",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.8,
+        "output_per_mtok": 3.2,
+        "cache_read_per_mtok": 0.2,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "video",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "kimi",
+      "lineage": "kimi",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "coding",
+        "agentic",
+        "long_context",
+        "tool_use",
+        "reasoning",
         "vision"
       ]
     },
@@ -7888,6 +8321,173 @@ public let harnProviderCatalogJSON = #"""
       ]
     },
     {
+      "id": "sambanova/DeepSeek-V4-Pro",
+      "name": "DeepSeek V4 Pro (SambaNova)",
+      "provider": "sambanova",
+      "aliases": [
+        "sambanova-deepseek"
+      ],
+      "context_window": 163840,
+      "logical_model": "deepseek-v4-pro",
+      "equivalence_group": "deepseek-v4-pro",
+      "served_variant": "sambanova-rdu",
+      "wire_model": "DeepSeek-V4-Pro",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.6,
+        "output_per_mtok": 1.2,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "deepseek",
+      "lineage": "deepseek",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "speed",
+        "reasoning",
+        "coding",
+        "tool_use",
+        "long_context"
+      ]
+    },
+    {
+      "id": "sambanova/Llama-4-Maverick",
+      "name": "Llama 4 Maverick (SambaNova)",
+      "provider": "sambanova",
+      "aliases": [
+        "sambanova-llama"
+      ],
+      "context_window": 131072,
+      "logical_model": "llama-4-maverick",
+      "equivalence_group": "llama-4-maverick",
+      "served_variant": "sambanova-rdu",
+      "wire_model": "Llama-4-Maverick-17B-128E-Instruct",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.63,
+        "output_per_mtok": 1.8,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "structured_output"
+      ],
+      "family": "llama",
+      "lineage": "llama",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "speed",
+        "vision",
+        "tool_use",
+        "long_context",
+        "cheap"
+      ]
+    },
+    {
       "id": "MiniMaxAI/MiniMax-M2.7",
       "name": "MiniMax M2.7 (Together)",
       "provider": "together",
@@ -8590,6 +9190,18 @@ public let harnProviderCatalogJSON = #"""
       "provider": "cohere"
     },
     {
+      "name": "deepinfra-deepseek",
+      "model_id": "deepinfra/deepseek-ai/DeepSeek-V4-Pro",
+      "provider": "deepinfra",
+      "tool_format": "native"
+    },
+    {
+      "name": "deepinfra-qwen3.6",
+      "model_id": "deepinfra/Qwen/Qwen3.6-35B-A3B",
+      "provider": "deepinfra",
+      "tool_format": "native"
+    },
+    {
       "name": "deepseek",
       "model_id": "deepseek-v4-flash",
       "provider": "deepseek"
@@ -8673,6 +9285,12 @@ public let harnProviderCatalogJSON = #"""
       "name": "kat-coder-pro-v2",
       "model_id": "kwaipilot/kat-coder-pro-v2",
       "provider": "openrouter"
+    },
+    {
+      "name": "kimi-direct",
+      "model_id": "moonshot/kimi-k2.6",
+      "provider": "moonshot",
+      "tool_format": "native"
     },
     {
       "name": "kimi-k2.7-code",
@@ -8814,6 +9432,18 @@ public let harnProviderCatalogJSON = #"""
       "provider": "mlx"
     },
     {
+      "name": "moonshot-kimi",
+      "model_id": "moonshot/kimi-k2.6",
+      "provider": "moonshot",
+      "tool_format": "native"
+    },
+    {
+      "name": "moonshot-kimi-k2.7-code",
+      "model_id": "moonshot/kimi-k2.7-code",
+      "provider": "moonshot",
+      "tool_format": "native"
+    },
+    {
       "name": "ollama-devstral-small-2",
       "model_id": "devstral-small-2:24b",
       "provider": "ollama"
@@ -8910,6 +9540,18 @@ public let harnProviderCatalogJSON = #"""
       "name": "qwen3.7-plus",
       "model_id": "qwen/qwen3.7-plus",
       "provider": "openrouter"
+    },
+    {
+      "name": "sambanova-deepseek",
+      "model_id": "sambanova/DeepSeek-V4-Pro",
+      "provider": "sambanova",
+      "tool_format": "native"
+    },
+    {
+      "name": "sambanova-llama",
+      "model_id": "sambanova/Llama-4-Maverick",
+      "provider": "sambanova",
+      "tool_format": "native"
     },
     {
       "name": "small",

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -415,6 +415,33 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "latency_p50_ms": 1600
     },
     {
+      "id": "deepinfra",
+      "display_name": "Deepinfra",
+      "classification": "hosted",
+      "endpoint": {
+        "base_url": "https://api.deepinfra.com/v1/openai",
+        "base_url_env": "DEEPINFRA_BASE_URL",
+        "chat_endpoint": "/chat/completions",
+        "completion_endpoint": "/completions"
+      },
+      "auth": {
+        "style": "bearer",
+        "env": [
+          "DEEPINFRA_API_KEY",
+          "DEEPINFRA_TOKEN"
+        ],
+        "required": true
+      },
+      "protocols": [
+        "openai_chat_completions"
+      ],
+      "features": [
+        "native_tools"
+      ],
+      "caveats": [],
+      "latency_p50_ms": 1500
+    },
+    {
       "id": "deepseek",
       "display_name": "Deepseek",
       "classification": "hosted",
@@ -695,6 +722,35 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "latency_p50_ms": 900
     },
     {
+      "id": "moonshot",
+      "display_name": "Moonshot",
+      "classification": "hosted",
+      "endpoint": {
+        "base_url": "https://api.moonshot.ai/v1",
+        "base_url_env": "MOONSHOT_BASE_URL",
+        "chat_endpoint": "/chat/completions",
+        "completion_endpoint": "/completions"
+      },
+      "auth": {
+        "style": "bearer",
+        "env": [
+          "MOONSHOT_API_KEY",
+          "KIMI_API_KEY"
+        ],
+        "required": true
+      },
+      "protocols": [
+        "openai_chat_completions"
+      ],
+      "features": [
+        "native_tools",
+        "reasoning",
+        "prompt_caching"
+      ],
+      "caveats": [],
+      "latency_p50_ms": 1900
+    },
+    {
       "id": "ollama",
       "display_name": "Ollama",
       "classification": "local",
@@ -772,6 +828,32 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "features": [],
       "caveats": [],
       "latency_p50_ms": 2200
+    },
+    {
+      "id": "sambanova",
+      "display_name": "Sambanova",
+      "classification": "hosted",
+      "endpoint": {
+        "base_url": "https://api.sambanova.ai/v1",
+        "base_url_env": "SAMBANOVA_BASE_URL",
+        "chat_endpoint": "/chat/completions",
+        "completion_endpoint": "/completions"
+      },
+      "auth": {
+        "style": "bearer",
+        "env": [
+          "SAMBANOVA_API_KEY"
+        ],
+        "required": true
+      },
+      "protocols": [
+        "openai_chat_completions"
+      ],
+      "features": [
+        "native_tools"
+      ],
+      "caveats": [],
+      "latency_p50_ms": 350
     },
     {
       "id": "tgi",
@@ -2576,6 +2658,178 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "reasoning",
         "multilingual",
         "vision"
+      ]
+    },
+    {
+      "id": "deepinfra/Qwen/Qwen3.6-35B-A3B",
+      "name": "Qwen3.6 35B A3B (DeepInfra)",
+      "provider": "deepinfra",
+      "aliases": [
+        "deepinfra-qwen3.6"
+      ],
+      "context_window": 262144,
+      "logical_model": "qwen3.6-35b-a3b",
+      "equivalence_group": "qwen3.6-35b-a3b",
+      "served_variant": "deepinfra",
+      "wire_model": "Qwen/Qwen3.6-35B-A3B",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.1,
+        "output_per_mtok": 0.3,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "qwen",
+      "lineage": "qwen3",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "coding",
+        "agentic",
+        "tool_use",
+        "long_context",
+        "cheap",
+        "vision"
+      ]
+    },
+    {
+      "id": "deepinfra/deepseek-ai/DeepSeek-V4-Pro",
+      "name": "DeepSeek V4 Pro (DeepInfra)",
+      "provider": "deepinfra",
+      "aliases": [
+        "deepinfra-deepseek"
+      ],
+      "context_window": 163840,
+      "logical_model": "deepseek-v4-pro",
+      "equivalence_group": "deepseek-v4-pro",
+      "served_variant": "deepinfra",
+      "wire_model": "deepseek-ai/DeepSeek-V4-Pro",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.5,
+        "output_per_mtok": 1.5,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "deepseek",
+      "lineage": "deepseek",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "reasoning",
+        "coding",
+        "tool_use",
+        "long_context",
+        "cheap"
       ]
     },
     {
@@ -4705,6 +4959,185 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "open_weight": true,
       "strengths": [
         "coding",
+        "vision"
+      ]
+    },
+    {
+      "id": "moonshot/kimi-k2.6",
+      "name": "Kimi K2.6 (Moonshot direct)",
+      "provider": "moonshot",
+      "aliases": [
+        "kimi-direct",
+        "moonshot-kimi"
+      ],
+      "context_window": 262144,
+      "logical_model": "moonshot-kimi-k2.6",
+      "equivalence_group": "moonshot-kimi-k2.6",
+      "served_variant": "moonshot-direct",
+      "wire_model": "kimi-k2.6",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.6,
+        "output_per_mtok": 2.5,
+        "cache_read_per_mtok": 0.15,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "kimi",
+      "lineage": "kimi",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "coding",
+        "agentic",
+        "long_context",
+        "tool_use",
+        "reasoning",
+        "vision"
+      ]
+    },
+    {
+      "id": "moonshot/kimi-k2.7-code",
+      "name": "Kimi K2.7 Code (Moonshot direct)",
+      "provider": "moonshot",
+      "aliases": [
+        "moonshot-kimi-k2.7-code"
+      ],
+      "context_window": 262144,
+      "logical_model": "moonshot-kimi-k2.7-code",
+      "equivalence_group": "moonshot-kimi-k2.7-code",
+      "served_variant": "moonshot-direct",
+      "wire_model": "kimi-k2.7-code",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.8,
+        "output_per_mtok": 3.2,
+        "cache_read_per_mtok": 0.2,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "video",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "kimi",
+      "lineage": "kimi",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "coding",
+        "agentic",
+        "long_context",
+        "tool_use",
+        "reasoning",
         "vision"
       ]
     },
@@ -7624,6 +8057,173 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       ]
     },
     {
+      "id": "sambanova/DeepSeek-V4-Pro",
+      "name": "DeepSeek V4 Pro (SambaNova)",
+      "provider": "sambanova",
+      "aliases": [
+        "sambanova-deepseek"
+      ],
+      "context_window": 163840,
+      "logical_model": "deepseek-v4-pro",
+      "equivalence_group": "deepseek-v4-pro",
+      "served_variant": "sambanova-rdu",
+      "wire_model": "DeepSeek-V4-Pro",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.6,
+        "output_per_mtok": 1.2,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "deepseek",
+      "lineage": "deepseek",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "speed",
+        "reasoning",
+        "coding",
+        "tool_use",
+        "long_context"
+      ]
+    },
+    {
+      "id": "sambanova/Llama-4-Maverick",
+      "name": "Llama 4 Maverick (SambaNova)",
+      "provider": "sambanova",
+      "aliases": [
+        "sambanova-llama"
+      ],
+      "context_window": 131072,
+      "logical_model": "llama-4-maverick",
+      "equivalence_group": "llama-4-maverick",
+      "served_variant": "sambanova-rdu",
+      "wire_model": "Llama-4-Maverick-17B-128E-Instruct",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.63,
+        "output_per_mtok": 1.8,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "structured_output"
+      ],
+      "family": "llama",
+      "lineage": "llama",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "speed",
+        "vision",
+        "tool_use",
+        "long_context",
+        "cheap"
+      ]
+    },
+    {
       "id": "MiniMaxAI/MiniMax-M2.7",
       "name": "MiniMax M2.7 (Together)",
       "provider": "together",
@@ -8326,6 +8926,18 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "provider": "cohere"
     },
     {
+      "name": "deepinfra-deepseek",
+      "model_id": "deepinfra/deepseek-ai/DeepSeek-V4-Pro",
+      "provider": "deepinfra",
+      "tool_format": "native"
+    },
+    {
+      "name": "deepinfra-qwen3.6",
+      "model_id": "deepinfra/Qwen/Qwen3.6-35B-A3B",
+      "provider": "deepinfra",
+      "tool_format": "native"
+    },
+    {
       "name": "deepseek",
       "model_id": "deepseek-v4-flash",
       "provider": "deepseek"
@@ -8409,6 +9021,12 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "name": "kat-coder-pro-v2",
       "model_id": "kwaipilot/kat-coder-pro-v2",
       "provider": "openrouter"
+    },
+    {
+      "name": "kimi-direct",
+      "model_id": "moonshot/kimi-k2.6",
+      "provider": "moonshot",
+      "tool_format": "native"
     },
     {
       "name": "kimi-k2.7-code",
@@ -8550,6 +9168,18 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "provider": "mlx"
     },
     {
+      "name": "moonshot-kimi",
+      "model_id": "moonshot/kimi-k2.6",
+      "provider": "moonshot",
+      "tool_format": "native"
+    },
+    {
+      "name": "moonshot-kimi-k2.7-code",
+      "model_id": "moonshot/kimi-k2.7-code",
+      "provider": "moonshot",
+      "tool_format": "native"
+    },
+    {
       "name": "ollama-devstral-small-2",
       "model_id": "devstral-small-2:24b",
       "provider": "ollama"
@@ -8646,6 +9276,18 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "name": "qwen3.7-plus",
       "model_id": "qwen/qwen3.7-plus",
       "provider": "openrouter"
+    },
+    {
+      "name": "sambanova-deepseek",
+      "model_id": "sambanova/DeepSeek-V4-Pro",
+      "provider": "sambanova",
+      "tool_format": "native"
+    },
+    {
+      "name": "sambanova-llama",
+      "model_id": "sambanova/Llama-4-Maverick",
+      "provider": "sambanova",
+      "tool_format": "native"
     },
     {
       "name": "small",

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -161,6 +161,33 @@
       "latency_p50_ms": 1600
     },
     {
+      "id": "deepinfra",
+      "display_name": "Deepinfra",
+      "classification": "hosted",
+      "endpoint": {
+        "base_url": "https://api.deepinfra.com/v1/openai",
+        "base_url_env": "DEEPINFRA_BASE_URL",
+        "chat_endpoint": "/chat/completions",
+        "completion_endpoint": "/completions"
+      },
+      "auth": {
+        "style": "bearer",
+        "env": [
+          "DEEPINFRA_API_KEY",
+          "DEEPINFRA_TOKEN"
+        ],
+        "required": true
+      },
+      "protocols": [
+        "openai_chat_completions"
+      ],
+      "features": [
+        "native_tools"
+      ],
+      "caveats": [],
+      "latency_p50_ms": 1500
+    },
+    {
       "id": "deepseek",
       "display_name": "Deepseek",
       "classification": "hosted",
@@ -441,6 +468,35 @@
       "latency_p50_ms": 900
     },
     {
+      "id": "moonshot",
+      "display_name": "Moonshot",
+      "classification": "hosted",
+      "endpoint": {
+        "base_url": "https://api.moonshot.ai/v1",
+        "base_url_env": "MOONSHOT_BASE_URL",
+        "chat_endpoint": "/chat/completions",
+        "completion_endpoint": "/completions"
+      },
+      "auth": {
+        "style": "bearer",
+        "env": [
+          "MOONSHOT_API_KEY",
+          "KIMI_API_KEY"
+        ],
+        "required": true
+      },
+      "protocols": [
+        "openai_chat_completions"
+      ],
+      "features": [
+        "native_tools",
+        "reasoning",
+        "prompt_caching"
+      ],
+      "caveats": [],
+      "latency_p50_ms": 1900
+    },
+    {
       "id": "ollama",
       "display_name": "Ollama",
       "classification": "local",
@@ -518,6 +574,32 @@
       "features": [],
       "caveats": [],
       "latency_p50_ms": 2200
+    },
+    {
+      "id": "sambanova",
+      "display_name": "Sambanova",
+      "classification": "hosted",
+      "endpoint": {
+        "base_url": "https://api.sambanova.ai/v1",
+        "base_url_env": "SAMBANOVA_BASE_URL",
+        "chat_endpoint": "/chat/completions",
+        "completion_endpoint": "/completions"
+      },
+      "auth": {
+        "style": "bearer",
+        "env": [
+          "SAMBANOVA_API_KEY"
+        ],
+        "required": true
+      },
+      "protocols": [
+        "openai_chat_completions"
+      ],
+      "features": [
+        "native_tools"
+      ],
+      "caveats": [],
+      "latency_p50_ms": 350
     },
     {
       "id": "tgi",
@@ -2322,6 +2404,178 @@
         "reasoning",
         "multilingual",
         "vision"
+      ]
+    },
+    {
+      "id": "deepinfra/Qwen/Qwen3.6-35B-A3B",
+      "name": "Qwen3.6 35B A3B (DeepInfra)",
+      "provider": "deepinfra",
+      "aliases": [
+        "deepinfra-qwen3.6"
+      ],
+      "context_window": 262144,
+      "logical_model": "qwen3.6-35b-a3b",
+      "equivalence_group": "qwen3.6-35b-a3b",
+      "served_variant": "deepinfra",
+      "wire_model": "Qwen/Qwen3.6-35B-A3B",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.1,
+        "output_per_mtok": 0.3,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "qwen",
+      "lineage": "qwen3",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "coding",
+        "agentic",
+        "tool_use",
+        "long_context",
+        "cheap",
+        "vision"
+      ]
+    },
+    {
+      "id": "deepinfra/deepseek-ai/DeepSeek-V4-Pro",
+      "name": "DeepSeek V4 Pro (DeepInfra)",
+      "provider": "deepinfra",
+      "aliases": [
+        "deepinfra-deepseek"
+      ],
+      "context_window": 163840,
+      "logical_model": "deepseek-v4-pro",
+      "equivalence_group": "deepseek-v4-pro",
+      "served_variant": "deepinfra",
+      "wire_model": "deepseek-ai/DeepSeek-V4-Pro",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.5,
+        "output_per_mtok": 1.5,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "deepseek",
+      "lineage": "deepseek",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "reasoning",
+        "coding",
+        "tool_use",
+        "long_context",
+        "cheap"
       ]
     },
     {
@@ -4451,6 +4705,185 @@
       "open_weight": true,
       "strengths": [
         "coding",
+        "vision"
+      ]
+    },
+    {
+      "id": "moonshot/kimi-k2.6",
+      "name": "Kimi K2.6 (Moonshot direct)",
+      "provider": "moonshot",
+      "aliases": [
+        "kimi-direct",
+        "moonshot-kimi"
+      ],
+      "context_window": 262144,
+      "logical_model": "moonshot-kimi-k2.6",
+      "equivalence_group": "moonshot-kimi-k2.6",
+      "served_variant": "moonshot-direct",
+      "wire_model": "kimi-k2.6",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.6,
+        "output_per_mtok": 2.5,
+        "cache_read_per_mtok": 0.15,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "kimi",
+      "lineage": "kimi",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "coding",
+        "agentic",
+        "long_context",
+        "tool_use",
+        "reasoning",
+        "vision"
+      ]
+    },
+    {
+      "id": "moonshot/kimi-k2.7-code",
+      "name": "Kimi K2.7 Code (Moonshot direct)",
+      "provider": "moonshot",
+      "aliases": [
+        "moonshot-kimi-k2.7-code"
+      ],
+      "context_window": 262144,
+      "logical_model": "moonshot-kimi-k2.7-code",
+      "equivalence_group": "moonshot-kimi-k2.7-code",
+      "served_variant": "moonshot-direct",
+      "wire_model": "kimi-k2.7-code",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": true,
+      "pricing": {
+        "input_per_mtok": 0.8,
+        "output_per_mtok": 3.2,
+        "cache_read_per_mtok": 0.2,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "video",
+        "prompt_caching",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "kimi",
+      "lineage": "kimi",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "deepseek"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "coding",
+        "agentic",
+        "long_context",
+        "tool_use",
+        "reasoning",
         "vision"
       ]
     },
@@ -7370,6 +7803,173 @@
       ]
     },
     {
+      "id": "sambanova/DeepSeek-V4-Pro",
+      "name": "DeepSeek V4 Pro (SambaNova)",
+      "provider": "sambanova",
+      "aliases": [
+        "sambanova-deepseek"
+      ],
+      "context_window": 163840,
+      "logical_model": "deepseek-v4-pro",
+      "equivalence_group": "deepseek-v4-pro",
+      "served_variant": "sambanova-rdu",
+      "wire_model": "DeepSeek-V4-Pro",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.6,
+        "output_per_mtok": 1.2,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "deepseek",
+      "lineage": "deepseek",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "qwen",
+        "kimi"
+      ],
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "speed",
+        "reasoning",
+        "coding",
+        "tool_use",
+        "long_context"
+      ]
+    },
+    {
+      "id": "sambanova/Llama-4-Maverick",
+      "name": "Llama 4 Maverick (SambaNova)",
+      "provider": "sambanova",
+      "aliases": [
+        "sambanova-llama"
+      ],
+      "context_window": 131072,
+      "logical_model": "llama-4-maverick",
+      "equivalence_group": "llama-4-maverick",
+      "served_variant": "sambanova-rdu",
+      "wire_model": "Llama-4-Maverick-17B-128E-Instruct",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text",
+          "image"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.63,
+        "output_per_mtok": 1.8,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "vision",
+        "structured_output"
+      ],
+      "family": "llama",
+      "lineage": "llama",
+      "complementary_with": [
+        "anthropic-claude",
+        "openai-gpt",
+        "google-gemini",
+        "deepseek",
+        "kimi"
+      ],
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "speed",
+        "vision",
+        "tool_use",
+        "long_context",
+        "cheap"
+      ]
+    },
+    {
       "id": "MiniMaxAI/MiniMax-M2.7",
       "name": "MiniMax M2.7 (Together)",
       "provider": "together",
@@ -8072,6 +8672,18 @@
       "provider": "cohere"
     },
     {
+      "name": "deepinfra-deepseek",
+      "model_id": "deepinfra/deepseek-ai/DeepSeek-V4-Pro",
+      "provider": "deepinfra",
+      "tool_format": "native"
+    },
+    {
+      "name": "deepinfra-qwen3.6",
+      "model_id": "deepinfra/Qwen/Qwen3.6-35B-A3B",
+      "provider": "deepinfra",
+      "tool_format": "native"
+    },
+    {
       "name": "deepseek",
       "model_id": "deepseek-v4-flash",
       "provider": "deepseek"
@@ -8155,6 +8767,12 @@
       "name": "kat-coder-pro-v2",
       "model_id": "kwaipilot/kat-coder-pro-v2",
       "provider": "openrouter"
+    },
+    {
+      "name": "kimi-direct",
+      "model_id": "moonshot/kimi-k2.6",
+      "provider": "moonshot",
+      "tool_format": "native"
     },
     {
       "name": "kimi-k2.7-code",
@@ -8296,6 +8914,18 @@
       "provider": "mlx"
     },
     {
+      "name": "moonshot-kimi",
+      "model_id": "moonshot/kimi-k2.6",
+      "provider": "moonshot",
+      "tool_format": "native"
+    },
+    {
+      "name": "moonshot-kimi-k2.7-code",
+      "model_id": "moonshot/kimi-k2.7-code",
+      "provider": "moonshot",
+      "tool_format": "native"
+    },
+    {
       "name": "ollama-devstral-small-2",
       "model_id": "devstral-small-2:24b",
       "provider": "ollama"
@@ -8392,6 +9022,18 @@
       "name": "qwen3.7-plus",
       "model_id": "qwen/qwen3.7-plus",
       "provider": "openrouter"
+    },
+    {
+      "name": "sambanova-deepseek",
+      "model_id": "sambanova/DeepSeek-V4-Pro",
+      "provider": "sambanova",
+      "tool_format": "native"
+    },
+    {
+      "name": "sambanova-llama",
+      "model_id": "sambanova/Llama-4-Maverick",
+      "provider": "sambanova",
+      "tool_format": "native"
     },
     {
       "name": "small",


### PR DESCRIPTION
## Summary

A meticulous pass over the LLM provider landscape against Harn's bundled catalog. Harn's catalog is already remarkably complete (anthropic, openai, openrouter, huggingface, ollama, gemini, mistral, cohere, xai, together, groq, cerebras, deepseek, fireworks, dashscope, minimax, zai, bedrock, azure_openai, vertex + local runtimes). The clear gaps were three **OpenAI-compatible** providers, now added as first-class catalog providers:

- **`moonshot`** — Moonshot AI's first-party Kimi K2 API (`api.moonshot.ai/v1`, `MOONSHOT_API_KEY`/`KIMI_API_KEY`). The Kimi family was previously only reachable through OpenRouter/Together aggregator routes; this adds the direct route with `kimi-k2.6` and `kimi-k2.7-code` rows.
- **`deepinfra`** — open-weight OpenAI-compatible host (`api.deepinfra.com/v1/openai`, `DEEPINFRA_API_KEY`), with DeepSeek V4 Pro and Qwen3.6 35B A3B routes.
- **`sambanova`** — fast RDU inference (`api.sambanova.ai/v1`, `SAMBANOVA_API_KEY`), an executor target alongside Groq/Cerebras with a different model mix (DeepSeek, Llama 4).

All three reuse the existing `openai_compat` wire path — **no new provider code**, just data + a one-line registration.

## What changed

Source fragments (the editable inputs):
- `catalog_sources/10-providers/all.toml` — three `[providers.*]` blocks + healthchecks.
- `catalog_sources/60-models/95-moonshot-deepinfra-sambanova.toml` — model rows keyed `provider/<wire-id>` with `wire_model` so they stay collision-free with the same weights hosted elsewhere.
- `catalog_sources/30-aliases/aliases.toml` — short aliases (`kimi-direct`/`moonshot-kimi`/`moonshot-kimi-k2.7-code`, `deepinfra-deepseek`/`deepinfra-qwen3.6`, `sambanova-deepseek`/`sambanova-llama`).
- `capability_sources/20-providers/{35-moonshot,36-deepinfra,37-sambanova}.toml` — capability-matrix rules (native tools default; thinking/prompt-caching/vision where applicable).
- `capability_sources/10-defaults/provider-defaults.toml` — `top_k_supported = false` (OpenAI semantics).
- `crates/harn-vm/src/llm/provider.rs` — registered the three names in `register_default_providers()`.

Regenerated artifacts (via `harn providers build-config` / `build-capabilities` / `export` / `matrix` / `support`):
- `providers.toml`, `capabilities.toml`
- `spec/provider-catalog/*` (json, schema, ts, swift)
- `docs/src/provider-matrix.md`, `docs/src/provider-support.md`, `docs/provider-support.json`

## Test plan
- [x] `harn providers build-config --check` / `build-capabilities --check` — snapshots in sync
- [x] `harn providers validate --check-artifacts` — **OK**
- [x] `harn providers matrix --check` / `support --check` — docs in sync
- [x] `scripts/check_docs_model_refs.sh` — OK
- [x] `cargo test -p harn-vm --lib llm::capabilities` — 57 passed, 0 failed
- [x] pre-commit hooks (clippy on harn-vm, ratchets, markdownlint, rustfmt) — all green

## Notes
Pure catalog/registry additions — no routing/escalation/tier-default changes, so the eval meter-stick convergence gate is not in scope. Burin Code picks these up after this lands and `.harn-version` is bumped; a companion Burin overlay PR adds the same routes ahead of that release.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XL8kMhywPD5cTS7mxmsmJn)_