### PR TITLE
feat(stdlib): add nullable_uuid_text projection helper to std/postgres/query

### DIFF
--- a/changelog.d/nullable-uuid-text-projection.added.md
+++ b/changelog.d/nullable-uuid-text-projection.added.md
@@ -1,0 +1,5 @@
+- `std/postgres/query` gains `nullable_uuid_text(name)` — the nullable counterpart to `uuid_text(name)`, rendering
+  `CASE WHEN name IS NULL THEN NULL ELSE name::text END AS name` as a trusted projection fragment. It preserves SQL
+  NULLs as JSON `null` instead of casting them to the string `"null"`, mirroring `nullable_timestamptz_json`, and
+  accepts table-qualified names (`sessions.forked_from_session_id`). This replaces the hand-rolled `CASE WHEN … END`
+  string concatenation that data-access modules wrote for nullable UUID/foreign-key columns.

--- a/conformance/tests/stdlib/postgres_query_helpers.expected
+++ b/conformance/tests/stdlib/postgres_query_helpers.expected
@@ -27,7 +27,8 @@ SELECT id::text AS id, to_json(created_at)#>>'{}' AS created_at, payload FROM re
 tenant-a
 true
 true
-vaults.id::text AS id, to_json(vaults.created_at)#>>'{}' AS created_at, CASE WHEN items.expires_at IS NULL THEN NULL ELSE to_json(items.expires_at)#>>'{}' END AS expires_at
+vaults.id::text AS id, CASE WHEN items.owner_id IS NULL THEN NULL ELSE items.owner_id::text END AS owner_id, to_json(vaults.created_at)#>>'{}' AS created_at, CASE WHEN items.expires_at IS NULL THEN NULL ELSE to_json(items.expires_at)#>>'{}' END AS expires_at
+true
 true
 SELECT data#>>'{}' AS data FROM events WHERE tags && '{a,b}'::text[] AND tenant_id = $1::uuid
 tenant-a

--- a/conformance/tests/stdlib/postgres_query_helpers.harn
+++ b/conformance/tests/stdlib/postgres_query_helpers.harn
@@ -9,6 +9,7 @@ import {
   named_raw_sql,
   named_sql,
   nullable_timestamptz_json,
+  nullable_uuid_text,
   one,
   quote_identifier,
   raw_sql,
@@ -150,6 +151,7 @@ LIMIT {limit}
   let qualified = columns(
     [
       uuid_text("vaults.id"),
+      nullable_uuid_text("items.owner_id"),
       timestamptz_json("vaults.created_at"),
       nullable_timestamptz_json("items.expires_at"),
     ],
@@ -159,6 +161,10 @@ LIMIT {limit}
     timestamptz_json("vaults.bad;drop")
   }
   __io_println(is_err(bad_qualified))
+  let bad_nullable_uuid = try {
+    nullable_uuid_text("items.bad;drop")
+  }
+  __io_println(is_err(bad_nullable_uuid))
   // raw_sql: braces are literal, no {name} scanning, positional params.
   let raw_query = raw_sql(
     "SELECT data#>>'{}' AS data FROM events WHERE tags && '{a,b}'::text[] AND tenant_id = $1::uuid",

--- a/crates/harn-stdlib/src/stdlib/postgres/query.harn
+++ b/crates/harn-stdlib/src/stdlib/postgres/query.harn
@@ -541,6 +541,28 @@ pub fn uuid_text(name: string) -> PgSqlFragment {
 }
 
 /**
+ * Render `CASE WHEN column IS NULL THEN NULL ELSE column::text END AS column`
+ * for nullable UUID columns as a trusted fragment, preserving SQL NULLs as JSON
+ * `null` instead of casting them to the string `"null"`.
+ *
+ * Accepts a table-qualified name (`sessions.forked_from_session_id`); the alias
+ * is the trailing segment (`forked_from_session_id`). This is the nullable
+ * counterpart to [`uuid_text`], mirroring [`nullable_timestamptz_json`].
+ *
+ * @effects: []
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: nullable_uuid_text("forked_from_session_id")
+ */
+pub fn nullable_uuid_text(name: string) -> PgSqlFragment {
+  let column = __qualified_column(name)
+  let alias = __column_alias(name)
+  return __sql_fragment(
+    "CASE WHEN " + column + " IS NULL THEN NULL ELSE " + column + "::text END AS " + alias,
+  )
+}
+
+/**
  * Render `to_json(column)#>>'{}' AS column` for timestamp columns as a trusted
  * fragment.
  *

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -824,6 +824,7 @@ repeated projection fragments easier to review:
 | `columns(parts)` | Join projection fragments/strings into one `{projection}` fragment |
 | `select_clause(parts)` | Render `SELECT ...` from projection parts as a fragment |
 | `uuid_text(name)` | Fragment `name::text AS name` |
+| `nullable_uuid_text(name)` | Fragment UUID/`::text` projection that preserves nulls |
 | `timestamptz_json(name)` | Fragment `to_json(name)#>>'{}' AS name` |
 | `nullable_timestamptz_json(name)` | Fragment timestamp projection that preserves nulls |
 

--- a/docs/src/postgres.md
+++ b/docs/src/postgres.md
@@ -234,6 +234,7 @@ carries the literal `'{}'` JSON path safely:
 |---|---|
 | `uuid_text("id")` | `id::text AS id` |
 | `uuid_text("vaults.id")` | `vaults.id::text AS id` |
+| `nullable_uuid_text("receipt_id")` | `CASE WHEN receipt_id IS NULL THEN NULL ELSE receipt_id::text END AS receipt_id` |
 | `timestamptz_json("created_at")` | `to_json(created_at)#>>'{}' AS created_at` |
 | `timestamptz_json("vaults.created_at")` | `to_json(vaults.created_at)#>>'{}' AS created_at` |
 | `nullable_timestamptz_json("finished_at")` | `CASE WHEN finished_at IS NULL THEN NULL ELSE to_json(finished_at)#>>'{}' END AS finished_at` |


### PR DESCRIPTION
## What

Adds `nullable_uuid_text(name)` to `std/postgres/query` — the nullable counterpart to `uuid_text(name)`. It renders `CASE WHEN name IS NULL THEN NULL ELSE name::text END AS name` as a trusted `PgSqlFragment`, preserving SQL NULLs as JSON `null` instead of casting them to the string `"null"`.

## Why

The module already had `uuid_text` (non-null `col::text AS col`) and `nullable_timestamptz_json` (nullable timestamp), but **no nullable `::text` projector**. Data-access code therefore hand-rolled `CASE WHEN col IS NULL THEN NULL ELSE col::text END AS col` as raw string concatenation for every nullable UUID/foreign-key column (e.g. `receipt_id`, `session_id`, `forked_from_session_id`). That asymmetry is a leaky abstraction and a recurring projection-boilerplate source across downstream `.harn` data-access modules.

This restores symmetry: `uuid_text` ↔ `nullable_uuid_text`, just like `timestamptz_json` ↔ `nullable_timestamptz_json`. Supports table-qualified names (`sessions.forked_from_session_id` → aliased to `forked_from_session_id`) and rejects unsafe identifiers exactly as the sibling helpers do.

## Tests

- Extended `conformance/tests/stdlib/postgres_query_helpers.harn`: exercises `nullable_uuid_text` inside a qualified `columns([...])` projection and asserts unsafe-name rejection. Snapshot updated; full stdlib conformance suite passes (290/290).
- Docs (`docs/src/postgres.md`, `docs/src/modules.md`) and a changelog fragment added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)