### PR TITLE
perf(cli): use mimalloc as the global allocator for the harn binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,6 +2375,7 @@ dependencies = [
  "jsonschema",
  "jsonwebtoken",
  "libc",
+ "mimalloc",
  "notify",
  "nu-ansi-term",
  "rand 0.10.1",
@@ -3551,6 +3552,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3758,6 +3768,15 @@ name = "micromap"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"

--- a/changelog.d/3297.fixed.md
+++ b/changelog.d/3297.fixed.md
@@ -1,5 +1,5 @@
 - **`parse_set_cookie` now trims whitespace around the cookie name and value
   before validation (#3297).** A `Set-Cookie: name = value` header was
-  previously dropped entirely (the un-trimmed `name ` failed `valid_cookie_name`)
+  previously dropped entirely (the un-trimmed `name` failed `valid_cookie_name`)
   and parsed values kept a stray leading space, diverging from the
   `Cookie`-header parser, which already trims both sides.

--- a/changelog.d/mimalloc-allocator.changed.md
+++ b/changelog.d/mimalloc-allocator.changed.md
@@ -1,0 +1,5 @@
+- **Allocator.** The `harn` binary now links [mimalloc](https://github.com/microsoft/mimalloc)
+  as its global allocator by default, lowering per-allocation latency and
+  fragmentation on the runtime's allocation-heavy copy-on-write workload.
+  Opt out with `--no-default-features` (or omit the new default-on `mimalloc`
+  Cargo feature) to fall back to the system allocator.

--- a/crates/harn-cli/Cargo.toml
+++ b/crates/harn-cli/Cargo.toml
@@ -70,6 +70,14 @@ async-trait = "0.1"
 axum = { version = "0.8", features = ["ws"] }
 axum-server = { version = "0.8", features = ["tls-rustls"] }
 ignore = "0.4"
+# Drop-in high-performance allocator for the `harn` binary. The VM/runtime is
+# heavily Arc/allocation-bound (copy-on-write collections, per-frame env
+# snapshots, transcript buffers), so the default-on `mimalloc` feature swaps
+# the system allocator for mimalloc, which reduces fragmentation and per-alloc
+# latency on exactly that workload. Gated behind a feature so a slim or
+# platform-constrained build can opt out with `--no-default-features` (or
+# `--features hostlib` alone) without touching source.
+mimalloc = { version = "0.1.52", default-features = false, optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "signal", "sync", "time", "process"] }
 serde_json = "1"
 serde_yml = "0.0.12"
@@ -139,7 +147,11 @@ harn-vm = { path = "../harn-vm", version = "0.8", features = ["otel"] }
 harn-stdlib = { path = "../harn-stdlib", version = "0.8" }
 
 [features]
-default = ["hostlib"]
+default = ["hostlib", "mimalloc"]
+# Link mimalloc as the global allocator for the `harn` binary (see the
+# dependency note above). Default-on; disable with `--no-default-features`
+# to fall back to the system allocator.
+mimalloc = ["dep:mimalloc"]
 # Wire `harn-hostlib`'s code-intelligence and tool builtins into the ACP
 # server. Default-on so `harn run`-driven scripts that name a hostlib
 # builtin work without extra flags. Disable with `--no-default-features` if

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -8,6 +8,20 @@
 
 use std::ffi::OsStr;
 
+/// Use mimalloc as the global allocator for the `harn` binary (and its
+/// `harn-lsp` / `harn-dap` multi-call aliases, which share this entrypoint).
+///
+/// The Harn runtime is allocation-bound: copy-on-write `Arc` collections,
+/// per-frame environment snapshots, transcript and event buffers, and LLM
+/// payload marshaling all churn small allocations. mimalloc handles that
+/// pattern with lower per-allocation latency and fragmentation than the
+/// default system allocator. Behind the default-on `mimalloc` feature so a
+/// `--no-default-features` build transparently falls back to the system
+/// allocator.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() {
     match invoked_as().as_deref() {
         Some("harn-lsp") => run_sidecar("harn-lsp", harn_lsp::run),


### PR DESCRIPTION
## Summary

First PR in a VM performance program. The Harn runtime is heavily
allocation-bound — copy-on-write `Arc` collections, per-frame environment
snapshots, transcript/event buffers, and LLM payload marshaling all churn small
allocations (a VM microbench recorded ~7,584 allocations/iteration). This swaps
the default system allocator for [mimalloc](https://github.com/microsoft/mimalloc)
on the `harn` binary, which is well-suited to exactly that small-allocation,
high-churn pattern.

## Changes

- Add `mimalloc` as a **default-on** Cargo feature on `harn-cli` and install it
  as the `#[global_allocator]` in `src/main.rs`. The binary is multi-call
  (`harn` / `harn-lsp` / `harn-dap` share this entrypoint), so all three
  artifacts pick it up.
- Disable with `--no-default-features` to fall back to the system allocator with
  no source change — no platform is locked into mimalloc.
- Incidental: fix a pre-existing `MD038` markdown-lint failure in
  `changelog.d/3297.fixed.md` that was blocking the markdown gate.

## Verification

- `cargo build -p harn-cli --bin harn` (links mimalloc, exit 0).
- Pre-commit + pre-push gates green: markdownlint, `cargo fmt`, and
  `cargo clippy --workspace`.

## Context

This is step 1 of a staged VM perf/rearchitecture effort. Follow-ups, in order:
shrink `VmValue` 32→16 bytes (box the oversized `Range` / `BuiltinRefId` /
`StructInstance` variants), cut collections over to persistent `imbl`
`Vector`/`OrdMap`, then a synchronous dispatch core. Each lands as its own PR.

https://claude.ai/code/session_01Hg27rCwZSvFbXJtF97kNxV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hg27rCwZSvFbXJtF97kNxV)_