### PR TITLE
ci: exempt nested READMEs from the changelog-fragment gate

### DIFF
--- a/.github/scripts/changelog-fragment-check.sh
+++ b/.github/scripts/changelog-fragment-check.sh
@@ -62,7 +62,11 @@ fi
 # any change outside the ignorable-by-default paths counts as user-visible
 # and requires a fragment. This deliberately defaults strict so we don't
 # silently ship runtime changes without notes.
-ignored_pattern='^(\.github/|docs/|spec/|README(\.md)?$|AGENTS\.md$|CLAUDE\.md$|CONTRIBUTING\.md$|\.gitignore$|\.gitattributes$|\.editorconfig$|\.markdownlint[^/]*$|changelog\.d/(\.gitkeep|README\.md)$|tests?/|conformance/|benchmarks/|evals/|examples/|experiments/|test_fixtures/|perf/|playground/|tree-sitter-harn/|editors/)'
+#
+# `README` is matched with an optional path prefix ((.*/)?) so crate- and
+# package-level READMEs (e.g. crates/harn-hostlib/README.md) are exempt too,
+# not just the repo-root README. A README is documentation wherever it lives.
+ignored_pattern='^(\.github/|docs/|spec/|(.*/)?README(\.md)?$|AGENTS\.md$|CLAUDE\.md$|CONTRIBUTING\.md$|\.gitignore$|\.gitattributes$|\.editorconfig$|\.markdownlint[^/]*$|changelog\.d/(\.gitkeep|README\.md)$|tests?/|conformance/|benchmarks/|evals/|examples/|experiments/|test_fixtures/|perf/|playground/|tree-sitter-harn/|editors/)'
 nontrivial=$(printf '%s\n' "$changed_files" | grep -Ev "$ignored_pattern" || true)
 if [ -z "$nontrivial" ]; then
   echo "::notice title=Changelog fragment gate::only docs/test/CI paths touched; pass."


### PR DESCRIPTION
## Problem
The changelog-fragment gate's ignore list anchors `README(\.md)?$` at the path root, so only the **repo-root** `README.md` is exempt. Crate- and package-level READMEs (e.g. `crates/harn-hostlib/README.md`) fell through and were treated as user-visible code requiring a changelog fragment.

This surfaced on #3296 — a pure docs link fix in `crates/harn-hostlib/README.md` failed the gate and had to be force-passed with the `no-changelog-needed` label.

## Fix
Allow an optional path prefix on the `README` branch of the pattern: `README(\.md)?$` → `(.*/)?README(\.md)?$`. Any `**/README(.md)` is now exempt, since a README is documentation wherever it lives.

The trailing `$` anchor still keeps README-*like* code filenames on the user-visible side, so this doesn't over-exempt.

## Verification
Exercised the exact `grep -Ev "$ignored_pattern"` against representative paths:

| Path | Result |
| --- | --- |
| `README.md` | exempt ✅ |
| `crates/harn-hostlib/README.md` | exempt ✅ (was the bug) |
| `crates/harn-vm/portal/README.md` | exempt ✅ |
| `crates/harn-vm/src/lib.rs` | user-visible ✅ |
| `crates/harn-hostlib/src/readme_generator.rs` | user-visible ✅ (not over-matched) |
| `crates/x/MY_README.md` | user-visible ✅ (not over-matched) |

Also ran the full script end-to-end against a synthetic nested-README-only diff: exits 0 with "only docs/test/CI paths touched; pass." `bash -n` is clean.

This PR touches only `.github/`, which the gate already exempts — so it doesn't trip its own check.

https://claude.ai/code/session_01KNGgEjq7vSaaV1LWnH3hgD

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNGgEjq7vSaaV1LWnH3hgD)_