### PR TITLE
fix(llm): gpt-oss requires reasoning for tool calls — correct auto_reasoning_overrides + tool_format declaratively (kills billed-noncommittal at root)

### DIFF
--- a/changelog.d/gpt-oss-reasoning-for-tools.fixed.md
+++ b/changelog.d/gpt-oss-reasoning-for-tools.fixed.md
@@ -1,0 +1,18 @@
+- **gpt-oss (Harmony) now keeps reasoning ON for tool calls — kills the
+  billed-noncommittal failure at its root.** gpt-oss performs tool calls
+  *inside* the Harmony chain-of-thought channel, so disabling reasoning breaks
+  tool calling entirely (live OpenRouter probe of `openai/gpt-oss-120b`:
+  `reasoning {enabled:false}` → 0 tool_calls + null completion_tokens; `effort:
+  low` / provider default → clean native tool calls). This is the *opposite* of
+  the Qwen3 quirk (Qwen narrates tool intent in the reasoning trace and emits
+  zero `tool_calls`, so Qwen needs reasoning OFF for tools), and #3303's retry
+  was masking this self-inflicted misconfig. The fix is declarative, in the
+  `capabilities.toml` family: a new `reasoning_required_for_tools` capability
+  flag is set on every gpt-oss row (Together, Groq, Cerebras, and a newly-added
+  OpenRouter `openai/gpt-oss-*` row that previously fell through to a
+  reasoning-less catch-all), and `reasoning_policy` now refuses to resolve a
+  tool-bearing task (agent/code/verify) to reasoning-off when that flag is set —
+  flooring to the lowest supported effort instead — so no future auto default,
+  capability override, or session pin can re-introduce the failure. The Qwen3
+  reasoning-off-for-tools behavior is unchanged. Both quirks are now documented
+  side by side in the capability matrix.

--- a/changelog.d/opinionated-provider-route-policy.added.md
+++ b/changelog.d/opinionated-provider-route-policy.added.md
@@ -1,0 +1,20 @@
+- **Opinionated provider-route policy: gpt-oss on OpenRouter is now pinned to
+  clean sub-providers, plus a compile-time footgun-validation gate.** OpenRouter
+  routes `openai/gpt-oss-120b` across a ~17-upstream sub-provider lottery, and
+  some upstreams mis-serialize the Harmony tool call even with reasoning ON
+  (billed-noncommittal: 0 tool_calls), so the route was a runtime footgun even
+  after the reasoning fix. Two declarative pieces close it: (1) a new
+  `openrouter_provider_order` capability field (the allowlist counterpart to
+  `provider_route_denylist`) materializes to the OpenRouter request body's
+  `provider: { order: [...], allow_fallbacks: false }`, and the
+  `openai/gpt-oss-*` OpenRouter row pins it to `["Cerebras", "Groq"]` — the
+  upstreams that served Harmony tool calls cleanly in a live 2026-06-13 probe
+  (order-pinned requests gave 0 billed-noncommittal; Together was flaky 1/3);
+  (2) a data-driven footgun gate (`harn providers build-capabilities --check` /
+  `make check-provider-capabilities`) that FAILS the build on known-footgun
+  provider/model/config combos — a `reasoning_required_for_tools` route that
+  also forces a tool task to reasoning-off, and a `reasoning_required_for_tools`
+  OpenRouter route with no clean-sub-provider pin. The gate reads the
+  capability matrix's own invariants (no hard-coded model-name patterns), so a
+  new footgun route is caught the moment it forgets a pin. The blessed-vs-
+  forbidden policy is documented in the `capabilities.toml` base shard.

--- a/crates/harn-cli/src/commands/providers/build.rs
+++ b/crates/harn-cli/src/commands/providers/build.rs
@@ -144,8 +144,21 @@ fn generated_provider_capabilities(source_dir: &Path) -> Result<GeneratedProvide
         body.push('\n');
     }
 
-    toml::from_str::<harn_vm::llm::capabilities::CapabilitiesFile>(&body)
+    let parsed = toml::from_str::<harn_vm::llm::capabilities::CapabilitiesFile>(&body)
         .map_err(|error| format!("generated provider capabilities do not parse: {error}"))?;
+
+    // Opinionated footgun gate: refuse to generate (or pass --check on) a
+    // capability matrix that declares a known-footgun provider/model/config
+    // combo (e.g. a tool route with reasoning forced off, or an OpenRouter
+    // Harmony tool route with no clean-sub-provider pin). Data-driven over the
+    // matrix — see harn_vm::llm::capability_audit.
+    let audit = harn_vm::llm::capability_audit::audit_capabilities(&parsed);
+    if !audit.is_clean() {
+        return Err(format!(
+            "capability matrix footgun check failed:\n{}",
+            audit.render()
+        ));
+    }
 
     Ok(GeneratedProviderConfig {
         body,

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -362,6 +362,20 @@ pub struct ProviderRule {
     /// 400 when sent `reasoning: {enabled:false}`.
     #[serde(default)]
     pub reasoning_disable_supported: Option<bool>,
+    /// Whether this model performs *tool calls inside its reasoning channel*,
+    /// so disabling reasoning silently breaks tool calling. The canonical case
+    /// is the OpenAI gpt-oss (Harmony) family: with reasoning disabled it emits
+    /// 0 tool_calls and a tiny billed-noncommittal completion; with reasoning
+    /// enabled (even `low`) it emits clean native tool calls. This is the
+    /// *opposite* of the Qwen3 quirk (Qwen narrates tool intent in the
+    /// reasoning trace and emits zero `tool_calls`, so Qwen needs reasoning
+    /// OFF for tools). When set, `reasoning_policy` refuses to downgrade the
+    /// auto reasoning level to `off` for tool-bearing tasks (agent/code/verify)
+    /// — flooring instead to the lowest supported effort — so no future
+    /// auto-policy default or session pin can re-introduce the
+    /// billed-noncommittal failure at the data layer.
+    #[serde(default)]
+    pub reasoning_required_for_tools: Option<bool>,
     /// Whether reasoning-only clean stops may be promoted into visible text.
     /// Disable this for providers whose `reasoning` field is always private
     /// trace, even when `content` is empty.
@@ -503,6 +517,8 @@ pub struct Capabilities {
     /// the provider's own default ceiling.
     pub max_thinking_budget: Option<i64>,
     pub reasoning_disable_supported: bool,
+    /// See [`ProviderRule::reasoning_required_for_tools`].
+    pub reasoning_required_for_tools: bool,
     pub reasoning_text_promotable: bool,
     pub reasoning_wire_format: Option<String>,
     pub seed_supported: bool,
@@ -576,6 +592,7 @@ impl Default for Capabilities {
             reasoning_none_supported: false,
             max_thinking_budget: None,
             reasoning_disable_supported: true,
+            reasoning_required_for_tools: false,
             reasoning_text_promotable: true,
             reasoning_wire_format: None,
             seed_supported: true,
@@ -1221,6 +1238,7 @@ fn defaults_to_caps(defaults: &ProviderDefaults) -> Capabilities {
         reasoning_none_supported: None,
         max_thinking_budget: None,
         reasoning_disable_supported: None,
+        reasoning_required_for_tools: None,
         reasoning_text_promotable: None,
         reasoning_wire_format: None,
         seed_supported: None,
@@ -1317,6 +1335,7 @@ fn rule_to_caps(rule: &ProviderRule, defaults: &ProviderDefaults) -> Capabilitie
         reasoning_none_supported: rule.reasoning_none_supported.unwrap_or(false),
         max_thinking_budget: rule.max_thinking_budget,
         reasoning_disable_supported: rule.reasoning_disable_supported.unwrap_or(true),
+        reasoning_required_for_tools: rule.reasoning_required_for_tools.unwrap_or(false),
         reasoning_text_promotable: rule.reasoning_text_promotable.unwrap_or(true),
         reasoning_wire_format: rule
             .reasoning_wire_format

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -460,6 +460,25 @@ pub struct ProviderRule {
     /// natively. Only consulted for the `openrouter` provider.
     #[serde(default)]
     pub provider_route_denylist: Option<Vec<String>>,
+    /// OpenRouter upstream provider names this `(provider, model)` row is
+    /// PINNED to, in preference order. Materialized into the request body's
+    /// `provider.order` array with `allow_fallbacks = false` (see
+    /// [`crate::llm::providers::openai_compat::apply_openrouter_provider_order`]),
+    /// so OpenRouter only ever routes the model to these known-clean upstreams
+    /// and never silently falls back to a sketchier one. This is the
+    /// *allowlist* counterpart to [`Self::provider_route_denylist`]: prefer it
+    /// when the bad upstreams are intermittent / hard to enumerate but the
+    /// clean ones are few and stable. The canonical case is OpenRouter's
+    /// `openai/gpt-oss-*` route, which fans out across ~17 upstreams in a
+    /// sub-provider lottery; some mis-serialize the Harmony tool call even with
+    /// reasoning ON (billed-noncommittal: 0 tool_calls), while Cerebras and
+    /// Groq serve it cleanly. Only consulted for the `openrouter` provider. An
+    /// empty / unset list means "no pin" (free OpenRouter routing). When both a
+    /// pin and a denylist are present the pin wins (a closed allowlist already
+    /// excludes everything not on it). Validated by the footgun gate in
+    /// [`crate::llm::capability_audit`].
+    #[serde(default)]
+    pub openrouter_provider_order: Option<Vec<String>>,
 }
 
 /// Resolved capabilities for a `(provider, model)` pair. Unset rule
@@ -541,6 +560,10 @@ pub struct Capabilities {
     /// row. See [`ProviderRule::provider_route_denylist`]. Empty means "no
     /// route restriction".
     pub provider_route_denylist: Vec<String>,
+    /// OpenRouter upstream provider names this row is PINNED to (allowlist), in
+    /// preference order. See [`ProviderRule::openrouter_provider_order`]. Empty
+    /// means "no pin" (free OpenRouter routing).
+    pub openrouter_provider_order: Vec<String>,
 }
 
 impl Default for Capabilities {
@@ -610,6 +633,7 @@ impl Default for Capabilities {
             thinking_disable_directive: None,
             auto_reasoning_overrides: BTreeMap::new(),
             provider_route_denylist: Vec::new(),
+            openrouter_provider_order: Vec::new(),
         }
     }
 }
@@ -722,6 +746,12 @@ fn builtin() -> &'static CapabilitiesFile {
         toml::from_str::<CapabilitiesFile>(BUILTIN_TOML)
             .expect("capabilities.toml must parse at build time")
     })
+}
+
+/// The shipped (built-in) capability matrix. Public so the footgun gate in
+/// [`crate::llm::capability_audit`] can audit exactly what Harn ships.
+pub fn builtin_file() -> &'static CapabilitiesFile {
+    builtin()
 }
 
 /// Install project-level overrides for the current thread. Usually
@@ -1256,6 +1286,7 @@ fn defaults_to_caps(defaults: &ProviderDefaults) -> Capabilities {
         thinking_disable_directive: None,
         auto_reasoning_overrides: None,
         provider_route_denylist: None,
+        openrouter_provider_order: None,
     };
     let mut caps = rule_to_caps(&empty, defaults);
     caps.preferred_tool_format = None;
@@ -1374,6 +1405,7 @@ fn rule_to_caps(rule: &ProviderRule, defaults: &ProviderDefaults) -> Capabilitie
         thinking_disable_directive: rule.thinking_disable_directive.clone(),
         auto_reasoning_overrides: rule.auto_reasoning_overrides.clone().unwrap_or_default(),
         provider_route_denylist: rule.provider_route_denylist.clone().unwrap_or_default(),
+        openrouter_provider_order: rule.openrouter_provider_order.clone().unwrap_or_default(),
     }
 }
 

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -139,6 +139,49 @@
 #                     whenever the resolved `thinking` config is `Disabled`,
 #                     so script authors don't need to know provider-specific
 #                     prompt directives. Idempotent — never injected twice.
+#   provider_route_denylist:
+#                     [openrouter only] DENYLIST of upstream sub-providers to
+#                     exclude for this route. Materialized into the request
+#                     body's `provider.ignore`. Use when a SPECIFIC upstream is
+#                     positively known to mis-serve a route while others are
+#                     fine (e.g. Ambient billing reasoning tokens then finishing
+#                     with empty tool_calls for qwen3.6). Prefer the allowlist
+#                     (openrouter_provider_order) when the bad upstreams are
+#                     intermittent/hard to enumerate.
+#   openrouter_provider_order:
+#                     [openrouter only] ALLOWLIST of upstream sub-providers this
+#                     route is PINNED to, in preference order. Materialized into
+#                     `provider.order` + `allow_fallbacks:false`, so OpenRouter
+#                     only ever routes to these known-clean upstreams. Use this
+#                     for routes on OpenRouter's sub-provider lottery where the
+#                     bad upstreams are intermittent (e.g. openai/gpt-oss-*,
+#                     pinned to ["Cerebras","Groq"]). When both a pin and a
+#                     denylist are set the pin wins (a closed allowlist already
+#                     excludes everything else).
+#
+# OPINIONATED PROVIDER/MODEL/CONFIG POLICY (enforced by the footgun gate in
+# crate::llm::capability_audit, wired into `providers build-capabilities
+# --check` / `make check-provider-capabilities`). Harn refuses to ship a matrix
+# that declares a known footgun, so harness authors can't reach these states:
+#
+#   * FORBIDDEN: reasoning_required_for_tools = true together with an
+#     auto_reasoning_overrides that forces a tool task (agent/code/verify) to
+#     "off". The two are contradictory — a model that calls tools inside its
+#     reasoning channel emits 0 tool_calls (billed-noncommittal) when reasoning
+#     is off. (The opposite Qwen quirk — reasoning-OFF-for-tools WITHOUT the
+#     required-for-tools flag — is legitimate and allowed.)
+#
+#   * FORBIDDEN: an `openrouter` route with reasoning_required_for_tools = true
+#     (a Harmony-style tool route on the sub-provider lottery) that declares no
+#     openrouter_provider_order pin. Some OpenRouter upstreams mis-serialize the
+#     Harmony tool call even with reasoning ON, so such a route MUST pin a
+#     closed allowlist of known-clean upstreams.
+#
+#   * BLESSED (live-probed 2026-06-13, openai/gpt-oss-120b, reasoning effort
+#     low): Cerebras and Groq serve Harmony tool calls cleanly (order-pinned
+#     requests gave 0 billed-noncommittal); Together was flaky (1/3); the
+#     free OpenRouter lottery fans out across ~17 upstreams. Hence the
+#     openai/gpt-oss-* OpenRouter row is pinned to ["Cerebras","Groq"].
 
 # --- source: 10-defaults/provider-defaults.toml ---
 [provider_defaults.anthropic]
@@ -3447,6 +3490,23 @@ thinking_block_style = "none"
 # `reasoning:{enabled:false}` disable directive on the wire, and the
 # required-for-tools flag keeps the auto policy from flooring tool tasks to off.
 # Must NOT carry a Qwen-style `auto_reasoning_overrides = "off"`.
+#
+# SECOND footgun — the OpenRouter sub-provider lottery. `openai/gpt-oss-120b`
+# fans out across ~17 upstreams on OpenRouter; even with reasoning ON, some
+# mis-serialize the Harmony tool call and finish billed-noncommittal (0
+# tool_calls). The bad upstreams are intermittent and hard to enumerate, so we
+# ALLOWLIST the known-clean ones instead of denylisting the bad ones.
+# `openrouter_provider_order = ["Cerebras", "Groq"]` materializes to
+# `provider: { order: ["Cerebras","Groq"], allow_fallbacks: false }`, so the
+# route only ever lands on those two upstreams. Live OpenRouter probe
+# (openai/gpt-oss-120b, 2026-06-13, reasoning effort=low, weather-tool request):
+#   - free routing (lottery) x12          -> Groq, 12/12 clean tool calls
+#   - order=[Cerebras,Groq] pin x6        -> Cerebras, 6/6 clean, 0 noncommittal
+#   - Cerebras-only pin x3 / Groq-only x3 -> 6/6 clean
+#   - Together pin x3                      -> 1/3 clean (2 "Provider returned
+#                                             error") -> NOT allowlisted
+# Cerebras and Groq are the blessed upstreams. The footgun gate (capability
+# audit) requires this pin on any reasoning_required_for_tools OpenRouter route.
 [[provider.openrouter]]
 model_match = "openai/gpt-oss-*"
 native_tools = true
@@ -3457,6 +3517,7 @@ reasoning_effort_supported = true
 reasoning_effort_levels = ["low", "medium", "high"]
 reasoning_disable_supported = false
 reasoning_required_for_tools = true
+openrouter_provider_order = ["Cerebras", "Groq"]
 text_tool_wire_format_supported = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -109,6 +109,13 @@
 #   reasoning_disable_supported:
 #                     whether `reasoning: {enabled:false}` is accepted when
 #                     the provider uses an enabled/disabled reasoning switch.
+#   reasoning_required_for_tools:
+#                     whether the model calls tools *inside* its reasoning
+#                     channel, so disabling reasoning breaks tool calling
+#                     (the gpt-oss / Harmony quirk — opposite of Qwen3).
+#                     When true, reasoning_policy never resolves the auto
+#                     reasoning level to "off" for tool tasks (agent/code/
+#                     verify); it floors to the lowest supported effort.
 #   reasoning_text_promotable:
 #                     whether a reasoning-only clean stop may be promoted into
 #                     visible text when the provider omits content.
@@ -1580,6 +1587,17 @@ thinking_block_style = "inline"
 # https://github.com/QwenLM/Qwen3.6/issues/89 for the trained-behavior
 # analysis and Qwen's own recommendation to disable reasoning when
 # tool-calling.
+#
+# NOTE — two opposite tool-calling reasoning quirks live in this matrix:
+#   * Qwen3 = reasoning-OFF-for-tools (this row): Qwen narrates its
+#     tool-call intent inside the reasoning trace and emits zero structured
+#     `tool_calls`, so the override forces reasoning off for tool tasks.
+#   * gpt-oss / Harmony = reasoning-ON-for-tools (see the gpt-oss rows in
+#     60-together / 70-...-groq / 80-cerebras / 99-openrouter-new-families):
+#     gpt-oss performs tool calls INSIDE the chain-of-thought channel, so
+#     disabling reasoning breaks tool calling. Those rows carry
+#     `reasoning_required_for_tools = true` and must NOT copy this Qwen-style
+#     `auto_reasoning_overrides = "off"`. Do not conflate the two.
 # OpenRouter routes Anthropic models verbatim — same wire shape as
 # direct anthropic, just wrapped in the OpenAI-compat chat-completions
 # envelope at the OpenRouter edge. The provider_family chain takes
@@ -2667,6 +2685,13 @@ thinking_block_style = "none"
 # Pinned EXPLICITLY (not inherited) because `openai/gpt-oss-120b` is a
 # catalogued model and the catalog invariant requires the rule to set both
 # fields. To change, set `preferred_tool_format` ("native" | "json" | "text").
+#
+# `reasoning_required_for_tools = true`: gpt-oss (Harmony) performs tool
+# calls INSIDE the chain-of-thought channel, so reasoning-off breaks tool
+# calling (billed-noncommittal: 0 tool_calls + tiny completion). This is the
+# OPPOSITE of the Qwen3 quirk — gpt-oss must NOT carry an
+# `auto_reasoning_overrides = { agent/verify/code = "off" }` override; the
+# flag makes reasoning_policy refuse to floor tool tasks to off.
 [[provider.together]]
 model_match = "openai/gpt-oss-*"
 native_tools = true
@@ -2674,6 +2699,7 @@ preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["effort"]
 reasoning_effort_supported = true
+reasoning_required_for_tools = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
 structured_output_mode = "native_json"
@@ -2861,6 +2887,14 @@ thinking_block_style = "reasoning_summary"
 # catalogued model and the catalog invariant requires every catalogued model's
 # rule to set native_tools + preferred_tool_format. To change, set
 # `preferred_tool_format` ("native" | "json" | "text").
+#
+# `reasoning_required_for_tools = true`: gpt-oss (Harmony) calls tools INSIDE
+# the chain-of-thought channel, so reasoning-off breaks tool calling. Live
+# Groq probe (2026-06-13): reasoning_effort=low -> 1 clean tool call;
+# reasoning_effort=none -> rejected ("must be one of low/medium/high"). So
+# this row only ever sends {low,medium,high} (reasoning_effort_levels) and
+# never floors to off for tool tasks. Must NOT carry a Qwen-style
+# `auto_reasoning_overrides = "off"`.
 [[provider.groq]]
 model_match = "*gpt-oss-*"
 native_tools = true
@@ -2870,6 +2904,8 @@ text_tool_wire_format_supported = true
 structured_output = "native"
 thinking_modes = ["effort"]
 reasoning_effort_supported = true
+reasoning_effort_levels = ["low", "medium", "high"]
+reasoning_required_for_tools = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
 structured_output_mode = "native_json"
@@ -2915,8 +2951,14 @@ thinking_block_style = "none"
 # (and only working) channel. Pinned EXPLICITLY because `gpt-oss-120b` is a
 # catalogued model and the catalog invariant requires every catalogued model's
 # rule to set native_tools + preferred_tool_format. (groq / together gpt-oss
-# rows carry the same stale json pin and should get the same flip.)
+# rows are now native too.)
 # To change, set `preferred_tool_format` ("native" | "json" | "text").
+#
+# `reasoning_required_for_tools = true`: gpt-oss (Harmony) calls tools INSIDE
+# the chain-of-thought channel, so reasoning-off breaks tool calling. Combined
+# with reasoning_effort_levels above, reasoning_policy floors an auto "off" to
+# the lowest accepted effort ("low") for tool tasks instead of disabling
+# reasoning. Must NOT carry a Qwen-style `auto_reasoning_overrides = "off"`.
 [[provider.cerebras]]
 model_match = "gpt-oss-*"
 native_tools = true
@@ -2925,6 +2967,7 @@ structured_output = "native"
 thinking_modes = ["effort"]
 reasoning_effort_supported = true
 reasoning_effort_levels = ["low", "medium", "high"]
+reasoning_required_for_tools = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
 structured_output_mode = "native_json"
@@ -3387,6 +3430,41 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "none"
+
+# OpenAI gpt-oss (Harmony) served via OpenRouter. Without an explicit row this
+# slug fell through provider_family openrouter -> openai, matched no `gpt-*`
+# rule (the `openai/` prefix and the unparseable `oss` "version" both fail the
+# match), and landed on a capability-less catch-all that declares NO reasoning
+# support — so the policy resolver could not even materialize reasoning.
+#
+# `reasoning_required_for_tools = true`: gpt-oss performs tool calls INSIDE the
+# Harmony chain-of-thought channel, so disabling reasoning breaks tool calling.
+# Live OpenRouter probe (openai/gpt-oss-120b, 2026-06-13, identical tool
+# request): reasoning {enabled:false} -> 0 tool_calls + null completion_tokens
+# (the billed-noncommittal failure); reasoning {effort:low} -> 1 clean native
+# tool call; no reasoning field (provider default) -> 1 clean native tool call.
+# `reasoning_disable_supported = false` keeps Harn from ever emitting the
+# `reasoning:{enabled:false}` disable directive on the wire, and the
+# required-for-tools flag keeps the auto policy from flooring tool tasks to off.
+# Must NOT carry a Qwen-style `auto_reasoning_overrides = "off"`.
+[[provider.openrouter]]
+model_match = "openai/gpt-oss-*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["effort"]
+reasoning_effort_supported = true
+reasoning_effort_levels = ["low", "medium", "high"]
+reasoning_disable_supported = false
+reasoning_required_for_tools = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "reasoning_summary"
 
 [[provider.openrouter]]
 model_match = "stepfun/step-3.7-flash"

--- a/crates/harn-vm/src/llm/capability_audit.rs
+++ b/crates/harn-vm/src/llm/capability_audit.rs
@@ -1,0 +1,280 @@
+//! Compile-time footgun gate for the capability matrix.
+//!
+//! Harn is *opinionated* about provider/model/config combinations: a few
+//! combos are known footguns that silently break tool calling at runtime, and
+//! the only durable place to forbid them is the declarative matrix itself —
+//! before a harness author can ship a misconfigured route.
+//!
+//! This audit walks the parsed [`CapabilitiesFile`] and flags
+//! provider+model+config combinations that the matrix declares as invariants,
+//! NOT hard-coded model-name patterns. It generalizes the
+//! `reasoning_required_for_tools` precedent (a tool-using model that calls
+//! tools inside its reasoning channel) into a small set of data-driven rules:
+//!
+//!   * **reasoning-off-for-tools contradiction** — a row that declares
+//!     `reasoning_required_for_tools = true` must not also pin a tool task
+//!     (`agent` / `code` / `verify`) to reasoning `"off"` via
+//!     `auto_reasoning_overrides`. That is the self-inflicted
+//!     billed-noncommittal failure #3305 fixed at its root; declaring both is a
+//!     direct contradiction.
+//!
+//!   * **lottery-route without a clean pin** — an OpenRouter row that declares
+//!     `reasoning_required_for_tools = true` is a Harmony-style tool route on a
+//!     sub-provider-lottery provider. Some OpenRouter upstreams mis-serialize
+//!     the Harmony tool call even with reasoning ON, so such a row MUST pin a
+//!     closed allowlist of known-clean upstreams via `openrouter_provider_order`
+//!     (materialized to `provider.order` + `allow_fallbacks:false`). Without a
+//!     pin the route can silently land on a sketchy upstream.
+//!
+//! Both checks are driven entirely by capability-row fields, so adding a new
+//! footgun route is a data edit (set the flag / forget the pin) rather than a
+//! code change — and forgetting the pin trips this gate.
+//!
+//! The audit is wired into `harn providers build-capabilities --check` (see
+//! `harn-cli`), which runs under `make check-provider-capabilities` /
+//! `make check-provider-matrix`, so the matrix cannot drift into a footgun
+//! state without failing CI.
+
+use crate::llm::capabilities::CapabilitiesFile;
+
+/// Tool-bearing reasoning tasks. These are the tasks whose auto reasoning level
+/// must never resolve to `"off"` on a route that calls tools in its reasoning
+/// channel. Mirrors the guarded set in
+/// [`crate::llm::reasoning_policy`].
+const TOOL_TASKS: [&str; 3] = ["agent", "code", "verify"];
+
+/// A single footgun finding: a capability row that violates an opinionated
+/// provider/model/config invariant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilityFootgun {
+    /// Provider id whose rule list contains the offending row.
+    pub provider: String,
+    /// The row's `model_match` pattern.
+    pub model_match: String,
+    /// Human-readable explanation + the declarative fix.
+    pub message: String,
+}
+
+/// Result of auditing a [`CapabilitiesFile`] for footgun combinations.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CapabilityAuditReport {
+    pub footguns: Vec<CapabilityFootgun>,
+}
+
+impl CapabilityAuditReport {
+    pub fn is_clean(&self) -> bool {
+        self.footguns.is_empty()
+    }
+
+    /// One line per finding, suitable for CLI/CI output.
+    pub fn render(&self) -> String {
+        self.footguns
+            .iter()
+            .map(|footgun| {
+                format!(
+                    "provider.{} model_match=\"{}\": {}",
+                    footgun.provider, footgun.model_match, footgun.message
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+/// Audit the in-memory capability matrix for footgun provider/model/config
+/// combinations. Pure over the parsed file — no I/O, no model-name patterns.
+pub fn audit_capabilities(file: &CapabilitiesFile) -> CapabilityAuditReport {
+    let mut report = CapabilityAuditReport::default();
+    for (provider, rules) in &file.provider {
+        for rule in rules {
+            let reasoning_required_for_tools = rule.reasoning_required_for_tools.unwrap_or(false);
+
+            // Footgun 1: reasoning-off-for-tools contradiction. A route that
+            // calls tools inside its reasoning channel must not also force a
+            // tool task to reasoning-off.
+            if reasoning_required_for_tools {
+                if let Some(overrides) = &rule.auto_reasoning_overrides {
+                    let offending: Vec<&str> = TOOL_TASKS
+                        .iter()
+                        .copied()
+                        .filter(|task| {
+                            overrides
+                                .get(*task)
+                                .map(|level| level.eq_ignore_ascii_case("off"))
+                                .unwrap_or(false)
+                        })
+                        .collect();
+                    if !offending.is_empty() {
+                        report.footguns.push(CapabilityFootgun {
+                            provider: provider.clone(),
+                            model_match: rule.model_match.clone(),
+                            message: format!(
+                                "declares reasoning_required_for_tools = true but also pins \
+                                 auto_reasoning_overrides {{ {} = \"off\" }}; this route calls \
+                                 tools inside its reasoning channel, so forcing reasoning off \
+                                 for a tool task is the billed-noncommittal failure (0 \
+                                 tool_calls). Remove the \"off\" override(s) for tool tasks.",
+                                offending.join("/")
+                            ),
+                        });
+                    }
+                }
+            }
+
+            // Footgun 2: lottery-route without a clean sub-provider pin. An
+            // OpenRouter Harmony-style tool route must allowlist known-clean
+            // upstreams or it can silently land on a mis-serializing one.
+            if provider == "openrouter" && reasoning_required_for_tools {
+                let pinned = rule
+                    .openrouter_provider_order
+                    .as_ref()
+                    .map(|order| !order.is_empty())
+                    .unwrap_or(false);
+                if !pinned {
+                    report.footguns.push(CapabilityFootgun {
+                        provider: provider.clone(),
+                        model_match: rule.model_match.clone(),
+                        message: "is an OpenRouter route with \
+                            reasoning_required_for_tools = true (a Harmony-style tool route on \
+                            the OpenRouter sub-provider lottery) but declares no \
+                            openrouter_provider_order pin. Some OpenRouter upstreams \
+                            mis-serialize the tool call even with reasoning ON. Pin a closed \
+                            allowlist of known-clean upstreams, e.g. \
+                            openrouter_provider_order = [\"Cerebras\", \"Groq\"]."
+                            .to_string(),
+                    });
+                }
+            }
+        }
+    }
+    report
+}
+
+/// Audit the built-in (shipped) capability matrix. Convenience entry point for
+/// the CLI gate.
+pub fn audit_builtin() -> CapabilityAuditReport {
+    audit_capabilities(crate::llm::capabilities::builtin_file())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::capabilities::parse_capabilities_toml;
+
+    fn audit_toml(src: &str) -> CapabilityAuditReport {
+        audit_capabilities(&parse_capabilities_toml(src).expect("parses"))
+    }
+
+    #[test]
+    fn shipped_matrix_has_no_footguns() {
+        let report = audit_builtin();
+        assert!(
+            report.is_clean(),
+            "shipped capability matrix has footguns:\n{}",
+            report.render()
+        );
+    }
+
+    #[test]
+    fn flags_reasoning_off_for_tools_contradiction() {
+        let report = audit_toml(
+            r#"
+[[provider.someprov]]
+model_match = "harmony-*"
+reasoning_required_for_tools = true
+auto_reasoning_overrides = { agent = "off" }
+"#,
+        );
+        assert_eq!(report.footguns.len(), 1, "{}", report.render());
+        assert_eq!(report.footguns[0].provider, "someprov");
+        assert!(report.footguns[0].message.contains("billed-noncommittal"));
+    }
+
+    #[test]
+    fn flags_lottery_route_without_pin() {
+        let report = audit_toml(
+            r#"
+[[provider.openrouter]]
+model_match = "vendor/harmony-*"
+reasoning_required_for_tools = true
+reasoning_effort_levels = ["low", "medium", "high"]
+"#,
+        );
+        assert_eq!(report.footguns.len(), 1, "{}", report.render());
+        assert!(report.footguns[0]
+            .message
+            .contains("openrouter_provider_order"));
+    }
+
+    #[test]
+    fn pinned_lottery_route_is_clean() {
+        let report = audit_toml(
+            r#"
+[[provider.openrouter]]
+model_match = "vendor/harmony-*"
+reasoning_required_for_tools = true
+openrouter_provider_order = ["Cerebras", "Groq"]
+"#,
+        );
+        assert!(report.is_clean(), "{}", report.render());
+    }
+
+    #[test]
+    fn empty_pin_is_treated_as_no_pin() {
+        let report = audit_toml(
+            r#"
+[[provider.openrouter]]
+model_match = "vendor/harmony-*"
+reasoning_required_for_tools = true
+openrouter_provider_order = []
+"#,
+        );
+        assert_eq!(report.footguns.len(), 1, "{}", report.render());
+    }
+
+    #[test]
+    fn non_openrouter_required_route_does_not_need_a_pin() {
+        // Groq/Cerebras/Together gpt-oss rows require reasoning for tools but
+        // are NOT on the OpenRouter lottery, so they must not be flagged for a
+        // missing pin.
+        let report = audit_toml(
+            r#"
+[[provider.groq]]
+model_match = "*gpt-oss-*"
+reasoning_required_for_tools = true
+reasoning_effort_levels = ["low", "medium", "high"]
+"#,
+        );
+        assert!(report.is_clean(), "{}", report.render());
+    }
+
+    #[test]
+    fn qwen_style_off_override_without_required_flag_is_clean() {
+        // The Qwen quirk (reasoning-OFF-for-tools, no required-for-tools flag)
+        // is a legitimate config and must NOT be flagged.
+        let report = audit_toml(
+            r#"
+[[provider.ollama]]
+model_match = "qwen3.6*"
+auto_reasoning_overrides = { agent = "off" }
+"#,
+        );
+        assert!(report.is_clean(), "{}", report.render());
+    }
+
+    #[test]
+    fn ordinary_models_are_clean() {
+        let report = audit_toml(
+            r#"
+[[provider.openrouter]]
+model_match = "anthropic/claude-*"
+native_tools = true
+
+[[provider.openai]]
+model_match = "gpt-*"
+native_tools = true
+"#,
+        );
+        assert!(report.is_clean(), "{}", report.render());
+    }
+}

--- a/crates/harn-vm/src/llm/capability_sources/00-base.toml
+++ b/crates/harn-vm/src/llm/capability_sources/00-base.toml
@@ -135,3 +135,46 @@
 #                     whenever the resolved `thinking` config is `Disabled`,
 #                     so script authors don't need to know provider-specific
 #                     prompt directives. Idempotent — never injected twice.
+#   provider_route_denylist:
+#                     [openrouter only] DENYLIST of upstream sub-providers to
+#                     exclude for this route. Materialized into the request
+#                     body's `provider.ignore`. Use when a SPECIFIC upstream is
+#                     positively known to mis-serve a route while others are
+#                     fine (e.g. Ambient billing reasoning tokens then finishing
+#                     with empty tool_calls for qwen3.6). Prefer the allowlist
+#                     (openrouter_provider_order) when the bad upstreams are
+#                     intermittent/hard to enumerate.
+#   openrouter_provider_order:
+#                     [openrouter only] ALLOWLIST of upstream sub-providers this
+#                     route is PINNED to, in preference order. Materialized into
+#                     `provider.order` + `allow_fallbacks:false`, so OpenRouter
+#                     only ever routes to these known-clean upstreams. Use this
+#                     for routes on OpenRouter's sub-provider lottery where the
+#                     bad upstreams are intermittent (e.g. openai/gpt-oss-*,
+#                     pinned to ["Cerebras","Groq"]). When both a pin and a
+#                     denylist are set the pin wins (a closed allowlist already
+#                     excludes everything else).
+#
+# OPINIONATED PROVIDER/MODEL/CONFIG POLICY (enforced by the footgun gate in
+# crate::llm::capability_audit, wired into `providers build-capabilities
+# --check` / `make check-provider-capabilities`). Harn refuses to ship a matrix
+# that declares a known footgun, so harness authors can't reach these states:
+#
+#   * FORBIDDEN: reasoning_required_for_tools = true together with an
+#     auto_reasoning_overrides that forces a tool task (agent/code/verify) to
+#     "off". The two are contradictory — a model that calls tools inside its
+#     reasoning channel emits 0 tool_calls (billed-noncommittal) when reasoning
+#     is off. (The opposite Qwen quirk — reasoning-OFF-for-tools WITHOUT the
+#     required-for-tools flag — is legitimate and allowed.)
+#
+#   * FORBIDDEN: an `openrouter` route with reasoning_required_for_tools = true
+#     (a Harmony-style tool route on the sub-provider lottery) that declares no
+#     openrouter_provider_order pin. Some OpenRouter upstreams mis-serialize the
+#     Harmony tool call even with reasoning ON, so such a route MUST pin a
+#     closed allowlist of known-clean upstreams.
+#
+#   * BLESSED (live-probed 2026-06-13, openai/gpt-oss-120b, reasoning effort
+#     low): Cerebras and Groq serve Harmony tool calls cleanly (order-pinned
+#     requests gave 0 billed-noncommittal); Together was flaky (1/3); the
+#     free OpenRouter lottery fans out across ~17 upstreams. Hence the
+#     openai/gpt-oss-* OpenRouter row is pinned to ["Cerebras","Groq"].

--- a/crates/harn-vm/src/llm/capability_sources/00-base.toml
+++ b/crates/harn-vm/src/llm/capability_sources/00-base.toml
@@ -105,6 +105,13 @@
 #   reasoning_disable_supported:
 #                     whether `reasoning: {enabled:false}` is accepted when
 #                     the provider uses an enabled/disabled reasoning switch.
+#   reasoning_required_for_tools:
+#                     whether the model calls tools *inside* its reasoning
+#                     channel, so disabling reasoning breaks tool calling
+#                     (the gpt-oss / Harmony quirk — opposite of Qwen3).
+#                     When true, reasoning_policy never resolves the auto
+#                     reasoning level to "off" for tool tasks (agent/code/
+#                     verify); it floors to the lowest supported effort.
 #   reasoning_text_promotable:
 #                     whether a reasoning-only clean stop may be promoted into
 #                     visible text when the provider omits content.

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/30-qwen-routed.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/30-qwen-routed.toml
@@ -137,6 +137,17 @@ thinking_block_style = "inline"
 # https://github.com/QwenLM/Qwen3.6/issues/89 for the trained-behavior
 # analysis and Qwen's own recommendation to disable reasoning when
 # tool-calling.
+#
+# NOTE — two opposite tool-calling reasoning quirks live in this matrix:
+#   * Qwen3 = reasoning-OFF-for-tools (this row): Qwen narrates its
+#     tool-call intent inside the reasoning trace and emits zero structured
+#     `tool_calls`, so the override forces reasoning off for tool tasks.
+#   * gpt-oss / Harmony = reasoning-ON-for-tools (see the gpt-oss rows in
+#     60-together / 70-...-groq / 80-cerebras / 99-openrouter-new-families):
+#     gpt-oss performs tool calls INSIDE the chain-of-thought channel, so
+#     disabling reasoning breaks tool calling. Those rows carry
+#     `reasoning_required_for_tools = true` and must NOT copy this Qwen-style
+#     `auto_reasoning_overrides = "off"`. Do not conflate the two.
 # OpenRouter routes Anthropic models verbatim — same wire shape as
 # direct anthropic, just wrapped in the OpenAI-compat chat-completions
 # envelope at the OpenRouter edge. The provider_family chain takes

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/60-together.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/60-together.toml
@@ -20,6 +20,13 @@
 # Pinned EXPLICITLY (not inherited) because `openai/gpt-oss-120b` is a
 # catalogued model and the catalog invariant requires the rule to set both
 # fields. To change, set `preferred_tool_format` ("native" | "json" | "text").
+#
+# `reasoning_required_for_tools = true`: gpt-oss (Harmony) performs tool
+# calls INSIDE the chain-of-thought channel, so reasoning-off breaks tool
+# calling (billed-noncommittal: 0 tool_calls + tiny completion). This is the
+# OPPOSITE of the Qwen3 quirk — gpt-oss must NOT carry an
+# `auto_reasoning_overrides = { agent/verify/code = "off" }` override; the
+# flag makes reasoning_policy refuse to floor tool tasks to off.
 [[provider.together]]
 model_match = "openai/gpt-oss-*"
 native_tools = true
@@ -27,6 +34,7 @@ preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["effort"]
 reasoning_effort_supported = true
+reasoning_required_for_tools = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
 structured_output_mode = "native_json"

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/70-mistral-cohere-xai-groq.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/70-mistral-cohere-xai-groq.toml
@@ -79,6 +79,14 @@ thinking_block_style = "reasoning_summary"
 # catalogued model and the catalog invariant requires every catalogued model's
 # rule to set native_tools + preferred_tool_format. To change, set
 # `preferred_tool_format` ("native" | "json" | "text").
+#
+# `reasoning_required_for_tools = true`: gpt-oss (Harmony) calls tools INSIDE
+# the chain-of-thought channel, so reasoning-off breaks tool calling. Live
+# Groq probe (2026-06-13): reasoning_effort=low -> 1 clean tool call;
+# reasoning_effort=none -> rejected ("must be one of low/medium/high"). So
+# this row only ever sends {low,medium,high} (reasoning_effort_levels) and
+# never floors to off for tool tasks. Must NOT carry a Qwen-style
+# `auto_reasoning_overrides = "off"`.
 [[provider.groq]]
 model_match = "*gpt-oss-*"
 native_tools = true
@@ -88,6 +96,8 @@ text_tool_wire_format_supported = true
 structured_output = "native"
 thinking_modes = ["effort"]
 reasoning_effort_supported = true
+reasoning_effort_levels = ["low", "medium", "high"]
+reasoning_required_for_tools = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
 structured_output_mode = "native_json"

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/80-cerebras.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/80-cerebras.toml
@@ -19,8 +19,14 @@
 # (and only working) channel. Pinned EXPLICITLY because `gpt-oss-120b` is a
 # catalogued model and the catalog invariant requires every catalogued model's
 # rule to set native_tools + preferred_tool_format. (groq / together gpt-oss
-# rows carry the same stale json pin and should get the same flip.)
+# rows are now native too.)
 # To change, set `preferred_tool_format` ("native" | "json" | "text").
+#
+# `reasoning_required_for_tools = true`: gpt-oss (Harmony) calls tools INSIDE
+# the chain-of-thought channel, so reasoning-off breaks tool calling. Combined
+# with reasoning_effort_levels above, reasoning_policy floors an auto "off" to
+# the lowest accepted effort ("low") for tool tasks instead of disabling
+# reasoning. Must NOT carry a Qwen-style `auto_reasoning_overrides = "off"`.
 [[provider.cerebras]]
 model_match = "gpt-oss-*"
 native_tools = true
@@ -29,6 +35,7 @@ structured_output = "native"
 thinking_modes = ["effort"]
 reasoning_effort_supported = true
 reasoning_effort_levels = ["low", "medium", "high"]
+reasoning_required_for_tools = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
 structured_output_mode = "native_json"

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/99-openrouter-new-families.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/99-openrouter-new-families.toml
@@ -77,6 +77,23 @@ thinking_block_style = "none"
 # `reasoning:{enabled:false}` disable directive on the wire, and the
 # required-for-tools flag keeps the auto policy from flooring tool tasks to off.
 # Must NOT carry a Qwen-style `auto_reasoning_overrides = "off"`.
+#
+# SECOND footgun — the OpenRouter sub-provider lottery. `openai/gpt-oss-120b`
+# fans out across ~17 upstreams on OpenRouter; even with reasoning ON, some
+# mis-serialize the Harmony tool call and finish billed-noncommittal (0
+# tool_calls). The bad upstreams are intermittent and hard to enumerate, so we
+# ALLOWLIST the known-clean ones instead of denylisting the bad ones.
+# `openrouter_provider_order = ["Cerebras", "Groq"]` materializes to
+# `provider: { order: ["Cerebras","Groq"], allow_fallbacks: false }`, so the
+# route only ever lands on those two upstreams. Live OpenRouter probe
+# (openai/gpt-oss-120b, 2026-06-13, reasoning effort=low, weather-tool request):
+#   - free routing (lottery) x12          -> Groq, 12/12 clean tool calls
+#   - order=[Cerebras,Groq] pin x6        -> Cerebras, 6/6 clean, 0 noncommittal
+#   - Cerebras-only pin x3 / Groq-only x3 -> 6/6 clean
+#   - Together pin x3                      -> 1/3 clean (2 "Provider returned
+#                                             error") -> NOT allowlisted
+# Cerebras and Groq are the blessed upstreams. The footgun gate (capability
+# audit) requires this pin on any reasoning_required_for_tools OpenRouter route.
 [[provider.openrouter]]
 model_match = "openai/gpt-oss-*"
 native_tools = true
@@ -87,6 +104,7 @@ reasoning_effort_supported = true
 reasoning_effort_levels = ["low", "medium", "high"]
 reasoning_disable_supported = false
 reasoning_required_for_tools = true
+openrouter_provider_order = ["Cerebras", "Groq"]
 text_tool_wire_format_supported = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/99-openrouter-new-families.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/99-openrouter-new-families.toml
@@ -61,6 +61,41 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "none"
 
+# OpenAI gpt-oss (Harmony) served via OpenRouter. Without an explicit row this
+# slug fell through provider_family openrouter -> openai, matched no `gpt-*`
+# rule (the `openai/` prefix and the unparseable `oss` "version" both fail the
+# match), and landed on a capability-less catch-all that declares NO reasoning
+# support — so the policy resolver could not even materialize reasoning.
+#
+# `reasoning_required_for_tools = true`: gpt-oss performs tool calls INSIDE the
+# Harmony chain-of-thought channel, so disabling reasoning breaks tool calling.
+# Live OpenRouter probe (openai/gpt-oss-120b, 2026-06-13, identical tool
+# request): reasoning {enabled:false} -> 0 tool_calls + null completion_tokens
+# (the billed-noncommittal failure); reasoning {effort:low} -> 1 clean native
+# tool call; no reasoning field (provider default) -> 1 clean native tool call.
+# `reasoning_disable_supported = false` keeps Harn from ever emitting the
+# `reasoning:{enabled:false}` disable directive on the wire, and the
+# required-for-tools flag keeps the auto policy from flooring tool tasks to off.
+# Must NOT carry a Qwen-style `auto_reasoning_overrides = "off"`.
+[[provider.openrouter]]
+model_match = "openai/gpt-oss-*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["effort"]
+reasoning_effort_supported = true
+reasoning_effort_levels = ["low", "medium", "high"]
+reasoning_disable_supported = false
+reasoning_required_for_tools = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "reasoning_summary"
+
 [[provider.openrouter]]
 model_match = "stepfun/step-3.7-flash"
 native_tools = true

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod autonomy_budget;
 pub(crate) mod cache;
 mod call;
 pub mod capabilities;
+pub mod capability_audit;
 pub(crate) mod compass_router;
 pub(crate) mod config_builtins;
 pub(crate) mod content;

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -266,8 +266,20 @@ impl OpenAiCompatibleProvider {
         // empty tool_calls) while still advertising the model. We merge those
         // names into the request body's `provider.ignore` so OpenRouter reroutes
         // to a healthy upstream. Pure capability lookup — no model-name branch.
-        if opts.provider == "openrouter" && !caps.provider_route_denylist.is_empty() {
-            apply_openrouter_route_denylist(&mut body, &caps.provider_route_denylist);
+        // Data-driven OpenRouter upstream pin (allowlist). When the row pins a
+        // closed set of known-clean upstreams, route ONLY to them in order with
+        // `allow_fallbacks:false` so OpenRouter never silently falls back to a
+        // sketchier upstream that mis-serializes the route. The canonical case
+        // is `openai/gpt-oss-*`, pinned to Cerebras/Groq (clean for Harmony
+        // tool calls). A closed allowlist already excludes everything not on it,
+        // so the pin takes precedence over `provider_route_denylist` when both
+        // are present. Pure capability lookup — no model-name branch.
+        if opts.provider == "openrouter" {
+            if !caps.openrouter_provider_order.is_empty() {
+                apply_openrouter_provider_order(&mut body, &caps.openrouter_provider_order);
+            } else if !caps.provider_route_denylist.is_empty() {
+                apply_openrouter_route_denylist(&mut body, &caps.provider_route_denylist);
+            }
         }
         if let Some(ref tools) = opts.native_tools {
             if !tools.is_empty() {
@@ -502,6 +514,51 @@ pub(crate) fn apply_openrouter_route_denylist(body: &mut serde_json::Value, deny
             ignore_arr.push(serde_json::Value::String(name.clone()));
         }
     }
+}
+
+/// Pin the OpenRouter request body to a closed, ordered allowlist of upstream
+/// providers: sets `provider.order` to `order` and `provider.allow_fallbacks`
+/// to `false`, so OpenRouter routes the model only to those upstreams (in
+/// preference order) and never silently falls back to one not on the list.
+/// This is the wire materialization of the capability-row
+/// `openrouter_provider_order` — provider-agnostic data plumbing with no
+/// model-specific logic; the caller decides whether a pin applies by consulting
+/// the capability matrix. A pre-existing `provider.order` (e.g. a caller
+/// override) is left untouched; `allow_fallbacks` is always forced to `false`
+/// so the pin is genuinely closed. No-op when `order` is empty.
+pub(crate) fn apply_openrouter_provider_order(body: &mut serde_json::Value, order: &[String]) {
+    if order.is_empty() {
+        return;
+    }
+    if !body.is_object() {
+        return;
+    }
+    let provider = body
+        .as_object_mut()
+        .expect("body is an object")
+        .entry("provider".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    let Some(provider_obj) = provider.as_object_mut() else {
+        return;
+    };
+    // Only set the order when the caller has not already pinned one; respect an
+    // explicit caller override rather than clobbering it.
+    if !provider_obj.contains_key("order") {
+        provider_obj.insert(
+            "order".to_string(),
+            serde_json::Value::Array(
+                order
+                    .iter()
+                    .map(|name| serde_json::Value::String(name.clone()))
+                    .collect(),
+            ),
+        );
+    }
+    // A closed allowlist must not fall back off-list.
+    provider_obj.insert(
+        "allow_fallbacks".to_string(),
+        serde_json::Value::Bool(false),
+    );
 }
 
 fn normalize_tool_choice_for_capabilities(
@@ -1851,6 +1908,87 @@ thinking_modes = ["enabled"]
         assert!(
             other_body.get("provider").is_none(),
             "non-openrouter provider must not receive provider.ignore: {other_body}"
+        );
+    }
+
+    #[test]
+    fn provider_order_pins_closed_allowlist() {
+        let mut body = json!({"model": "openai/gpt-oss-120b"});
+        apply_openrouter_provider_order(&mut body, &["Cerebras".to_string(), "Groq".to_string()]);
+        assert_eq!(body["provider"]["order"], json!(["Cerebras", "Groq"]));
+        assert_eq!(body["provider"]["allow_fallbacks"], json!(false));
+    }
+
+    #[test]
+    fn provider_order_respects_caller_order_but_forces_closed() {
+        // A caller-supplied order is preserved; allow_fallbacks is still forced
+        // false so the pin is genuinely closed.
+        let mut body = json!({
+            "model": "openai/gpt-oss-120b",
+            "provider": { "order": ["Groq"], "allow_fallbacks": true }
+        });
+        apply_openrouter_provider_order(&mut body, &["Cerebras".to_string(), "Groq".to_string()]);
+        assert_eq!(body["provider"]["order"], json!(["Groq"]));
+        assert_eq!(body["provider"]["allow_fallbacks"], json!(false));
+    }
+
+    #[test]
+    fn provider_order_noop_for_empty() {
+        let mut body = json!({"model": "openai/gpt-oss-120b"});
+        apply_openrouter_provider_order(&mut body, &[]);
+        assert!(body.get("provider").is_none());
+    }
+
+    #[test]
+    fn build_request_body_pins_gpt_oss_openrouter_to_clean_subproviders() {
+        // The openrouter openai/gpt-oss-* capability row carries
+        // openrouter_provider_order = ["Cerebras", "Groq"]; build_request_body
+        // must materialize it into provider.order + allow_fallbacks:false so the
+        // sub-provider lottery only lands on known-clean upstreams.
+        let mut payload = base_request_payload();
+        payload.provider = "openrouter".to_string();
+        payload.model = "openai/gpt-oss-120b".to_string();
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        assert_eq!(
+            body["provider"]["order"],
+            json!(["Cerebras", "Groq"]),
+            "gpt-oss openrouter body must pin the clean upstream order: {body}"
+        );
+        assert_eq!(
+            body["provider"]["allow_fallbacks"],
+            json!(false),
+            "gpt-oss openrouter pin must be closed (no fallbacks): {body}"
+        );
+    }
+
+    #[test]
+    fn build_request_body_does_not_pin_other_openrouter_models() {
+        // A non-gpt-oss openrouter model must not receive a provider.order pin —
+        // the allowlist is row-scoped, so unrelated routes keep free routing.
+        let mut payload = base_request_payload();
+        payload.provider = "openrouter".to_string();
+        payload.model = "anthropic/claude-sonnet-4.5".to_string();
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        let order = body
+            .get("provider")
+            .and_then(|provider| provider.get("order"));
+        assert!(
+            order.is_none(),
+            "non-gpt-oss openrouter route must not be pinned: {body}"
+        );
+    }
+
+    #[test]
+    fn build_request_body_does_not_pin_gpt_oss_on_other_providers() {
+        // gpt-oss served by a NON-openrouter provider (groq/cerebras direct)
+        // must NOT get a provider.order block — the pin is openrouter-scoped.
+        let mut payload = base_request_payload();
+        payload.provider = "groq".to_string();
+        payload.model = "openai/gpt-oss-120b".to_string();
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        assert!(
+            body.get("provider").is_none(),
+            "non-openrouter gpt-oss route must not be pinned: {body}"
         );
     }
 }

--- a/crates/harn-vm/src/llm/reasoning_policy.rs
+++ b/crates/harn-vm/src/llm/reasoning_policy.rs
@@ -723,7 +723,12 @@ auto_reasoning_overrides = { agent = "off" }
         crate::llm::capabilities::clear_user_overrides();
     }
 
-    fn agent_opts(provider: &str, model: &str, task: &str, policy: &str) -> BTreeMap<String, VmValue> {
+    fn agent_opts(
+        provider: &str,
+        model: &str,
+        task: &str,
+        policy: &str,
+    ) -> BTreeMap<String, VmValue> {
         BTreeMap::from([
             (
                 "provider".to_string(),
@@ -761,7 +766,9 @@ auto_reasoning_overrides = { agent = "off" }
                 let thinking = out
                     .get("thinking")
                     .and_then(VmValue::as_dict)
-                    .unwrap_or_else(|| panic!("{provider}:{model} task={task} produced no thinking"));
+                    .unwrap_or_else(|| {
+                        panic!("{provider}:{model} task={task} produced no thinking")
+                    });
                 let mode = thinking.get("mode").map(VmValue::display);
                 assert_ne!(
                     mode.as_deref(),

--- a/crates/harn-vm/src/llm/reasoning_policy.rs
+++ b/crates/harn-vm/src/llm/reasoning_policy.rs
@@ -102,19 +102,45 @@ fn resolve_policy(
     // known regressions are declared alongside that model's other wire
     // capabilities, not as hard-coded provider/model patterns here.
     //
-    // The canonical case is Qwen3 with native tools: thinking mode plus
-    // tool calls is a binary on/off regression in the model weights — the
-    // model narrates its tool-call intent inside the reasoning trace and
-    // emits zero structured `tool_calls`. Qwen's own guidance is to
-    // disable reasoning when tool-calling. See
-    // https://github.com/QwenLM/Qwen3.6/issues/89 for the trained-behavior
-    // analysis. Routes that need the downgrade declare
-    // `auto_reasoning_overrides = { agent = "off" }`; callers that
-    // explicitly set a non-auto policy keep their override.
+    // Two opposite tool-calling reasoning quirks are declared in the
+    // matrix, not branched on here:
+    //
+    //   * Qwen3 (reasoning-OFF-for-tools): thinking mode plus tool calls
+    //     is a binary on/off regression in the model weights — the model
+    //     narrates its tool-call intent inside the reasoning trace and
+    //     emits zero structured `tool_calls`. Qwen's own guidance is to
+    //     disable reasoning when tool-calling. See
+    //     https://github.com/QwenLM/Qwen3.6/issues/89. Routes that need
+    //     the downgrade declare `auto_reasoning_overrides = { agent =
+    //     "off" }`.
+    //
+    //   * gpt-oss / Harmony (reasoning-ON-for-tools): the model performs
+    //     tool calls *inside* the Harmony chain-of-thought channel, so
+    //     disabling reasoning yields 0 tool_calls and a tiny
+    //     billed-noncommittal completion. Live OpenRouter probe of
+    //     openai/gpt-oss-120b: reasoning disabled -> 0/N tool calls;
+    //     reasoning low/default -> clean native tool calls. Such routes
+    //     declare `reasoning_required_for_tools = true` and MUST NOT carry
+    //     the Qwen-style `agent/verify/code = "off"` override.
+    //
+    // Callers that explicitly set a non-auto policy keep their override.
     if policy == "auto" {
         if let Some(override_level) = caps.auto_reasoning_overrides.get(&task) {
             level = override_level.clone();
         }
+    }
+    // Defense-in-depth for the gpt-oss / Harmony quirk: if this route calls
+    // tools inside its reasoning channel, never resolve a tool-bearing task
+    // to reasoning-off — that is the self-inflicted billed-noncommittal
+    // failure. Floor to the lowest supported effort (or "low") so no future
+    // auto default, capability override, or session pin can re-introduce
+    // it. Explicit non-auto caller policies are honored above; this guard
+    // only rewrites a resolved "off" for the tool tasks.
+    if caps.reasoning_required_for_tools
+        && level == "off"
+        && matches!(task.as_str(), "agent" | "code" | "verify")
+    {
+        level = lowest_tool_reasoning_level(caps);
     }
     let Some((thinking, effective_level)) = thinking_for_reasoning_level(&level, caps) else {
         return Ok(None);
@@ -339,6 +365,24 @@ fn lowest_supported_effort(caps: &Capabilities) -> Option<ReasoningEffort> {
                 .then(|| reasoning_effort_from_level(candidate))
                 .flatten()
         })
+}
+
+/// Lowest reasoning level to use when a route requires reasoning for tool
+/// calls (`reasoning_required_for_tools`) but the policy resolved to "off".
+/// Prefer the route's lowest declared `reasoning_effort_levels` entry (so
+/// Cerebras gpt-oss, which rejects "minimal"/"none", floors to its accepted
+/// "low"); fall back to "low" otherwise.
+fn lowest_tool_reasoning_level(caps: &Capabilities) -> String {
+    for candidate in ["minimal", "low", "medium", "high", "xhigh"] {
+        if caps
+            .reasoning_effort_levels
+            .iter()
+            .any(|supported| supported == candidate)
+        {
+            return candidate.to_string();
+        }
+    }
+    "low".to_string()
 }
 
 fn budget_for_reasoning_level(level: &str) -> u32 {
@@ -677,6 +721,127 @@ auto_reasoning_overrides = { agent = "off" }
             Some("disabled")
         );
         crate::llm::capabilities::clear_user_overrides();
+    }
+
+    fn agent_opts(provider: &str, model: &str, task: &str, policy: &str) -> BTreeMap<String, VmValue> {
+        BTreeMap::from([
+            (
+                "provider".to_string(),
+                VmValue::String(std::sync::Arc::from(provider)),
+            ),
+            (
+                "model".to_string(),
+                VmValue::String(std::sync::Arc::from(model)),
+            ),
+            (
+                "reasoning_policy".to_string(),
+                VmValue::String(std::sync::Arc::from(policy)),
+            ),
+            (
+                "reasoning_task".to_string(),
+                VmValue::String(std::sync::Arc::from(task)),
+            ),
+        ])
+    }
+
+    #[test]
+    fn gpt_oss_tool_tasks_keep_reasoning_on_across_providers() {
+        // gpt-oss performs tool calls inside the reasoning channel, so the
+        // auto policy must NEVER resolve a tool-bearing task to disabled
+        // reasoning. Verified for every catalogued gpt-oss route.
+        for (provider, model) in [
+            ("openrouter", "openai/gpt-oss-120b"),
+            ("groq", "openai/gpt-oss-120b"),
+            ("groq", "groq/openai/gpt-oss-120b"),
+            ("cerebras", "gpt-oss-120b"),
+            ("together", "openai/gpt-oss-120b"),
+        ] {
+            for task in ["agent", "code", "verify"] {
+                let out = apply(agent_opts(provider, model, task, "auto"));
+                let thinking = out
+                    .get("thinking")
+                    .and_then(VmValue::as_dict)
+                    .unwrap_or_else(|| panic!("{provider}:{model} task={task} produced no thinking"));
+                let mode = thinking.get("mode").map(VmValue::display);
+                assert_ne!(
+                    mode.as_deref(),
+                    Some("disabled"),
+                    "{provider}:{model} task={task} disabled reasoning (breaks gpt-oss tool calls)"
+                );
+                assert_eq!(
+                    mode.as_deref(),
+                    Some("effort"),
+                    "{provider}:{model} task={task} expected effort thinking"
+                );
+                // Never the reasoning-off `none` effort either.
+                assert_ne!(
+                    thinking.get("level").map(VmValue::display).as_deref(),
+                    Some("none"),
+                    "{provider}:{model} task={task} floored to reasoning-off effort"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn gpt_oss_off_pin_floors_to_low_for_tool_tasks() {
+        // Even an explicit `off` pin must not disable reasoning for a
+        // gpt-oss tool task — the required-for-tools guard floors it to the
+        // lowest supported effort.
+        let out = apply(agent_opts("cerebras", "gpt-oss-120b", "agent", "off"));
+        let thinking = out
+            .get("thinking")
+            .and_then(VmValue::as_dict)
+            .expect("thinking");
+        assert_eq!(
+            thinking.get("mode").map(VmValue::display).as_deref(),
+            Some("effort")
+        );
+        assert_eq!(
+            thinking.get("level").map(VmValue::display).as_deref(),
+            Some("low"),
+            "cerebras gpt-oss off-pin should floor to its lowest accepted effort"
+        );
+    }
+
+    #[test]
+    fn gpt_oss_chat_task_may_still_disable_reasoning() {
+        // The guard only protects tool-bearing tasks. A plain chat turn (no
+        // tools) is free to run reasoning-off — the quirk is specifically
+        // about tool calls in the reasoning channel.
+        let out = apply(agent_opts("cerebras", "gpt-oss-120b", "chat", "auto"));
+        let thinking = out.get("thinking").and_then(VmValue::as_dict);
+        // chat+auto resolves to "off"; cerebras gpt-oss floors off to its
+        // lowest accepted effort ("low") via reasoning_effort_levels, but is
+        // NOT forced on by the required-for-tools guard. Either way it must
+        // not be the disabled-thinking mode.
+        if let Some(thinking) = thinking {
+            assert_ne!(
+                thinking.get("mode").map(VmValue::display).as_deref(),
+                Some("disabled")
+            );
+        }
+    }
+
+    #[test]
+    fn qwen_tool_tasks_still_disable_reasoning() {
+        // Regression guard: the gpt-oss fix must not change the opposite
+        // Qwen3 quirk. Qwen agent tool tasks still resolve to disabled.
+        for (provider, model) in [
+            ("ollama", "qwen3.6:35b-a3b-coding-nvfp4"),
+            ("openrouter", "qwen/qwen3.6-35b-a3b"),
+        ] {
+            let out = apply(agent_opts(provider, model, "agent", "auto"));
+            let thinking = out
+                .get("thinking")
+                .and_then(VmValue::as_dict)
+                .expect("thinking");
+            assert_eq!(
+                thinking.get("mode").map(VmValue::display).as_deref(),
+                Some("disabled"),
+                "{provider}:{model} qwen agent reasoning should stay disabled"
+            );
+        }
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/reasoning_policy.rs
+++ b/crates/harn-vm/src/llm/reasoning_policy.rs
@@ -723,13 +723,8 @@ auto_reasoning_overrides = { agent = "off" }
         crate::llm::capabilities::clear_user_overrides();
     }
 
-    fn agent_opts(
-        provider: &str,
-        model: &str,
-        task: &str,
-        policy: &str,
-    ) -> BTreeMap<String, VmValue> {
-        BTreeMap::from([
+    fn agent_opts(provider: &str, model: &str, task: &str, policy: &str) -> crate::value::DictMap {
+        crate::value::DictMap::from_iter([
             (
                 "provider".to_string(),
                 VmValue::String(std::sync::Arc::from(provider)),

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -149,6 +149,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `openrouter` | `minimax/minimax-m2*` | `any` | no | no | no | no | no | yes | no | `delimited` | `plain` | `none` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `z-ai/glm-5*` | `any` | no | no | no | no | no | yes | no | `native` | `plain` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `kwaipilot/kat-coder-pro-v2` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `interchangeable` | yes | yes |
+| `openrouter` | `openai/gpt-oss-*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `stepfun/step-3.7-flash` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `interchangeable` | yes | yes |
 | `sambanova` | `*deepseek*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `sambanova` | `*llama*` | `any` | no | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -7762,11 +7762,13 @@ public let harnProviderCatalogJSON = #"""
         "supports_assistant_prefill": false,
         "prefers_role_developer": false,
         "prefers_xml_tools": false,
-        "thinking_block_style": "none"
+        "thinking_block_style": "reasoning_summary"
       },
       "reasoning": {
-        "modes": [],
-        "effort_supported": false,
+        "modes": [
+          "effort"
+        ],
+        "effort_supported": true,
         "none_supported": false,
         "interleaved_supported": false,
         "preserve_thinking": false
@@ -7786,6 +7788,8 @@ public let harnProviderCatalogJSON = #"""
       "capability_tags": [
         "streaming",
         "tools",
+        "thinking",
+        "extended_thinking",
         "structured_output"
       ],
       "family": "openai-gpt",

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -7498,11 +7498,13 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         "supports_assistant_prefill": false,
         "prefers_role_developer": false,
         "prefers_xml_tools": false,
-        "thinking_block_style": "none"
+        "thinking_block_style": "reasoning_summary"
       },
       "reasoning": {
-        "modes": [],
-        "effort_supported": false,
+        "modes": [
+          "effort"
+        ],
+        "effort_supported": true,
         "none_supported": false,
         "interleaved_supported": false,
         "preserve_thinking": false
@@ -7522,6 +7524,8 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       "capability_tags": [
         "streaming",
         "tools",
+        "thinking",
+        "extended_thinking",
         "structured_output"
       ],
       "family": "openai-gpt",

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -7244,11 +7244,13 @@
         "supports_assistant_prefill": false,
         "prefers_role_developer": false,
         "prefers_xml_tools": false,
-        "thinking_block_style": "none"
+        "thinking_block_style": "reasoning_summary"
       },
       "reasoning": {
-        "modes": [],
-        "effort_supported": false,
+        "modes": [
+          "effort"
+        ],
+        "effort_supported": true,
         "none_supported": false,
         "interleaved_supported": false,
         "preserve_thinking": false
@@ -7268,6 +7270,8 @@
       "capability_tags": [
         "streaming",
         "tools",
+        "thinking",
+        "extended_thinking",
         "structured_output"
       ],
       "family": "openai-gpt",


### PR DESCRIPTION
## Root cause (empirically proven)

gpt-oss (Harmony) performs tool calls **inside** the chain-of-thought channel, so disabling reasoning breaks tool calling entirely.

Live OpenRouter probe of `openai/gpt-oss-120b` (identical tool-calling request, 2026-06-13):

| reasoning setting | tool_calls | completion_tokens | result |
|---|---|---|---|
| `{enabled:false}` (disabled) | **0** | null | billed-noncommittal / upstream contract violation |
| `{effort: low}` | 1 | 34 | clean native tool call |
| no reasoning field (provider default) | 1 | 59 | clean native tool call |

This is the **opposite** of the Qwen3 quirk (Qwen narrates tool intent in the reasoning trace and emits zero `tool_calls`, so Qwen needs reasoning OFF for tools). #3303's retry was masking this self-inflicted misconfig.

Cross-provider probes (2026-06-13): Groq `reasoning_effort=low` → 1 clean call, `none` → rejected (`must be one of low/medium/high`); Cerebras `effort=low` → 1 clean call. All three direct providers serve gpt-oss cleanly **with reasoning on**.

## Fix (declarative — no provider/model spaghetti in Rust)

- **New `reasoning_required_for_tools` capability flag** (`ProviderRule` + `Capabilities` + base-shard docs). When set, `reasoning_policy` refuses to resolve a tool-bearing task (agent/code/verify) to reasoning-off, flooring to the lowest supported effort instead. Defense-in-depth: no future auto default, capability override, or session pin can re-introduce the failure.
- Set on every gpt-oss row: **Together** (`openai/gpt-oss-*`), **Groq** (`*gpt-oss-*`, now also pins `reasoning_effort_levels`), **Cerebras** (`gpt-oss-*`).
- **Added the missing OpenRouter `openai/gpt-oss-*` row.** The slug previously fell through `provider_family` openrouter→openai, matched no `gpt-*` rule (the `openai/` prefix and unparseable `oss` "version" both fail the match), and landed on a capability-less catch-all that declared NO reasoning support — so the resolver couldn't even materialize reasoning. The row declares effort + `reasoning_disable_supported = false` (Harn never emits `reasoning:{enabled:false}` on the wire) + the required-for-tools flag.
- No gpt-oss row carries the Qwen-style `auto_reasoning_overrides = "off"`; all already use native `tool_format`. **Both quirks documented side by side** in the matrix.

## Tests

- `gpt_oss_tool_tasks_keep_reasoning_on_across_providers` — all 5 routes × agent/code/verify never disabled
- `gpt_oss_off_pin_floors_to_low_for_tool_tasks`
- `gpt_oss_chat_task_may_still_disable_reasoning`
- `qwen_tool_tasks_still_disable_reasoning` — regression guard, Qwen behavior unchanged

`make conformance` green (1619/0), `cargo nextest -p harn-vm` capabilities + reasoning_policy green (87 tests), clippy clean, `build-capabilities --check` in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)