### PR TITLE
perf(vm): box oversized VmValue variants to shrink the value 32→24 bytes

### DIFF
--- a/changelog.d/3297.fixed.md
+++ b/changelog.d/3297.fixed.md
@@ -1,5 +1,5 @@
 - **`parse_set_cookie` now trims whitespace around the cookie name and value
   before validation (#3297).** A `Set-Cookie: name = value` header was
-  previously dropped entirely (the un-trimmed `name ` failed `valid_cookie_name`)
+  previously dropped entirely (the un-trimmed `name` failed `valid_cookie_name`)
   and parsed values kept a stray leading space, diverging from the
   `Cookie`-header parser, which already trims both sides.

--- a/changelog.d/vm-value-box-oversized.changed.md
+++ b/changelog.d/vm-value-box-oversized.changed.md
@@ -1,0 +1,6 @@
+- **VM value size.** `VmValue` is now 24 bytes (down from 32). The two
+  oversized inline payloads — `Range` (a `start`/`end`/`inclusive` triple) and
+  `BuiltinRefId` (an id plus an `Arc<str>` name) — are boxed behind a shared
+  pointer, so no variant inflates the common `Int` / `Float` / `List` / `Dict` /
+  `String` shapes the interpreter copies on every push, pop, clone, and
+  local-slot write.

--- a/crates/harn-vm/src/stdlib/math.rs
+++ b/crates/harn-vm/src/stdlib/math.rs
@@ -389,7 +389,7 @@ fn range_internal_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
     let start = args.first().and_then(|a| a.as_int()).unwrap_or(0);
     let end = args.get(1).and_then(|a| a.as_int()).unwrap_or(0);
     let inclusive = args.get(2).map(|a| a.is_truthy()).unwrap_or(false);
-    Ok(VmValue::Range(VmRange {
+    Ok(VmValue::range(VmRange {
         start,
         end,
         inclusive,
@@ -422,7 +422,7 @@ fn range_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
             )));
         }
     };
-    Ok(VmValue::Range(VmRange {
+    Ok(VmValue::range(VmRange {
         start,
         end,
         inclusive: false,

--- a/crates/harn-vm/src/typecheck.rs
+++ b/crates/harn-vm/src/typecheck.rs
@@ -149,7 +149,7 @@ fn matches_type_with_generics(
             "struct" => matches!(value, VmValue::StructInstance { .. }),
             "closure" => matches!(
                 value,
-                VmValue::Closure(_) | VmValue::BuiltinRef(_) | VmValue::BuiltinRefId { .. }
+                VmValue::Closure(_) | VmValue::BuiltinRef(_) | VmValue::BuiltinRefId(_)
             ),
             _ => {
                 if !nominal_type_names.iter().any(|ty| ty == name) {
@@ -235,7 +235,7 @@ fn matches_type_with_generics(
         },
         TypeExpr::FnType { .. } => matches!(
             value,
-            VmValue::Closure(_) | VmValue::BuiltinRef(_) | VmValue::BuiltinRefId { .. }
+            VmValue::Closure(_) | VmValue::BuiltinRef(_) | VmValue::BuiltinRefId(_)
         ),
         TypeExpr::Never => false,
         TypeExpr::LitString(s) => matches!(value, VmValue::String(rs) if rs.as_ref() == s),

--- a/crates/harn-vm/src/value/core.rs
+++ b/crates/harn-vm/src/value/core.rs
@@ -120,12 +120,30 @@ impl VmEnumVariant {
     }
 }
 
+/// Boxed payload for [`VmValue::BuiltinRefId`].
+///
+/// Pairs the compact [`BuiltinId`] used for direct dispatch with the builtin's
+/// registered name (kept for policy checks, diagnostics, and name-keyed
+/// fallback). Stored behind a `Shared` pointer in the value so the `{ id, name
+/// }` pair does not widen every `VmValue` to its 24-byte footprint.
+#[derive(Debug, Clone)]
+pub struct VmBuiltinRefId {
+    pub id: BuiltinId,
+    pub name: Shared<str>,
+}
+
 /// VM runtime value.
 ///
 /// Rare compound payloads use shared pointers so stack/local-slot traffic is
-/// bounded by the common scalar and pointer-sized value shapes. Unsafe layouts
-/// such as NaN boxing or tagged pointers are deliberately deferred until Harn
-/// has a stronger object/heap story.
+/// bounded by the common scalar and pointer-sized value shapes. The two
+/// oversized inline payloads — `Range` (a 24-byte `start/end/inclusive`
+/// triple) and `BuiltinRefId` (an id + `Arc<str>` name) — are boxed behind a
+/// `Shared` pointer so no variant exceeds a fat pointer. That keeps `VmValue`
+/// at 24 bytes (down from 32) without inflating the common `Int` / `Float` /
+/// `List` / `Dict` / `String` shapes the interpreter moves on every push,
+/// pop, clone, and local-slot write. Unsafe layouts such as NaN boxing or
+/// tagged pointers are deliberately deferred until Harn has a stronger
+/// object/heap story.
 #[derive(Debug, Clone)]
 pub enum VmValue {
     Int(i64),
@@ -141,12 +159,11 @@ pub enum VmValue {
     /// referenced as a value (e.g. `snake_dict.rekey(snake_to_camel)`). The
     /// contained string is the builtin's registered name.
     BuiltinRef(Shared<str>),
-    /// Compact builtin reference for callback positions. Carries the name for
-    /// policy, diagnostics, and fallback if the ID cannot be used.
-    BuiltinRefId {
-        id: BuiltinId,
-        name: Shared<str>,
-    },
+    /// Compact builtin reference for callback positions. The boxed
+    /// [`VmBuiltinRefId`] carries the id plus the name for policy,
+    /// diagnostics, and fallback if the ID cannot be used. Boxed so the
+    /// `{ id, name }` pair does not widen every `VmValue`.
+    BuiltinRefId(Shared<VmBuiltinRefId>),
     Duration(i64),
     EnumVariant(Shared<VmEnumVariant>),
     StructInstance {
@@ -162,7 +179,10 @@ pub enum VmValue {
     Set(Shared<Vec<VmValue>>),
     Generator(Shared<VmGenerator>),
     Stream(Shared<VmStream>),
-    Range(VmRange),
+    /// Lazy numeric range. Boxed behind a `Shared` pointer so its 24-byte
+    /// `start/end/inclusive` payload does not set the whole-enum size; cloning
+    /// a range value is then a refcount bump.
+    Range(Shared<VmRange>),
     /// Lazy iterator handle. Single-pass, fused. See `crate::vm::iter::VmIter`.
     Iter(crate::vm::iter::VmIterHandle),
     /// Two-element pair value. Produced by `pair(a, b)`, yielded by the
@@ -239,6 +259,19 @@ impl VmValue {
         VmValue::TaskHandle(id.into())
     }
 
+    /// Construct a boxed [`VmValue::Range`] from a [`VmRange`].
+    pub fn range(range: VmRange) -> Self {
+        VmValue::Range(Shared::new(range))
+    }
+
+    /// Construct a boxed [`VmValue::BuiltinRefId`] from its id and name.
+    pub fn builtin_ref_id(id: BuiltinId, name: impl Into<Shared<str>>) -> Self {
+        VmValue::BuiltinRefId(Shared::new(VmBuiltinRefId {
+            id,
+            name: name.into(),
+        }))
+    }
+
     pub fn channel(handle: VmChannelHandle) -> Self {
         VmValue::Channel(Shared::new(handle))
     }
@@ -290,7 +323,7 @@ impl VmValue {
             VmValue::Dict(d) => !d.is_empty(),
             VmValue::Closure(_) => true,
             VmValue::BuiltinRef(_) => true,
-            VmValue::BuiltinRefId { .. } => true,
+            VmValue::BuiltinRefId(_) => true,
             VmValue::Duration(ms) => *ms != 0,
             VmValue::EnumVariant(_) => true,
             VmValue::StructInstance { .. } => true,
@@ -324,7 +357,7 @@ impl VmValue {
             VmValue::Dict(_) => "dict",
             VmValue::Closure(_) => "closure",
             VmValue::BuiltinRef(_) => "builtin",
-            VmValue::BuiltinRefId { .. } => "builtin",
+            VmValue::BuiltinRefId(_) => "builtin",
             VmValue::Duration(_) => "duration",
             VmValue::EnumVariant(_) => "enum",
             VmValue::StructInstance { .. } => "struct",
@@ -508,8 +541,8 @@ impl VmValue {
             VmValue::BuiltinRef(name) => {
                 let _ = write!(out, "<builtin {name}>");
             }
-            VmValue::BuiltinRefId { name, .. } => {
-                let _ = write!(out, "<builtin {name}>");
+            VmValue::BuiltinRefId(r) => {
+                let _ = write!(out, "<builtin {}>", r.name);
             }
             VmValue::Duration(ms) => {
                 let sign = if *ms < 0 { "-" } else { "" };

--- a/crates/harn-vm/src/value/mod.rs
+++ b/crates/harn-vm/src/value/mod.rs
@@ -10,7 +10,7 @@ pub type VmMutex<T> = parking_lot::Mutex<T>;
 pub use build::VmDictExt;
 pub use core::{
     string_char_count, struct_fields_to_map, StructLayout, VmAsyncBuiltinFn, VmBuiltinFn,
-    VmEnumVariant, VmValue,
+    VmBuiltinRefId, VmEnumVariant, VmValue,
 };
 pub use env::{closest_match, ModuleFunctionRegistry, ModuleState, VmClosure, VmEnv};
 pub use error::{

--- a/crates/harn-vm/src/value/structural.rs
+++ b/crates/harn-vm/src/value/structural.rs
@@ -16,9 +16,9 @@ pub fn values_identical(a: &VmValue, b: &VmValue) -> bool {
         (VmValue::String(x), VmValue::String(y)) => Arc::ptr_eq(x, y) || x == y,
         (VmValue::Bytes(x), VmValue::Bytes(y)) => Arc::ptr_eq(x, y) || x == y,
         (VmValue::BuiltinRef(x), VmValue::BuiltinRef(y)) => x == y,
-        (VmValue::BuiltinRefId { name: x, .. }, VmValue::BuiltinRefId { name: y, .. }) => x == y,
-        (VmValue::BuiltinRef(x), VmValue::BuiltinRefId { name: y, .. })
-        | (VmValue::BuiltinRefId { name: y, .. }, VmValue::BuiltinRef(x)) => x == y,
+        (VmValue::BuiltinRefId(x), VmValue::BuiltinRefId(y)) => x.name == y.name,
+        (VmValue::BuiltinRef(x), VmValue::BuiltinRefId(y))
+        | (VmValue::BuiltinRefId(y), VmValue::BuiltinRef(x)) => x.as_ref() == y.name.as_ref(),
         (VmValue::Pair(x), VmValue::Pair(y)) => Arc::ptr_eq(x, y),
         // Primitives: identity collapses to structural equality.
         _ => values_equal(a, b),
@@ -38,7 +38,7 @@ pub fn value_identity_key(v: &VmValue) -> String {
         VmValue::String(x) => format!("string@{:p}", x.as_ptr()),
         VmValue::Bytes(x) => format!("bytes@{:p}", Arc::as_ptr(x)),
         VmValue::BuiltinRef(name) => format!("builtin@{name}"),
-        VmValue::BuiltinRefId { name, .. } => format!("builtin@{name}"),
+        VmValue::BuiltinRefId(r) => format!("builtin@{}", r.name),
         other => format!("{}@{}", other.type_name(), other.display()),
     }
 }
@@ -203,9 +203,9 @@ pub fn values_equal(a: &VmValue, b: &VmValue) -> bool {
         (VmValue::String(x), VmValue::String(y)) => x == y,
         (VmValue::Bytes(x), VmValue::Bytes(y)) => x == y,
         (VmValue::BuiltinRef(x), VmValue::BuiltinRef(y)) => x == y,
-        (VmValue::BuiltinRefId { name: x, .. }, VmValue::BuiltinRefId { name: y, .. }) => x == y,
-        (VmValue::BuiltinRef(x), VmValue::BuiltinRefId { name: y, .. })
-        | (VmValue::BuiltinRefId { name: y, .. }, VmValue::BuiltinRef(x)) => x == y,
+        (VmValue::BuiltinRefId(x), VmValue::BuiltinRefId(y)) => x.name == y.name,
+        (VmValue::BuiltinRef(x), VmValue::BuiltinRefId(y))
+        | (VmValue::BuiltinRefId(y), VmValue::BuiltinRef(x)) => x.as_ref() == y.name.as_ref(),
         (VmValue::Bool(x), VmValue::Bool(y)) => x == y,
         (VmValue::Nil, VmValue::Nil) => true,
         (VmValue::Int(x), VmValue::Float(y)) => (*x as f64) == *y,

--- a/crates/harn-vm/src/value/tests.rs
+++ b/crates/harn-vm/src/value/tests.rs
@@ -11,9 +11,16 @@ static_assertions::assert_impl_all!(VmAsyncBuiltinFn: Send, Sync);
 #[cfg(target_pointer_width = "64")]
 #[test]
 fn vm_value_layout_budget() {
-    assert_eq!(std::mem::size_of::<VmValue>(), 32);
-    assert_eq!(std::mem::size_of::<Option<VmValue>>(), 32);
+    // The two oversized inline payloads (`Range` and `BuiltinRefId`, each 24
+    // bytes) are boxed behind a `Shared` pointer, so the widest variant is now
+    // a 16-byte fat pointer (`Arc<str>`) and the whole enum is 24 bytes — down
+    // from 32. Shrinking further requires a thin-pointer string type (tracked
+    // separately); `Arc<str>` is what currently sets the 16-byte floor.
+    assert_eq!(std::mem::size_of::<VmValue>(), 24);
+    assert_eq!(std::mem::size_of::<Option<VmValue>>(), 24);
     assert_eq!(std::mem::size_of::<Arc<VmEnumVariant>>(), 8);
+    assert_eq!(std::mem::size_of::<Arc<VmRange>>(), 8);
+    assert_eq!(std::mem::size_of::<Arc<VmBuiltinRefId>>(), 8);
     assert_eq!(std::mem::size_of::<VmChannelHandle>(), 40);
     assert_eq!(std::mem::size_of::<Arc<VmChannelHandle>>(), 8);
     assert_eq!(std::mem::size_of::<VmAtomicHandle>(), 8);

--- a/crates/harn-vm/src/vm/dispatch.rs
+++ b/crates/harn-vm/src/vm/dispatch.rs
@@ -376,13 +376,13 @@ impl Vm {
                 }
                 self.call_named_builtin(name, args.into_vec()).await
             }
-            VmValue::BuiltinRefId { id, name } => {
+            VmValue::BuiltinRefId(r) => {
                 if let Some(result) =
-                    self.try_call_sync_builtin_id_or_name_args(Some(*id), name, &args)
+                    self.try_call_sync_builtin_id_or_name_args(Some(r.id), &r.name, &args)
                 {
                     return result;
                 }
-                self.call_builtin_id_or_name(*id, name, args.into_vec())
+                self.call_builtin_id_or_name(r.id, &r.name, args.into_vec())
                     .await
             }
             other => Err(VmError::TypeError(format!(
@@ -404,7 +404,7 @@ impl Vm {
     pub(crate) fn is_callable_value(v: &VmValue) -> bool {
         matches!(
             v,
-            VmValue::Closure(_) | VmValue::BuiltinRef(_) | VmValue::BuiltinRefId { .. }
+            VmValue::Closure(_) | VmValue::BuiltinRef(_) | VmValue::BuiltinRefId(_)
         )
     }
 

--- a/crates/harn-vm/src/vm/iter.rs
+++ b/crates/harn-vm/src/vm/iter.rs
@@ -1206,7 +1206,7 @@ mod tests {
     fn inclusive_range_at_i64_max_yields_the_endpoint() {
         run_iter_test(async {
             let mut vm = crate::vm::Vm::new();
-            let VmValue::Iter(handle) = iter_from_value(VmValue::Range(VmRange {
+            let VmValue::Iter(handle) = iter_from_value(VmValue::range(VmRange {
                 start: i64::MAX,
                 end: i64::MAX,
                 inclusive: true,
@@ -1225,7 +1225,7 @@ mod tests {
     fn exclusive_range_at_i64_max_is_empty() {
         run_iter_test(async {
             let mut vm = crate::vm::Vm::new();
-            let VmValue::Iter(handle) = iter_from_value(VmValue::Range(VmRange {
+            let VmValue::Iter(handle) = iter_from_value(VmValue::range(VmRange {
                 start: i64::MAX,
                 end: i64::MAX,
                 inclusive: false,

--- a/crates/harn-vm/src/vm/methods/dispatch.rs
+++ b/crates/harn-vm/src/vm/methods/dispatch.rs
@@ -71,8 +71,8 @@ impl crate::vm::Vm {
                         )))
                     }
                 }
-                VmValue::BuiltinRefId { name, .. } => {
-                    let qualified = format!("{name}.{method}");
+                VmValue::BuiltinRefId(r) => {
+                    let qualified = format!("{}.{method}", r.name);
                     if self.builtins.contains_key(&qualified)
                         || self.async_builtins.contains_key(&qualified)
                     {

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -990,8 +990,8 @@ impl super::super::Vm {
                 self.call_named_value_from_stack_args(&name, args_start, callee_idx, None)
                     .await?;
             }
-            VmValue::BuiltinRefId { id, name } => {
-                self.call_named_value_from_stack_args(&name, args_start, callee_idx, Some(id))
+            VmValue::BuiltinRefId(r) => {
+                self.call_named_value_from_stack_args(&r.name, args_start, callee_idx, Some(r.id))
                     .await?;
             }
             _ => {
@@ -1024,8 +1024,8 @@ impl super::super::Vm {
             VmValue::BuiltinRef(name) => {
                 self.call_named_value(&name, args, None).await?;
             }
-            VmValue::BuiltinRefId { id, name } => {
-                self.call_named_value(&name, args, Some(id)).await?;
+            VmValue::BuiltinRefId(r) => {
+                self.call_named_value(&r.name, args, Some(r.id)).await?;
             }
             _ => {
                 return Err(VmError::TypeError(format!(
@@ -1724,8 +1724,8 @@ impl super::super::Vm {
                 self.call_named_value_from_stack_args(&name, args_start, args_start, None)
                     .await?;
             }
-            VmValue::BuiltinRefId { id, name } => {
-                self.call_named_value_from_stack_args(&name, args_start, args_start, Some(id))
+            VmValue::BuiltinRefId(r) => {
+                self.call_named_value_from_stack_args(&r.name, args_start, args_start, Some(r.id))
                     .await?;
             }
             _ => {

--- a/crates/harn-vm/src/vm/ops/iter.rs
+++ b/crates/harn-vm/src/vm/ops/iter.rs
@@ -399,7 +399,7 @@ mod tests {
     fn iter_init_inclusive_range_at_i64_max_is_not_empty() {
         run_iter_init_test(async {
             let mut vm = Vm::new();
-            vm.stack.push(VmValue::Range(crate::value::VmRange {
+            vm.stack.push(VmValue::range(crate::value::VmRange {
                 start: i64::MAX,
                 end: i64::MAX,
                 inclusive: true,

--- a/crates/harn-vm/src/vm/ops/stack.rs
+++ b/crates/harn-vm/src/vm/ops/stack.rs
@@ -72,10 +72,10 @@ impl super::super::Vm {
             self.stack.push(val.clone());
         } else if let Some(id) = self.registered_builtin_id(name) {
             // Allow bare builtin references so they can be passed as callbacks.
-            self.stack.push(VmValue::BuiltinRefId {
+            self.stack.push(VmValue::builtin_ref_id(
                 id,
-                name: Self::constant_name_rc(&chunk, idx, name),
-            });
+                Self::constant_name_rc(&chunk, idx, name),
+            ));
         } else if self.builtins.contains_key(name) || self.async_builtins.contains_key(name) {
             // Collided IDs cannot use the direct index, but remain valid callbacks.
             self.stack.push(VmValue::BuiltinRef(Self::constant_name_rc(


### PR DESCRIPTION
## Summary

Second PR in the VM performance program (after #3300, mimalloc). `VmValue` was
**32 bytes**, forced by its two widest *inline* payloads:

- `Range` — a 24-byte `start`/`end`/`inclusive` triple, and
- `BuiltinRefId` — an id plus an `Arc<str>` name (24 bytes).

The interpreter copies a `VmValue` on every stack push, pop, clone, local-slot
write, and argument pass, so the enum's width is one of the hottest constants in
the whole runtime.

This boxes both oversized variants behind a `Shared` pointer
(`Range(Shared<VmRange>)` and a new boxed `VmBuiltinRefId` payload). The widest
remaining variant is a 16-byte `Arc<str>` fat pointer, so the whole enum is now
**24 bytes — a 25% reduction** in the most-moved datum, with no inflation of the
common `Int` / `Float` / `List` / `Dict` / `String` shapes. `Range` and
`BuiltinRefId` are rare on the hot stack, so the added indirection is paid only
where it doesn't matter; cloning either is now a refcount bump rather than a
24-byte memcpy.

## Changes

- `Range(VmRange)` → `Range(Shared<VmRange>)`; `BuiltinRefId { id, name }` →
  `BuiltinRefId(Shared<VmBuiltinRefId>)` with a new boxed payload struct.
- New `VmValue::range(..)` / `VmValue::builtin_ref_id(..)` constructors centralize
  the boxing. `Range` match sites are unchanged (auto-deref through the pointer);
  `BuiltinRefId` matches move to tuple form.
- `vm_value_layout_budget` now pins **24 bytes**. Reaching 16 needs a
  thin-pointer string type (`Arc<str>`'s fat pointer is the current floor) —
  tracked as a follow-up.

## Verification

- `cargo check -p harn-vm`, `cargo clippy -p harn-vm --all-targets` — clean.
- `cargo test -p harn-vm --lib` — **3,695 passed**. The 3 failures are
  pre-existing environment-capability tests (Linux Landlock unavailable,
  overlayfs write-injection, git commit-signing server) unrelated to this change
  and green on CI.
- Pre-commit/pre-push gates green (markdown, fmt, `clippy --workspace`).

## Program context

Next: thin-pointer strings (24→16 bytes), then persistent `imbl`
`Vector`/`OrdMap` collections, then a synchronous dispatch core.

https://claude.ai/code/session_01Hg27rCwZSvFbXJtF97kNxV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hg27rCwZSvFbXJtF97kNxV)_