### PR TITLE
fix(vm): stop deeply nested values from aborting the process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object 0.37.3",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,7 +1239,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-module",
  "log",
- "object",
+ "object 0.39.1",
  "target-lexicon",
 ]
 
@@ -2819,6 +2828,7 @@ dependencies = [
  "sha3",
  "sqlx-core",
  "sqlx-postgres",
+ "stacker",
  "static_assertions",
  "subtle",
  "sysinfo",
@@ -4076,6 +4086,15 @@ dependencies = [
 
 [[package]]
 name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
 version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
@@ -4633,6 +4652,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -5879,6 +5908,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "static_assertions"
@@ -7414,7 +7456,7 @@ dependencies = [
  "log",
  "mach2",
  "memfd",
- "object",
+ "object 0.39.1",
  "once_cell",
  "postcard",
  "pulley-interpreter",
@@ -7454,7 +7496,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indexmap",
  "log",
- "object",
+ "object 0.39.1",
  "postcard",
  "rustc-demangle",
  "semver",
@@ -7517,7 +7559,7 @@ dependencies = [
  "gimli",
  "itertools 0.14.0",
  "log",
- "object",
+ "object 0.39.1",
  "pulley-interpreter",
  "smallvec 1.15.1",
  "target-lexicon",
@@ -7575,7 +7617,7 @@ dependencies = [
  "cfg-if",
  "cranelift-codegen",
  "log",
- "object",
+ "object 0.39.1",
  "wasmtime-environ",
 ]
 
@@ -7599,7 +7641,7 @@ dependencies = [
  "cranelift-codegen",
  "gimli",
  "log",
- "object",
+ "object 0.39.1",
  "target-lexicon",
  "wasmparser 0.248.0",
  "wasmtime-environ",

--- a/changelog.d/value-recursion-stack-safety.security.md
+++ b/changelog.d/value-recursion-stack-safety.security.md
@@ -1,0 +1,14 @@
+- **Deeply nested values can no longer abort the process with a native stack
+  overflow.** A script could build a value nested far deeper than the call
+  stack tolerates (`x = [x]` in a loop adds no VM frames, so `max_vm_frames`
+  never fired), then crash the whole host — `SIGABRT`, bypassing every runtime
+  limit — simply by comparing (`==`), printing, `json_stringify`-ing, sorting,
+  hashing (set/dict de-dup), or even just dropping it. The recursive value
+  walks (equality, ordering, structural hashing, display, JSON) now grow the
+  native stack on demand (the approach serde/rustc/syn take, via `stacker`), so
+  deep-but-finite data completes instead of crashing; value teardown across the
+  VM's slot/scope lifecycle is now iterative; and the `serde`-backed
+  pretty-JSON / YAML encoders reject values past `max_value_depth` (1024) with a
+  catchable error rather than overflowing. Mirrors `serde_json`'s
+  deserialization recursion limit and CPython's recursion guards in its C-level
+  `json`/comparison paths.

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -78,6 +78,11 @@ hmac = "0.13"
 sha1 = "0.11"
 sha2 = "0.11"
 sha3 = "0.12"
+# On-demand native stack growth for recursive walks over arbitrarily deep
+# `VmValue` trees (display, equality, ordering, hashing, JSON). Same approach
+# serde/rustc/syn use to keep deeply nested data from overflowing the OS
+# thread stack and aborting the process. See `value::recursion`.
+stacker = "0.1"
 blake3 = "1"
 md-5 = "0.11"
 aes-gcm = "0.10"

--- a/crates/harn-vm/src/runtime_limits.rs
+++ b/crates/harn-vm/src/runtime_limits.rs
@@ -51,6 +51,12 @@ pub struct RuntimeLimits {
     pub max_schema_nudge_lines: usize,
     /// Maximum object keys listed in LLM schema-correction nudges.
     pub max_schema_nudge_keys: usize,
+    /// Maximum `VmValue` nesting depth accepted by serializers that hand the
+    /// value tree to a third-party recursive encoder we cannot make
+    /// stack-safe internally (pretty JSON, YAML). Our own walks grow the
+    /// native stack on demand (see `value::recursion`); this ceiling keeps
+    /// adversarially nested data from overflowing those external encoders.
+    pub max_value_depth: usize,
 }
 
 impl RuntimeLimits {
@@ -76,6 +82,7 @@ impl RuntimeLimits {
         max_schema_nudge_depth: 3,
         max_schema_nudge_lines: 8,
         max_schema_nudge_keys: 16,
+        max_value_depth: 1024,
     };
 
     /// Return the value for a named limit.
@@ -101,6 +108,7 @@ impl RuntimeLimits {
             "max_schema_nudge_depth" => self.max_schema_nudge_depth,
             "max_schema_nudge_lines" => self.max_schema_nudge_lines,
             "max_schema_nudge_keys" => self.max_schema_nudge_keys,
+            "max_value_depth" => self.max_value_depth,
             _ => return None,
         })
     }
@@ -276,6 +284,12 @@ pub const RUNTIME_LIMIT_DESCRIPTIONS: &[RuntimeLimitDescription] = &[
         host_configurable: false,
         protects: "keeps schema-retry object-key previews compact for wide objects",
     },
+    RuntimeLimitDescription {
+        name: "max_value_depth",
+        user_visible: false,
+        host_configurable: false,
+        protects: "bounds value nesting handed to external pretty-JSON/YAML encoders so deep data cannot overflow their recursion",
+    },
 ];
 
 #[cfg(test)]
@@ -305,6 +319,7 @@ mod tests {
         assert_eq!(limits.max_schema_nudge_depth, 3);
         assert_eq!(limits.max_schema_nudge_lines, 8);
         assert_eq!(limits.max_schema_nudge_keys, 16);
+        assert_eq!(limits.max_value_depth, 1024);
     }
 
     #[test]
@@ -338,6 +353,7 @@ mod tests {
                 "max_schema_nudge_depth",
                 "max_schema_nudge_lines",
                 "max_schema_nudge_keys",
+                "max_value_depth",
             ]
         );
         assert!(report.entries.iter().all(|entry| entry.value > 0));

--- a/crates/harn-vm/src/stdlib/json.rs
+++ b/crates/harn-vm/src/stdlib/json.rs
@@ -13,6 +13,27 @@ use crate::vm::Vm;
 /// VM's per-thread parse caches share a predictable ceiling.
 const JSON_PARSE_CACHE_LIMIT: usize = RuntimeLimits::DEFAULT.max_json_parse_cache_entries;
 
+/// Deepest `VmValue` nesting we will hand to a third-party recursive encoder
+/// (pretty JSON via `serde_json`, YAML via `serde_yml`). Our own JSON writer
+/// grows the stack on demand, but those library serializers recurse without a
+/// hook we can guard, so a value past this depth is rejected with a catchable
+/// error rather than aborting the process. See `value::recursion`.
+const MAX_SERIALIZE_DEPTH: usize = RuntimeLimits::DEFAULT.max_value_depth;
+
+/// Reject values nested too deep for the external (serde) encoders to walk
+/// without overflowing the native stack.
+fn ensure_serializable_depth(value: &VmValue, builtin: &str) -> Result<(), VmError> {
+    if crate::value::recursion::depth_within(value, MAX_SERIALIZE_DEPTH) {
+        Ok(())
+    } else {
+        Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
+            format!(
+                "{builtin}: value nesting exceeds the maximum serialization depth ({MAX_SERIALIZE_DEPTH})"
+            ),
+        ))))
+    }
+}
+
 thread_local! {
     static JSON_PARSE_CACHE: RefCell<BTreeMap<String, VmValue>> = const { RefCell::new(BTreeMap::new()) };
 }
@@ -57,6 +78,7 @@ fn json_stringify_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
 #[harn_builtin(sig = "json_stringify_pretty(value: any) -> string", category = "json")]
 fn json_stringify_pretty_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let val = args.first().unwrap_or(&VmValue::Nil);
+    ensure_serializable_depth(val, "json_stringify_pretty")?;
     serde_json::to_string_pretty(&vm_value_to_data_value(val))
         .map(|text| VmValue::String(std::sync::Arc::from(text)))
         .map_err(|error| {
@@ -109,6 +131,7 @@ fn yaml_parse_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
 #[harn_builtin(sig = "yaml_stringify(value: any) -> string", category = "json")]
 fn yaml_stringify_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let value = args.first().unwrap_or(&VmValue::Nil);
+    ensure_serializable_depth(value, "yaml_stringify")?;
     let data_value = vm_value_to_data_value(value);
     serde_yml::to_string(&data_value)
         .map(|text| VmValue::String(std::sync::Arc::from(text)))
@@ -620,21 +643,27 @@ pub(crate) fn vm_value_to_data_value(value: &VmValue) -> serde_json::Value {
         VmValue::Bool(b) => serde_json::json!(b),
         VmValue::Nil => serde_json::Value::Null,
         VmValue::List(items) | VmValue::Set(items) => {
-            serde_json::Value::Array(items.iter().map(vm_value_to_data_value).collect())
+            crate::value::recursion::guard_recursion(|| {
+                serde_json::Value::Array(items.iter().map(vm_value_to_data_value).collect())
+            })
         }
-        VmValue::Dict(map) => serde_json::Value::Object(
-            map.iter()
-                .map(|(key, value)| (key.clone(), vm_value_to_data_value(value)))
-                .collect(),
-        ),
-        VmValue::StructInstance { .. } => serde_json::Value::Object(
-            value
-                .struct_fields_map()
-                .unwrap_or_default()
-                .iter()
-                .map(|(key, value)| (key.clone(), vm_value_to_data_value(value)))
-                .collect(),
-        ),
+        VmValue::Dict(map) => crate::value::recursion::guard_recursion(|| {
+            serde_json::Value::Object(
+                map.iter()
+                    .map(|(key, value)| (key.clone(), vm_value_to_data_value(value)))
+                    .collect(),
+            )
+        }),
+        VmValue::StructInstance { .. } => crate::value::recursion::guard_recursion(|| {
+            serde_json::Value::Object(
+                value
+                    .struct_fields_map()
+                    .unwrap_or_default()
+                    .iter()
+                    .map(|(key, value)| (key.clone(), vm_value_to_data_value(value)))
+                    .collect(),
+            )
+        }),
         // Ranges stringify like Display (`"1 to 5"`); use `.to_list()` in Harn
         // to materialise an int array.
         VmValue::Range(_) => serde_json::json!(value.display()),
@@ -669,41 +698,47 @@ fn write_vm_value_to_json(val: &VmValue, out: &mut String) {
         VmValue::Nil => out.push_str("null"),
         VmValue::List(items) | VmValue::Set(items) => {
             out.push('[');
-            for (i, item) in items.iter().enumerate() {
-                if i > 0 {
-                    out.push(',');
+            crate::value::recursion::guard_recursion(|| {
+                for (i, item) in items.iter().enumerate() {
+                    if i > 0 {
+                        out.push(',');
+                    }
+                    write_vm_value_to_json(item, out);
                 }
-                write_vm_value_to_json(item, out);
-            }
+            });
             out.push(']');
         }
         VmValue::Dict(map) => {
             out.push('{');
-            for (i, (k, v)) in map.iter().enumerate() {
-                if i > 0 {
-                    out.push(',');
+            crate::value::recursion::guard_recursion(|| {
+                for (i, (k, v)) in map.iter().enumerate() {
+                    if i > 0 {
+                        out.push(',');
+                    }
+                    out.push_str(&escape_json_string_vm(k));
+                    out.push(':');
+                    write_vm_value_to_json(v, out);
                 }
-                out.push_str(&escape_json_string_vm(k));
-                out.push(':');
-                write_vm_value_to_json(v, out);
-            }
+            });
             out.push('}');
         }
         VmValue::StructInstance { .. } => {
             out.push('{');
-            for (i, (k, v)) in val
-                .struct_fields_map()
-                .unwrap_or_default()
-                .iter()
-                .enumerate()
-            {
-                if i > 0 {
-                    out.push(',');
+            crate::value::recursion::guard_recursion(|| {
+                for (i, (k, v)) in val
+                    .struct_fields_map()
+                    .unwrap_or_default()
+                    .iter()
+                    .enumerate()
+                {
+                    if i > 0 {
+                        out.push(',');
+                    }
+                    out.push_str(&escape_json_string_vm(k));
+                    out.push(':');
+                    write_vm_value_to_json(v, out);
                 }
-                out.push_str(&escape_json_string_vm(k));
-                out.push(':');
-                write_vm_value_to_json(v, out);
-            }
+            });
             out.push('}');
         }
         VmValue::Range(_) => out.push_str(&escape_json_string_vm(&val.display())),
@@ -787,6 +822,41 @@ mod tests {
     fn extract_from_code_fence() {
         let text = "Here is the result:\n```json\n{\"key\": \"value\"}\n```\nDone.";
         assert_eq!(extract_json_from_text(text), "{\"key\": \"value\"}");
+    }
+
+    fn deep_list(depth: usize) -> VmValue {
+        let mut v = VmValue::Int(0);
+        for _ in 0..depth {
+            v = VmValue::List(std::sync::Arc::new(vec![v]));
+        }
+        v
+    }
+
+    #[test]
+    fn compact_json_handles_deeply_nested_value_without_overflow() {
+        // `json_stringify` writes JSON directly with a stack-growing walk, so a
+        // value far deeper than any frame budget serializes instead of
+        // aborting the process.
+        let deep = deep_list(200_000);
+        let json = vm_value_to_json(&deep);
+        assert!(json.starts_with("[[") || json.starts_with('['));
+        assert!(json.ends_with("0]") || json.ends_with(']'));
+        crate::value::recursion::dismantle(deep);
+    }
+
+    #[test]
+    fn pretty_serializer_rejects_values_too_deep_for_serde() {
+        // The serde-backed pretty/YAML encoders recurse without a hook we can
+        // guard, so values past `max_value_depth` are rejected with a
+        // catchable error rather than overflowing the stack.
+        let deep = deep_list(MAX_SERIALIZE_DEPTH + 10);
+        let err = ensure_serializable_depth(&deep, "json_stringify_pretty")
+            .expect_err("value deeper than the limit must be rejected");
+        assert!(matches!(err, VmError::Thrown(_)));
+        // A value within the limit is accepted.
+        let shallow = deep_list(8);
+        assert!(ensure_serializable_depth(&shallow, "json_stringify_pretty").is_ok());
+        crate::value::recursion::dismantle(deep);
     }
 
     #[test]

--- a/crates/harn-vm/src/value/core.rs
+++ b/crates/harn-vm/src/value/core.rs
@@ -514,24 +514,28 @@ impl VmValue {
             VmValue::Nil => out.push_str("nil"),
             VmValue::List(items) => {
                 out.push('[');
-                for (i, item) in items.iter().enumerate() {
-                    if i > 0 {
-                        out.push_str(", ");
+                crate::value::recursion::guard_recursion(|| {
+                    for (i, item) in items.iter().enumerate() {
+                        if i > 0 {
+                            out.push_str(", ");
+                        }
+                        item.write_display(out);
                     }
-                    item.write_display(out);
-                }
+                });
                 out.push(']');
             }
             VmValue::Dict(map) => {
                 out.push('{');
-                for (i, (k, v)) in map.iter().enumerate() {
-                    if i > 0 {
-                        out.push_str(", ");
+                crate::value::recursion::guard_recursion(|| {
+                    for (i, (k, v)) in map.iter().enumerate() {
+                        if i > 0 {
+                            out.push_str(", ");
+                        }
+                        out.push_str(k);
+                        out.push_str(": ");
+                        v.write_display(out);
                     }
-                    out.push_str(k);
-                    out.push_str(": ");
-                    v.write_display(out);
-                }
+                });
                 out.push('}');
             }
             VmValue::Closure(c) => {
@@ -566,25 +570,29 @@ impl VmValue {
                     let _ = write!(out, "{}.{}", enum_variant.enum_name, enum_variant.variant);
                 } else {
                     let _ = write!(out, "{}.{}(", enum_variant.enum_name, enum_variant.variant);
-                    for (i, v) in enum_variant.fields.iter().enumerate() {
-                        if i > 0 {
-                            out.push_str(", ");
+                    crate::value::recursion::guard_recursion(|| {
+                        for (i, v) in enum_variant.fields.iter().enumerate() {
+                            if i > 0 {
+                                out.push_str(", ");
+                            }
+                            v.write_display(out);
                         }
-                        v.write_display(out);
-                    }
+                    });
                     out.push(')');
                 }
             }
             VmValue::StructInstance { layout, fields } => {
                 let _ = write!(out, "{} {{", layout.struct_name());
-                for (i, (k, v)) in struct_fields_to_map(layout, fields).iter().enumerate() {
-                    if i > 0 {
-                        out.push_str(", ");
+                crate::value::recursion::guard_recursion(|| {
+                    for (i, (k, v)) in struct_fields_to_map(layout, fields).iter().enumerate() {
+                        if i > 0 {
+                            out.push_str(", ");
+                        }
+                        out.push_str(k);
+                        out.push_str(": ");
+                        v.write_display(out);
                     }
-                    out.push_str(k);
-                    out.push_str(": ");
-                    v.write_display(out);
-                }
+                });
                 out.push('}');
             }
             VmValue::TaskHandle(id) => {
@@ -607,12 +615,14 @@ impl VmValue {
             }
             VmValue::Set(items) => {
                 out.push_str("set(");
-                for (i, item) in items.iter().enumerate() {
-                    if i > 0 {
-                        out.push_str(", ");
+                crate::value::recursion::guard_recursion(|| {
+                    for (i, item) in items.iter().enumerate() {
+                        if i > 0 {
+                            out.push_str(", ");
+                        }
+                        item.write_display(out);
                     }
-                    item.write_display(out);
-                }
+                });
                 out.push(')');
             }
             VmValue::Generator(g) => {
@@ -649,9 +659,11 @@ impl VmValue {
             }
             VmValue::Pair(p) => {
                 out.push('(');
-                p.0.write_display(out);
-                out.push_str(", ");
-                p.1.write_display(out);
+                crate::value::recursion::guard_recursion(|| {
+                    p.0.write_display(out);
+                    out.push_str(", ");
+                    p.1.write_display(out);
+                });
                 out.push(')');
             }
         }

--- a/crates/harn-vm/src/value/env.rs
+++ b/crates/harn-vm/src/value/env.rs
@@ -83,6 +83,29 @@ impl Scope {
     }
 }
 
+impl Drop for Scope {
+    fn drop(&mut self) {
+        // Deeply nested script values (e.g. `x = [x]` built in a loop, which
+        // adds no VM call frames and so never trips `max_vm_frames`) live in
+        // scope bindings. Their default recursive drop would overflow the
+        // native stack and abort the whole process — an uncatchable failure.
+        // When this scope holds the last reference to its bindings and any
+        // value is a nested container, tear the bindings down iteratively
+        // instead. `Arc::get_mut` succeeds only for a uniquely-owned scope, so
+        // shared snapshots fall through to the cheap default drop and the real
+        // teardown happens later at the last owner (also a `Scope`).
+        if let Some(map) = Arc::get_mut(&mut self.vars) {
+            if map
+                .values()
+                .any(|(value, _)| super::recursion::is_recursive_container(value))
+            {
+                let bindings = std::mem::take(map);
+                super::recursion::dismantle_values(bindings.into_values().map(|(value, _)| value));
+            }
+        }
+    }
+}
+
 impl Default for VmEnv {
     fn default() -> Self {
         Self::new()
@@ -142,7 +165,11 @@ impl VmEnv {
                     )));
                 }
             }
-            Arc::make_mut(&mut scope.vars).insert(name.to_string(), (value, mutable));
+            if let Some((previous, _)) =
+                Arc::make_mut(&mut scope.vars).insert(name.to_string(), (value, mutable))
+            {
+                super::recursion::dismantle(previous);
+            }
         }
         Ok(())
     }
@@ -163,7 +190,13 @@ impl VmEnv {
                 if !mutable {
                     return Err(VmError::ImmutableAssignment(name.to_string()));
                 }
-                Arc::make_mut(&mut scope.vars).insert(name.to_string(), (value, true));
+                if let Some((previous, _)) =
+                    Arc::make_mut(&mut scope.vars).insert(name.to_string(), (value, true))
+                {
+                    // Iterative teardown so overwriting a deeply nested binding
+                    // cannot overflow the stack on drop (scalars are a no-op).
+                    super::recursion::dismantle(previous);
+                }
                 return Ok(());
             }
         }

--- a/crates/harn-vm/src/value/mod.rs
+++ b/crates/harn-vm/src/value/mod.rs
@@ -3,6 +3,7 @@ mod core;
 mod env;
 mod error;
 mod handles;
+pub(crate) mod recursion;
 mod structural;
 
 pub type VmMutex<T> = parking_lot::Mutex<T>;

--- a/crates/harn-vm/src/value/recursion.rs
+++ b/crates/harn-vm/src/value/recursion.rs
@@ -1,0 +1,170 @@
+//! Stack-safety guards for recursive walks over arbitrarily deep `VmValue`
+//! trees.
+//!
+//! Harn scripts can build values nested far deeper than the native call stack
+//! tolerates without ever tripping a runtime limit: `x = [x]` inside a loop
+//! adds no VM call frames, so [`crate::runtime_limits::RuntimeLimits::max_vm_frames`]
+//! never fires, and a `200_000`-deep list costs only a few MB. Walking such a
+//! value recursively — for `==`, ordering, hashing, display, or JSON
+//! serialization — then overflows the OS thread stack and aborts the whole
+//! process (`SIGABRT`), an uncatchable failure that bypasses every VM resource
+//! guard. Dropping the value has the same hazard.
+//!
+//! Two complementary mechanisms keep these walks safe:
+//!
+//! * [`guard_recursion`] grows the native stack on demand (the approach serde,
+//!   rustc, and syn take via the `stacker` crate) so a deep-but-finite value
+//!   completes instead of crashing. It is applied around the *recursive
+//!   descent* in container arms only, so scalar and wide collections pay
+//!   nothing while deep nesting grows the stack one level at a time.
+//! * [`dismantle_values`] tears values down iteratively, used by `Drop` impls
+//!   that own nested values so teardown never recurses on the native stack.
+//!   This is sound precisely because `VmValue` deliberately has no `Drop`
+//!   impl, so children can be moved out of uniquely-owned `Arc`s.
+
+use std::sync::Arc;
+
+use super::VmValue;
+
+/// Native stack we insist on having free before recursing one more container
+/// level. When less remains, [`guard_recursion`] allocates a fresh segment.
+const RED_ZONE: usize = 256 * 1024;
+
+/// Size of each on-demand stack segment [`guard_recursion`] allocates.
+const STACK_PER_SEGMENT: usize = 4 * 1024 * 1024;
+
+/// Run `f`, first ensuring at least [`RED_ZONE`] bytes of native stack are
+/// available and growing onto a fresh segment otherwise. When the stack is
+/// ample (the overwhelmingly common case) this is a single stack-pointer
+/// comparison, so callers can wrap each recursive descent cheaply.
+#[inline]
+pub fn guard_recursion<R>(f: impl FnOnce() -> R) -> R {
+    stacker::maybe_grow(RED_ZONE, STACK_PER_SEGMENT, f)
+}
+
+/// Whether `value` owns nested `VmValue`s and therefore could form an
+/// arbitrarily deep chain whose recursive drop would overflow the stack.
+#[inline]
+pub fn is_recursive_container(value: &VmValue) -> bool {
+    matches!(
+        value,
+        VmValue::List(_)
+            | VmValue::Set(_)
+            | VmValue::Dict(_)
+            | VmValue::Pair(_)
+            | VmValue::EnumVariant(_)
+            | VmValue::StructInstance { .. }
+            | VmValue::Closure(_)
+    )
+}
+
+/// The greatest nesting depth in `value`, capped at `limit + 1` so the scan
+/// stays cheap and itself never recurses. A flat scalar is depth `0`; a list
+/// of scalars is depth `1`. Used by serializers that must reject values too
+/// deep for a third-party recursive encoder.
+pub fn depth_within(value: &VmValue, limit: usize) -> bool {
+    // Iterative DFS with an explicit (value, depth) worklist so the depth
+    // probe cannot itself overflow.
+    let mut stack: Vec<(&VmValue, usize)> = vec![(value, 0)];
+    while let Some((value, depth)) = stack.pop() {
+        if depth > limit {
+            return false;
+        }
+        match value {
+            VmValue::List(items) | VmValue::Set(items) => {
+                for item in items.iter() {
+                    stack.push((item, depth + 1));
+                }
+            }
+            VmValue::Dict(map) => {
+                for item in map.values() {
+                    stack.push((item, depth + 1));
+                }
+            }
+            VmValue::Pair(pair) => {
+                stack.push((&pair.0, depth + 1));
+                stack.push((&pair.1, depth + 1));
+            }
+            VmValue::EnumVariant(variant) => {
+                for field in variant.fields.iter() {
+                    stack.push((field, depth + 1));
+                }
+            }
+            VmValue::StructInstance { fields, .. } => {
+                for field in fields.iter().flatten() {
+                    stack.push((field, depth + 1));
+                }
+            }
+            _ => {}
+        }
+    }
+    true
+}
+
+/// Drop a batch of values without recursing on the native stack.
+///
+/// Nested children of uniquely-owned containers are moved onto an explicit
+/// heap worklist and processed iteratively, so a value nested arbitrarily deep
+/// tears down in bounded stack space. Shared payloads (`Arc::into_inner`
+/// returns `None`) are left intact for their last owner to reclaim — which,
+/// for script values, is itself a `Scope`/closure whose `Drop` routes back
+/// here.
+/// Drop a single value without recursing on the native stack. Cheap for
+/// scalars; see [`dismantle_values`] for the iterative teardown of containers.
+#[inline]
+pub fn dismantle(value: VmValue) {
+    if is_recursive_container(&value) {
+        dismantle_values(std::iter::once(value));
+    }
+}
+
+pub fn dismantle_values<I: IntoIterator<Item = VmValue>>(values: I) {
+    let mut stack: Vec<VmValue> = values.into_iter().collect();
+    while let Some(value) = stack.pop() {
+        match value {
+            VmValue::List(items) | VmValue::Set(items) => {
+                if let Some(mut items) = Arc::into_inner(items) {
+                    stack.append(&mut items);
+                }
+            }
+            VmValue::Dict(map) => {
+                if let Some(map) = Arc::into_inner(map) {
+                    stack.extend(map.into_values());
+                }
+            }
+            VmValue::Pair(pair) => {
+                if let Some(pair) = Arc::into_inner(pair) {
+                    stack.push(pair.0);
+                    stack.push(pair.1);
+                }
+            }
+            VmValue::EnumVariant(variant) => {
+                if let Some(variant) = Arc::into_inner(variant) {
+                    if let Some(mut fields) = Arc::into_inner(variant.fields) {
+                        stack.append(&mut fields);
+                    }
+                }
+            }
+            VmValue::StructInstance { fields, .. } => {
+                if let Some(fields) = Arc::into_inner(fields) {
+                    stack.extend(fields.into_iter().flatten());
+                }
+            }
+            VmValue::Closure(closure) => {
+                // A closure can capture nested values in its environment. When
+                // we hold the last reference, take ownership of the captured
+                // scopes' bindings so they tear down iteratively too; the
+                // `Scope` `Drop` impl re-routes here for anything still shared.
+                if let Some(mut closure) = Arc::into_inner(closure) {
+                    for scope in &mut closure.env.scopes {
+                        if let Some(vars) = Arc::get_mut(&mut scope.vars) {
+                            stack.extend(std::mem::take(vars).into_values().map(|(v, _)| v));
+                        }
+                    }
+                }
+            }
+            // Scalars and identity/handle values: dropped here, no recursion.
+            _ => {}
+        }
+    }
+}

--- a/crates/harn-vm/src/value/structural.rs
+++ b/crates/harn-vm/src/value/structural.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
+use super::recursion::guard_recursion;
 use super::VmValue;
 
 /// Reference / identity equality. For heap-allocated refcounted values
@@ -99,25 +100,30 @@ fn write_structural_hash_key(v: &VmValue, out: &mut String) {
         }
         VmValue::List(items) => {
             out.push('L');
-            for item in items.iter() {
-                write_structural_hash_key(item, out);
-                out.push(',');
-            }
+            guard_recursion(|| {
+                for item in items.iter() {
+                    write_structural_hash_key(item, out);
+                    out.push(',');
+                }
+            });
             out.push(']');
         }
         VmValue::Dict(map) => {
             out.push('D');
-            for (k, v) in map.iter() {
-                write_len_prefixed(k, out);
-                out.push('=');
-                write_structural_hash_key(v, out);
-                out.push(',');
-            }
+            guard_recursion(|| {
+                for (k, v) in map.iter() {
+                    write_len_prefixed(k, out);
+                    out.push('=');
+                    write_structural_hash_key(v, out);
+                    out.push(',');
+                }
+            });
             out.push('}');
         }
         VmValue::Set(items) => {
             // Sets need sorted keys for order-independence
-            let mut keys: Vec<String> = items.iter().map(value_structural_hash_key).collect();
+            let mut keys: Vec<String> =
+                guard_recursion(|| items.iter().map(value_structural_hash_key).collect());
             keys.sort();
             out.push('S');
             for k in &keys {
@@ -132,19 +138,23 @@ fn write_structural_hash_key(v: &VmValue, out: &mut String) {
         // `values_equal` treats as equal, must hash alike.
         VmValue::Pair(pair) => {
             out.push('P');
-            write_structural_hash_key(&pair.0, out);
-            out.push(',');
-            write_structural_hash_key(&pair.1, out);
+            guard_recursion(|| {
+                write_structural_hash_key(&pair.0, out);
+                out.push(',');
+                write_structural_hash_key(&pair.1, out);
+            });
             out.push(';');
         }
         VmValue::EnumVariant(ev) => {
             out.push('E');
             write_len_prefixed(&ev.enum_name, out);
             write_len_prefixed(&ev.variant, out);
-            for field in ev.fields.iter() {
-                write_structural_hash_key(field, out);
-                out.push(',');
-            }
+            guard_recursion(|| {
+                for field in ev.fields.iter() {
+                    write_structural_hash_key(field, out);
+                    out.push(',');
+                }
+            });
             out.push(';');
         }
         VmValue::StructInstance { layout, fields } => {
@@ -152,12 +162,14 @@ fn write_structural_hash_key(v: &VmValue, out: &mut String) {
             // order in the layout never affects the key.
             out.push('I');
             write_len_prefixed(layout.struct_name(), out);
-            for (k, v) in super::struct_fields_to_map(layout, fields) {
-                write_len_prefixed(&k, out);
-                out.push('=');
-                write_structural_hash_key(&v, out);
-                out.push(',');
-            }
+            guard_recursion(|| {
+                for (k, v) in super::struct_fields_to_map(layout, fields) {
+                    write_len_prefixed(&k, out);
+                    out.push('=');
+                    write_structural_hash_key(&v, out);
+                    out.push(',');
+                }
+            });
             out.push('}');
         }
         other => {
@@ -218,22 +230,27 @@ pub fn values_equal(a: &VmValue, b: &VmValue) -> bool {
             a.value.load(Ordering::SeqCst) == b.value.load(Ordering::SeqCst)
         }
         (VmValue::List(a), VmValue::List(b)) => {
-            a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| values_equal(x, y))
+            a.len() == b.len()
+                && guard_recursion(|| a.iter().zip(b.iter()).all(|(x, y)| values_equal(x, y)))
         }
         (VmValue::Dict(a), VmValue::Dict(b)) => {
             a.len() == b.len()
-                && a.iter()
-                    .zip(b.iter())
-                    .all(|((k1, v1), (k2, v2))| k1 == k2 && values_equal(v1, v2))
+                && guard_recursion(|| {
+                    a.iter()
+                        .zip(b.iter())
+                        .all(|((k1, v1), (k2, v2))| k1 == k2 && values_equal(v1, v2))
+                })
         }
         (VmValue::EnumVariant(a), VmValue::EnumVariant(b)) => {
             a.enum_name == b.enum_name
                 && a.variant == b.variant
                 && a.fields.len() == b.fields.len()
-                && a.fields
-                    .iter()
-                    .zip(b.fields.iter())
-                    .all(|(x, y)| values_equal(x, y))
+                && guard_recursion(|| {
+                    a.fields
+                        .iter()
+                        .zip(b.fields.iter())
+                        .all(|(x, y)| values_equal(x, y))
+                })
         }
         (
             VmValue::StructInstance {
@@ -251,13 +268,16 @@ pub fn values_equal(a: &VmValue, b: &VmValue) -> bool {
             let a_map = super::struct_fields_to_map(a_layout, a_fields);
             let b_map = super::struct_fields_to_map(b_layout, b_fields);
             a_map.len() == b_map.len()
-                && a_map
-                    .iter()
-                    .zip(b_map.iter())
-                    .all(|((k1, v1), (k2, v2))| k1 == k2 && values_equal(v1, v2))
+                && guard_recursion(|| {
+                    a_map
+                        .iter()
+                        .zip(b_map.iter())
+                        .all(|((k1, v1), (k2, v2))| k1 == k2 && values_equal(v1, v2))
+                })
         }
         (VmValue::Set(a), VmValue::Set(b)) => {
-            a.len() == b.len() && a.iter().all(|x| b.iter().any(|y| values_equal(x, y)))
+            a.len() == b.len()
+                && guard_recursion(|| a.iter().all(|x| b.iter().any(|y| values_equal(x, y))))
         }
         (VmValue::Generator(_), VmValue::Generator(_)) => false, // generators are never equal
         (VmValue::Stream(_), VmValue::Stream(_)) => false,       // streams are never equal
@@ -266,7 +286,7 @@ pub fn values_equal(a: &VmValue, b: &VmValue) -> bool {
         }
         (VmValue::Iter(a), VmValue::Iter(b)) => Arc::ptr_eq(a, b),
         (VmValue::Pair(a), VmValue::Pair(b)) => {
-            values_equal(&a.0, &b.0) && values_equal(&a.1, &b.1)
+            guard_recursion(|| values_equal(&a.0, &b.0) && values_equal(&a.1, &b.1))
         }
         // Harness handles carry runtime capability state, not values. Two
         // handles that refer to the same backing capability are still
@@ -325,14 +345,14 @@ pub fn try_compare_values(a: &VmValue, b: &VmValue) -> Option<i32> {
         (VmValue::Int(x), VmValue::Float(y)) => float_ordering(*x as f64, *y),
         (VmValue::Float(x), VmValue::Int(y)) => float_ordering(*x, *y as f64),
         (VmValue::String(x), VmValue::String(y)) => Some(x.cmp(y) as i32),
-        (VmValue::Pair(x), VmValue::Pair(y)) => {
+        (VmValue::Pair(x), VmValue::Pair(y)) => guard_recursion(|| {
             let c = try_compare_values(&x.0, &y.0)?;
             if c != 0 {
                 Some(c)
             } else {
                 try_compare_values(&x.1, &y.1)
             }
-        }
+        }),
         _ => Some(0),
     }
 }

--- a/crates/harn-vm/src/value/tests.rs
+++ b/crates/harn-vm/src/value/tests.rs
@@ -362,3 +362,107 @@ fn try_compare_reports_nan_as_unordered() {
     // The total-order wrapper keeps a sort-stable fallback of 0.
     assert_eq!(compare_values(&nan, &VmValue::Float(5.0)), 0);
 }
+
+// --- Deeply nested value recursion guards -------------------------------
+//
+// A Harn script can build a value nested far deeper than the native call
+// stack tolerates (e.g. `x = [x]` in a loop, which adds no VM call frames and
+// so never trips `max_vm_frames`). Before the recursion guards, walking or
+// dropping such a value overflowed the OS thread stack and aborted the whole
+// process. These tests build a value far deeper than any stack frame budget
+// and assert the core operations complete and the value tears down safely.
+//
+// NOTE: each test must `dismantle` the deep value before it leaves scope —
+// a bare `VmValue` dropped in plain Rust (outside the VM's guarded
+// slot/scope teardown) would otherwise recurse on drop.
+
+const DEEP: usize = 200_000;
+
+fn deep_list(depth: usize) -> VmValue {
+    let mut v = i(0);
+    for _ in 0..depth {
+        v = list(vec![v]);
+    }
+    v
+}
+
+#[test]
+fn deeply_nested_equality_does_not_overflow() {
+    let a = deep_list(DEEP);
+    let b = deep_list(DEEP);
+    assert!(values_equal(&a, &a));
+    assert!(values_equal(&a, &b));
+    // A divergence deep in the structure is still detected correctly.
+    let c = {
+        let mut v = i(1);
+        for _ in 0..DEEP {
+            v = list(vec![v]);
+        }
+        v
+    };
+    assert!(!values_equal(&a, &c));
+    super::recursion::dismantle(a);
+    super::recursion::dismantle(b);
+    super::recursion::dismantle(c);
+}
+
+#[test]
+fn deeply_nested_display_and_hash_do_not_overflow() {
+    let a = deep_list(DEEP);
+    // Display produces a string and structural hashing produces a key; both
+    // walk the whole structure. We only assert they return without aborting.
+    assert!(a.display().starts_with('['));
+    assert!(!value_structural_hash_key(&a).is_empty());
+    // Hash keys remain consistent with equality for deep values.
+    let b = deep_list(DEEP);
+    assert_eq!(value_structural_hash_key(&a), value_structural_hash_key(&b));
+    super::recursion::dismantle(a);
+    super::recursion::dismantle(b);
+}
+
+#[test]
+fn deeply_nested_compare_does_not_overflow() {
+    // Ordering only recurses through nested pairs; build a deep pair chain.
+    let mut a = i(0);
+    let mut b = i(0);
+    for _ in 0..DEEP {
+        a = VmValue::Pair(std::sync::Arc::new((i(1), a)));
+        b = VmValue::Pair(std::sync::Arc::new((i(1), b)));
+    }
+    assert_eq!(try_compare_values(&a, &b), Some(0));
+    super::recursion::dismantle(a);
+    super::recursion::dismantle(b);
+}
+
+#[test]
+fn dismantle_tears_down_deep_value_without_recursing() {
+    // The whole point: this value's recursive drop would overflow the stack,
+    // but `dismantle` reclaims it iteratively.
+    let deep = deep_list(DEEP);
+    super::recursion::dismantle(deep);
+}
+
+#[test]
+fn dismantle_preserves_shared_children() {
+    // A child still referenced elsewhere must survive dismantling its parent.
+    let shared = list(vec![i(1), i(2)]);
+    let parent = list(vec![shared.clone(), i(3)]);
+    super::recursion::dismantle(parent);
+    // `shared` is intact and usable.
+    assert!(values_equal(&shared, &list(vec![i(1), i(2)])));
+}
+
+#[test]
+fn depth_within_reports_nesting_correctly() {
+    use super::recursion::depth_within;
+    assert!(depth_within(&i(0), 0));
+    assert!(depth_within(&list(vec![i(1)]), 1));
+    assert!(!depth_within(&list(vec![i(1)]), 0));
+    let three = list(vec![list(vec![list(vec![i(1)])])]);
+    assert!(depth_within(&three, 3));
+    assert!(!depth_within(&three, 2));
+    // A value deeper than the limit is rejected without overflowing.
+    let deep = deep_list(DEEP);
+    assert!(!depth_within(&deep, 1024));
+    super::recursion::dismantle(deep);
+}

--- a/crates/harn-vm/src/vm/ops/collections.rs
+++ b/crates/harn-vm/src/vm/ops/collections.rs
@@ -543,13 +543,16 @@ impl super::super::Vm {
                         return Err(Self::list_index_type_error(&index));
                     };
                     let idx = resolve_list_assign_index(i, items.len())?;
-                    Arc::make_mut(items)[idx] = new_value;
+                    let cell = &mut Arc::make_mut(items)[idx];
+                    crate::value::recursion::dismantle(std::mem::replace(cell, new_value));
                     slot.synced = false;
                     return Ok(());
                 }
                 VmValue::Dict(map) => {
                     let key = index.display();
-                    Arc::make_mut(map).insert(key, new_value);
+                    if let Some(previous) = Arc::make_mut(map).insert(key, new_value) {
+                        crate::value::recursion::dismantle(previous);
+                    }
                     slot.synced = false;
                     return Ok(());
                 }
@@ -618,7 +621,9 @@ impl super::super::Vm {
         }
 
         if let VmValue::Dict(map) = &mut slot.value {
-            Arc::make_mut(map).insert(prop_name.to_string(), new_value);
+            if let Some(previous) = Arc::make_mut(map).insert(prop_name.to_string(), new_value) {
+                crate::value::recursion::dismantle(previous);
+            }
             slot.synced = false;
             return Ok(());
         }
@@ -673,13 +678,16 @@ impl super::super::Vm {
                     return Err(Self::list_index_type_error(&index));
                 };
                 let idx = resolve_list_assign_index(i, items.len())?;
-                Arc::make_mut(items)[idx] = new_value;
+                let cell = &mut Arc::make_mut(items)[idx];
+                crate::value::recursion::dismantle(std::mem::replace(cell, new_value));
                 slot.synced = false;
                 Ok(())
             }
             VmValue::Dict(map) => {
                 let key = index.display();
-                Arc::make_mut(map).insert(key, new_value);
+                if let Some(previous) = Arc::make_mut(map).insert(key, new_value) {
+                    crate::value::recursion::dismantle(previous);
+                }
                 slot.synced = false;
                 Ok(())
             }

--- a/crates/harn-vm/src/vm/ops/stack.rs
+++ b/crates/harn-vm/src/vm/ops/stack.rs
@@ -185,7 +185,9 @@ impl super::super::Vm {
                 "Invalid local slot index: {slot_idx}"
             )));
         };
-        slot.value = val;
+        // Tear down any nested value being overwritten iteratively so a deep
+        // local cannot overflow the stack on drop (scalars are a no-op).
+        crate::value::recursion::dismantle(std::mem::replace(&mut slot.value, val));
         slot.initialized = true;
         slot.synced = false;
         Ok(())
@@ -216,7 +218,9 @@ impl super::super::Vm {
         if !slot.initialized {
             return Err(VmError::UndefinedVariable(info.name.clone()));
         }
-        slot.value = val;
+        // Tear down any nested value being overwritten iteratively so a deep
+        // local cannot overflow the stack on drop (scalars are a no-op).
+        crate::value::recursion::dismantle(std::mem::replace(&mut slot.value, val));
         slot.synced = false;
         Ok(())
     }

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -35,6 +35,21 @@ pub(crate) struct LocalSlot {
     pub(crate) synced: bool,
 }
 
+impl Drop for LocalSlot {
+    fn drop(&mut self) {
+        // Slot locals hold script values directly (e.g. a `var` bound to a
+        // deeply nested list). When a frame is torn down, the default
+        // recursive drop of such a value would overflow the native stack and
+        // abort the process. For the overwhelmingly common scalar slot this is
+        // a single `matches!` check and then the normal trivial drop; only a
+        // nested container is moved out and torn down iteratively, so hot
+        // frame teardown is unaffected.
+        if crate::value::recursion::is_recursive_container(&self.value) {
+            crate::value::recursion::dismantle(std::mem::replace(&mut self.value, VmValue::Nil));
+        }
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct InterruptHandler {
     pub(crate) handle: i64,
@@ -548,7 +563,7 @@ impl Vm {
                     return Err(VmError::ImmutableAssignment(name.to_string()));
                 }
                 if let Some(slot) = frame.local_slots.get_mut(idx) {
-                    slot.value = value;
+                    crate::value::recursion::dismantle(std::mem::replace(&mut slot.value, value));
                     slot.initialized = true;
                     slot.synced = false;
                     return Ok(true);


### PR DESCRIPTION
## Summary

A Harn script can build a value nested far deeper than the native call stack tolerates and then **crash the entire host process with an uncatchable stack overflow (`SIGABRT`), bypassing every VM resource guard**.

The key gap: the VM bounds *call-frame* recursion (`max_vm_frames` → catchable "Stack overflow: too many nested calls"), but **building deep data needs no recursion**. `x = [x]` in a loop adds zero VM frames, so `max_vm_frames` never fires, yet a 200k-deep list costs only a few MB. Any walk over that value then overflows the OS thread stack:

```harn
fn main(harness: Harness) {
  var x: any = 0
  var i = 0
  while i < 200000 { x = [x]; i = i + 1 }
  let same = x == x          // SIGABRT, exit 134 — before this fix
}
```

Confirmed crashing (exit 134) on: equality (`==`), `print`/string interpolation, `json_stringify`, sorting, set/dict de-dup (structural hashing), and even **plain drop** (build a deep value, do nothing, return).

### Analog
This is the same correctness/security bug class as **`serde_json`'s deserialization recursion limit** and **CPython's recursion guards in its C-level `json`/comparison code** — native recursion over attacker-influenced nested data that the language's own limits don't cover. For an AI-agent runtime, that nested data routinely originates from LLM/MCP/HTTP output that scripts parse and manipulate.

## Fix (generalizable, durable, across the whole value layer)

- **`value::recursion`** — `guard_recursion` grows the native stack on demand (the approach serde/rustc/syn take, via `stacker`). Applied to the *recursive descent in container arms only* of equality, ordering, structural hashing, display, and JSON serialization, so scalars and wide collections pay nothing and deep nesting grows the stack one level at a time, completing instead of crashing. (The infallible helpers have ~1900 call sites, so returning errors isn't viable — growing the stack is the right, zero-churn tool.)
- **Iterative teardown across the VM's value lifecycle** — a `Drop` for slot locals (`LocalSlot`) and env scopes (`Scope`), plus slot/var reassignment and collection element/property replacement, route a replaced nested value through an iterative `dismantle`. Sound because `VmValue` deliberately has no `Drop`, so payloads move out of uniquely-owned `Arc`s; shared payloads are left for their last owner (also a guarded slot/scope).
- **External encoders** — the `serde_json`/`serde_yml` pretty/YAML serializers recurse without a hook we can guard, so values past a new `max_value_depth` (1024) are rejected with a **catchable** error rather than overflowing.

## Verification

- All previously-crashing vectors now succeed (or, for pretty/YAML past the depth limit, raise a catchable error the script can `try`/`catch`): equality, display, JSON, drop-only, slot reassignment, return-value, dict/subscript element-orphan.
- New Rust regression tests build values far deeper than any frame budget and assert equality/ordering/hashing/display/JSON complete and tear down safely, plus depth-limit coverage for the external encoders (`crates/harn-vm/src/value/tests.rs`, `stdlib/json.rs`).
- `cargo test -p harn-vm --lib` — new tests green; the only failures are pre-existing environment-dependent tests (process sandbox, git, overlay-fs) that fail identically on the base branch.
- `cargo fmt --check` and `cargo clippy -p harn-vm --lib --tests -- -D warnings` clean.

A second small commit fixes an unrelated pre-existing MD038 markdownlint error in `changelog.d/3297.fixed.md` that the (newer) lint gate flagged and that was blocking push/CI.

## Notes
- No `VmValue` layout change (still 32 bytes; the size-budget test passes).
- `max_value_depth` is added to `RuntimeLimits` (additive; all constructors use `..default()`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01XqypiqrRXsq4EgkoFqhc5w)_