### PR TITLE
perf(vm): back VmValue::Dict with a persistent imbl::OrdMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "archery"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +499,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +646,12 @@ name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -2790,6 +2808,7 @@ dependencies = [
  "hmac",
  "httpdate",
  "ignore",
+ "imbl",
  "ipnet",
  "jsonwebtoken",
  "keyring",
@@ -3225,6 +3244,31 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "imbl"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e525189e5f603908d0c6e0d402cb5de9c4b2c8866151fabc4ebd771ed2630a2e"
+dependencies = [
+ "archery",
+ "bitmaps",
+ "imbl-sized-chunks",
+ "rand_core 0.9.5",
+ "rand_xoshiro",
+ "serde_core",
+ "version_check",
+ "wide",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps",
 ]
 
 [[package]]
@@ -4852,6 +4896,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5324,6 +5377,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -7783,6 +7845,16 @@ name = "whoami"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
 
 [[package]]
 name = "wiggle"

--- a/changelog.d/vm-persistent-dict.changed.md
+++ b/changelog.d/vm-persistent-dict.changed.md
@@ -1,0 +1,8 @@
+- **VM dicts are now persistent.** `VmValue::Dict` is backed by a structurally
+  shared `imbl::OrdMap` instead of a `BTreeMap`. Copy-on-write dict mutation —
+  performed on every `dict[key] = value` / property assignment when the value is
+  aliased (on the stack, in another local, or captured by a closure) — drops
+  from an O(n) deep clone of every key and entry to an O(log n) path copy,
+  removing the dominant allocation cost in mutation-heavy scripts. Dict
+  ordering, equality, identity (`===`), iteration, and the full read/write API
+  are unchanged.

--- a/crates/harn-cli/src/commands/check/script_rules.rs
+++ b/crates/harn-cli/src/commands/check/script_rules.rs
@@ -341,7 +341,7 @@ mod imp {
             for (k, v) in pairs {
                 map.insert((*k).to_string(), v.clone());
             }
-            VmValue::Dict(Arc::new(map))
+            VmValue::dict(map)
         }
 
         fn s(text: &str) -> VmValue {

--- a/crates/harn-cli/src/commands/eval_prompt.rs
+++ b/crates/harn-cli/src/commands/eval_prompt.rs
@@ -496,7 +496,7 @@ fn render_fleet(
     bindings: Option<&VmValue>,
 ) -> Vec<ModelRender> {
     let base = template_path.parent();
-    let bindings_dict: Option<BTreeMap<String, VmValue>> = bindings.and_then(|v| match v {
+    let bindings_dict: Option<harn_vm::value::DictMap> = bindings.and_then(|v| match v {
         VmValue::Dict(dict) => Some(dict.as_ref().clone()),
         _ => None,
     });

--- a/crates/harn-cli/src/commands/eval_prompt_context.rs
+++ b/crates/harn-cli/src/commands/eval_prompt_context.rs
@@ -513,7 +513,7 @@ fn context_case_bindings(
     assembled: &AssembledContext,
     selected_artifact_ids: &[String],
     dropped_artifact_ids: &[String],
-) -> Result<BTreeMap<String, VmValue>, String> {
+) -> Result<harn_vm::value::DictMap, String> {
     let mut bindings = match base_bindings {
         Some(VmValue::Dict(dict)) => dict.as_ref().clone(),
         Some(other) => {
@@ -522,7 +522,7 @@ fn context_case_bindings(
                 other.type_name()
             ));
         }
-        None => BTreeMap::new(),
+        None => harn_vm::value::DictMap::new(),
     };
     if let Some(case_bindings) = case_bindings {
         let object = case_bindings
@@ -614,7 +614,7 @@ fn render_context_variants(
     fleet: &[FleetEntry],
     template_source: &str,
     template_path: &Path,
-    bindings: &BTreeMap<String, VmValue>,
+    bindings: &harn_vm::value::DictMap,
     expect: &ContextExpectation,
 ) -> Vec<ContextVariantReport> {
     let base = template_path.parent();

--- a/crates/harn-cli/src/commands/run/mod.rs
+++ b/crates/harn-cli/src/commands/run/mod.rs
@@ -2378,7 +2378,7 @@ pub(crate) async fn connect_mcp_servers(
     harn_vm::mcp_register_servers(registrations);
 
     if !mcp_dict.is_empty() {
-        vm.set_global("mcp", harn_vm::VmValue::Dict(std::sync::Arc::new(mcp_dict)));
+        vm.set_global("mcp", harn_vm::VmValue::dict(mcp_dict));
     }
 }
 

--- a/crates/harn-cli/src/skill_loader.rs
+++ b/crates/harn-cli/src/skill_loader.rs
@@ -134,7 +134,7 @@ pub fn load_skills(inputs: &SkillLoaderInputs) -> LoadedSkills {
         }
         let mut entry = match skill_manifest_ref_to_vm(winner) {
             VmValue::Dict(map) => (*map).clone(),
-            _ => BTreeMap::new(),
+            _ => harn_vm::value::DictMap::new(),
         };
         let strip_hooks = should_strip_executable_frontmatter(provenance.as_ref());
         if let Some(report) = provenance.as_ref() {
@@ -159,7 +159,7 @@ pub fn load_skills(inputs: &SkillLoaderInputs) -> LoadedSkills {
             },
         );
         included_winners.push(winner.clone());
-        entries.push(VmValue::Dict(std::sync::Arc::new(entry)));
+        entries.push(VmValue::dict(entry));
     }
 
     let included_ids: std::collections::BTreeSet<String> = included_winners
@@ -178,13 +178,13 @@ pub fn load_skills(inputs: &SkillLoaderInputs) -> LoadedSkills {
         .map(|winner| (winner.id.clone(), winner.unknown_fields.clone()))
         .collect();
 
-    let mut registry: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut registry: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
     registry.put_str("_type", "skill_registry");
     registry.insert(
         "skills".to_string(),
         VmValue::List(std::sync::Arc::new(entries)),
     );
-    let registry_value = VmValue::Dict(std::sync::Arc::new(registry));
+    let registry_value = VmValue::dict(registry);
     let fetcher = build_policy_fetcher(discovery.clone(), registry_url, fetch_policies);
 
     LoadedSkills {
@@ -391,14 +391,14 @@ fn provenance_to_vm(report: &VerificationReport) -> VmValue {
                 Some(&endorsement.signed_at),
             ) {
                 VmValue::Dict(map) => (*map).clone(),
-                _ => BTreeMap::new(),
+                _ => harn_vm::value::DictMap::new(),
             };
             item.insert("trusted".to_string(), VmValue::Bool(endorsement.trusted));
             item.put_str("status", status_label(endorsement.status));
             if let Some(error) = endorsement.error.as_deref() {
                 item.put_str("error", error);
             }
-            VmValue::Dict(std::sync::Arc::new(item))
+            VmValue::dict(item)
         })
         .collect();
     dict.insert(
@@ -426,12 +426,12 @@ fn provenance_to_vm(report: &VerificationReport) -> VmValue {
     );
     dict.insert(
         "trust_policy_input".to_string(),
-        VmValue::Dict(std::sync::Arc::new(policy_input)),
+        VmValue::dict(policy_input),
     );
     if let Some(error) = report.error.as_deref() {
         dict.put_str("error", error);
     }
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn signer_policy_input(fingerprint: &str, signed_at: Option<&str>) -> VmValue {
@@ -442,7 +442,7 @@ fn signer_policy_input(fingerprint: &str, signed_at: Option<&str>) -> VmValue {
     if let Some(signed_at) = signed_at {
         dict.put_str("signed_at", signed_at);
     }
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn status_label(status: VerificationStatus) -> &'static str {

--- a/crates/harn-dap/src/debugger/breakpoints.rs
+++ b/crates/harn-dap/src/debugger/breakpoints.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 
-use harn_vm::VmValue;
 use serde_json::json;
 
 use super::state::Debugger;
@@ -395,7 +394,7 @@ pub(crate) fn condition_for_line(
 #[allow(dead_code)]
 pub(crate) fn check_condition_literal(
     condition: &str,
-    variables: &BTreeMap<String, VmValue>,
+    variables: &harn_vm::value::DictMap,
 ) -> Result<bool, String> {
     for op in &["==", "!=", ">=", "<=", ">", "<"] {
         if let Some((lhs, rhs)) = condition.split_once(op) {
@@ -448,7 +447,7 @@ impl Debugger {
         &mut self,
         bp_conditions: &[(i64, Option<String>)],
         line: i64,
-        variables: &BTreeMap<String, VmValue>,
+        variables: &harn_vm::value::DictMap,
     ) -> BreakpointCondition {
         let Some(condition) = condition_for_line(bp_conditions, line) else {
             return BreakpointCondition::Fire;
@@ -485,7 +484,7 @@ impl Debugger {
     pub(crate) fn classify_breakpoint_hit(
         &mut self,
         line: i64,
-        variables: &BTreeMap<String, VmValue>,
+        variables: &harn_vm::value::DictMap,
     ) -> BreakpointAction {
         // Find the matching breakpoint — there may be more than one on
         // a line in theory, but setBreakpoints de-dupes per file so in

--- a/crates/harn-dap/src/debugger/state.rs
+++ b/crates/harn-dap/src/debugger/state.rs
@@ -53,7 +53,7 @@ pub struct Debugger {
     pub(crate) next_bp_id: i64,
     pub(crate) vm: Option<Vm>,
     /// Variables captured at the current stop point.
-    pub(crate) variables: BTreeMap<String, VmValue>,
+    pub(crate) variables: harn_vm::value::DictMap,
     /// Current execution state.
     pub(crate) stopped: bool,
     /// Current line in the source.
@@ -196,7 +196,7 @@ impl Debugger {
             breakpoints: Vec::new(),
             next_bp_id: 1,
             vm: None,
-            variables: BTreeMap::new(),
+            variables: harn_vm::value::DictMap::new(),
             stopped: false,
             current_line: 0,
             step_mode: StepMode::Continue,

--- a/crates/harn-dap/src/debugger/tests.rs
+++ b/crates/harn-dap/src/debugger/tests.rs
@@ -358,13 +358,11 @@ fn test_evaluate() {
 
 #[test]
 fn test_evaluate_dot_access() {
-    use std::sync::Arc;
-
     let mut dbg = Debugger::new();
     let mut inner = BTreeMap::new();
     inner.insert("bar".to_string(), VmValue::Int(99));
     dbg.variables
-        .insert("foo".to_string(), VmValue::Dict(Arc::new(inner)));
+        .insert("foo".to_string(), VmValue::dict(inner));
 
     let responses = dbg.handle_message(make_request(
         1,
@@ -379,15 +377,12 @@ fn test_evaluate_dot_access() {
 
 #[test]
 fn test_evaluate_nested_dot_access() {
-    use std::sync::Arc;
-
     let mut dbg = Debugger::new();
     let mut inner = BTreeMap::new();
     inner.insert("c".to_string(), VmValue::String("deep".into()));
     let mut outer = BTreeMap::new();
-    outer.insert("b".to_string(), VmValue::Dict(Arc::new(inner)));
-    dbg.variables
-        .insert("a".to_string(), VmValue::Dict(Arc::new(outer)));
+    outer.insert("b".to_string(), VmValue::dict(inner));
+    dbg.variables.insert("a".to_string(), VmValue::dict(outer));
 
     let responses = dbg.handle_message(make_request(
         1,
@@ -401,13 +396,10 @@ fn test_evaluate_nested_dot_access() {
 
 #[test]
 fn test_evaluate_complex_value_has_var_ref() {
-    use std::sync::Arc;
-
     let mut dbg = Debugger::new();
     let mut map = BTreeMap::new();
     map.insert("key".to_string(), VmValue::Int(1));
-    dbg.variables
-        .insert("d".to_string(), VmValue::Dict(Arc::new(map)));
+    dbg.variables.insert("d".to_string(), VmValue::dict(map));
 
     let responses = dbg.handle_message(make_request(
         1,
@@ -1012,7 +1004,6 @@ fn test_modules_with_explicit_zero_module_count_returns_all() {
 #[test]
 fn test_triggered_breakpoint_skipped_until_trigger_fires() {
     use super::breakpoints::BreakpointAction;
-    use std::collections::BTreeMap;
 
     let mut dbg = Debugger::new();
     // Arrange two breakpoints: trigger (id=1, line 5) and dependent
@@ -1036,7 +1027,7 @@ fn test_triggered_breakpoint_skipped_until_trigger_fires() {
         .expect("dep BP present");
 
     // With no trigger fired, hitting line 10 must skip.
-    let vars: BTreeMap<String, harn_vm::VmValue> = BTreeMap::new();
+    let vars: harn_vm::value::DictMap = Default::default();
     let action = dbg.classify_breakpoint_hit(10, &vars);
     assert!(
         matches!(action, BreakpointAction::Skip),
@@ -1427,7 +1418,7 @@ fn test_hit_condition_matches_parses_all_forms() {
     assert_eq!(hit_condition_matches("hello", 1), None);
     assert_eq!(hit_condition_matches("= =1", 1), None);
 
-    let mut vars = BTreeMap::new();
+    let mut vars = harn_vm::value::DictMap::new();
     vars.insert("count".to_string(), VmValue::Int(5));
     vars.put_str("label", "ready");
 

--- a/crates/harn-dap/src/host_bridge.rs
+++ b/crates/harn-dap/src/host_bridge.rs
@@ -218,7 +218,7 @@ impl HostCallBridge for DapHostBridge {
         &self,
         capability: &str,
         operation: &str,
-        params: &BTreeMap<String, VmValue>,
+        params: &harn_vm::value::DictMap,
     ) -> Result<Option<VmValue>, VmError> {
         let start = std::time::Instant::now();
         self.emit_output("host_call", &format!("→ {capability}.{operation}"));
@@ -334,7 +334,7 @@ pub fn deliver_reply(pending: &PendingMap, request_seq: i64, reply: DapHostCallR
 // (private to the LLM module). This is a small, stable surface that's
 // straightforward to keep in sync with `VmValue`.
 
-fn vm_dict_to_json(params: &BTreeMap<String, VmValue>) -> Value {
+fn vm_dict_to_json(params: &harn_vm::value::DictMap) -> Value {
     let mut map = serde_json::Map::with_capacity(params.len());
     for (k, v) in params.iter() {
         map.insert(k.clone(), vm_value_to_json(v));
@@ -383,11 +383,11 @@ fn json_to_vm_value(value: Value) -> VmValue {
             arr.into_iter().map(json_to_vm_value).collect(),
         )),
         Value::Object(obj) => {
-            let map: BTreeMap<String, VmValue> = obj
+            let map: harn_vm::value::DictMap = obj
                 .into_iter()
                 .map(|(k, v)| (k, json_to_vm_value(v)))
                 .collect();
-            VmValue::Dict(std::sync::Arc::new(map))
+            VmValue::dict(map)
         }
     }
 }
@@ -531,7 +531,7 @@ mod tests {
             },
         );
 
-        let mut params = BTreeMap::new();
+        let mut params = harn_vm::value::DictMap::new();
         params.insert("path".into(), VmValue::String(std::sync::Arc::from("foo")));
         let result = bridge
             .dispatch("workspace", "read_text", &params)
@@ -563,7 +563,7 @@ mod tests {
             },
         );
 
-        let result = bridge.dispatch("workspace", "missing_op", &BTreeMap::new());
+        let result = bridge.dispatch("workspace", "missing_op", &harn_vm::value::DictMap::new());
         helper.join().expect("helper panicked");
 
         match result {
@@ -587,7 +587,7 @@ mod tests {
         );
 
         let result = bridge
-            .dispatch("session", "active_roots", &BTreeMap::new())
+            .dispatch("session", "active_roots", &harn_vm::value::DictMap::new())
             .expect("dispatch ok")
             .expect("Some");
         helper.join().expect("helper panicked");

--- a/crates/harn-hostlib/benches/ast_parse.rs
+++ b/crates/harn-hostlib/benches/ast_parse.rs
@@ -8,7 +8,6 @@
 //!
 //! Run with `cargo bench --bench ast_parse`.
 
-use std::collections::BTreeMap;
 use std::hint::black_box;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -24,11 +23,11 @@ fn ast_registry() -> BuiltinRegistry {
 }
 
 fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in pairs {
         map.insert((*k).into(), v.clone());
     }
-    VmValue::Dict(Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn fixture_path(rel: &str) -> PathBuf {

--- a/crates/harn-hostlib/benches/code_index_cypher.rs
+++ b/crates/harn-hostlib/benches/code_index_cypher.rs
@@ -13,7 +13,6 @@
 //! Criterion reports the median + outlier-filtered p95 of every benchmark.
 //! Run with `cargo bench --bench code_index_cypher`.
 
-use std::collections::BTreeMap;
 use std::fs;
 use std::hint::black_box;
 use std::path::PathBuf;
@@ -32,11 +31,11 @@ const FILE_COUNT: usize = 200;
 const LINES_PER_FILE: usize = 500;
 
 fn dict(entries: &[(&str, VmValue)]) -> VmValue {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
         map.insert((*k).to_string(), v.clone());
     }
-    VmValue::Dict(Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn call(registry: &BuiltinRegistry, name: &str, payload: VmValue) -> VmValue {

--- a/crates/harn-hostlib/src/ast/apply_node.rs
+++ b/crates/harn-hostlib/src/ast/apply_node.rs
@@ -209,7 +209,7 @@ fn applied_response(
     replacement: &str,
     dry_run: bool,
 ) -> VmValue {
-    VmValue::Dict(Arc::new(
+    VmValue::dict(
         [
             ("result".to_string(), str_value("applied")),
             ("applied".to_string(), VmValue::Bool(true)),
@@ -230,8 +230,8 @@ fn applied_response(
             ("preview".to_string(), str_value(lossy_str(after))),
         ]
         .into_iter()
-        .collect(),
-    ))
+        .collect::<harn_vm::value::DictMap>(),
+    )
 }
 
 fn no_match_response(path: &str, query: &str, target_capture: &str, details: &str) -> VmValue {
@@ -246,7 +246,7 @@ fn no_match_response(path: &str, query: &str, target_capture: &str, details: &st
 }
 
 fn ambiguous_response(match_count: usize, spans: &[Span]) -> VmValue {
-    VmValue::Dict(Arc::new(
+    VmValue::dict(
         [
             ("result".to_string(), str_value("ambiguous")),
             ("applied".to_string(), VmValue::Bool(false)),
@@ -264,8 +264,8 @@ fn ambiguous_response(match_count: usize, spans: &[Span]) -> VmValue {
             ),
         ]
         .into_iter()
-        .collect(),
-    ))
+        .collect::<harn_vm::value::DictMap>(),
+    )
 }
 
 fn no_nth_response(match_count: usize, requested: usize, path: &str, query: &str) -> VmValue {
@@ -350,7 +350,7 @@ fn span_to_value(span: &Span) -> VmValue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
+
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -359,11 +359,11 @@ mod tests {
     }
 
     fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
-        let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut map: harn_vm::value::DictMap = Default::default();
         for (k, v) in pairs {
             map.insert((*k).to_string(), v.clone());
         }
-        VmValue::Dict(Arc::new(map))
+        VmValue::dict(map)
     }
 
     fn field<'a>(value: &'a VmValue, key: &str) -> &'a VmValue {

--- a/crates/harn-hostlib/src/ast/batch_apply.rs
+++ b/crates/harn-hostlib/src/ast/batch_apply.rs
@@ -165,9 +165,7 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 /// Accept the replacement under either `replacement` or its `fix` alias
 /// (the rule model, Epic A, will speak `fix`; the raw primitive accepts
 /// both today). Exactly one must be present.
-fn resolve_replacement(
-    dict: &std::collections::BTreeMap<String, VmValue>,
-) -> Result<String, HostlibError> {
+fn resolve_replacement(dict: &harn_vm::value::DictMap) -> Result<String, HostlibError> {
     let replacement = optional_string(BUILTIN, dict, "replacement")?;
     let fix = optional_string(BUILTIN, dict, "fix")?;
     match (replacement, fix) {
@@ -449,7 +447,7 @@ impl Summary {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
+
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -462,11 +460,11 @@ mod tests {
     }
 
     fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
-        let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut map: harn_vm::value::DictMap = Default::default();
         for (k, v) in pairs {
             map.insert((*k).to_string(), v.clone());
         }
-        VmValue::Dict(Arc::new(map))
+        VmValue::dict(map)
     }
 
     fn field<'a>(value: &'a VmValue, key: &str) -> &'a VmValue {

--- a/crates/harn-hostlib/src/ast/bracket_balance.rs
+++ b/crates/harn-hostlib/src/ast/bracket_balance.rs
@@ -250,7 +250,7 @@ mod tests {
                 VmValue::String(std::sync::Arc::from("rust")),
             ),
         ]);
-        let payload = VmValue::Dict(std::sync::Arc::new(raw));
+        let payload = VmValue::dict(raw);
         let result = run(&[payload]).expect("handler runs");
         match &result {
             VmValue::Dict(d) => {

--- a/crates/harn-hostlib/src/ast/capabilities.rs
+++ b/crates/harn-hostlib/src/ast/capabilities.rs
@@ -85,18 +85,17 @@ fn unsupported_language_response(hint: &str) -> VmValue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
 
     fn invoke(dict: VmValue) -> VmValue {
         run(&[dict]).expect("capabilities runs")
     }
 
     fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
-        let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut map: harn_vm::value::DictMap = Default::default();
         for (k, v) in pairs {
             map.insert((*k).to_string(), v.clone());
         }
-        VmValue::Dict(Arc::new(map))
+        VmValue::dict(map)
     }
 
     fn field<'a>(value: &'a VmValue, key: &str) -> &'a VmValue {

--- a/crates/harn-hostlib/src/ast/dry_run.rs
+++ b/crates/harn-hostlib/src/ast/dry_run.rs
@@ -45,7 +45,7 @@
 //! use `+++ /dev/null`. Missing trailing newlines surface as the
 //! conventional `\ No newline at end of file` markers.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -163,8 +163,8 @@ pub(super) fn run_with_code_index(
 // ---------------------------------------------------------------------------
 
 fn require_plan(
-    dict: &BTreeMap<String, VmValue>,
-) -> Result<Vec<Arc<BTreeMap<String, VmValue>>>, HostlibError> {
+    dict: &harn_vm::value::DictMap,
+) -> Result<Vec<Arc<harn_vm::value::DictMap>>, HostlibError> {
     match dict.get("plan") {
         None | Some(VmValue::Nil) => Err(HostlibError::MissingParameter {
             builtin: BUILTIN,
@@ -237,7 +237,7 @@ fn dispatch_op(
     code_index: Option<&SharedIndex>,
     session_id: &str,
     index: usize,
-    raw: &Arc<BTreeMap<String, VmValue>>,
+    raw: &Arc<harn_vm::value::DictMap>,
 ) -> OpOutcome {
     let dict = raw.as_ref();
     let op_name = match dict.get("op") {
@@ -276,11 +276,11 @@ fn dispatch_op(
     }
 }
 
-fn run_apply_node(session_id: &str, raw: &Arc<BTreeMap<String, VmValue>>) -> OpOutcome {
+fn run_apply_node(session_id: &str, raw: &Arc<harn_vm::value::DictMap>) -> OpOutcome {
     delegate_to_builtin(session_id, raw, "apply_node", super::apply_node::run)
 }
 
-fn run_insert_at_anchor(session_id: &str, raw: &Arc<BTreeMap<String, VmValue>>) -> OpOutcome {
+fn run_insert_at_anchor(session_id: &str, raw: &Arc<harn_vm::value::DictMap>) -> OpOutcome {
     delegate_to_builtin(
         session_id,
         raw,
@@ -296,15 +296,15 @@ fn run_insert_at_anchor(session_id: &str, raw: &Arc<BTreeMap<String, VmValue>>) 
 /// even if the caller passed conflicting values.
 fn delegate_to_builtin(
     session_id: &str,
-    raw: &Arc<BTreeMap<String, VmValue>>,
+    raw: &Arc<harn_vm::value::DictMap>,
     op_label: &'static str,
     runner: fn(&[VmValue]) -> Result<VmValue, HostlibError>,
 ) -> OpOutcome {
-    let mut forwarded: BTreeMap<String, VmValue> = (**raw).clone();
+    let mut forwarded: harn_vm::value::DictMap = (**raw).clone();
     forwarded.remove("op");
     forwarded.insert("session_id".to_string(), str_value(session_id));
     forwarded.insert("dry_run".to_string(), VmValue::Bool(false));
-    let request = VmValue::Dict(Arc::new(forwarded));
+    let request = VmValue::dict(forwarded);
     match runner(&[request]) {
         Ok(VmValue::Dict(result)) => parse_builtin_outcome(&result, op_label),
         Ok(_) => OpOutcome::Error {
@@ -319,7 +319,7 @@ fn delegate_to_builtin(
 }
 
 fn parse_builtin_outcome(
-    result: &Arc<BTreeMap<String, VmValue>>,
+    result: &Arc<harn_vm::value::DictMap>,
     op_label: &'static str,
 ) -> OpOutcome {
     let result_str = match result.get("result") {
@@ -375,7 +375,7 @@ fn classify_builtin_failure(result: &str) -> &'static str {
 fn run_rename_symbol(
     code_index: Option<&SharedIndex>,
     session_id: &str,
-    raw: &Arc<BTreeMap<String, VmValue>>,
+    raw: &Arc<harn_vm::value::DictMap>,
 ) -> OpOutcome {
     let Some(index) = code_index else {
         return OpOutcome::Rejected {
@@ -386,7 +386,7 @@ fn run_rename_symbol(
             path: None,
         };
     };
-    let mut forwarded: BTreeMap<String, VmValue> = (**raw).clone();
+    let mut forwarded: harn_vm::value::DictMap = (**raw).clone();
     forwarded.remove("op");
     forwarded.insert("session_id".to_string(), str_value(session_id));
     forwarded.insert("dry_run".to_string(), VmValue::Bool(false));
@@ -394,7 +394,7 @@ fn run_rename_symbol(
         .entry("scope".to_string())
         .or_insert_with(|| str_value("workspace"));
 
-    let request = VmValue::Dict(Arc::new(forwarded));
+    let request = VmValue::dict(forwarded);
     match crate::code_index::run_rename_symbol(index, &[request]) {
         Ok(VmValue::Dict(result)) => parse_rename_outcome(&result),
         Ok(_) => OpOutcome::Error {
@@ -408,7 +408,7 @@ fn run_rename_symbol(
     }
 }
 
-fn parse_rename_outcome(result: &Arc<BTreeMap<String, VmValue>>) -> OpOutcome {
+fn parse_rename_outcome(result: &Arc<harn_vm::value::DictMap>) -> OpOutcome {
     let result_str = match result.get("result") {
         Some(VmValue::String(s)) => s.to_string(),
         _ => {
@@ -462,7 +462,7 @@ fn classify_rename_failure(result: &str) -> &'static str {
     }
 }
 
-fn rename_touched_paths(result: &Arc<BTreeMap<String, VmValue>>) -> Vec<PathBuf> {
+fn rename_touched_paths(result: &Arc<harn_vm::value::DictMap>) -> Vec<PathBuf> {
     match result.get("touched_files") {
         Some(VmValue::List(files)) => files
             .iter()
@@ -478,14 +478,14 @@ fn rename_touched_paths(result: &Arc<BTreeMap<String, VmValue>>) -> Vec<PathBuf>
     }
 }
 
-fn int_field(result: &Arc<BTreeMap<String, VmValue>>, key: &str) -> Option<i64> {
+fn int_field(result: &Arc<harn_vm::value::DictMap>, key: &str) -> Option<i64> {
     match result.get(key) {
         Some(VmValue::Int(n)) => Some(*n),
         _ => None,
     }
 }
 
-fn run_safe_text_patch(session_id: &str, raw: &Arc<BTreeMap<String, VmValue>>) -> OpOutcome {
+fn run_safe_text_patch(session_id: &str, raw: &Arc<harn_vm::value::DictMap>) -> OpOutcome {
     let dict = raw.as_ref();
     let path_str = match require_string(BUILTIN, dict, "path") {
         Ok(s) => s,
@@ -825,11 +825,11 @@ mod tests {
     }
 
     fn vm_dict(pairs: &[(&str, VmValue)]) -> VmValue {
-        let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut map: harn_vm::value::DictMap = Default::default();
         for (k, v) in pairs {
             map.insert((*k).to_string(), v.clone());
         }
-        VmValue::Dict(Arc::new(map))
+        VmValue::dict(map)
     }
 
     fn vm_list(items: &[VmValue]) -> VmValue {

--- a/crates/harn-hostlib/src/ast/function_body.rs
+++ b/crates/harn-hostlib/src/ast/function_body.rs
@@ -20,7 +20,7 @@
 //! the joined text plus a regex-derived list of return-object field
 //! names for hosts that build API contract summaries.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use harn_vm::VmValue;
@@ -50,7 +50,7 @@ pub(super) struct ExtractedBody {
 
 impl ExtractedBody {
     fn to_vm_value(&self) -> VmValue {
-        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut dict: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
         dict.insert("name".into(), str_value(&self.name));
         dict.insert("body_text".into(), str_value(&self.body_text));
         dict.insert("start_line".into(), VmValue::Int(self.start_line as i64));
@@ -60,7 +60,7 @@ impl ExtractedBody {
             "return_object_fields".into(),
             VmValue::List(Arc::new(fields)),
         );
-        VmValue::Dict(Arc::new(dict))
+        VmValue::dict(dict)
     }
 }
 
@@ -82,7 +82,7 @@ pub(super) fn run_single(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     );
     let brace_based = !matches!(language, Language::Python);
 
-    let mut response: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut response: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
     response.insert(
         "path".into(),
         match path_for_response {
@@ -113,7 +113,7 @@ pub(super) fn run_single(args: &[VmValue]) -> Result<VmValue, HostlibError> {
             VmValue::List(Arc::new(Vec::new())),
         );
     }
-    Ok(VmValue::Dict(Arc::new(response)))
+    Ok(VmValue::dict(response))
 }
 
 pub(super) fn run_bulk(args: &[VmValue]) -> Result<VmValue, HostlibError> {
@@ -126,7 +126,7 @@ pub(super) fn run_bulk(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 
     let tree = parse_source(&source, language)?;
     let unique: BTreeSet<String> = names.iter().cloned().collect();
-    let mut bodies_dict: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut bodies_dict: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
     for name in &unique {
         if let Some(body) = extract_body(&tree, &source, language, name, container.as_deref()) {
             bodies_dict.insert(name.clone(), body.to_vm_value());
@@ -142,7 +142,7 @@ pub(super) fn run_bulk(args: &[VmValue]) -> Result<VmValue, HostlibError> {
         }
     }
 
-    let mut response: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut response: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
     response.insert(
         "path".into(),
         match path_for_response {
@@ -152,14 +152,14 @@ pub(super) fn run_bulk(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     );
     response.insert("language".into(), str_value(language.name()));
     response.insert("brace_based".into(), VmValue::Bool(brace_based));
-    response.insert("bodies".into(), VmValue::Dict(Arc::new(bodies_dict)));
+    response.insert("bodies".into(), VmValue::dict(bodies_dict));
     response.insert("missing".into(), VmValue::List(Arc::new(missing)));
-    Ok(VmValue::Dict(Arc::new(response)))
+    Ok(VmValue::dict(response))
 }
 
 fn require_string_list(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Vec<String>, HostlibError> {
     let Some(raw) = dict.get(key) else {
@@ -201,7 +201,7 @@ fn require_string_list(
 /// (with optional `language` override).
 fn load_input(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
 ) -> Result<(String, Language, Option<String>), HostlibError> {
     let source_in = optional_string(builtin, dict, "source")?;
     let path_in = optional_string(builtin, dict, "path")?;

--- a/crates/harn-hostlib/src/ast/imports.rs
+++ b/crates/harn-hostlib/src/ast/imports.rs
@@ -23,7 +23,6 @@
 //! }
 //! ```
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use harn_vm::VmValue;
@@ -108,10 +107,10 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
         .iter()
         .map(|stmt| {
             let line = locate_first_line(stmt, &lines);
-            let mut entry: BTreeMap<String, VmValue> = BTreeMap::new();
+            let mut entry: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
             entry.insert("text".into(), str_value(stmt));
             entry.insert("line".into(), VmValue::Int(line as i64));
-            VmValue::Dict(Arc::new(entry))
+            VmValue::dict(entry)
         })
         .collect();
 

--- a/crates/harn-hostlib/src/ast/insert_at_anchor.rs
+++ b/crates/harn-hostlib/src/ast/insert_at_anchor.rs
@@ -747,11 +747,11 @@ mod tests {
     }
 
     fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
-        let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut map: harn_vm::value::DictMap = Default::default();
         for (k, v) in pairs {
             map.insert((*k).to_string(), v.clone());
         }
-        VmValue::Dict(Arc::new(map))
+        VmValue::dict(map)
     }
 
     fn field<'a>(value: &'a VmValue, key: &str) -> &'a VmValue {

--- a/crates/harn-hostlib/src/ast/mutation.rs
+++ b/crates/harn-hostlib/src/ast/mutation.rs
@@ -22,7 +22,6 @@
 //! consumers: tree-sitter-oriented editor features and line-based file
 //! editing helpers.
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use harn_vm::VmValue;
@@ -417,11 +416,11 @@ fn not_found_response(available: Vec<String>, suggestions: Vec<String>) -> VmVal
     let suggestions_list = VmValue::List(Arc::new(
         suggestions.into_iter().map(|s| str_value(&s)).collect(),
     ));
-    let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut dict: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
     dict.insert("result".into(), str_value("not_found"));
     dict.insert("available".into(), available_list);
     dict.insert("suggestions".into(), suggestions_list);
-    VmValue::Dict(Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn ambiguous_response(match_count: usize) -> VmValue {
@@ -440,11 +439,11 @@ mod tests {
     }
 
     fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
-        let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut map: harn_vm::value::DictMap = Default::default();
         for (k, v) in pairs {
             map.insert((*k).to_string(), v.clone());
         }
-        VmValue::Dict(Arc::new(map))
+        VmValue::dict(map)
     }
 
     fn dict_field<'a>(value: &'a VmValue, key: &str) -> &'a VmValue {

--- a/crates/harn-hostlib/src/ast/parse_errors.rs
+++ b/crates/harn-hostlib/src/ast/parse_errors.rs
@@ -416,11 +416,10 @@ mod tests {
     use super::*;
 
     fn run_with(content: &str, language: &str) -> VmValue {
-        use std::collections::BTreeMap;
-        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut dict: harn_vm::value::DictMap = Default::default();
         dict.insert("content".into(), VmValue::String(Arc::from(content)));
         dict.insert("language".into(), VmValue::String(Arc::from(language)));
-        run(&[VmValue::Dict(Arc::new(dict))]).expect("parse_errors run")
+        run(&[VmValue::dict(dict)]).expect("parse_errors run")
     }
 
     fn list_field(value: &VmValue, key: &str) -> Arc<Vec<VmValue>> {
@@ -600,9 +599,8 @@ mod tests {
 
     #[test]
     fn rejects_when_no_content_or_path() {
-        use std::collections::BTreeMap;
-        let dict: BTreeMap<String, VmValue> = BTreeMap::new();
-        let err = run(&[VmValue::Dict(Arc::new(dict))]).expect_err("must reject empty payload");
+        let dict: harn_vm::value::DictMap = Default::default();
+        let err = run(&[VmValue::dict(dict)]).expect_err("must reject empty payload");
         match err {
             HostlibError::MissingParameter { builtin, param } => {
                 assert_eq!(builtin, BUILTIN);

--- a/crates/harn-hostlib/src/ast/search.rs
+++ b/crates/harn-hostlib/src/ast/search.rs
@@ -33,7 +33,6 @@
 //! on syntax errors — it queries whatever (possibly partial) tree it gets and
 //! reports `had_errors` so the caller can decide.
 
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -286,7 +285,7 @@ fn ok_response(
 }
 
 fn match_to_value(m: &SearchMatch) -> VmValue {
-    let captures: BTreeMap<String, VmValue> = m
+    let captures: harn_vm::value::DictMap = m
         .captures
         .iter()
         .map(|c| {
@@ -302,7 +301,7 @@ fn match_to_value(m: &SearchMatch) -> VmValue {
     build_dict([
         ("range", span_to_value(&m.range)),
         ("text", str_value(&m.text)),
-        ("captures", VmValue::Dict(Arc::new(captures))),
+        ("captures", VmValue::dict(captures)),
     ])
 }
 
@@ -390,11 +389,11 @@ mod tests {
     }
 
     fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
-        let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut map: harn_vm::value::DictMap = Default::default();
         for (k, v) in pairs {
             map.insert((*k).to_string(), v.clone());
         }
-        VmValue::Dict(Arc::new(map))
+        VmValue::dict(map)
     }
 
     fn field<'a>(value: &'a VmValue, key: &str) -> &'a VmValue {

--- a/crates/harn-hostlib/src/ast/structural_diff.rs
+++ b/crates/harn-hostlib/src/ast/structural_diff.rs
@@ -167,7 +167,7 @@ struct Limits {
 }
 
 impl Limits {
-    fn from_payload(dict: &BTreeMap<String, VmValue>) -> Result<Self, HostlibError> {
+    fn from_payload(dict: &harn_vm::value::DictMap) -> Result<Self, HostlibError> {
         Ok(Self {
             max_bytes: optional_limit(dict, "max_bytes", DEFAULT_MAX_BYTES)?,
             max_nodes: optional_limit(dict, "max_nodes", DEFAULT_MAX_NODES)?,
@@ -209,7 +209,7 @@ impl Limits {
 }
 
 fn optional_limit(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
     default: usize,
 ) -> Result<usize, HostlibError> {

--- a/crates/harn-hostlib/src/ast/symbols_call.rs
+++ b/crates/harn-hostlib/src/ast/symbols_call.rs
@@ -57,7 +57,7 @@ pub(super) fn run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 }
 
 fn parse_kinds_filter(
-    dict: &std::collections::BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
 ) -> Result<Option<HashSet<String>>, HostlibError> {
     let Some(raw) = dict.get("kinds") else {
         return Ok(None);

--- a/crates/harn-hostlib/src/ast/types.rs
+++ b/crates/harn-hostlib/src/ast/types.rs
@@ -8,7 +8,6 @@
 
 #![allow(missing_docs)]
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use harn_vm::VmValue;
@@ -81,7 +80,7 @@ pub struct Symbol {
 impl Symbol {
     /// Render as a `VmValue::Dict` matching `schemas/ast/symbols.response.json`.
     pub fn to_vm_value(&self) -> VmValue {
-        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut dict: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
         dict.insert(
             "name".into(),
             VmValue::String(Arc::from(self.name.as_str())),
@@ -105,7 +104,7 @@ impl Symbol {
         dict.insert("start_col".into(), VmValue::Int(self.start_col as i64));
         dict.insert("end_row".into(), VmValue::Int(self.end_row as i64));
         dict.insert("end_col".into(), VmValue::Int(self.end_col as i64));
-        VmValue::Dict(Arc::new(dict))
+        VmValue::dict(dict)
     }
 }
 
@@ -123,7 +122,7 @@ pub struct OutlineItem {
 
 impl OutlineItem {
     pub fn to_vm_value(&self) -> VmValue {
-        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut dict: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
         dict.insert(
             "name".into(),
             VmValue::String(Arc::from(self.name.as_str())),
@@ -140,7 +139,7 @@ impl OutlineItem {
         dict.insert("end_row".into(), VmValue::Int(self.end_row as i64));
         let kids: Vec<VmValue> = self.children.iter().map(OutlineItem::to_vm_value).collect();
         dict.insert("children".into(), VmValue::List(Arc::new(kids)));
-        VmValue::Dict(Arc::new(dict))
+        VmValue::dict(dict)
     }
 }
 
@@ -162,7 +161,7 @@ pub struct ParsedNode {
 
 impl ParsedNode {
     pub fn to_vm_value(&self) -> VmValue {
-        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut dict: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
         dict.insert("id".into(), VmValue::Int(self.id as i64));
         dict.insert(
             "parent_id".into(),
@@ -180,7 +179,7 @@ impl ParsedNode {
         dict.insert("start_col".into(), VmValue::Int(self.start_col as i64));
         dict.insert("end_row".into(), VmValue::Int(self.end_row as i64));
         dict.insert("end_col".into(), VmValue::Int(self.end_col as i64));
-        VmValue::Dict(Arc::new(dict))
+        VmValue::dict(dict)
     }
 }
 
@@ -216,7 +215,7 @@ impl ParseError {
     /// localized, model-authored syntax mistake. Edit-validation gates use this
     /// to avoid hard-rejecting a correct edit on a grammar blind spot.
     pub fn to_vm_value_with_span(&self, spans_full_source: bool) -> VmValue {
-        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut dict: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
         dict.insert("start_row".into(), VmValue::Int(self.start_row as i64));
         dict.insert("start_col".into(), VmValue::Int(self.start_col as i64));
         dict.insert("end_row".into(), VmValue::Int(self.end_row as i64));
@@ -233,7 +232,7 @@ impl ParseError {
         );
         dict.insert("missing".into(), VmValue::Bool(self.missing));
         dict.insert("spans_full_source".into(), VmValue::Bool(spans_full_source));
-        VmValue::Dict(Arc::new(dict))
+        VmValue::dict(dict)
     }
 }
 
@@ -250,7 +249,7 @@ pub struct UndefinedName {
 
 impl UndefinedName {
     pub fn to_vm_value(&self) -> VmValue {
-        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut dict: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
         dict.insert(
             "name".into(),
             VmValue::String(Arc::from(self.name.as_str())),
@@ -263,6 +262,6 @@ impl UndefinedName {
             "message".into(),
             VmValue::String(Arc::from(message.as_str())),
         );
-        VmValue::Dict(Arc::new(dict))
+        VmValue::dict(dict)
     }
 }

--- a/crates/harn-hostlib/src/ast/undefined_names.rs
+++ b/crates/harn-hostlib/src/ast/undefined_names.rs
@@ -1401,13 +1401,12 @@ mod ruby {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
 
     fn run_with(content: &str, language: &str) -> VmValue {
-        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut dict: harn_vm::value::DictMap = Default::default();
         dict.insert("content".into(), VmValue::String(Arc::from(content)));
         dict.insert("language".into(), VmValue::String(Arc::from(language)));
-        run(&[VmValue::Dict(Arc::new(dict))]).expect("undefined_names run")
+        run(&[VmValue::dict(dict)]).expect("undefined_names run")
     }
 
     fn names(result: &VmValue) -> Vec<String> {
@@ -1515,8 +1514,8 @@ mod tests {
 
     #[test]
     fn missing_payload_is_rejected() {
-        let dict: std::collections::BTreeMap<String, VmValue> = std::collections::BTreeMap::new();
-        let err = run(&[VmValue::Dict(Arc::new(dict))]).expect_err("must reject");
+        let dict: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
+        let err = run(&[VmValue::dict(dict)]).expect_err("must reject");
         match err {
             HostlibError::MissingParameter { builtin, .. } => assert_eq!(builtin, BUILTIN),
             other => panic!("got {other:?}"),

--- a/crates/harn-hostlib/src/code_index/builtins.rs
+++ b/crates/harn-hostlib/src/code_index/builtins.rs
@@ -7,7 +7,7 @@
 //! op also reads from the capability's `current_agent` slot, but for
 //! every other op the index mutex is the source of truth.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -853,11 +853,11 @@ pub(super) fn run_cypher(index: &SharedIndex, args: &[VmValue]) -> Result<VmValu
     let rows_vm: Vec<VmValue> = rows
         .into_iter()
         .map(|row| {
-            let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+            let mut map: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
             for (k, v) in row {
                 map.insert(k, v.to_vm());
             }
-            VmValue::Dict(Arc::new(map))
+            VmValue::dict(map)
         })
         .collect();
 
@@ -1019,7 +1019,7 @@ fn ensure_state<'a>(
 
 fn parse_hash(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<u64, HostlibError> {
     match dict.get(key) {
@@ -1050,7 +1050,7 @@ fn parse_hash(
 
 fn require_positive_u64(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<u64, HostlibError> {
     let raw = require_non_negative_u64(builtin, dict, key)?;
@@ -1066,7 +1066,7 @@ fn require_positive_u64(
 
 fn require_positive_file_id(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<FileId, HostlibError> {
     let raw = require_positive_u64(builtin, dict, key)?;
@@ -1079,7 +1079,7 @@ fn require_positive_file_id(
 
 fn require_non_negative_u64(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<u64, HostlibError> {
     match value_args::optional_i64_no_default(builtin, dict, key)? {
@@ -1098,7 +1098,7 @@ fn require_non_negative_u64(
 
 fn optional_positive_u64(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Option<u64>, HostlibError> {
     match dict.get(key) {
@@ -1109,7 +1109,7 @@ fn optional_positive_u64(
 
 fn optional_non_negative_u64(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
     default: u64,
 ) -> Result<u64, HostlibError> {
@@ -1121,7 +1121,7 @@ fn optional_non_negative_u64(
 
 fn optional_positive_i64(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Option<i64>, HostlibError> {
     match value_args::optional_i64_no_default(builtin, dict, key)? {
@@ -1137,7 +1137,7 @@ fn optional_positive_i64(
 
 fn optional_positive_usize(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Option<usize>, HostlibError> {
     match optional_positive_u64(builtin, dict, key)? {
@@ -1235,7 +1235,7 @@ fn hit_to_value(hit: Hit) -> VmValue {
 }
 
 fn import_entry(module: &str, resolved: Option<&str>, kind: &str) -> VmValue {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
     map.insert("module".into(), str_value(module));
     map.insert(
         "resolved_path".into(),
@@ -1245,7 +1245,7 @@ fn import_entry(module: &str, resolved: Option<&str>, kind: &str) -> VmValue {
         },
     );
     map.insert("kind".into(), str_value(kind));
-    VmValue::Dict(Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn empty_query_response() -> VmValue {

--- a/crates/harn-hostlib/src/code_index/rename.rs
+++ b/crates/harn-hostlib/src/code_index/rename.rs
@@ -919,7 +919,7 @@ fn sha256_hex(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
+
     use std::fs;
     use tempfile::tempdir;
 
@@ -930,11 +930,11 @@ mod tests {
     }
 
     fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
-        let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut map: harn_vm::value::DictMap = Default::default();
         for (k, v) in pairs {
             map.insert((*k).to_string(), v.clone());
         }
-        VmValue::Dict(Arc::new(map))
+        VmValue::dict(map)
     }
 
     fn field<'a>(value: &'a VmValue, key: &str) -> &'a VmValue {

--- a/crates/harn-hostlib/src/error.rs
+++ b/crates/harn-hostlib/src/error.rs
@@ -4,8 +4,6 @@
 //! so that Harn scripts see structured exceptions rather than panics.
 
 use harn_vm::VmDictExt;
-use std::collections::BTreeMap;
-use std::sync::Arc;
 
 use harn_vm::{VmError, VmValue};
 
@@ -108,13 +106,13 @@ impl From<HostlibError> for VmError {
         let builtin = err.builtin();
         let message = err.to_string();
 
-        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut dict: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
         dict.put_str("kind", kind);
         dict.put_str("builtin", builtin);
         dict.put_str("message", message);
         if let Some(path) = path {
             dict.put_str("path", path);
         }
-        VmError::Thrown(VmValue::Dict(Arc::new(dict)))
+        VmError::Thrown(VmValue::dict(dict))
     }
 }

--- a/crates/harn-hostlib/src/fs_watch/mod.rs
+++ b/crates/harn-hostlib/src/fs_watch/mod.rs
@@ -3,7 +3,7 @@
 //! Wraps `notify` to deliver coalesced file-change batches into Harn's
 //! session-scoped `AgentEvent` stream.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Mutex, OnceLock};
@@ -209,7 +209,7 @@ struct SubscribeRequest {
 }
 
 impl SubscribeRequest {
-    fn from_dict(dict: &BTreeMap<String, VmValue>) -> Result<Self, HostlibError> {
+    fn from_dict(dict: &harn_vm::value::DictMap) -> Result<Self, HostlibError> {
         let root_param = optional_string(SUBSCRIBE_BUILTIN, dict, "root")?;
         let raw_paths = optional_string_list(SUBSCRIBE_BUILTIN, dict, "paths")?;
         let raw_globs = optional_string_list(SUBSCRIBE_BUILTIN, dict, "globs")?;
@@ -448,7 +448,7 @@ fn normalize_kind(kind: &EventKind) -> &'static str {
     }
 }
 
-fn parse_kinds(dict: &BTreeMap<String, VmValue>) -> Result<BTreeSet<String>, HostlibError> {
+fn parse_kinds(dict: &harn_vm::value::DictMap) -> Result<BTreeSet<String>, HostlibError> {
     let values = optional_string_list(SUBSCRIBE_BUILTIN, dict, "kinds")?.unwrap_or_else(|| {
         DEFAULT_KINDS
             .iter()
@@ -572,7 +572,7 @@ mod tests {
                     .unwrap()
             }),
             gitignore: None,
-            kinds: parse_kinds(&BTreeMap::new()).unwrap(),
+            kinds: parse_kinds(&harn_vm::value::DictMap::new()).unwrap(),
         }
     }
 
@@ -640,7 +640,7 @@ mod tests {
     #[test]
     fn kind_filter_allows_access_and_other_events() {
         let root = std::env::current_dir().unwrap();
-        let mut config = BTreeMap::new();
+        let mut config = harn_vm::value::DictMap::new();
         config.insert(
             "kinds".to_string(),
             VmValue::List(std::sync::Arc::new(vec![

--- a/crates/harn-hostlib/src/sandbox/local.rs
+++ b/crates/harn-hostlib/src/sandbox/local.rs
@@ -513,7 +513,7 @@ fn exec_result_from_value(value: VmValue) -> SandboxResult<ExecResult> {
     })
 }
 
-fn dict_string(map: &BTreeMap<String, VmValue>, key: &str) -> SandboxResult<String> {
+fn dict_string(map: &harn_vm::value::DictMap, key: &str) -> SandboxResult<String> {
     match map.get(key) {
         Some(VmValue::String(value)) => Ok(value.to_string()),
         Some(other) => Err(SandboxError::Exec(format!(
@@ -526,7 +526,7 @@ fn dict_string(map: &BTreeMap<String, VmValue>, key: &str) -> SandboxResult<Stri
     }
 }
 
-fn dict_int(map: &BTreeMap<String, VmValue>, key: &str) -> SandboxResult<i32> {
+fn dict_int(map: &harn_vm::value::DictMap, key: &str) -> SandboxResult<i32> {
     match map.get(key) {
         Some(VmValue::Int(value)) => Ok(*value as i32),
         Some(other) => Err(SandboxError::Exec(format!(

--- a/crates/harn-hostlib/src/scanner/mod.rs
+++ b/crates/harn-hostlib/src/scanner/mod.rs
@@ -540,7 +540,7 @@ fn scan_incremental_handler(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 
 fn parse_options(
     builtin: &'static str,
-    dict: &std::collections::BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
 ) -> Result<ScanProjectOptions, HostlibError> {
     let include_hidden = optional_bool(builtin, dict, "include_hidden", false)?;
     let respect_gitignore = optional_bool(builtin, dict, "respect_gitignore", true)?;
@@ -578,7 +578,7 @@ fn parse_options(
 
 fn parse_changed_paths(
     builtin: &'static str,
-    dict: &std::collections::BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
 ) -> Result<Option<Vec<String>>, HostlibError> {
     let value = match dict.get("changed_paths") {
         None | Some(VmValue::Nil) => return Ok(None),
@@ -771,7 +771,7 @@ mod tests {
 
     #[test]
     fn builtin_option_defaults_match_request_schemas() {
-        let dict = std::collections::BTreeMap::new();
+        let dict = harn_vm::value::DictMap::new();
 
         let scan_project = parse_options(SCAN_PROJECT_BUILTIN, &dict).unwrap();
         let scan_incremental = parse_options(SCAN_INCREMENTAL_BUILTIN, &dict).unwrap();

--- a/crates/harn-hostlib/src/secret_store/mod.rs
+++ b/crates/harn-hostlib/src/secret_store/mod.rs
@@ -162,7 +162,7 @@ fn handle_list(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 
 fn require_nonempty_string(
     builtin: &'static str,
-    dict: &std::collections::BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<String, HostlibError> {
     let value = require_string(builtin, dict, key)?;

--- a/crates/harn-hostlib/src/tools/args.rs
+++ b/crates/harn-hostlib/src/tools/args.rs
@@ -6,7 +6,6 @@
 //! [`HostlibError`] variants on shape mismatches so the script side gets a
 //! structured exception.
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use harn_vm::VmValue;
@@ -20,10 +19,10 @@ use crate::value_args;
 pub fn dict_arg(
     builtin: &'static str,
     args: &[VmValue],
-) -> Result<Arc<BTreeMap<String, VmValue>>, HostlibError> {
+) -> Result<Arc<harn_vm::value::DictMap>, HostlibError> {
     match args.first() {
         Some(VmValue::Dict(dict)) => Ok(dict.clone()),
-        Some(VmValue::Nil) | None => Ok(Arc::new(BTreeMap::new())),
+        Some(VmValue::Nil) | None => Ok(Arc::new(harn_vm::value::DictMap::new())),
         Some(other) => Err(HostlibError::InvalidParameter {
             builtin,
             param: "params",
@@ -39,7 +38,7 @@ pub fn dict_arg(
 /// Required string field.
 pub fn require_string(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<String, HostlibError> {
     value_args::require_string(builtin, dict, key)
@@ -48,7 +47,7 @@ pub fn require_string(
 /// Optional string field. Missing/`Nil` returns `None`.
 pub fn optional_string(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Option<String>, HostlibError> {
     value_args::optional_string(builtin, dict, key)
@@ -57,7 +56,7 @@ pub fn optional_string(
 /// Optional `bool`. Defaults to `default` when missing or `Nil`.
 pub fn optional_bool(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
     default: bool,
 ) -> Result<bool, HostlibError> {
@@ -70,7 +69,7 @@ pub fn optional_bool(
 /// floats).
 pub fn optional_int(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
     default: i64,
 ) -> Result<i64, HostlibError> {
@@ -80,7 +79,7 @@ pub fn optional_int(
 /// Optional list of strings. Missing/`Nil` returns `Vec::new()`.
 pub fn optional_string_list(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Vec<String>, HostlibError> {
     value_args::optional_string_list(builtin, dict, key).map(|value| value.unwrap_or_default())
@@ -93,7 +92,7 @@ pub fn optional_string_list(
 #[cfg(feature = "ast")]
 pub fn optional_int_list(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Vec<i64>, HostlibError> {
     match dict.get(key) {
@@ -123,11 +122,11 @@ where
     I: IntoIterator<Item = (K, VmValue)>,
     K: Into<String>,
 {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
     for (k, v) in entries {
         map.insert(k.into(), v);
     }
-    VmValue::Dict(Arc::new(map))
+    VmValue::dict(map)
 }
 
 /// Convenience constructor for `VmValue::String` from a `&str`.
@@ -139,7 +138,7 @@ pub fn str_value(s: impl AsRef<str>) -> VmValue {
 mod tests {
     use super::*;
 
-    fn dict(entries: [(&'static str, VmValue); 1]) -> BTreeMap<String, VmValue> {
+    fn dict(entries: [(&'static str, VmValue); 1]) -> harn_vm::value::DictMap {
         entries
             .into_iter()
             .map(|(key, value)| (key.to_string(), value))

--- a/crates/harn-hostlib/src/tools/cancel_handle.rs
+++ b/crates/harn-hostlib/src/tools/cancel_handle.rs
@@ -12,7 +12,6 @@
 
 use harn_vm::VmDictExt;
 use std::collections::BTreeMap;
-use std::sync::Arc;
 use std::time::Duration;
 
 use harn_vm::VmValue;
@@ -43,5 +42,5 @@ pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     if let Some(result) = outcome.result {
         out.insert("result".to_string(), result);
     }
-    Ok(VmValue::Dict(Arc::new(out)))
+    Ok(VmValue::dict(out))
 }

--- a/crates/harn-hostlib/src/tools/inspect_test_results.rs
+++ b/crates/harn-hostlib/src/tools/inspect_test_results.rs
@@ -145,7 +145,7 @@ pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     }
     let entries: Vec<VmValue> = records
         .into_iter()
-        .map(|r| VmValue::Dict(Arc::new(record_to_map(r))))
+        .map(|r| VmValue::dict(record_to_map(r)))
         .collect();
     Ok(ResponseBuilder::new()
         .str("result_handle", handle)
@@ -153,8 +153,8 @@ pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
         .build())
 }
 
-fn record_to_map(record: test_parsers::TestRecord) -> BTreeMap<String, VmValue> {
-    let mut map = BTreeMap::new();
+fn record_to_map(record: test_parsers::TestRecord) -> harn_vm::value::DictMap {
+    let mut map = harn_vm::value::DictMap::new();
     map.put_str("name", record.name);
     map.put_str("status", record.status.as_str());
     map.insert(

--- a/crates/harn-hostlib/src/tools/mod.rs
+++ b/crates/harn-hostlib/src/tools/mod.rs
@@ -35,7 +35,6 @@
 //! opt-in model keeps the deterministic-tool surface sandbox-friendly.
 
 use harn_vm::VmDictExt;
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use harn_vm::VmValue;
@@ -218,11 +217,11 @@ fn handle_enable(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     match feature.as_str() {
         permissions::FEATURE_TOOLS_DETERMINISTIC => {
             let newly_enabled = permissions::enable(&feature);
-            let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+            let mut map: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
             map.put_str("feature", feature);
             map.insert("enabled".to_string(), VmValue::Bool(true));
             map.insert("newly_enabled".to_string(), VmValue::Bool(newly_enabled));
-            Ok(VmValue::Dict(Arc::new(map)))
+            Ok(VmValue::dict(map))
         }
         other => Err(HostlibError::InvalidParameter {
             builtin: "hostlib_enable",

--- a/crates/harn-hostlib/src/tools/payload.rs
+++ b/crates/harn-hostlib/src/tools/payload.rs
@@ -18,7 +18,7 @@ use crate::value_args;
 pub(crate) fn require_dict_arg(
     builtin: &'static str,
     args: &[VmValue],
-) -> Result<BTreeMap<String, VmValue>, HostlibError> {
+) -> Result<harn_vm::value::DictMap, HostlibError> {
     let first = args.first().ok_or(HostlibError::MissingParameter {
         builtin,
         param: "request",
@@ -39,7 +39,7 @@ pub(crate) fn require_dict_arg(
 /// Optional string field on a request dict.
 pub(crate) fn optional_string(
     builtin: &'static str,
-    map: &BTreeMap<String, VmValue>,
+    map: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Option<String>, HostlibError> {
     value_args::optional_string(builtin, map, key)
@@ -48,7 +48,7 @@ pub(crate) fn optional_string(
 /// Optional bool field on a request dict.
 pub(crate) fn optional_bool(
     builtin: &'static str,
-    map: &BTreeMap<String, VmValue>,
+    map: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Option<bool>, HostlibError> {
     value_args::optional_bool(builtin, map, key)
@@ -57,7 +57,7 @@ pub(crate) fn optional_bool(
 /// Optional non-negative integer field on a request dict.
 pub(crate) fn optional_u64(
     builtin: &'static str,
-    map: &BTreeMap<String, VmValue>,
+    map: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Option<u64>, HostlibError> {
     value_args::optional_u64(builtin, map, key)
@@ -67,7 +67,7 @@ pub(crate) fn optional_u64(
 /// or absent values as "no timeout".
 pub(crate) fn optional_timeout(
     builtin: &'static str,
-    map: &BTreeMap<String, VmValue>,
+    map: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Option<Duration>, HostlibError> {
     Ok(optional_u64(builtin, map, key)?.and_then(|ms| {
@@ -82,7 +82,7 @@ pub(crate) fn optional_timeout(
 /// Optional `Vec<String>` field on a request dict (e.g. `argv`, `packages`).
 pub(crate) fn optional_string_list(
     builtin: &'static str,
-    map: &BTreeMap<String, VmValue>,
+    map: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Option<Vec<String>>, HostlibError> {
     value_args::optional_string_list(builtin, map, key)
@@ -91,7 +91,7 @@ pub(crate) fn optional_string_list(
 /// Optional `BTreeMap<String, String>` field on a request dict (e.g. `env`).
 pub(crate) fn optional_string_map(
     builtin: &'static str,
-    map: &BTreeMap<String, VmValue>,
+    map: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Option<BTreeMap<String, String>>, HostlibError> {
     let Some(value) = map.get(key) else {
@@ -124,7 +124,7 @@ pub(crate) fn optional_string_map(
 /// Required string field on a request dict — fails if missing or wrong type.
 pub(crate) fn require_string(
     builtin: &'static str,
-    map: &BTreeMap<String, VmValue>,
+    map: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<String, HostlibError> {
     value_args::require_string(builtin, map, key)

--- a/crates/harn-hostlib/src/tools/proc.rs
+++ b/crates/harn-hostlib/src/tools/proc.rs
@@ -284,7 +284,7 @@ pub(crate) fn process_error_to_hostlib(builtin: &'static str, err: ProcessError)
 pub(crate) fn build_response(
     outcome: SpawnOutcome,
     handle_id: Option<String>,
-    policy_context: Option<BTreeMap<String, VmValue>>,
+    policy_context: Option<harn_vm::value::DictMap>,
 ) -> VmValue {
     let mut builder = ResponseBuilder::new()
         .str("command_id", outcome.command_id.clone())
@@ -319,7 +319,7 @@ pub(crate) fn build_response(
         Some(handle_id) => builder.str("handle_id", handle_id),
         None => builder.nil("handle_id"),
     };
-    let mut sandbox = BTreeMap::new();
+    let mut sandbox = harn_vm::value::DictMap::new();
     sandbox.put_str("kind", sandbox_kind());
     sandbox.insert("enforced".to_string(), VmValue::Bool(sandbox_enforced()));
     builder = builder.dict("sandbox", sandbox);
@@ -338,7 +338,7 @@ pub(crate) fn running_response(
     command_display: String,
 ) -> VmValue {
     let artifacts = planned_artifact_paths(&command_id);
-    let mut sandbox = BTreeMap::new();
+    let mut sandbox = harn_vm::value::DictMap::new();
     sandbox.put_str("kind", sandbox_kind());
     sandbox.insert("enforced".to_string(), VmValue::Bool(sandbox_enforced()));
     let mut builder = ResponseBuilder::new()

--- a/crates/harn-hostlib/src/tools/response.rs
+++ b/crates/harn-hostlib/src/tools/response.rs
@@ -1,7 +1,6 @@
 //! Helpers for assembling [`VmValue::Dict`] response bodies that match the
 //! `schemas/tools/<method>.response.json` contracts.
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use harn_vm::VmValue;
@@ -9,13 +8,13 @@ use harn_vm::VmValue;
 /// Type-erased builder for the dict that becomes a tool's response.
 #[derive(Default)]
 pub(crate) struct ResponseBuilder {
-    inner: BTreeMap<String, VmValue>,
+    inner: harn_vm::value::DictMap,
 }
 
 impl ResponseBuilder {
     pub(crate) fn new() -> Self {
         Self {
-            inner: BTreeMap::new(),
+            inner: harn_vm::value::DictMap::new(),
         }
     }
 
@@ -53,9 +52,8 @@ impl ResponseBuilder {
         self
     }
 
-    pub(crate) fn dict(mut self, key: &str, value: BTreeMap<String, VmValue>) -> Self {
-        self.inner
-            .insert(key.to_string(), VmValue::Dict(Arc::new(value)));
+    pub(crate) fn dict(mut self, key: &str, value: harn_vm::value::DictMap) -> Self {
+        self.inner.insert(key.to_string(), VmValue::dict(value));
         self
     }
 
@@ -66,6 +64,6 @@ impl ResponseBuilder {
     }
 
     pub(crate) fn build(self) -> VmValue {
-        VmValue::Dict(Arc::new(self.inner))
+        VmValue::dict(self.inner)
     }
 }

--- a/crates/harn-hostlib/src/tools/run_build_command.rs
+++ b/crates/harn-hostlib/src/tools/run_build_command.rs
@@ -94,7 +94,7 @@ pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let diagnostic_values: Vec<VmValue> = diagnostics
         .into_iter()
         .map(|d| {
-            let mut entry: BTreeMap<String, VmValue> = BTreeMap::new();
+            let mut entry: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
             entry.put_str("severity", d.severity.as_str());
             entry.put_str("message", d.message);
             entry.insert(
@@ -111,7 +111,7 @@ pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
                 "column".to_string(),
                 d.column.map(VmValue::Int).unwrap_or(VmValue::Nil),
             );
-            VmValue::Dict(Arc::new(entry))
+            VmValue::dict(entry)
         })
         .collect();
 

--- a/crates/harn-hostlib/src/tools/run_command.rs
+++ b/crates/harn-hostlib/src/tools/run_command.rs
@@ -19,8 +19,6 @@
 
 use harn_vm::VmDictExt;
 use harn_vm::VmValue;
-use std::collections::BTreeMap;
-use std::sync::Arc;
 use std::time::Duration;
 
 use crate::error::HostlibError;
@@ -174,7 +172,7 @@ fn initial_background_snapshot(
         info.command_display.clone(),
     ) {
         VmValue::Dict(map) => (*map).clone(),
-        _ => BTreeMap::new(),
+        _ => harn_vm::value::DictMap::new(),
     };
     response.put_str("feedback_kind", "tool_progress");
     response.insert("duration_ms".to_string(), VmValue::Int(wait_ms as i64));
@@ -182,12 +180,10 @@ fn initial_background_snapshot(
     response.put_str("stderr", inline_stderr);
     response.insert("byte_count".to_string(), VmValue::Int(byte_count as i64));
     response.insert("line_count".to_string(), VmValue::Int(line_count as i64));
-    VmValue::Dict(Arc::new(response))
+    VmValue::dict(response)
 }
 
-fn parse_command(
-    map: &std::collections::BTreeMap<String, VmValue>,
-) -> Result<(String, Vec<String>), HostlibError> {
+fn parse_command(map: &harn_vm::value::DictMap) -> Result<(String, Vec<String>), HostlibError> {
     match optional_string(NAME, map, "mode")?
         .as_deref()
         .unwrap_or("argv")
@@ -206,7 +202,7 @@ fn parse_command(
                     builtin: NAME,
                     param: "command",
                 })?;
-            let mut invocation = BTreeMap::new();
+            let mut invocation = harn_vm::value::DictMap::new();
             invocation.put_str("command", command);
             if let Some(shell_id) = optional_string(NAME, map, "shell_id")? {
                 invocation.put_str("shell_id", shell_id);
@@ -249,7 +245,7 @@ fn parse_command(
 }
 
 fn parse_env_mode(
-    map: &std::collections::BTreeMap<String, VmValue>,
+    map: &harn_vm::value::DictMap,
     env_supplied: bool,
 ) -> Result<EnvMode, HostlibError> {
     match optional_string(NAME, map, "env_mode")?.as_deref() {
@@ -268,9 +264,7 @@ fn parse_env_mode(
     }
 }
 
-fn parse_capture(
-    map: &std::collections::BTreeMap<String, VmValue>,
-) -> Result<CaptureConfig, HostlibError> {
+fn parse_capture(map: &harn_vm::value::DictMap) -> Result<CaptureConfig, HostlibError> {
     let mut capture = CaptureConfig::default();
     if let Some(capture_value) = map.get("capture") {
         match capture_value {

--- a/crates/harn-hostlib/src/tools/run_test.rs
+++ b/crates/harn-hostlib/src/tools/run_test.rs
@@ -119,8 +119,8 @@ pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     Ok(builder.build())
 }
 
-fn summary_to_dict(summary: TestSummaryData) -> BTreeMap<String, VmValue> {
-    let mut map = BTreeMap::new();
+fn summary_to_dict(summary: TestSummaryData) -> harn_vm::value::DictMap {
+    let mut map = harn_vm::value::DictMap::new();
     map.insert("passed".to_string(), VmValue::Int(summary.passed as i64));
     map.insert("failed".to_string(), VmValue::Int(summary.failed as i64));
     map.insert("skipped".to_string(), VmValue::Int(summary.skipped as i64));

--- a/crates/harn-hostlib/src/value_args.rs
+++ b/crates/harn-hostlib/src/value_args.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use harn_vm::VmValue;
 
 use crate::error::HostlibError;
@@ -21,7 +19,7 @@ pub(crate) fn describe(value: &VmValue) -> &'static str {
 
 pub(crate) fn require_string(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<String, HostlibError> {
     optional_string(builtin, dict, key)?.ok_or(HostlibError::MissingParameter {
@@ -32,7 +30,7 @@ pub(crate) fn require_string(
 
 pub(crate) fn optional_string(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Option<String>, HostlibError> {
     match dict.get(key) {
@@ -48,7 +46,7 @@ pub(crate) fn optional_string(
 
 pub(crate) fn optional_bool(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Option<bool>, HostlibError> {
     match dict.get(key) {
@@ -64,7 +62,7 @@ pub(crate) fn optional_bool(
 
 pub(crate) fn optional_i64(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
     default: i64,
 ) -> Result<i64, HostlibError> {
@@ -76,7 +74,7 @@ pub(crate) fn optional_i64(
 
 pub(crate) fn optional_i64_no_default(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Option<i64>, HostlibError> {
     match dict.get(key) {
@@ -87,7 +85,7 @@ pub(crate) fn optional_i64_no_default(
 
 pub(crate) fn optional_u64(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Option<u64>, HostlibError> {
     match optional_i64_no_default(builtin, dict, key)? {
@@ -103,7 +101,7 @@ pub(crate) fn optional_u64(
 
 pub(crate) fn optional_string_list(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<Option<Vec<String>>, HostlibError> {
     match dict.get(key) {

--- a/crates/harn-hostlib/tests/ast_builtins.rs
+++ b/crates/harn-hostlib/tests/ast_builtins.rs
@@ -6,7 +6,6 @@
 //!
 //! Parse-latency characterization lives in `benches/ast_parse.rs`.
 
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -20,11 +19,11 @@ fn ast_registry() -> BuiltinRegistry {
 }
 
 fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in pairs {
         map.insert((*k).into(), v.clone());
     }
-    VmValue::Dict(Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn fixture_path(rel: &str) -> PathBuf {

--- a/crates/harn-hostlib/tests/ast_function_body_imports.rs
+++ b/crates/harn-hostlib/tests/ast_function_body_imports.rs
@@ -5,7 +5,6 @@
 //! full Harn-side surface (parameter parsing → schema-shaped Dict
 //! response).
 
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -19,11 +18,11 @@ fn ast_registry() -> BuiltinRegistry {
 }
 
 fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in pairs {
         map.insert((*k).into(), v.clone());
     }
-    VmValue::Dict(Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn invoke(registry: &BuiltinRegistry, name: &str, payload: VmValue) -> VmValue {

--- a/crates/harn-hostlib/tests/ast_language_coverage.rs
+++ b/crates/harn-hostlib/tests/ast_language_coverage.rs
@@ -7,7 +7,6 @@
 //! real edit round-trip through parse → query → splice → re-validate" is
 //! the single contract every language must satisfy.
 
-use std::collections::BTreeMap;
 use std::io::Write;
 use std::sync::Arc;
 
@@ -22,11 +21,11 @@ fn registry() -> BuiltinRegistry {
 }
 
 fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in pairs {
         map.insert((*k).into(), v.clone());
     }
-    VmValue::Dict(Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn vm_string(s: &str) -> VmValue {

--- a/crates/harn-hostlib/tests/code_index.rs
+++ b/crates/harn-hostlib/tests/code_index.rs
@@ -6,7 +6,6 @@
 //! these tests proves the schema-locked surface returns the right shape
 //! for embedders.
 
-use std::collections::BTreeMap;
 use std::fs;
 use std::sync::Arc;
 
@@ -23,11 +22,11 @@ fn build_registry() -> (BuiltinRegistry, CodeIndexCapability) {
 }
 
 fn dict(entries: &[(&str, VmValue)]) -> VmValue {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
         map.insert((*k).to_string(), v.clone());
     }
-    VmValue::Dict(Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn call(registry: &BuiltinRegistry, name: &str, payload: VmValue) -> VmValue {
@@ -39,7 +38,7 @@ fn call(registry: &BuiltinRegistry, name: &str, payload: VmValue) -> VmValue {
     })
 }
 
-fn extract_dict(value: &VmValue) -> Arc<BTreeMap<String, VmValue>> {
+fn extract_dict(value: &VmValue) -> Arc<harn_vm::value::DictMap> {
     match value {
         VmValue::Dict(d) => d.clone(),
         other => panic!("expected dict, got {other:?}"),

--- a/crates/harn-hostlib/tests/code_index_cypher_recall.rs
+++ b/crates/harn-hostlib/tests/code_index_cypher_recall.rs
@@ -5,7 +5,7 @@
 //! every Cypher query, and asserts that aggregate recall is ≥ 80% — the
 //! threshold defined in issue #2434's acceptance criteria.
 
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -19,11 +19,11 @@ fn fixture_root() -> PathBuf {
 }
 
 fn dict(entries: &[(&str, VmValue)]) -> VmValue {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
         map.insert((*k).to_string(), v.clone());
     }
-    VmValue::Dict(Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn call(registry: &BuiltinRegistry, name: &str, payload: VmValue) -> VmValue {
@@ -33,7 +33,7 @@ fn call(registry: &BuiltinRegistry, name: &str, payload: VmValue) -> VmValue {
     (entry.handler)(&[payload]).unwrap_or_else(|err| panic!("builtin {name} failed: {err:?}"))
 }
 
-fn extract_dict(value: &VmValue) -> Arc<BTreeMap<String, VmValue>> {
+fn extract_dict(value: &VmValue) -> Arc<harn_vm::value::DictMap> {
     match value {
         VmValue::Dict(d) => d.clone(),
         other => panic!("expected dict, got {other:?}"),

--- a/crates/harn-hostlib/tests/code_index_graph_surface.rs
+++ b/crates/harn-hostlib/tests/code_index_graph_surface.rs
@@ -3,7 +3,6 @@
 //! `code_index.freshness`. Drives the public registry surface so the
 //! schemas and error shape are exercised together.
 
-use std::collections::BTreeMap;
 use std::fs;
 use std::sync::Arc;
 
@@ -13,11 +12,11 @@ use harn_hostlib::{
 use harn_vm::VmValue;
 
 fn dict(entries: &[(&str, VmValue)]) -> VmValue {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
         map.insert((*k).to_string(), v.clone());
     }
-    VmValue::Dict(Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn call(registry: &BuiltinRegistry, name: &str, payload: VmValue) -> VmValue {
@@ -27,7 +26,7 @@ fn call(registry: &BuiltinRegistry, name: &str, payload: VmValue) -> VmValue {
     (entry.handler)(&[payload]).unwrap_or_else(|err| panic!("builtin {name} failed: {err:?}"))
 }
 
-fn extract_dict(value: &VmValue) -> Arc<BTreeMap<String, VmValue>> {
+fn extract_dict(value: &VmValue) -> Arc<harn_vm::value::DictMap> {
     match value {
         VmValue::Dict(d) => d.clone(),
         other => panic!("expected dict, got {other:?}"),

--- a/crates/harn-hostlib/tests/code_index_live_state.rs
+++ b/crates/harn-hostlib/tests/code_index_live_state.rs
@@ -7,7 +7,6 @@
 //! handful of native threads to make sure the in-process mutex serialises
 //! everyone correctly.
 
-use std::collections::BTreeMap;
 use std::fs;
 use std::sync::Arc;
 use std::thread;
@@ -25,11 +24,11 @@ fn build() -> (BuiltinRegistry, CodeIndexCapability) {
 }
 
 fn dict(entries: &[(&str, VmValue)]) -> VmValue {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
         map.insert((*k).to_string(), v.clone());
     }
-    VmValue::Dict(Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn call(registry: &BuiltinRegistry, name: &str, payload: VmValue) -> VmValue {
@@ -48,7 +47,7 @@ fn try_call(
     (entry.handler)(&[payload])
 }
 
-fn extract_dict(value: &VmValue) -> Arc<BTreeMap<String, VmValue>> {
+fn extract_dict(value: &VmValue) -> Arc<harn_vm::value::DictMap> {
     match value {
         VmValue::Dict(d) => d.clone(),
         other => panic!("expected dict, got {other:?}"),

--- a/crates/harn-hostlib/tests/code_index_scenario.rs
+++ b/crates/harn-hostlib/tests/code_index_scenario.rs
@@ -16,7 +16,6 @@
 //! asserts the same set of invariants over a live repo. CI doesn't set the
 //! env var so the synthetic fixture path is the default.
 
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -26,11 +25,11 @@ use harn_hostlib::{
 use harn_vm::VmValue;
 
 fn dict(entries: &[(&str, VmValue)]) -> VmValue {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
         map.insert((*k).to_string(), v.clone());
     }
-    VmValue::Dict(Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn call(registry: &BuiltinRegistry, name: &str, payload: VmValue) -> VmValue {
@@ -40,7 +39,7 @@ fn call(registry: &BuiltinRegistry, name: &str, payload: VmValue) -> VmValue {
     (entry.handler)(&[payload]).unwrap_or_else(|err| panic!("builtin {name} failed: {err:?}"))
 }
 
-fn extract_dict(value: &VmValue) -> Arc<BTreeMap<String, VmValue>> {
+fn extract_dict(value: &VmValue) -> Arc<harn_vm::value::DictMap> {
     match value {
         VmValue::Dict(d) => d.clone(),
         other => panic!("expected dict, got {other:?}"),

--- a/crates/harn-hostlib/tests/code_librarian_recall.rs
+++ b/crates/harn-hostlib/tests/code_librarian_recall.rs
@@ -9,7 +9,7 @@
 //! contract: the librarian must deliver at least the same aggregate
 //! recall the raw Cypher executor does (≥ 80% per #2434).
 
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashSet};
 use std::path::PathBuf;
 
 use harn_lexer::Lexer;
@@ -50,7 +50,7 @@ fn extract_list(value: &VmValue) -> std::sync::Arc<Vec<VmValue>> {
     }
 }
 
-fn extract_dict(value: &VmValue) -> std::sync::Arc<BTreeMap<String, VmValue>> {
+fn extract_dict(value: &VmValue) -> std::sync::Arc<harn_vm::value::DictMap> {
     match value {
         VmValue::Dict(d) => d.clone(),
         other => panic!("expected dict, got {other:?}"),

--- a/crates/harn-hostlib/tests/fs_path_scope.rs
+++ b/crates/harn-hostlib/tests/fs_path_scope.rs
@@ -9,7 +9,6 @@
 //! VM-side. In-root paths must still succeed, and relative paths must be
 //! resolved before the check so the two surfaces agree.
 
-use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -66,11 +65,11 @@ impl Drop for PolicyGuard {
 }
 
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
         map.insert(k.to_string(), v.clone());
     }
-    vec![VmValue::Dict(Arc::new(map))]
+    vec![VmValue::dict(map)]
 }
 
 fn vm_string(s: &str) -> VmValue {

--- a/crates/harn-hostlib/tests/fs_snapshot.rs
+++ b/crates/harn-hostlib/tests/fs_snapshot.rs
@@ -8,7 +8,6 @@
 //! mints a unique session id, so the process-wide snapshot store keys
 //! cleanly. No process-wide reset is required.
 
-use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -31,11 +30,11 @@ fn registry() -> BuiltinRegistry {
 }
 
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
         map.insert(k.to_string(), v.clone());
     }
-    vec![VmValue::Dict(Arc::new(map))]
+    vec![VmValue::dict(map)]
 }
 
 fn vm_string(s: &str) -> VmValue {

--- a/crates/harn-hostlib/tests/fs_staging.rs
+++ b/crates/harn-hostlib/tests/fs_staging.rs
@@ -1,6 +1,5 @@
 //! Integration tests for session-scoped staged filesystem mode.
 
-use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -22,11 +21,11 @@ fn registry() -> BuiltinRegistry {
 }
 
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
         map.insert(k.to_string(), v.clone());
     }
-    vec![VmValue::Dict(Arc::new(map))]
+    vec![VmValue::dict(map)]
 }
 
 fn vm_string(s: &str) -> VmValue {

--- a/crates/harn-hostlib/tests/fs_watch.rs
+++ b/crates/harn-hostlib/tests/fs_watch.rs
@@ -20,12 +20,12 @@ fn list(values: &[&str]) -> VmValue {
 }
 
 fn dict(entries: impl IntoIterator<Item = (&'static str, VmValue)>) -> VmValue {
-    VmValue::Dict(Arc::new(
+    VmValue::dict(
         entries
             .into_iter()
             .map(|(key, value)| (key.to_string(), value))
             .collect::<BTreeMap<_, _>>(),
-    ))
+    )
 }
 
 #[test]

--- a/crates/harn-hostlib/tests/process_tools.rs
+++ b/crates/harn-hostlib/tests/process_tools.rs
@@ -40,18 +40,18 @@ fn registry() -> BuiltinRegistry {
     registry
 }
 
-fn call(builtin: &str, request: BTreeMap<String, VmValue>) -> Result<VmValue, HostlibError> {
+fn call(builtin: &str, request: harn_vm::value::DictMap) -> Result<VmValue, HostlibError> {
     harn_hostlib::tools::permissions::enable_for_test();
     let registry = registry();
     let entry = registry
         .find(builtin)
         .unwrap_or_else(|| panic!("builtin {builtin} not registered"));
-    let arg = VmValue::Dict(Arc::new(request));
+    let arg = VmValue::dict(request);
     (entry.handler)(&[arg])
 }
 
-fn dict() -> BTreeMap<String, VmValue> {
-    BTreeMap::new()
+fn dict() -> harn_vm::value::DictMap {
+    harn_vm::value::DictMap::new()
 }
 
 fn vstr(value: &str) -> VmValue {
@@ -62,35 +62,35 @@ fn vlist_str(values: &[&str]) -> VmValue {
     VmValue::List(Arc::new(values.iter().map(|s| vstr(s)).collect()))
 }
 
-fn require_dict(value: VmValue) -> BTreeMap<String, VmValue> {
+fn require_dict(value: VmValue) -> harn_vm::value::DictMap {
     match value {
         VmValue::Dict(map) => (*map).clone(),
         other => panic!("expected dict response, got {other:?}"),
     }
 }
 
-fn require_int(map: &BTreeMap<String, VmValue>, key: &str) -> i64 {
+fn require_int(map: &harn_vm::value::DictMap, key: &str) -> i64 {
     match map.get(key) {
         Some(VmValue::Int(i)) => *i,
         other => panic!("expected int at {key}, got {other:?}"),
     }
 }
 
-fn require_str(map: &BTreeMap<String, VmValue>, key: &str) -> String {
+fn require_str(map: &harn_vm::value::DictMap, key: &str) -> String {
     match map.get(key) {
         Some(VmValue::String(s)) => s.to_string(),
         other => panic!("expected string at {key}, got {other:?}"),
     }
 }
 
-fn require_bool(map: &BTreeMap<String, VmValue>, key: &str) -> bool {
+fn require_bool(map: &harn_vm::value::DictMap, key: &str) -> bool {
     match map.get(key) {
         Some(VmValue::Bool(b)) => *b,
         other => panic!("expected bool at {key}, got {other:?}"),
     }
 }
 
-fn require_nil(map: &BTreeMap<String, VmValue>, key: &str) {
+fn require_nil(map: &harn_vm::value::DictMap, key: &str) {
     assert!(
         matches!(map.get(key), Some(VmValue::Nil)),
         "expected nil at {key}, got {:?}",
@@ -98,7 +98,7 @@ fn require_nil(map: &BTreeMap<String, VmValue>, key: &str) {
     );
 }
 
-fn require_nested_dict(map: &BTreeMap<String, VmValue>, key: &str) -> BTreeMap<String, VmValue> {
+fn require_nested_dict(map: &harn_vm::value::DictMap, key: &str) -> harn_vm::value::DictMap {
     match map.get(key) {
         Some(VmValue::Dict(value)) => (**value).clone(),
         other => panic!("expected dict at {key}, got {other:?}"),
@@ -285,13 +285,13 @@ fn run_command_supports_explicit_shell_mode() {
     let (spawner, _controller, _guard) =
         install_mock_with(MockProcessConfig::with_stdout(0, "shell-ok\n"));
 
-    let mut shell: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut shell: harn_vm::value::DictMap = Default::default();
     shell.insert("id".into(), vstr("sh"));
 
     let mut req = dict();
     req.insert("mode".into(), vstr("shell"));
     req.insert("command".into(), vstr("echo shell-ok"));
-    req.insert("shell".into(), VmValue::Dict(Arc::new(shell)));
+    req.insert("shell".into(), VmValue::dict(shell));
     let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
     assert_eq!(require_str(&resp, "stdout").trim(), "shell-ok");
 
@@ -334,7 +334,7 @@ fn run_command_caps_inline_output_and_read_command_output_reads_artifact() {
     let (_spawner, _controller, _guard) =
         install_mock_with(MockProcessConfig::with_stdout(0, payload));
 
-    let mut capture: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut capture: harn_vm::value::DictMap = Default::default();
     capture.insert("max_inline_bytes".into(), VmValue::Int(8));
 
     let mut req = dict();
@@ -342,7 +342,7 @@ fn run_command_caps_inline_output_and_read_command_output_reads_artifact() {
         "argv".into(),
         vlist_str(&["bash", "-c", "for i in $(seq 1 2000); do printf x; done"]),
     );
-    req.insert("capture".into(), VmValue::Dict(Arc::new(capture)));
+    req.insert("capture".into(), VmValue::dict(capture));
     let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
 
     assert_eq!(require_str(&resp, "stdout").len(), 8);
@@ -370,7 +370,7 @@ fn run_command_passes_env_when_supplied() {
     let (spawner, _controller, _guard) =
         install_mock_with(MockProcessConfig::with_stdout(0, "value-42\n"));
 
-    let mut env_dict: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut env_dict: harn_vm::value::DictMap = Default::default();
     env_dict.insert("PATH".into(), vstr("/bin:/usr/bin"));
     env_dict.insert("HOSTLIB_TEST_VAR".into(), vstr("value-42"));
 
@@ -379,7 +379,7 @@ fn run_command_passes_env_when_supplied() {
         "argv".into(),
         vlist_str(&["bash", "-c", "echo $HOSTLIB_TEST_VAR"]),
     );
-    req.insert("env".into(), VmValue::Dict(Arc::new(env_dict)));
+    req.insert("env".into(), VmValue::dict(env_dict));
     let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
     assert_eq!(require_str(&resp, "stdout").trim(), "value-42");
 
@@ -444,7 +444,7 @@ fn run_command_rejects_out_of_range_capture_limit() {
 
     let mut req = dict();
     req.insert("argv".into(), vlist_str(&["true"]));
-    req.insert("capture".into(), VmValue::Dict(Arc::new(capture)));
+    req.insert("capture".into(), VmValue::dict(capture));
     let err = call("hostlib_tools_run_command", req).unwrap_err();
     assert!(
         matches!(err, HostlibError::InvalidParameter { param, .. } if param == "max_inline_bytes")
@@ -1000,7 +1000,7 @@ fn cancel_handle_can_wait_for_timed_out_result() {
     start_req.insert("capture".into(), {
         let mut capture = BTreeMap::new();
         capture.insert("max_inline_bytes".into(), VmValue::Int(200));
-        VmValue::Dict(Arc::new(capture))
+        VmValue::dict(capture)
     });
     let start = require_dict(call("hostlib_tools_run_command", start_req).unwrap());
     let handle_id = require_str(&start, "handle_id");

--- a/crates/harn-hostlib/tests/process_tools_e2e.rs
+++ b/crates/harn-hostlib/tests/process_tools_e2e.rs
@@ -15,7 +15,6 @@
 
 #![cfg(unix)]
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use harn_hostlib::tools::ToolsCapability;
@@ -28,18 +27,18 @@ fn registry() -> BuiltinRegistry {
     registry
 }
 
-fn call(builtin: &str, request: BTreeMap<String, VmValue>) -> Result<VmValue, HostlibError> {
+fn call(builtin: &str, request: harn_vm::value::DictMap) -> Result<VmValue, HostlibError> {
     harn_hostlib::tools::permissions::enable_for_test();
     let registry = registry();
     let entry = registry
         .find(builtin)
         .unwrap_or_else(|| panic!("builtin {builtin} not registered"));
-    let arg = VmValue::Dict(Arc::new(request));
+    let arg = VmValue::dict(request);
     (entry.handler)(&[arg])
 }
 
-fn dict() -> BTreeMap<String, VmValue> {
-    BTreeMap::new()
+fn dict() -> harn_vm::value::DictMap {
+    harn_vm::value::DictMap::new()
 }
 
 fn vstr(value: &str) -> VmValue {
@@ -50,28 +49,28 @@ fn vlist_str(values: &[&str]) -> VmValue {
     VmValue::List(Arc::new(values.iter().map(|s| vstr(s)).collect()))
 }
 
-fn require_dict(value: VmValue) -> BTreeMap<String, VmValue> {
+fn require_dict(value: VmValue) -> harn_vm::value::DictMap {
     match value {
         VmValue::Dict(map) => (*map).clone(),
         other => panic!("expected dict response, got {other:?}"),
     }
 }
 
-fn require_int(map: &BTreeMap<String, VmValue>, key: &str) -> i64 {
+fn require_int(map: &harn_vm::value::DictMap, key: &str) -> i64 {
     match map.get(key) {
         Some(VmValue::Int(i)) => *i,
         other => panic!("expected int at {key}, got {other:?}"),
     }
 }
 
-fn require_str(map: &BTreeMap<String, VmValue>, key: &str) -> String {
+fn require_str(map: &harn_vm::value::DictMap, key: &str) -> String {
     match map.get(key) {
         Some(VmValue::String(s)) => s.to_string(),
         other => panic!("expected string at {key}, got {other:?}"),
     }
 }
 
-fn require_bool(map: &BTreeMap<String, VmValue>, key: &str) -> bool {
+fn require_bool(map: &harn_vm::value::DictMap, key: &str) -> bool {
     match map.get(key) {
         Some(VmValue::Bool(b)) => *b,
         other => panic!("expected bool at {key}, got {other:?}"),

--- a/crates/harn-hostlib/tests/secret_store.rs
+++ b/crates/harn-hostlib/tests/secret_store.rs
@@ -70,11 +70,11 @@ fn registry() -> BuiltinRegistry {
 }
 
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
         map.insert(k.to_string(), v.clone());
     }
-    vec![VmValue::Dict(Arc::new(map))]
+    vec![VmValue::dict(map)]
 }
 
 fn vm_string(s: &str) -> VmValue {

--- a/crates/harn-hostlib/tests/secret_store_os_native.rs
+++ b/crates/harn-hostlib/tests/secret_store_os_native.rs
@@ -30,11 +30,11 @@ fn registry() -> BuiltinRegistry {
 }
 
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
         map.insert(k.to_string(), v.clone());
     }
-    vec![VmValue::Dict(Arc::new(map))]
+    vec![VmValue::dict(map)]
 }
 
 fn vm_string(s: &str) -> VmValue {

--- a/crates/harn-hostlib/tests/tools_file_io.rs
+++ b/crates/harn-hostlib/tests/tools_file_io.rs
@@ -1,6 +1,5 @@
 //! Integration tests for `hostlib_tools_{read_file,write_file,delete_file,list_directory}`.
 
-use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -19,11 +18,11 @@ fn registry() -> BuiltinRegistry {
 }
 
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
         map.insert(k.to_string(), v.clone());
     }
-    vec![VmValue::Dict(Arc::new(map))]
+    vec![VmValue::dict(map)]
 }
 
 fn vm_string(s: &str) -> VmValue {

--- a/crates/harn-hostlib/tests/tools_git.rs
+++ b/crates/harn-hostlib/tests/tools_git.rs
@@ -11,7 +11,6 @@
 //! mutating test (`git_status_reports_dirty_paths`) keeps building its own
 //! repo so it does not pollute the shared one.
 
-use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::Command;
 use std::sync::Arc;
@@ -31,11 +30,11 @@ fn registry() -> BuiltinRegistry {
 }
 
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
         map.insert(k.to_string(), v.clone());
     }
-    vec![VmValue::Dict(Arc::new(map))]
+    vec![VmValue::dict(map)]
 }
 
 fn vm_string(s: &str) -> VmValue {

--- a/crates/harn-hostlib/tests/tools_outline.rs
+++ b/crates/harn-hostlib/tests/tools_outline.rs
@@ -1,6 +1,5 @@
 //! Integration tests for `hostlib_tools_get_file_outline`.
 
-use std::collections::BTreeMap;
 use std::fs;
 use std::sync::Arc;
 
@@ -18,11 +17,11 @@ fn registry() -> BuiltinRegistry {
 }
 
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
         map.insert(k.to_string(), v.clone());
     }
-    vec![VmValue::Dict(Arc::new(map))]
+    vec![VmValue::dict(map)]
 }
 
 fn vm_string(s: &str) -> VmValue {

--- a/crates/harn-hostlib/tests/tools_search.rs
+++ b/crates/harn-hostlib/tests/tools_search.rs
@@ -1,6 +1,5 @@
 //! Integration tests for `hostlib_tools_search`.
 
-use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
@@ -19,11 +18,11 @@ fn registry() -> BuiltinRegistry {
 }
 
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
         map.insert(k.to_string(), v.clone());
     }
-    vec![VmValue::Dict(Arc::new(map))]
+    vec![VmValue::dict(map)]
 }
 
 fn vm_string(s: &str) -> VmValue {

--- a/crates/harn-rules-hostlib/src/lib.rs
+++ b/crates/harn-rules-hostlib/src/lib.rs
@@ -396,7 +396,7 @@ fn lint_run(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 /// Parse a `severity` dict param (`{rule: "error"|"warning"|"info"}`) into the
 /// linter's override map. Unknown severities are skipped.
 fn parse_severity_overrides(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
 ) -> std::collections::HashMap<String, harn_lint::LintSeverity> {
     let mut out = std::collections::HashMap::new();
     if let Some(VmValue::Dict(map)) = dict.get("severity") {
@@ -443,7 +443,7 @@ fn lint_diagnostic_vm(diag: &harn_lint::LintDiagnostic) -> VmValue {
 
 fn compile_rule(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
 ) -> Result<CompiledRule, HostlibError> {
     let toml = require_string(builtin, dict, "rule")?;
     let rule = Rule::from_toml_str(&toml).map_err(|e| HostlibError::InvalidParameter {
@@ -463,7 +463,7 @@ fn compile_rule(
 /// undetectable files are skipped).
 fn load_files(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
 ) -> Result<Vec<SourceFile>, HostlibError> {
     if let Some(source) = optional_string(dict, "source") {
         let language_name = require_string(builtin, dict, "language")?;
@@ -505,7 +505,7 @@ fn load_files(
 }
 
 fn match_to_vm(path: &std::path::Path, m: &RuleMatch) -> VmValue {
-    let captures: BTreeMap<String, VmValue> = m
+    let captures: harn_vm::value::DictMap = m
         .bindings
         .iter()
         .map(|(name, b)| (name.clone(), str_vm(&b.text)))
@@ -518,7 +518,7 @@ fn match_to_vm(path: &std::path::Path, m: &RuleMatch) -> VmValue {
         ("start_col", VmValue::Int(m.span.start_col as i64)),
         ("end_row", VmValue::Int(m.span.end_row as i64)),
         ("end_col", VmValue::Int(m.span.end_col as i64)),
-        ("captures", VmValue::Dict(Arc::new(captures))),
+        ("captures", VmValue::dict(captures)),
         ("capture_metadata", capture_metadata),
     ])
 }
@@ -550,7 +550,7 @@ struct ReportSpec {
 /// The `node` value handed to a visitor: the matched text, its metavar
 /// captures, and its span.
 fn node_vm(m: &RuleMatch) -> VmValue {
-    let captures: BTreeMap<String, VmValue> = m
+    let captures: harn_vm::value::DictMap = m
         .bindings
         .iter()
         .map(|(name, b)| (name.clone(), str_vm(&b.text)))
@@ -558,7 +558,7 @@ fn node_vm(m: &RuleMatch) -> VmValue {
     let capture_metadata = capture_metadata_vm(m);
     dict_vm([
         ("text", str_vm(&m.text)),
-        ("captures", VmValue::Dict(Arc::new(captures))),
+        ("captures", VmValue::dict(captures)),
         ("capture_metadata", capture_metadata),
         ("start_row", VmValue::Int(m.span.start_row as i64)),
         ("start_col", VmValue::Int(m.span.start_col as i64)),
@@ -568,13 +568,13 @@ fn node_vm(m: &RuleMatch) -> VmValue {
 }
 
 fn capture_metadata_vm(m: &RuleMatch) -> VmValue {
-    let metadata: BTreeMap<String, VmValue> = m
+    let metadata: harn_vm::value::DictMap = m
         .bindings
         .iter()
         .filter(|(_, binding)| !binding.metadata.is_empty())
         .map(|(name, binding)| (name.clone(), binding_metadata_vm(&binding.metadata)))
         .collect();
-    VmValue::Dict(Arc::new(metadata))
+    VmValue::dict(metadata)
 }
 
 fn binding_metadata_vm(metadata: &BindingMetadata) -> VmValue {
@@ -585,7 +585,7 @@ fn binding_metadata_vm(metadata: &BindingMetadata) -> VmValue {
     if let Some(resolved) = &metadata.resolved {
         entries.insert("resolved".into(), resolved_binding_vm(resolved));
     }
-    VmValue::Dict(Arc::new(entries))
+    VmValue::dict(entries)
 }
 
 fn resolved_binding_vm(resolved: &ResolvedBinding) -> VmValue {
@@ -694,7 +694,7 @@ fn report_from_item(v: &VmValue) -> Option<ReportSpec> {
     }
 }
 
-fn report_from_dict(d: &BTreeMap<String, VmValue>) -> ReportSpec {
+fn report_from_dict(d: &harn_vm::value::DictMap) -> ReportSpec {
     ReportSpec {
         message: optional_string(d, "message"),
         fix: optional_string(d, "fix"),
@@ -736,11 +736,11 @@ fn json_to_vm(value: &serde_json::Value) -> VmValue {
         serde_json::Value::Array(items) => {
             VmValue::List(Arc::new(items.iter().map(json_to_vm).collect()))
         }
-        serde_json::Value::Object(map) => VmValue::Dict(Arc::new(
+        serde_json::Value::Object(map) => VmValue::dict(
             map.iter()
                 .map(|(k, v)| (k.clone(), json_to_vm(v)))
-                .collect(),
-        )),
+                .collect::<harn_vm::value::DictMap>(),
+        ),
     }
 }
 
@@ -751,10 +751,10 @@ fn json_to_vm(value: &serde_json::Value) -> VmValue {
 fn first_dict(
     builtin: &'static str,
     args: &[VmValue],
-) -> Result<Arc<BTreeMap<String, VmValue>>, HostlibError> {
+) -> Result<Arc<harn_vm::value::DictMap>, HostlibError> {
     match args.first() {
         Some(VmValue::Dict(dict)) => Ok(dict.clone()),
-        Some(VmValue::Nil) | None => Ok(Arc::new(BTreeMap::new())),
+        Some(VmValue::Nil) | None => Ok(Arc::new(harn_vm::value::DictMap::new())),
         Some(_) => Err(HostlibError::InvalidParameter {
             builtin,
             param: "params",
@@ -765,7 +765,7 @@ fn first_dict(
 
 fn require_string(
     builtin: &'static str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &harn_vm::value::DictMap,
     key: &'static str,
 ) -> Result<String, HostlibError> {
     match dict.get(key) {
@@ -777,14 +777,14 @@ fn require_string(
     }
 }
 
-fn optional_string(dict: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn optional_string(dict: &harn_vm::value::DictMap, key: &str) -> Option<String> {
     match dict.get(key) {
         Some(VmValue::String(s)) => Some(s.to_string()),
         _ => None,
     }
 }
 
-fn optional_string_list(dict: &BTreeMap<String, VmValue>, key: &str) -> Vec<String> {
+fn optional_string_list(dict: &harn_vm::value::DictMap, key: &str) -> Vec<String> {
     match dict.get(key) {
         Some(VmValue::List(items)) => items
             .iter()
@@ -797,7 +797,7 @@ fn optional_string_list(dict: &BTreeMap<String, VmValue>, key: &str) -> Vec<Stri
     }
 }
 
-fn optional_bool(dict: &BTreeMap<String, VmValue>, key: &str, default: bool) -> bool {
+fn optional_bool(dict: &harn_vm::value::DictMap, key: &str, default: bool) -> bool {
     match dict.get(key) {
         Some(VmValue::Bool(b)) => *b,
         _ => default,
@@ -809,11 +809,11 @@ fn str_vm(s: impl AsRef<str>) -> VmValue {
 }
 
 fn dict_vm<const N: usize>(entries: [(&str, VmValue); N]) -> VmValue {
-    let map: BTreeMap<String, VmValue> = entries
+    let map: harn_vm::value::DictMap = entries
         .into_iter()
         .map(|(k, v)| (k.to_string(), v))
         .collect();
-    VmValue::Dict(Arc::new(map))
+    VmValue::dict(map)
 }
 
 #[cfg(test)]
@@ -821,11 +821,11 @@ mod tests {
     use super::*;
 
     fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
-        let map: BTreeMap<String, VmValue> = pairs
+        let map: harn_vm::value::DictMap = pairs
             .iter()
             .map(|(k, v)| (k.to_string(), v.clone()))
             .collect();
-        VmValue::Dict(Arc::new(map))
+        VmValue::dict(map)
     }
 
     fn get<'a>(v: &'a VmValue, key: &str) -> &'a VmValue {

--- a/crates/harn-serve/src/adapters/acp/builtins.rs
+++ b/crates/harn-serve/src/adapters/acp/builtins.rs
@@ -22,7 +22,7 @@ pub(super) async fn register_acp_builtins(vm: &mut harn_vm::Vm, bridge: Arc<AcpB
         .map(|result| {
             normalize_host_capability_manifest(harn_vm::bridge::json_result_to_vm_value(&result))
         })
-        .unwrap_or_else(|_| harn_vm::VmValue::Dict(Arc::new(std::collections::BTreeMap::new())));
+        .unwrap_or_else(|_| harn_vm::VmValue::dict(std::collections::BTreeMap::new()));
     let selected_shell =
         if manifest_has_operation(&host_capability_manifest, "process", "get_default_shell") {
             bridge
@@ -283,7 +283,7 @@ pub(super) async fn acp_terminal_exec(
             "success".to_string(),
             harn_vm::VmValue::Bool(output.status.success()),
         );
-        return Ok(harn_vm::VmValue::Dict(Arc::new(map)));
+        return Ok(harn_vm::VmValue::dict(map));
     }
 
     // wait_for_exit returns the stdout/stderr/combined/exitCode payload.
@@ -352,7 +352,7 @@ pub(super) async fn acp_terminal_exec(
                 .is_some_and(|code| code == 0);
             normalized.insert("success".to_string(), harn_vm::VmValue::Bool(success));
         }
-        return Ok(harn_vm::VmValue::Dict(Arc::new(normalized)));
+        return Ok(harn_vm::VmValue::dict(normalized));
     }
     Ok(output)
 }
@@ -379,7 +379,7 @@ async fn kill_and_release_terminal(bridge: &AcpBridge, terminal_id: &str) {
 
 pub(super) fn normalize_host_capability_manifest(value: harn_vm::VmValue) -> harn_vm::VmValue {
     let Some(root) = value.as_dict() else {
-        return harn_vm::VmValue::Dict(Arc::new(BTreeMap::new()));
+        return harn_vm::VmValue::dict(BTreeMap::new());
     };
 
     let mut normalized = BTreeMap::new();
@@ -394,21 +394,18 @@ pub(super) fn normalize_host_capability_manifest(value: harn_vm::VmValue) -> har
                         normalized_entry.insert("ops".to_string(), harn_vm::VmValue::List(ops));
                     }
                 }
-                normalized.insert(
-                    capability.clone(),
-                    harn_vm::VmValue::Dict(Arc::new(normalized_entry)),
-                );
+                normalized.insert(capability.clone(), harn_vm::VmValue::dict(normalized_entry));
             }
             harn_vm::VmValue::List(list) => {
                 let mut dict = BTreeMap::new();
                 dict.insert("ops".to_string(), harn_vm::VmValue::List(list.clone()));
-                normalized.insert(capability.clone(), harn_vm::VmValue::Dict(Arc::new(dict)));
+                normalized.insert(capability.clone(), harn_vm::VmValue::dict(dict));
             }
             _ => {}
         }
     }
 
-    harn_vm::VmValue::Dict(Arc::new(normalized))
+    harn_vm::VmValue::dict(normalized)
 }
 
 fn operation_names_from_value(
@@ -443,7 +440,7 @@ fn manifest_has_operation(manifest: &harn_vm::VmValue, capability: &str, op: &st
 /// expose a terminal capability. Uses the same selected-shell descriptor
 /// carried on `terminal/create`.
 fn local_shell_exec(cmd: &str, shell: &harn_vm::VmValue) -> std::io::Result<std::process::Output> {
-    let mut params = BTreeMap::new();
+    let mut params = harn_vm::value::DictMap::new();
     params.insert(
         "command".to_string(),
         harn_vm::VmValue::String(Arc::from(cmd.to_string())),

--- a/crates/harn-serve/src/adapters/acp/execute.rs
+++ b/crates/harn-serve/src/adapters/acp/execute.rs
@@ -133,7 +133,7 @@ pub(super) async fn execute_chunk(
 
     let mcp_globals = load_host_mcp_clients(host_bridge.clone()).await;
     if !mcp_globals.is_empty() {
-        vm.set_global("mcp", harn_vm::VmValue::Dict(Arc::new(mcp_globals)));
+        vm.set_global("mcp", harn_vm::VmValue::dict(mcp_globals));
     }
 
     builtins::register_acp_builtins(&mut vm, bridge.clone()).await;

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -60,10 +60,10 @@ async fn recv_json(rx: &mut mpsc::UnboundedReceiver<String>) -> serde_json::Valu
 /// `clippy --all-targets -D warnings` run stays clean.
 #[cfg(feature = "hostlib")]
 fn make_acp_test_message(role: &str, content: &str) -> VmValue {
-    VmValue::Dict(Arc::new(BTreeMap::from([
+    VmValue::dict(BTreeMap::from([
         ("role".to_string(), VmValue::String(Arc::from(role))),
         ("content".to_string(), VmValue::String(Arc::from(content))),
-    ])))
+    ]))
 }
 
 async fn start_acp_channel_session() -> (
@@ -1119,7 +1119,7 @@ async fn acp_fs_mode_commit_and_discard_staged_hostlib_writes() {
         (registry
             .find("hostlib_tools_write_file")
             .expect("write_file builtin")
-            .handler)(&[VmValue::Dict(Arc::new(args))])
+            .handler)(&[VmValue::dict(args)])
         .expect("stage write");
     };
     stage_write(&committed_file, "draft");
@@ -1386,7 +1386,7 @@ fn normalize_host_capabilities_wraps_array_entries_in_ops_dicts() {
         ))])),
     );
 
-    let normalized = normalize_host_capability_manifest(VmValue::Dict(Arc::new(root)));
+    let normalized = normalize_host_capability_manifest(VmValue::dict(root));
     let manifest = normalized.as_dict().expect("dict manifest");
     let project = manifest
         .get("project")
@@ -1410,17 +1410,14 @@ fn normalize_host_capabilities_derives_ops_from_operation_metadata() {
     let mut operations = BTreeMap::new();
     operations.insert(
         "get_default_shell".to_string(),
-        VmValue::Dict(Arc::new(BTreeMap::new())),
+        VmValue::dict(BTreeMap::new()),
     );
     let mut process = BTreeMap::new();
-    process.insert(
-        "operations".to_string(),
-        VmValue::Dict(Arc::new(operations)),
-    );
+    process.insert("operations".to_string(), VmValue::dict(operations));
     let mut root = BTreeMap::new();
-    root.insert("process".to_string(), VmValue::Dict(Arc::new(process)));
+    root.insert("process".to_string(), VmValue::dict(process));
 
-    let normalized = normalize_host_capability_manifest(VmValue::Dict(Arc::new(root)));
+    let normalized = normalize_host_capability_manifest(VmValue::dict(root));
     let manifest = normalized.as_dict().expect("dict manifest");
     let process = manifest
         .get("process")

--- a/crates/harn-serve/src/core.rs
+++ b/crates/harn-serve/src/core.rs
@@ -744,8 +744,8 @@ fn first_param_is_harness(function: &crate::ExportedFunction) -> bool {
 fn build_pipeline_globals(
     arguments: &CallArguments,
     function: &crate::ExportedFunction,
-) -> Result<BTreeMap<String, VmValue>, DispatchError> {
-    let mut globals = BTreeMap::new();
+) -> Result<harn_vm::value::DictMap, DispatchError> {
+    let mut globals = harn_vm::value::DictMap::new();
     match arguments {
         CallArguments::Positional(values) => {
             for (index, param) in function.params.iter().enumerate() {
@@ -805,11 +805,11 @@ fn json_to_vm_value(value: &serde_json::Value) -> VmValue {
         serde_json::Value::Array(items) => VmValue::List(Arc::new(
             items.iter().map(json_to_vm_value).collect::<Vec<_>>(),
         )),
-        serde_json::Value::Object(map) => VmValue::Dict(Arc::new(
+        serde_json::Value::Object(map) => VmValue::dict(
             map.iter()
                 .map(|(key, value)| (key.clone(), json_to_vm_value(value)))
-                .collect(),
-        )),
+                .collect::<harn_vm::value::DictMap>(),
+        ),
     }
 }
 
@@ -1287,18 +1287,16 @@ pub fn whoami(harness: Harness) -> string {
         // Structured guards (mcp/pg call counts, LLM preflight) carry the
         // dimension on the `limit` field.
         let structured = |limit: &str| {
-            harn_vm::VmError::Thrown(harn_vm::VmValue::Dict(std::sync::Arc::new(
-                std::collections::BTreeMap::from([
-                    (
-                        "category".to_string(),
-                        harn_vm::VmValue::String(std::sync::Arc::from("budget_exceeded")),
-                    ),
-                    (
-                        "limit".to_string(),
-                        harn_vm::VmValue::String(std::sync::Arc::from(limit)),
-                    ),
-                ]),
-            )))
+            harn_vm::VmError::Thrown(harn_vm::VmValue::dict(std::collections::BTreeMap::from([
+                (
+                    "category".to_string(),
+                    harn_vm::VmValue::String(std::sync::Arc::from("budget_exceeded")),
+                ),
+                (
+                    "limit".to_string(),
+                    harn_vm::VmValue::String(std::sync::Arc::from(limit)),
+                ),
+            ])))
         };
         assert_eq!(
             budget_category_from_error(&structured("mcp_calls")).as_deref(),

--- a/crates/harn-serve/src/mcp_prompts.rs
+++ b/crates/harn-serve/src/mcp_prompts.rs
@@ -211,7 +211,7 @@ impl FilePrompt {
             }
         }
 
-        let mut bindings = BTreeMap::new();
+        let mut bindings = harn_vm::value::DictMap::new();
         for (key, value) in object {
             bindings.insert(key.clone(), harn_vm::json_to_vm_value(value));
         }

--- a/crates/harn-serve/tests/site_auth.rs
+++ b/crates/harn-serve/tests/site_auth.rs
@@ -11,7 +11,6 @@
 //! All cases drive the router through `tower::ServiceExt::oneshot`,
 //! mirroring `tests/site_hosting.rs`.
 
-use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -126,7 +125,7 @@ impl HostCallBridge for ContextEchoBridge {
         &self,
         capability: &str,
         operation: &str,
-        _params: &BTreeMap<String, VmValue>,
+        _params: &harn_vm::value::DictMap,
     ) -> Result<Option<VmValue>, VmError> {
         if capability != "embedder" || operation != "auth_context" {
             return Ok(None);

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -53,6 +53,11 @@ harn-parser = { path = "../harn-parser", version = "0.8" }
 harn-stdlib = { path = "../harn-stdlib", version = "0.8" }
 async-trait = "0.1"
 bincode = { version = "2.0", features = ["serde"] }
+# Persistent (immutable, structurally shared) collections backing VmValue's
+# Dict/List payloads. Copy-on-write mutation becomes an O(log n) path copy
+# instead of an O(n) BTreeMap/Vec deep clone, which is the dominant allocation
+# cost when an aliased collection is updated in a loop.
+imbl = { version = "7", features = ["serde"] }
 chrono = "0.4"
 chrono-tz = "0.10.4"
 croner = "3.0.1"

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -977,7 +977,7 @@ pub fn inject_prompt_from_live_client(
             }
         })),
     );
-    inject_message(id, VmValue::Dict(std::sync::Arc::new(message)))
+    inject_message(id, VmValue::dict(message))
 }
 
 pub fn route_live_permission_request(
@@ -1339,7 +1339,7 @@ fn truncate_state(state: &mut SessionState, keep_first: usize) -> Option<Session
         .transcript
         .as_dict()
         .cloned()
-        .unwrap_or_else(BTreeMap::new);
+        .unwrap_or_else(crate::value::DictMap::new);
     let messages: Vec<VmValue> = match dict.get("messages") {
         Some(VmValue::List(list)) => list.iter().cloned().collect(),
         _ => Vec::new(),
@@ -1378,8 +1378,7 @@ fn truncate_state(state: &mut SessionState, keep_first: usize) -> Option<Session
             VmValue::List(std::sync::Arc::new(retained)),
         );
         next.remove("summary");
-        apply_transcript_with_budget(state, VmValue::Dict(std::sync::Arc::new(next)), "truncate")
-            .ok()?;
+        apply_transcript_with_budget(state, VmValue::dict(next), "truncate").ok()?;
     }
     state.touch();
     Some(SessionTruncateResult {
@@ -1453,8 +1452,7 @@ pub fn trim(id: &str, keep_last: usize) -> Option<usize> {
             "messages".to_string(),
             VmValue::List(std::sync::Arc::new(retained)),
         );
-        apply_transcript_with_budget(state, VmValue::Dict(std::sync::Arc::new(next)), "trim")
-            .ok()?;
+        apply_transcript_with_budget(state, VmValue::dict(next), "trim").ok()?;
         Some(kept)
     })
 }
@@ -1481,7 +1479,7 @@ pub fn inject_message(id: &str, message: VmValue) -> Result<(), String> {
             .transcript
             .as_dict()
             .cloned()
-            .unwrap_or_else(BTreeMap::new);
+            .unwrap_or_else(crate::value::DictMap::new);
         let mut messages: Vec<VmValue> = match dict.get("messages") {
             Some(VmValue::List(list)) => list.iter().cloned().collect(),
             _ => Vec::new(),
@@ -1490,7 +1488,7 @@ pub fn inject_message(id: &str, message: VmValue) -> Result<(), String> {
             Some(VmValue::List(list)) => list.iter().cloned().collect(),
             _ => crate::llm::helpers::transcript_events_from_messages(&messages),
         };
-        let new_message = VmValue::Dict(std::sync::Arc::new(msg_dict));
+        let new_message = VmValue::dict(msg_dict);
         let message_index = messages.len();
         events.push(crate::llm::helpers::transcript_event_from_message(
             &new_message,
@@ -1512,11 +1510,7 @@ pub fn inject_message(id: &str, message: VmValue) -> Result<(), String> {
                 _ => None,
             })
             .unwrap_or(VmValue::Nil);
-        apply_transcript_with_budget(
-            state,
-            VmValue::Dict(std::sync::Arc::new(next)),
-            "inject_message",
-        )?;
+        apply_transcript_with_budget(state, VmValue::dict(next), "inject_message")?;
         emit_identified_user_message_event(id, &persisted_message);
         emit_llm_message_event(id, message_index, &persisted_message);
         Ok(())
@@ -1569,7 +1563,7 @@ struct TranscriptBudgetUsage {
     approx_bytes: Option<usize>,
 }
 
-fn transcript_messages_from_dict(dict: &BTreeMap<String, VmValue>) -> Vec<VmValue> {
+fn transcript_messages_from_dict(dict: &crate::value::DictMap) -> Vec<VmValue> {
     match dict.get("messages") {
         Some(VmValue::List(list)) => list.iter().cloned().collect(),
         _ => Vec::new(),
@@ -1584,7 +1578,7 @@ fn transcript_message_count(transcript: &VmValue) -> usize {
         .unwrap_or(0)
 }
 
-fn transcript_events_from_dict(dict: &BTreeMap<String, VmValue>) -> Vec<VmValue> {
+fn transcript_events_from_dict(dict: &crate::value::DictMap) -> Vec<VmValue> {
     match dict.get("events") {
         Some(VmValue::List(list)) => list.iter().cloned().collect(),
         _ => {
@@ -1738,7 +1732,7 @@ fn append_event_to_transcript(transcript: VmValue, event: VmValue) -> VmValue {
         "events".to_string(),
         VmValue::List(std::sync::Arc::new(events)),
     );
-    VmValue::Dict(std::sync::Arc::new(next))
+    VmValue::dict(next)
 }
 
 fn tail_message_capacity(
@@ -1758,7 +1752,10 @@ fn trim_transcript_for_budget(
     policy: &SessionTranscriptBudgetPolicy,
     keep_last: usize,
 ) -> VmValue {
-    let dict = transcript.as_dict().cloned().unwrap_or_else(BTreeMap::new);
+    let dict = transcript
+        .as_dict()
+        .cloned()
+        .unwrap_or_else(crate::value::DictMap::new);
     let messages = transcript_messages_from_dict(&dict);
     let keep = keep_last.min(tail_message_capacity(policy, true));
     let start = messages.len().saturating_sub(keep);
@@ -1775,7 +1772,7 @@ fn trim_transcript_for_budget(
         VmValue::List(std::sync::Arc::new(retained)),
     );
     next.remove("summary");
-    VmValue::Dict(std::sync::Arc::new(next))
+    VmValue::dict(next)
 }
 
 struct BudgetCompactionLiveEvent {
@@ -1795,7 +1792,10 @@ fn compact_transcript_for_budget(
     keep_last: usize,
     session_id: &str,
 ) -> BudgetCompactionResult {
-    let dict = transcript.as_dict().cloned().unwrap_or_else(BTreeMap::new);
+    let dict = transcript
+        .as_dict()
+        .cloned()
+        .unwrap_or_else(crate::value::DictMap::new);
     let messages = transcript_messages_from_dict(&dict);
     let message_capacity = policy.max_messages.min(tail_event_capacity(policy, 2));
     // Auto-compaction may widen a suffix to start on a clean user-turn boundary,
@@ -1881,7 +1881,7 @@ fn compact_transcript_for_budget(
         next.remove("summary");
     }
     BudgetCompactionResult {
-        transcript: VmValue::Dict(std::sync::Arc::new(next)),
+        transcript: VmValue::dict(next),
         live_event,
     }
 }
@@ -2415,7 +2415,7 @@ pub fn prune_invalid_reminder_events(id: &str) -> usize {
             );
             let _ = apply_transcript_with_budget(
                 state,
-                VmValue::Dict(std::sync::Arc::new(next)),
+                VmValue::dict(next),
                 "prune_invalid_reminder_events",
             );
             state.touch();
@@ -2498,7 +2498,7 @@ pub fn inject_reminder(
             .transcript
             .as_dict()
             .cloned()
-            .unwrap_or_else(BTreeMap::new);
+            .unwrap_or_else(crate::value::DictMap::new);
         let mut events: Vec<VmValue> = match dict.get("events") {
             Some(VmValue::List(list)) => list.iter().cloned().collect(),
             _ => dict
@@ -2529,11 +2529,7 @@ pub fn inject_reminder(
             "events".to_string(),
             VmValue::List(std::sync::Arc::new(events)),
         );
-        apply_transcript_with_budget(
-            state,
-            VmValue::Dict(std::sync::Arc::new(next)),
-            "inject_reminder",
-        )?;
+        apply_transcript_with_budget(state, VmValue::dict(next), "inject_reminder")?;
         state.touch();
         Ok(())
     })?;
@@ -2601,7 +2597,7 @@ fn append_event_to_state(
         .transcript
         .as_dict()
         .cloned()
-        .unwrap_or_else(BTreeMap::new);
+        .unwrap_or_else(crate::value::DictMap::new);
     let mut events: Vec<VmValue> = match dict.get("events") {
         Some(VmValue::List(list)) => list.iter().cloned().collect(),
         _ => dict
@@ -2619,7 +2615,7 @@ fn append_event_to_state(
         "events".to_string(),
         VmValue::List(std::sync::Arc::new(events)),
     );
-    apply_transcript_with_budget(state, VmValue::Dict(std::sync::Arc::new(next)), action)
+    apply_transcript_with_budget(state, VmValue::dict(next), action)
 }
 
 /// Replace the transcript's message list wholesale. Used by the
@@ -2648,7 +2644,7 @@ pub fn replace_messages_with_summary(
             .transcript
             .as_dict()
             .cloned()
-            .unwrap_or_else(BTreeMap::new);
+            .unwrap_or_else(crate::value::DictMap::new);
         let vm_messages: Vec<VmValue> = messages
             .iter()
             .map(crate::stdlib::json_to_vm_value)
@@ -2669,11 +2665,7 @@ pub fn replace_messages_with_summary(
         } else {
             next.remove("summary");
         }
-        apply_transcript_with_budget(
-            state,
-            VmValue::Dict(std::sync::Arc::new(next)),
-            "replace_messages",
-        )?;
+        apply_transcript_with_budget(state, VmValue::dict(next), "replace_messages")?;
         Ok(())
     })
 }
@@ -2787,7 +2779,7 @@ pub fn record_system_prompt(id: &str, system_prompt: &str) -> Result<(), String>
             .transcript
             .as_dict()
             .cloned()
-            .unwrap_or_else(BTreeMap::new);
+            .unwrap_or_else(crate::value::DictMap::new);
         let mut next = dict;
         apply_system_prompt_metadata(&mut next, system_prompt);
         if changed {
@@ -2809,11 +2801,7 @@ pub fn record_system_prompt(id: &str, system_prompt: &str) -> Result<(), String>
                 VmValue::List(std::sync::Arc::new(events)),
             );
         }
-        apply_transcript_with_budget(
-            state,
-            VmValue::Dict(std::sync::Arc::new(next)),
-            "record_system_prompt",
-        )?;
+        apply_transcript_with_budget(state, VmValue::dict(next), "record_system_prompt")?;
         Ok(())
     })
 }
@@ -3167,7 +3155,7 @@ fn clone_transcript_with_id(transcript: &VmValue, new_id: &str) -> VmValue {
     };
     let mut next = dict.clone();
     next.put_str("id", new_id);
-    VmValue::Dict(std::sync::Arc::new(next))
+    VmValue::dict(next)
 }
 
 fn clone_transcript_with_parent(transcript: &VmValue, parent_id: &str) -> VmValue {
@@ -3179,21 +3167,21 @@ fn clone_transcript_with_parent(transcript: &VmValue, parent_id: &str) -> VmValu
         Some(VmValue::Dict(metadata)) => {
             let mut metadata = metadata.as_ref().clone();
             metadata.put_str("parent_session_id", parent_id);
-            VmValue::Dict(std::sync::Arc::new(metadata))
+            VmValue::dict(metadata)
         }
-        _ => VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        _ => VmValue::dict(BTreeMap::from([(
             "parent_session_id".to_string(),
             VmValue::String(std::sync::Arc::from(parent_id.to_string())),
-        )]))),
+        )])),
     };
     next.insert("metadata".to_string(), metadata);
-    VmValue::Dict(std::sync::Arc::new(next))
+    VmValue::dict(next)
 }
 
-fn apply_system_prompt_metadata(next: &mut BTreeMap<String, VmValue>, system_prompt: &str) {
+fn apply_system_prompt_metadata(next: &mut crate::value::DictMap, system_prompt: &str) {
     let mut metadata = match next.get("metadata") {
         Some(VmValue::Dict(metadata)) => metadata.as_ref().clone(),
-        _ => BTreeMap::new(),
+        _ => crate::value::DictMap::new(),
     };
     metadata.insert(
         "system_prompt".to_string(),
@@ -3201,10 +3189,7 @@ fn apply_system_prompt_metadata(next: &mut BTreeMap<String, VmValue>, system_pro
             system_prompt,
         )),
     );
-    next.insert(
-        "metadata".to_string(),
-        VmValue::Dict(std::sync::Arc::new(metadata)),
-    );
+    next.insert("metadata".to_string(), VmValue::dict(metadata));
 }
 
 fn transcript_with_session_metadata(transcript: VmValue, state: &SessionState) -> VmValue {
@@ -3214,7 +3199,7 @@ fn transcript_with_session_metadata(transcript: VmValue, state: &SessionState) -
     let mut next = dict.clone();
     let mut metadata = match next.get("metadata") {
         Some(VmValue::Dict(metadata)) => metadata.as_ref().clone(),
-        _ => BTreeMap::new(),
+        _ => crate::value::DictMap::new(),
     };
     if let Some(tool_format) = state.tool_format.as_ref() {
         metadata.put_str("tool_format", tool_format.clone());
@@ -3248,7 +3233,7 @@ fn transcript_with_session_metadata(transcript: VmValue, state: &SessionState) -
     }
     if let Some(last_action) = state.last_transcript_budget_action.as_ref() {
         let usage = transcript_usage(
-            &VmValue::Dict(std::sync::Arc::new(next.clone())),
+            &VmValue::dict(next.clone()),
             state.transcript_budget_policy.max_approx_bytes.is_some(),
         );
         metadata.insert(
@@ -3261,12 +3246,9 @@ fn transcript_with_session_metadata(transcript: VmValue, state: &SessionState) -
         );
     }
     if !metadata.is_empty() {
-        next.insert(
-            "metadata".to_string(),
-            VmValue::Dict(std::sync::Arc::new(metadata)),
-        );
+        next.insert("metadata".to_string(), VmValue::dict(metadata));
     }
-    VmValue::Dict(std::sync::Arc::new(next))
+    VmValue::dict(next)
 }
 
 fn session_snapshot(state: &SessionState) -> VmValue {
@@ -3384,7 +3366,7 @@ fn session_snapshot(state: &SessionState) -> VmValue {
         "redo_checkpoint_count".to_string(),
         VmValue::Int(state.redo_stack.len() as i64),
     );
-    VmValue::Dict(std::sync::Arc::new(next))
+    VmValue::dict(next)
 }
 
 fn update_lineage(

--- a/crates/harn-vm/src/agent_sessions_tests.rs
+++ b/crates/harn-vm/src/agent_sessions_tests.rs
@@ -6,18 +6,17 @@ use crate::agent_events::{
 use crate::event_log::{active_event_log, EventLog, Topic};
 use crate::value::VmDictExt;
 use futures::StreamExt as _;
-use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 fn make_msg(role: &str, content: &str) -> VmValue {
-    let mut m: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut m: crate::value::DictMap = crate::value::DictMap::new();
     m.put_str("role", role);
     m.put_str("content", content);
-    VmValue::Dict(std::sync::Arc::new(m))
+    VmValue::dict(m)
 }
 
 fn scratchpad_value(note: &str) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    VmValue::dict(crate::value::DictMap::from_iter([
         (
             "schema".to_string(),
             VmValue::String(std::sync::Arc::from("harn.agent_scratchpad.v1")),
@@ -25,7 +24,7 @@ fn scratchpad_value(note: &str) -> VmValue {
         (
             "facts".to_string(),
             VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
-                std::sync::Arc::new(BTreeMap::from([
+                std::sync::Arc::new(crate::value::DictMap::from_iter([
                     (
                         "text".to_string(),
                         VmValue::String(std::sync::Arc::from(note.to_string())),
@@ -40,13 +39,13 @@ fn scratchpad_value(note: &str) -> VmValue {
         (
             "refs".to_string(),
             VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
-                std::sync::Arc::new(BTreeMap::from([(
+                std::sync::Arc::new(crate::value::DictMap::from_iter([(
                     "id".to_string(),
                     VmValue::String(std::sync::Arc::from("turn:1")),
                 )])),
             )])),
         ),
-    ])))
+    ]))
 }
 
 fn message_count(id: &str) -> usize {
@@ -669,10 +668,10 @@ fn scratchpad_rejects_non_dict_and_oversized_values() {
     .unwrap_err();
     assert!(non_dict_error.contains("must be a dict"));
 
-    let oversized = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+    let oversized = VmValue::dict(crate::value::DictMap::from_iter([(
         "notes".to_string(),
         VmValue::String(std::sync::Arc::from("x".repeat(MAX_SCRATCHPAD_BYTES + 1))),
-    )])));
+    )]));
     let oversized_error =
         set_scratchpad(&id, oversized, "test", None, serde_json::json!({})).unwrap_err();
     assert!(
@@ -728,11 +727,11 @@ fn inject_identified_user_message_emits_replayable_user_event() {
     let captured = Arc::new(Mutex::new(Vec::new()));
     register_sink(&id, Arc::new(CapturingSink(captured.clone())));
 
-    let mut message = BTreeMap::new();
+    let mut message = crate::value::DictMap::new();
     message.put_str("role", "user");
     message.put_str("content", "queued follow-up");
     message.put_str("messageId", "msg_inj_test");
-    inject_message(&id, VmValue::Dict(std::sync::Arc::new(message))).unwrap();
+    inject_message(&id, VmValue::dict(message)).unwrap();
 
     let events = captured.lock().expect("capture sink poisoned");
     assert_eq!(events.len(), 1);
@@ -956,7 +955,7 @@ fn child_sessions_record_parent_lineage() {
 fn branch_event_index_counts_non_message_events() {
     reset_session_store();
     let src = open_or_create(Some("branch-event-index".into()));
-    let transcript = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    let transcript = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "id".to_string(),
             VmValue::String(std::sync::Arc::from(src.clone())),
@@ -971,21 +970,21 @@ fn branch_event_index_counts_non_message_events() {
         (
             "events".to_string(),
             VmValue::List(std::sync::Arc::new(vec![
-                VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+                VmValue::dict(crate::value::DictMap::from_iter([(
                     "kind".to_string(),
                     VmValue::String(std::sync::Arc::from("message")),
-                )]))),
-                VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+                )])),
+                VmValue::dict(crate::value::DictMap::from_iter([(
                     "kind".to_string(),
                     VmValue::String(std::sync::Arc::from("sub_agent_start")),
-                )]))),
-                VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+                )])),
+                VmValue::dict(crate::value::DictMap::from_iter([(
                     "kind".to_string(),
                     VmValue::String(std::sync::Arc::from("message")),
-                )]))),
+                )])),
             ])),
         ),
-    ])));
+    ]));
     store_transcript(&src, transcript).unwrap();
 
     let dst = fork_at(&src, 2, Some("branch-event-index-child".into())).expect("fork_at");

--- a/crates/harn-vm/src/call_budget.rs
+++ b/crates/harn-vm/src/call_budget.rs
@@ -113,7 +113,7 @@ fn budget_exceeded_error(kind: CallBudgetKind, spent: u64, max: u64) -> VmError 
             kind.noun(max != 1),
         ),
     );
-    VmError::Thrown(VmValue::Dict(std::sync::Arc::new(dict)))
+    VmError::Thrown(VmValue::dict(dict))
 }
 
 /// RAII guard for [`install_mcp_call_budget`]. Restores the prior MCP

--- a/crates/harn-vm/src/channel_guardrails.rs
+++ b/crates/harn-vm/src/channel_guardrails.rs
@@ -53,7 +53,6 @@
 //!   of the guardrail.
 
 use std::cell::RefCell;
-use std::collections::BTreeMap;
 use std::sync::OnceLock;
 
 use regex::Regex;
@@ -149,14 +148,14 @@ fn err(message: impl Into<String>) -> VmError {
     VmError::Thrown(VmValue::String(std::sync::Arc::from(message.into())))
 }
 
-fn dict_string(dict: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn dict_string(dict: &crate::value::DictMap, key: &str) -> Option<String> {
     match dict.get(key) {
         Some(VmValue::String(s)) if !s.is_empty() => Some(s.to_string()),
         _ => None,
     }
 }
 
-fn dict_string_list(dict: &BTreeMap<String, VmValue>, key: &str) -> Vec<String> {
+fn dict_string_list(dict: &crate::value::DictMap, key: &str) -> Vec<String> {
     match dict.get(key) {
         Some(VmValue::List(items)) => items
             .iter()
@@ -174,7 +173,7 @@ fn dict_string_list(dict: &BTreeMap<String, VmValue>, key: &str) -> Vec<String> 
 /// synthesised). Idempotent on `id`: re-registering the same id replaces
 /// the prior entry so callers can update a guardrail's config without
 /// duplicate evaluations.
-pub fn register(config: &BTreeMap<String, VmValue>) -> Result<String, VmError> {
+pub fn register(config: &crate::value::DictMap) -> Result<String, VmError> {
     let kind_label = dict_string(config, "kind")
         .ok_or_else(|| err("channel_guardrail_register: `kind` must be a non-empty string"))?;
     let kind = match kind_label.as_str() {
@@ -497,6 +496,7 @@ fn verdict_from_label(label: &str, reason: String) -> Result<Verdict, VmError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use serde_json::json;
 
     fn ctx() -> serde_json::Value {
@@ -506,7 +506,7 @@ mod tests {
     #[test]
     fn prompt_injection_signature_blocks_ignore_previous() {
         clear();
-        let mut cfg = BTreeMap::new();
+        let mut cfg = crate::value::DictMap::new();
         cfg.insert(
             "kind".into(),
             VmValue::String(std::sync::Arc::from("prompt_injection_signature")),
@@ -525,7 +525,7 @@ mod tests {
     #[test]
     fn prompt_injection_signature_walks_nested_strings() {
         clear();
-        let mut cfg = BTreeMap::new();
+        let mut cfg = crate::value::DictMap::new();
         cfg.insert(
             "kind".into(),
             VmValue::String(std::sync::Arc::from("prompt_injection_signature")),
@@ -548,7 +548,7 @@ mod tests {
     #[test]
     fn safe_payload_passes() {
         clear();
-        let mut cfg = BTreeMap::new();
+        let mut cfg = crate::value::DictMap::new();
         cfg.insert(
             "kind".into(),
             VmValue::String(std::sync::Arc::from("prompt_injection_signature")),
@@ -564,7 +564,7 @@ mod tests {
     #[test]
     fn warn_on_hit_yields_warn_verdict() {
         clear();
-        let mut cfg = BTreeMap::new();
+        let mut cfg = crate::value::DictMap::new();
         cfg.insert(
             "kind".into(),
             VmValue::String(std::sync::Arc::from("prompt_injection_signature")),
@@ -584,7 +584,7 @@ mod tests {
     #[test]
     fn applies_to_filter_skips_other_channels() {
         clear();
-        let mut cfg = BTreeMap::new();
+        let mut cfg = crate::value::DictMap::new();
         cfg.insert(
             "kind".into(),
             VmValue::String(std::sync::Arc::from("prompt_injection_signature")),
@@ -613,7 +613,7 @@ mod tests {
     #[test]
     fn unregister_removes_entry() {
         clear();
-        let mut cfg = BTreeMap::new();
+        let mut cfg = crate::value::DictMap::new();
         cfg.insert(
             "kind".into(),
             VmValue::String(std::sync::Arc::from("prompt_injection_signature")),
@@ -632,7 +632,7 @@ mod tests {
     #[test]
     fn duplicate_id_replaces_entry() {
         clear();
-        let mut cfg = BTreeMap::new();
+        let mut cfg = crate::value::DictMap::new();
         cfg.insert(
             "kind".into(),
             VmValue::String(std::sync::Arc::from("prompt_injection_signature")),
@@ -649,14 +649,14 @@ mod tests {
     #[test]
     fn block_short_circuits_after_first_block() {
         clear();
-        let mut a = BTreeMap::new();
+        let mut a = crate::value::DictMap::new();
         a.insert(
             "kind".into(),
             VmValue::String(std::sync::Arc::from("prompt_injection_signature")),
         );
         a.insert("id".into(), VmValue::String(std::sync::Arc::from("first")));
         register(&a).unwrap();
-        let mut b = BTreeMap::new();
+        let mut b = crate::value::DictMap::new();
         b.insert(
             "kind".into(),
             VmValue::String(std::sync::Arc::from("prompt_injection_signature")),

--- a/crates/harn-vm/src/channels/mod.rs
+++ b/crates/harn-vm/src/channels/mod.rs
@@ -1292,7 +1292,7 @@ fn required_string(value: Option<&VmValue>, builtin: &str, name: &str) -> Result
 }
 
 fn option_string(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Option<String>, VmError> {
@@ -1310,7 +1310,7 @@ fn option_string(
 }
 
 fn option_non_negative_int(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Option<u64>, VmError> {
@@ -1325,7 +1325,7 @@ fn option_non_negative_int(
 }
 
 fn option_duration_ms(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Option<i64>, VmError> {
@@ -1340,7 +1340,7 @@ fn option_duration_ms(
     }
 }
 
-fn dict_string(values: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn dict_string(values: &crate::value::DictMap, key: &str) -> Option<String> {
     match values.get(key) {
         Some(VmValue::String(value)) if !value.is_empty() => Some(value.to_string()),
         _ => None,

--- a/crates/harn-vm/src/checkpoint.rs
+++ b/crates/harn-vm/src/checkpoint.rs
@@ -170,7 +170,7 @@ fn json_to_vm(jv: &serde_json::Value) -> VmValue {
             for (k, v) in map {
                 m.insert(k.clone(), json_to_vm(v));
             }
-            VmValue::Dict(std::sync::Arc::new(m))
+            VmValue::dict(m)
         }
     }
 }

--- a/crates/harn-vm/src/compiler/closures.rs
+++ b/crates/harn-vm/src/compiler/closures.rs
@@ -129,10 +129,10 @@ impl Compiler {
                 .as_ref()
                 .and_then(Self::type_expr_to_schema_value)
                 .unwrap_or_else(|| {
-                    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+                    VmValue::dict(BTreeMap::from([(
                         "type".to_string(),
                         VmValue::String(std::sync::Arc::from("any")),
-                    )])))
+                    )]))
                 });
             let public_schema =
                 schema::schema_to_json_schema_value(&base_schema).map_err(|error| {
@@ -146,14 +146,14 @@ impl Compiler {
                 })?;
             let mut param_schema = match public_schema {
                 VmValue::Dict(map) => (*map).clone(),
-                _ => BTreeMap::new(),
+                _ => crate::value::DictMap::new(),
             };
 
             if p.default_value.is_some() {
                 param_schema.insert("required".to_string(), VmValue::Bool(false));
             }
 
-            self.emit_vm_value_literal(&VmValue::Dict(std::sync::Arc::new(param_schema)));
+            self.emit_vm_value_literal(&VmValue::dict(param_schema));
 
             if let Some(default_value) = p.default_value.as_ref() {
                 let default_key = self.string_constant("default");

--- a/crates/harn-vm/src/compiler/optimizer.rs
+++ b/crates/harn-vm/src/compiler/optimizer.rs
@@ -79,7 +79,7 @@ fn constant_value(expr: &SNode) -> Option<VmValue> {
                     constant_value(&entry.value)?,
                 );
             }
-            Some(VmValue::Dict(std::sync::Arc::new(values)))
+            Some(VmValue::dict(values))
         }
         _ => None,
     }
@@ -170,7 +170,7 @@ fn fold_add(left: VmValue, right: VmValue) -> Option<VmValue> {
                     .iter()
                     .map(|(key, value)| (key.clone(), value.clone())),
             );
-            Some(VmValue::Dict(std::sync::Arc::new(out)))
+            Some(VmValue::dict(out))
         }
         _ => None,
     }

--- a/crates/harn-vm/src/compiler/state.rs
+++ b/crates/harn-vm/src/compiler/state.rs
@@ -478,12 +478,10 @@ impl Compiler {
         match type_expr {
             harn_parser::TypeExpr::Named(name) => match name.as_str() {
                 "int" | "float" | "string" | "bool" | "list" | "dict" | "set" | "nil"
-                | "closure" | "bytes" => {
-                    Some(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
-                        "type".to_string(),
-                        VmValue::String(std::sync::Arc::from(name.as_str())),
-                    )]))))
-                }
+                | "closure" | "bytes" => Some(VmValue::dict(BTreeMap::from([(
+                    "type".to_string(),
+                    VmValue::String(std::sync::Arc::from(name.as_str())),
+                )]))),
                 _ => None,
             },
             harn_parser::TypeExpr::Shape(fields)
@@ -499,17 +497,14 @@ impl Compiler {
                 }
                 let mut out = BTreeMap::new();
                 out.put_str("type", "dict");
-                out.insert(
-                    "properties".to_string(),
-                    VmValue::Dict(std::sync::Arc::new(properties)),
-                );
+                out.insert("properties".to_string(), VmValue::dict(properties));
                 if !required.is_empty() {
                     out.insert(
                         "required".to_string(),
                         VmValue::List(std::sync::Arc::new(required)),
                     );
                 }
-                Some(VmValue::Dict(std::sync::Arc::new(out)))
+                Some(VmValue::dict(out))
             }
             harn_parser::TypeExpr::List(inner) => {
                 let mut out = BTreeMap::new();
@@ -517,7 +512,7 @@ impl Compiler {
                 if let Some(item_schema) = Self::type_expr_to_schema_value(inner) {
                     out.insert("items".to_string(), item_schema);
                 }
-                Some(VmValue::Dict(std::sync::Arc::new(out)))
+                Some(VmValue::dict(out))
             }
             harn_parser::TypeExpr::DictType(key, value) => {
                 let mut out = BTreeMap::new();
@@ -527,7 +522,7 @@ impl Compiler {
                         out.insert("additional_properties".to_string(), value_schema);
                     }
                 }
-                Some(VmValue::Dict(std::sync::Arc::new(out)))
+                Some(VmValue::dict(out))
             }
             harn_parser::TypeExpr::Union(members) => {
                 // Special-case unions of literals: emit as `enum: [...]`
@@ -548,7 +543,7 @@ impl Compiler {
                             _ => unreachable!(),
                         })
                         .collect::<Vec<_>>();
-                    return Some(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+                    return Some(VmValue::dict(BTreeMap::from([
                         (
                             "type".to_string(),
                             VmValue::String(std::sync::Arc::from("string")),
@@ -557,7 +552,7 @@ impl Compiler {
                             "enum".to_string(),
                             VmValue::List(std::sync::Arc::new(values)),
                         ),
-                    ]))));
+                    ])));
                 }
                 if !members.is_empty()
                     && members
@@ -571,7 +566,7 @@ impl Compiler {
                             _ => unreachable!(),
                         })
                         .collect::<Vec<_>>();
-                    return Some(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+                    return Some(VmValue::dict(BTreeMap::from([
                         (
                             "type".to_string(),
                             VmValue::String(std::sync::Arc::from("int")),
@@ -580,7 +575,7 @@ impl Compiler {
                             "enum".to_string(),
                             VmValue::List(std::sync::Arc::new(values)),
                         ),
-                    ]))));
+                    ])));
                 }
                 let branches = members
                     .iter()
@@ -589,10 +584,10 @@ impl Compiler {
                 if branches.is_empty() {
                     None
                 } else {
-                    Some(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+                    Some(VmValue::dict(BTreeMap::from([(
                         "union".to_string(),
                         VmValue::List(std::sync::Arc::new(branches)),
-                    )]))))
+                    )])))
                 }
             }
             harn_parser::TypeExpr::Intersection(members) => {
@@ -606,44 +601,38 @@ impl Compiler {
                 if branches.is_empty() {
                     None
                 } else {
-                    Some(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+                    Some(VmValue::dict(BTreeMap::from([(
                         "all_of".to_string(),
                         VmValue::List(std::sync::Arc::new(branches)),
-                    )]))))
+                    )])))
                 }
             }
-            harn_parser::TypeExpr::FnType { .. } => {
-                Some(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
-                    "type".to_string(),
-                    VmValue::String(std::sync::Arc::from("closure")),
-                )]))))
-            }
+            harn_parser::TypeExpr::FnType { .. } => Some(VmValue::dict(BTreeMap::from([(
+                "type".to_string(),
+                VmValue::String(std::sync::Arc::from("closure")),
+            )]))),
             harn_parser::TypeExpr::Applied { .. } => None,
             harn_parser::TypeExpr::Iter(_)
             | harn_parser::TypeExpr::Generator(_)
             | harn_parser::TypeExpr::Stream(_) => None,
             harn_parser::TypeExpr::Never => None,
-            harn_parser::TypeExpr::LitString(s) => {
-                Some(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
-                    (
-                        "type".to_string(),
-                        VmValue::String(std::sync::Arc::from("string")),
-                    ),
-                    (
-                        "const".to_string(),
-                        VmValue::String(std::sync::Arc::from(s.as_str())),
-                    ),
-                ]))))
-            }
-            harn_parser::TypeExpr::LitInt(v) => {
-                Some(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
-                    (
-                        "type".to_string(),
-                        VmValue::String(std::sync::Arc::from("int")),
-                    ),
-                    ("const".to_string(), VmValue::Int(*v)),
-                ]))))
-            }
+            harn_parser::TypeExpr::LitString(s) => Some(VmValue::dict(BTreeMap::from([
+                (
+                    "type".to_string(),
+                    VmValue::String(std::sync::Arc::from("string")),
+                ),
+                (
+                    "const".to_string(),
+                    VmValue::String(std::sync::Arc::from(s.as_str())),
+                ),
+            ]))),
+            harn_parser::TypeExpr::LitInt(v) => Some(VmValue::dict(BTreeMap::from([
+                (
+                    "type".to_string(),
+                    VmValue::String(std::sync::Arc::from("int")),
+                ),
+                ("const".to_string(), VmValue::Int(*v)),
+            ]))),
             harn_parser::TypeExpr::Owned(inner) => Self::type_expr_to_schema_value(inner),
         }
     }

--- a/crates/harn-vm/src/composition/mod.rs
+++ b/crates/harn-vm/src/composition/mod.rs
@@ -880,7 +880,7 @@ fn register_composition_map_bounded_builtin(vm: &mut Vm, runtime: CompositionRun
             );
             dict.insert("succeeded".to_string(), VmValue::Int(succeeded));
             dict.insert("failed".to_string(), VmValue::Int(failed));
-            Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+            Ok(VmValue::dict(dict))
         }
     });
 }

--- a/crates/harn-vm/src/durable_rate_limit.rs
+++ b/crates/harn-vm/src/durable_rate_limit.rs
@@ -98,7 +98,7 @@ async fn durable_rate_limit_acquire_impl(
 
 pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[&DURABLE_RATE_LIMIT_ACQUIRE_IMPL_DEF];
 
-fn parse_state_path(options: &BTreeMap<String, VmValue>) -> Result<PathBuf, VmError> {
+fn parse_state_path(options: &crate::value::DictMap) -> Result<PathBuf, VmError> {
     match options.get("state_path") {
         Some(VmValue::String(path)) if !path.trim().is_empty() => Ok(
             crate::stdlib::process::resolve_source_relative_path(path.trim()),
@@ -114,7 +114,7 @@ fn parse_state_path(options: &BTreeMap<String, VmValue>) -> Result<PathBuf, VmEr
     }
 }
 
-fn parse_buckets(options: &BTreeMap<String, VmValue>) -> Result<Vec<RateBucket>, VmError> {
+fn parse_buckets(options: &crate::value::DictMap) -> Result<Vec<RateBucket>, VmError> {
     let buckets = match options.get("buckets") {
         Some(VmValue::List(items)) => {
             let mut parsed = Vec::with_capacity(items.len());
@@ -155,7 +155,7 @@ fn parse_buckets(options: &BTreeMap<String, VmValue>) -> Result<Vec<RateBucket>,
     Ok(buckets)
 }
 
-fn parse_bucket(dict: &BTreeMap<String, VmValue>) -> Result<RateBucket, VmError> {
+fn parse_bucket(dict: &crate::value::DictMap) -> Result<RateBucket, VmError> {
     let key = required_string_field(dict, "key")?;
     let limit = required_positive_u64_field(dict, "limit")?;
     let units = optional_non_negative_u64_field(dict, "units")?.unwrap_or(1);
@@ -169,7 +169,7 @@ fn parse_bucket(dict: &BTreeMap<String, VmValue>) -> Result<RateBucket, VmError>
 }
 
 fn required_string_field(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
     key: &'static str,
 ) -> Result<String, VmError> {
     match dict.get(key) {
@@ -185,7 +185,7 @@ fn required_string_field(
 }
 
 fn required_positive_u64_field(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
     key: &'static str,
 ) -> Result<u64, VmError> {
     let value = optional_non_negative_u64_field(dict, key)?.ok_or_else(|| {
@@ -202,7 +202,7 @@ fn required_positive_u64_field(
 }
 
 fn optional_non_negative_u64_field(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
     key: &'static str,
 ) -> Result<Option<u64>, VmError> {
     match dict.get(key) {
@@ -224,7 +224,7 @@ fn optional_non_negative_u64_field(
 }
 
 fn optional_duration_ms(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
     key: &'static str,
 ) -> Result<Option<u64>, VmError> {
     match dict.get(key) {
@@ -485,7 +485,7 @@ fn result_value(
     );
     dict.put_str("state_path", state_path.to_string_lossy());
     dict.insert("buckets".to_string(), bucket_list_value(buckets));
-    VmValue::Dict(Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn bucket_list_value(buckets: &[RateBucket]) -> VmValue {
@@ -493,7 +493,7 @@ fn bucket_list_value(buckets: &[RateBucket]) -> VmValue {
         buckets
             .iter()
             .map(|bucket| {
-                VmValue::Dict(Arc::new(BTreeMap::from([
+                VmValue::dict(BTreeMap::from([
                     (
                         "key".to_string(),
                         VmValue::String(Arc::from(bucket.key.as_str())),
@@ -508,7 +508,7 @@ fn bucket_list_value(buckets: &[RateBucket]) -> VmValue {
                         "window_ms".to_string(),
                         VmValue::Int(u64_to_i64(bucket.window_ms)),
                     ),
-                ])))
+                ]))
             })
             .collect(),
     ))

--- a/crates/harn-vm/src/durable_rate_limit/tests.rs
+++ b/crates/harn-vm/src/durable_rate_limit/tests.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::{compile_source, register_vm_stdlib, reset_thread_local_state, Vm};
 use rusqlite::{params, Connection};
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Barrier};
 
@@ -134,17 +133,17 @@ fn concurrent_threads_do_not_over_reserve_shared_bucket() {
 
 #[test]
 fn duplicate_bucket_keys_are_rejected() {
-    let options = BTreeMap::from([(
+    let options = crate::value::DictMap::from_iter([(
         "buckets".to_string(),
         VmValue::List(Arc::new(vec![
-            VmValue::Dict(Arc::new(BTreeMap::from([
+            VmValue::dict(crate::value::DictMap::from_iter([
                 ("key".to_string(), VmValue::String(Arc::from("same"))),
                 ("limit".to_string(), VmValue::Int(1)),
-            ]))),
-            VmValue::Dict(Arc::new(BTreeMap::from([
+            ])),
+            VmValue::dict(crate::value::DictMap::from_iter([
                 ("key".to_string(), VmValue::String(Arc::from("same"))),
                 ("limit".to_string(), VmValue::Int(1)),
-            ]))),
+            ])),
         ])),
     )]);
     let error = parse_buckets(&options).expect_err("duplicate keys should fail");

--- a/crates/harn-vm/src/egress/mod.rs
+++ b/crates/harn-vm/src/egress/mod.rs
@@ -961,7 +961,7 @@ fn ensure_env_seeded() -> Result<(), VmError> {
     }
 }
 
-fn policy_from_config(config: &BTreeMap<String, VmValue>) -> Result<EgressPolicy, VmError> {
+fn policy_from_config(config: &crate::value::DictMap) -> Result<EgressPolicy, VmError> {
     let allow = match config.get("allow") {
         Some(VmValue::List(items)) => parse_rule_values(items)?,
         Some(VmValue::Nil) => Vec::new(),
@@ -1102,7 +1102,7 @@ fn policy_summary() -> VmValue {
     } else {
         dict.insert("configured".to_string(), VmValue::Bool(false));
     }
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 impl EgressRule {
@@ -1283,7 +1283,7 @@ impl EgressBlocked {
                 .unwrap_or(VmValue::Nil),
         );
         dict.put_str("reason", self.reason.as_str());
-        VmError::Thrown(VmValue::Dict(std::sync::Arc::new(dict)))
+        VmError::Thrown(VmValue::dict(dict))
     }
 }
 

--- a/crates/harn-vm/src/harness_net.rs
+++ b/crates/harn-vm/src/harness_net.rs
@@ -422,7 +422,7 @@ pub fn violation_vm_error(audit: &NetPolicyAudit) -> VmError {
     if audit.bypass {
         dict.insert("bypass".to_string(), VmValue::Bool(true));
     }
-    VmError::Thrown(VmValue::Dict(std::sync::Arc::new(dict)))
+    VmError::Thrown(VmValue::dict(dict))
 }
 
 /// Build the request envelope handed to the user `on_violation`
@@ -449,7 +449,7 @@ pub fn violation_request_value(audit: &NetPolicyAudit) -> VmValue {
             .map(|raw| VmValue::String(std::sync::Arc::from(raw)))
             .unwrap_or(VmValue::Nil),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 /// Emit a `harness.net.policy.audit` event to the active event log,
@@ -530,7 +530,7 @@ pub mod parse {
         }
     }
 
-    fn rule_from_dict(dict: &BTreeMap<String, VmValue>) -> Result<NetPolicyRule, VmError> {
+    fn rule_from_dict(dict: &crate::value::DictMap) -> Result<NetPolicyRule, VmError> {
         let tag = dict
             .get(RULE_TAG_KEY)
             .and_then(|v| match v {
@@ -585,7 +585,7 @@ pub mod parse {
     }
 
     fn require_string(
-        dict: &BTreeMap<String, VmValue>,
+        dict: &crate::value::DictMap,
         key: &str,
         callee: &str,
     ) -> Result<String, VmError> {
@@ -601,7 +601,7 @@ pub mod parse {
 
     /// Build a `NetPolicy` value from the `{allow, deny, default,
     /// on_violation}` dict produced by `NetPolicy.create(...)`.
-    pub fn policy_from_dict(dict: &BTreeMap<String, VmValue>) -> Result<NetPolicy, VmError> {
+    pub fn policy_from_dict(dict: &crate::value::DictMap) -> Result<NetPolicy, VmError> {
         let allow = parse_rule_list(dict.get("allow"), "allow")?;
         let deny = parse_rule_list(dict.get("deny"), "deny")?;
         let default = match dict.get("default") {

--- a/crates/harn-vm/src/http/client.rs
+++ b/crates/harn-vm/src/http/client.rs
@@ -1,6 +1,6 @@
 use crate::value::VmDictExt;
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{HashMap, VecDeque};
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -75,13 +75,13 @@ struct HttpProxyConfig {
 #[derive(Clone)]
 pub(super) struct HttpSession {
     pub(super) client: reqwest::Client,
-    options: BTreeMap<String, VmValue>,
+    options: crate::value::DictMap,
 }
 
 pub(super) struct HttpRequestParts {
     pub(super) method: reqwest::Method,
     pub(super) headers: reqwest::header::HeaderMap,
-    recorded_headers: BTreeMap<String, VmValue>,
+    recorded_headers: crate::value::DictMap,
     pub(super) body: Option<String>,
     multipart: Option<MultipartRequest>,
 }
@@ -103,7 +103,7 @@ struct MultipartField {
 struct HttpStreamHandle {
     kind: HttpStreamKind,
     status: i64,
-    headers: BTreeMap<String, VmValue>,
+    headers: crate::value::DictMap,
     pending: VecDeque<u8>,
     closed: bool,
 }
@@ -131,36 +131,30 @@ pub(super) fn clear_http_streams() {
 
 fn build_http_response(
     status: i64,
-    headers: BTreeMap<String, VmValue>,
+    headers: crate::value::DictMap,
     body: String,
     final_url: &str,
 ) -> VmValue {
-    let mut result = BTreeMap::new();
+    let mut result = crate::value::DictMap::new();
     result.insert("status".to_string(), VmValue::Int(status));
-    result.insert(
-        "headers".to_string(),
-        VmValue::Dict(std::sync::Arc::new(headers)),
-    );
+    result.insert("headers".to_string(), VmValue::dict(headers));
     result.put_str("body", body);
     result.put_str("final_url", final_url);
     result.insert(
         "ok".to_string(),
         VmValue::Bool((200..300).contains(&(status as u16))),
     );
-    VmValue::Dict(std::sync::Arc::new(result))
+    VmValue::dict(result)
 }
 
 fn build_http_download_response(
     status: i64,
-    headers: BTreeMap<String, VmValue>,
+    headers: crate::value::DictMap,
     bytes_written: u64,
 ) -> VmValue {
-    let mut result = BTreeMap::new();
+    let mut result = crate::value::DictMap::new();
     result.insert("status".to_string(), VmValue::Int(status));
-    result.insert(
-        "headers".to_string(),
-        VmValue::Dict(std::sync::Arc::new(headers)),
-    );
+    result.insert("headers".to_string(), VmValue::dict(headers));
     result.insert(
         "bytes_written".to_string(),
         VmValue::Int(u64_to_vm_int(bytes_written)),
@@ -169,15 +163,15 @@ fn build_http_download_response(
         "ok".to_string(),
         VmValue::Bool((200..300).contains(&(status as u16))),
     );
-    VmValue::Dict(std::sync::Arc::new(result))
+    VmValue::dict(result)
 }
 
 fn u64_to_vm_int(value: u64) -> i64 {
     value.min(i64::MAX as u64) as i64
 }
 
-fn response_headers(headers: &reqwest::header::HeaderMap) -> BTreeMap<String, VmValue> {
-    let mut resp_headers = BTreeMap::new();
+fn response_headers(headers: &reqwest::header::HeaderMap) -> crate::value::DictMap {
+    let mut resp_headers = crate::value::DictMap::new();
     for (name, value) in headers {
         if let Ok(v) = value.to_str() {
             resp_headers.insert(
@@ -190,9 +184,9 @@ fn response_headers(headers: &reqwest::header::HeaderMap) -> BTreeMap<String, Vm
 }
 
 fn merge_options(
-    base: &BTreeMap<String, VmValue>,
-    overrides: &BTreeMap<String, VmValue>,
-) -> BTreeMap<String, VmValue> {
+    base: &crate::value::DictMap,
+    overrides: &crate::value::DictMap,
+) -> crate::value::DictMap {
     let mut merged = base.clone();
     for (key, value) in overrides {
         merged.insert(key.clone(), value.clone());
@@ -274,7 +268,7 @@ fn parse_multipart_field(value: &VmValue) -> Result<MultipartField, VmError> {
 }
 
 fn parse_multipart_request(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<Option<MultipartRequest>, VmError> {
     let Some(value) = options.get("multipart") else {
         return Ok(None);
@@ -351,12 +345,12 @@ async fn http_verb_handler(
         match (args.get(1), args.get(2)) {
             (Some(VmValue::Dict(d)), None) => (**d).clone(),
             (_, Some(VmValue::Dict(d))) => (**d).clone(),
-            _ => BTreeMap::new(),
+            _ => crate::value::DictMap::new(),
         }
     } else {
         match args.get(1) {
             Some(VmValue::Dict(d)) => (**d).clone(),
-            _ => BTreeMap::new(),
+            _ => crate::value::DictMap::new(),
         }
     };
     if has_body && !(matches!(args.get(1), Some(VmValue::Dict(_))) && args.get(2).is_none()) {
@@ -366,7 +360,7 @@ async fn http_verb_handler(
     vm_execute_http_request(method, &url, &options).await
 }
 
-fn parse_proxy_config(options: &BTreeMap<String, VmValue>) -> Option<HttpProxyConfig> {
+fn parse_proxy_config(options: &crate::value::DictMap) -> Option<HttpProxyConfig> {
     let proxy = options.get("proxy")?;
     let (url, no_proxy) = match proxy {
         VmValue::Dict(dict) => (
@@ -404,7 +398,7 @@ fn parse_proxy_config(options: &BTreeMap<String, VmValue>) -> Option<HttpProxyCo
     })
 }
 
-fn parse_tls_config(options: &BTreeMap<String, VmValue>) -> HttpTlsConfig {
+fn parse_tls_config(options: &crate::value::DictMap) -> HttpTlsConfig {
     let Some(tls) = options.get("tls").and_then(|value| value.as_dict()) else {
         return HttpTlsConfig::default();
     };
@@ -433,7 +427,7 @@ fn parse_tls_config(options: &BTreeMap<String, VmValue>) -> HttpTlsConfig {
     }
 }
 
-fn parse_retry_statuses(options: &BTreeMap<String, VmValue>) -> Vec<u16> {
+fn parse_retry_statuses(options: &crate::value::DictMap) -> Vec<u16> {
     match options.get("retry_on") {
         Some(VmValue::List(values)) => {
             let statuses: Vec<u16> = values
@@ -452,7 +446,7 @@ fn parse_retry_statuses(options: &BTreeMap<String, VmValue>) -> Vec<u16> {
     }
 }
 
-fn parse_retry_methods(options: &BTreeMap<String, VmValue>) -> Vec<String> {
+fn parse_retry_methods(options: &crate::value::DictMap) -> Vec<String> {
     match options.get("retry_methods") {
         Some(VmValue::List(values)) => {
             let methods: Vec<String> = values
@@ -476,7 +470,7 @@ fn parse_retry_methods(options: &BTreeMap<String, VmValue>) -> Vec<String> {
     }
 }
 
-pub(super) fn parse_http_options(options: &BTreeMap<String, VmValue>) -> HttpRequestConfig {
+pub(super) fn parse_http_options(options: &crate::value::DictMap) -> HttpRequestConfig {
     let (ssrf_block_private, ssrf_allow_loopback) = crate::egress::current_ssrf_client_settings();
     let resolved_ip_rules = crate::egress::current_resolved_ip_rules();
     let total_timeout_ms = vm_get_int_option(options, "total_timeout_ms", -1);
@@ -784,14 +778,14 @@ fn verify_tls_pin(response: &reqwest::Response, pins: &[String]) -> Result<(), V
 
 pub(super) fn parse_http_request_parts(
     method: &str,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<HttpRequestParts, VmError> {
     let req_method = method
         .parse::<reqwest::Method>()
         .map_err(|e| vm_error(format!("http: invalid method '{method}': {e}")))?;
 
     let mut header_map = reqwest::header::HeaderMap::new();
-    let mut recorded_headers = BTreeMap::new();
+    let mut recorded_headers = crate::value::DictMap::new();
 
     if let Some(auth_val) = options.get("auth") {
         match auth_val {
@@ -871,7 +865,7 @@ pub(super) fn parse_http_request_parts(
 
 fn final_http_url(
     url: &str,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     builtin: &str,
 ) -> Result<String, VmError> {
     let Some(query) = options.get("query").and_then(VmValue::as_dict) else {
@@ -890,7 +884,7 @@ fn final_http_url(
     Ok(parsed.to_string())
 }
 
-pub(super) fn session_from_options(options: &BTreeMap<String, VmValue>) -> Option<String> {
+pub(super) fn session_from_options(options: &crate::value::DictMap) -> Option<String> {
     options
         .get("session")
         .and_then(|value| handle_from_value(value, "http_request").ok())
@@ -958,7 +952,7 @@ fn parse_retry_after_header(value: &reqwest::header::HeaderValue) -> Option<Dura
     value.to_str().ok().and_then(parse_retry_after_value)
 }
 
-fn mock_retry_after(status: u16, headers: &BTreeMap<String, VmValue>) -> Option<Duration> {
+fn mock_retry_after(status: u16, headers: &crate::value::DictMap) -> Option<Duration> {
     if !(status == 429 || status == 503) {
         return None;
     }
@@ -1041,7 +1035,7 @@ pub(super) fn compute_retry_delay(
 pub(super) async fn vm_execute_http_request(
     method: &str,
     url: &str,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     if let Some(session_id) = session_from_options(options) {
         return vm_execute_http_session_request(&session_id, method, url, options).await;
@@ -1056,7 +1050,7 @@ pub(super) async fn vm_execute_http_session_request(
     session_id: &str,
     method: &str,
     url: &str,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     let session = HTTP_SESSIONS.with(|sessions| sessions.borrow().get(session_id).cloned());
     let Some(session) = session else {
@@ -1074,7 +1068,7 @@ async fn vm_execute_http_request_with_client(
     config: &HttpRequestConfig,
     method: &str,
     url: &str,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     let parts = parse_http_request_parts(method, options)?;
     let final_url = final_http_url(url, options, "http")?;
@@ -1176,7 +1170,7 @@ async fn vm_execute_http_request_with_client(
 pub(super) async fn vm_http_download(
     url: &str,
     dst_path: &str,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     let method = options
         .get("method")
@@ -1429,7 +1423,7 @@ fn finalize_http_download_temp(
 
 pub(super) async fn vm_http_stream_open(
     url: &str,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     let method = options
         .get("method")
@@ -1579,17 +1573,14 @@ pub(super) fn vm_http_stream_info(stream_id: &str) -> Result<VmValue, VmError> {
         let handle = streams
             .get(stream_id)
             .ok_or_else(|| vm_error(format!("http_stream_info: unknown stream '{stream_id}'")))?;
-        let mut dict = BTreeMap::new();
+        let mut dict = crate::value::DictMap::new();
         dict.insert("status".to_string(), VmValue::Int(handle.status));
-        dict.insert(
-            "headers".to_string(),
-            VmValue::Dict(std::sync::Arc::new(handle.headers.clone())),
-        );
+        dict.insert("headers".to_string(), VmValue::dict(handle.headers.clone()));
         dict.insert(
             "ok".to_string(),
             VmValue::Bool((200..300).contains(&(handle.status as u16))),
         );
-        Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+        Ok(VmValue::dict(dict))
     })
 }
 
@@ -1631,7 +1622,7 @@ pub(super) fn register_http_client_builtins(vm: &mut Vm) {
         }
         let options = match args.get(2) {
             Some(VmValue::Dict(d)) => (**d).clone(),
-            _ => BTreeMap::new(),
+            _ => crate::value::DictMap::new(),
         };
         vm_execute_http_request(&method, &url, &options).await
     });
@@ -1739,15 +1730,15 @@ pub(super) fn register_http_client_builtins(vm: &mut Vm) {
 mod tests {
     use super::*;
 
-    fn proxy_options(password: &str) -> BTreeMap<String, VmValue> {
-        BTreeMap::from([
+    fn proxy_options(password: &str) -> crate::value::DictMap {
+        crate::value::DictMap::from_iter([
             (
                 "proxy".to_string(),
                 VmValue::String(std::sync::Arc::from("http://proxy.local:8080")),
             ),
             (
                 "proxy_auth".to_string(),
-                VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+                VmValue::dict(crate::value::DictMap::from_iter([
                     (
                         "user".to_string(),
                         VmValue::String(std::sync::Arc::from("alice")),
@@ -1756,7 +1747,7 @@ mod tests {
                         "pass".to_string(),
                         VmValue::String(std::sync::Arc::from(password)),
                     ),
-                ]))),
+                ])),
             ),
         ])
     }
@@ -1781,7 +1772,7 @@ mod tests {
 
     #[test]
     fn download_response_saturates_large_byte_count() {
-        let response = build_http_download_response(200, BTreeMap::new(), u64::MAX);
+        let response = build_http_download_response(200, crate::value::DictMap::new(), u64::MAX);
         let response = response.as_dict().expect("response dict");
         assert_eq!(response["bytes_written"].as_int(), Some(i64::MAX));
     }

--- a/crates/harn-vm/src/http/mock.rs
+++ b/crates/harn-vm/src/http/mock.rs
@@ -8,7 +8,7 @@ use crate::value::VmValue;
 pub(super) struct MockResponse {
     pub(super) status: i64,
     pub(super) body: String,
-    pub(super) headers: BTreeMap<String, VmValue>,
+    pub(super) headers: crate::value::DictMap,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -58,7 +58,7 @@ struct HttpMock {
 struct HttpMockCall {
     method: String,
     url: String,
-    headers: BTreeMap<String, VmValue>,
+    headers: crate::value::DictMap,
     body: Option<String>,
 }
 
@@ -150,10 +150,7 @@ pub(super) fn http_mock_calls_value(redact_sensitive: bool) -> Vec<VmValue> {
                 dict.put_str("url", redact_mock_call_url(&call.url, redact_sensitive));
                 dict.insert(
                     "headers".to_string(),
-                    VmValue::Dict(std::sync::Arc::new(mock_call_headers_value(
-                        &call.headers,
-                        redact_sensitive,
-                    ))),
+                    VmValue::dict(mock_call_headers_value(&call.headers, redact_sensitive)),
                 );
                 dict.insert(
                     "body".to_string(),
@@ -162,13 +159,13 @@ pub(super) fn http_mock_calls_value(redact_sensitive: bool) -> Vec<VmValue> {
                         None => VmValue::Nil,
                     },
                 );
-                VmValue::Dict(std::sync::Arc::new(dict))
+                VmValue::dict(dict)
             })
             .collect()
     })
 }
 
-pub(super) fn parse_mock_responses(response: &BTreeMap<String, VmValue>) -> Vec<MockResponse> {
+pub(super) fn parse_mock_responses(response: &crate::value::DictMap) -> Vec<MockResponse> {
     let scripted = response
         .get("responses")
         .and_then(|value| match value {
@@ -189,7 +186,7 @@ pub(super) fn parse_mock_responses(response: &BTreeMap<String, VmValue>) -> Vec<
     }
 }
 
-fn parse_mock_response_dict(response: &BTreeMap<String, VmValue>) -> MockResponse {
+fn parse_mock_response_dict(response: &crate::value::DictMap) -> MockResponse {
     let status = response
         .get("status")
         .and_then(|v| v.as_int())
@@ -213,7 +210,7 @@ fn parse_mock_response_dict(response: &BTreeMap<String, VmValue>) -> MockRespons
 pub(super) fn consume_http_mock(
     method: &str,
     url: &str,
-    headers: BTreeMap<String, VmValue>,
+    headers: crate::value::DictMap,
     body: Option<String>,
 ) -> Option<MockResponse> {
     let response = HTTP_MOCKS.with(|mocks| {
@@ -291,9 +288,9 @@ pub(super) fn redact_mock_call_url(url: &str, redact: bool) -> String {
 }
 
 pub(super) fn mock_call_headers_value(
-    headers: &BTreeMap<String, VmValue>,
+    headers: &crate::value::DictMap,
     redact_headers: bool,
-) -> BTreeMap<String, VmValue> {
+) -> crate::value::DictMap {
     if !redact_headers {
         return headers.clone();
     }

--- a/crates/harn-vm/src/http/mod.rs
+++ b/crates/harn-vm/src/http/mod.rs
@@ -1,6 +1,6 @@
 use crate::value::VmDictExt;
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::value::{VmClosure, VmError, VmValue};
@@ -27,7 +27,7 @@ pub use mock::{http_mock_calls_snapshot, push_http_mock, HttpMockCallSnapshot, H
 pub(crate) async fn execute_http_request(
     method: &str,
     url: &str,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     client::vm_execute_http_request(method, url, options).await
 }
@@ -115,18 +115,18 @@ pub(super) fn handle_from_value(value: &VmValue, builtin: &str) -> Result<String
     }
 }
 
-pub(super) fn get_options_arg(args: &[VmValue], index: usize) -> BTreeMap<String, VmValue> {
+pub(super) fn get_options_arg(args: &[VmValue], index: usize) -> crate::value::DictMap {
     args.get(index)
         .and_then(|value| value.as_dict())
         .cloned()
         .unwrap_or_default()
 }
 
-fn dict_value(entries: BTreeMap<String, VmValue>) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(entries))
+fn dict_value(entries: crate::value::DictMap) -> VmValue {
+    VmValue::dict(entries)
 }
 
-fn get_bool_option(options: &BTreeMap<String, VmValue>, key: &str, default: bool) -> bool {
+fn get_bool_option(options: &crate::value::DictMap, key: &str, default: bool) -> bool {
     match options.get(key) {
         Some(VmValue::Bool(value)) => *value,
         _ => default,
@@ -134,7 +134,7 @@ fn get_bool_option(options: &BTreeMap<String, VmValue>, key: &str, default: bool
 }
 
 fn get_usize_option(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     key: &str,
     default: usize,
 ) -> Result<usize, VmError> {
@@ -146,7 +146,7 @@ fn get_usize_option(
 }
 
 fn get_optional_usize_option(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     key: &str,
 ) -> Result<Option<usize>, VmError> {
     match options.get(key).and_then(VmValue::as_int) {
@@ -178,13 +178,13 @@ fn closure_arg(args: &[VmValue], index: usize, builtin: &str) -> Result<Arc<VmCl
 }
 
 fn http_server_handle_value(id: &str) -> VmValue {
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.insert("id".to_string(), VmValue::string(id));
     dict.insert("kind".to_string(), VmValue::string("http_server"));
     dict_value(dict)
 }
 
-fn header_lookup_value(headers: &BTreeMap<String, VmValue>, name: &str) -> VmValue {
+fn header_lookup_value(headers: &crate::value::DictMap, name: &str) -> VmValue {
     headers
         .iter()
         .find(|(candidate, _)| candidate.eq_ignore_ascii_case(name))
@@ -192,7 +192,7 @@ fn header_lookup_value(headers: &BTreeMap<String, VmValue>, name: &str) -> VmVal
         .unwrap_or(VmValue::Nil)
 }
 
-fn headers_from_value(value: &VmValue) -> BTreeMap<String, VmValue> {
+fn headers_from_value(value: &VmValue) -> crate::value::DictMap {
     match value {
         VmValue::Dict(dict) => dict
             .get("headers")
@@ -212,17 +212,17 @@ fn headers_from_value(value: &VmValue) -> BTreeMap<String, VmValue> {
                     })
                     .collect()
             }),
-        _ => BTreeMap::new(),
+        _ => crate::value::DictMap::new(),
     }
 }
 
-fn normalize_headers(value: Option<&VmValue>) -> BTreeMap<String, VmValue> {
+fn normalize_headers(value: Option<&VmValue>) -> crate::value::DictMap {
     match value.and_then(VmValue::as_dict) {
         Some(headers) => headers
             .iter()
             .map(|(key, value)| (key.to_ascii_lowercase(), VmValue::string(value.display())))
             .collect(),
-        None => BTreeMap::new(),
+        None => crate::value::DictMap::new(),
     }
 }
 
@@ -258,9 +258,9 @@ fn hex_val(byte: u8) -> Option<u8> {
     }
 }
 
-fn split_path_and_query(raw_path: &str) -> (String, BTreeMap<String, VmValue>) {
+fn split_path_and_query(raw_path: &str) -> (String, crate::value::DictMap) {
     let (path, query) = raw_path.split_once('?').unwrap_or((raw_path, ""));
-    let mut query_map = BTreeMap::new();
+    let mut query_map = crate::value::DictMap::new();
     for pair in query.split('&').filter(|part| !part.is_empty()) {
         let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
         query_map.insert(percent_decode(key), VmValue::string(percent_decode(value)));
@@ -271,7 +271,7 @@ fn split_path_and_query(raw_path: &str) -> (String, BTreeMap<String, VmValue>) {
     )
 }
 
-fn request_body_bytes(input: &BTreeMap<String, VmValue>) -> Vec<u8> {
+fn request_body_bytes(input: &crate::value::DictMap) -> Vec<u8> {
     match input.get("raw_body").or_else(|| input.get("body")) {
         Some(VmValue::Bytes(bytes)) => bytes.as_ref().clone(),
         Some(value) => value.display().into_bytes(),
@@ -282,9 +282,9 @@ fn request_body_bytes(input: &BTreeMap<String, VmValue>) -> Vec<u8> {
 fn request_value(
     method: &str,
     path: &str,
-    path_params: BTreeMap<String, VmValue>,
-    mut query: BTreeMap<String, VmValue>,
-    input: &BTreeMap<String, VmValue>,
+    path_params: crate::value::DictMap,
+    mut query: crate::value::DictMap,
+    input: &crate::value::DictMap,
     body_bytes: &[u8],
     retain_raw_body: bool,
 ) -> VmValue {
@@ -298,7 +298,7 @@ fn request_value(
 
     let headers = normalize_headers(input.get("headers"));
     let body = String::from_utf8_lossy(body_bytes).into_owned();
-    let mut request = BTreeMap::new();
+    let mut request = crate::value::DictMap::new();
     request.insert("method".to_string(), VmValue::string(method));
     request.insert("path".to_string(), VmValue::string(path));
     let path_params = dict_value(path_params);
@@ -349,12 +349,12 @@ fn normalize_status(status: i64) -> i64 {
 
 fn response_with_kind(
     status: i64,
-    mut headers: BTreeMap<String, VmValue>,
+    mut headers: crate::value::DictMap,
     body: VmValue,
     body_kind: &str,
 ) -> VmValue {
     let status = normalize_status(status);
-    let mut response = BTreeMap::new();
+    let mut response = crate::value::DictMap::new();
     if body_kind == "json" && matches!(header_lookup_value(&headers, "content-type"), VmValue::Nil)
     {
         headers.insert(
@@ -417,13 +417,13 @@ fn normalize_response(value: VmValue) -> VmValue {
                 .unwrap_or(VmValue::Nil);
             response_with_kind(status, headers, body, &body_kind)
         }
-        VmValue::Nil => response_with_kind(204, BTreeMap::new(), VmValue::Nil, "text"),
-        other => response_with_kind(200, BTreeMap::new(), other, "text"),
+        VmValue::Nil => response_with_kind(204, crate::value::DictMap::new(), VmValue::Nil, "text"),
+        other => response_with_kind(200, crate::value::DictMap::new(), other, "text"),
     }
 }
 
 fn body_limit_response(limit: usize, actual: usize) -> VmValue {
-    let mut headers = BTreeMap::new();
+    let mut headers = crate::value::DictMap::new();
     headers.insert(
         "content-type".to_string(),
         VmValue::string("text/plain; charset=utf-8"),
@@ -444,26 +444,31 @@ fn body_limit_response(limit: usize, actual: usize) -> VmValue {
 fn not_found_response(method: &str, path: &str) -> VmValue {
     response_with_kind(
         404,
-        BTreeMap::new(),
+        crate::value::DictMap::new(),
         VmValue::string(format!("no route for {method} {path}")),
         "text",
     )
 }
 
 fn unavailable_response(message: &str) -> VmValue {
-    response_with_kind(503, BTreeMap::new(), VmValue::string(message), "text")
+    response_with_kind(
+        503,
+        crate::value::DictMap::new(),
+        VmValue::string(message),
+        "text",
+    )
 }
 
-fn route_template_match(template: &str, path: &str) -> Option<BTreeMap<String, VmValue>> {
+fn route_template_match(template: &str, path: &str) -> Option<crate::value::DictMap> {
     let template_segments: Vec<&str> = template.trim_matches('/').split('/').collect();
     let path_segments: Vec<&str> = path.trim_matches('/').split('/').collect();
     if template == "/" && path == "/" {
-        return Some(BTreeMap::new());
+        return Some(crate::value::DictMap::new());
     }
     if template_segments.len() != path_segments.len() {
         return None;
     }
-    let mut params = BTreeMap::new();
+    let mut params = crate::value::DictMap::new();
     for (tmpl, actual) in template_segments.iter().zip(path_segments.iter()) {
         if tmpl.starts_with('{') && tmpl.ends_with('}') && tmpl.len() > 2 {
             params.insert(
@@ -486,7 +491,7 @@ fn matching_route(
     server: &HttpServer,
     method: &str,
     path: &str,
-) -> Option<(HttpServerRoute, BTreeMap<String, VmValue>)> {
+) -> Option<(HttpServerRoute, crate::value::DictMap)> {
     server.routes.iter().find_map(|route| {
         if route.method != "*" && !route.method.eq_ignore_ascii_case(method) {
             return None;
@@ -623,7 +628,7 @@ fn register_http_tls_builtins(vm: &mut Vm) {
             false,
             "http",
             false,
-            BTreeMap::new(),
+            crate::value::DictMap::new(),
         ))
     });
     vm.register_builtin("http_server_tls_edge", |args, _out| {
@@ -654,7 +659,7 @@ fn register_http_tls_builtins(vm: &mut Vm) {
                 "http_server_tls_pem: private key not found: {key_path}"
             )));
         }
-        let mut extra = BTreeMap::new();
+        let mut extra = crate::value::DictMap::new();
         extra.put_str("cert_path", cert_path);
         extra.put_str("key_path", key_path);
         Ok(http_server_tls_config_value(
@@ -668,7 +673,7 @@ fn register_http_tls_builtins(vm: &mut Vm) {
                 "http_server_tls_self_signed_dev: failed to generate certificate: {error}"
             ))
         })?;
-        let mut extra = BTreeMap::new();
+        let mut extra = crate::value::DictMap::new();
         extra.insert(
             "hosts".to_string(),
             VmValue::List(std::sync::Arc::new(
@@ -694,9 +699,7 @@ fn register_http_tls_builtins(vm: &mut Vm) {
                 "http_server_security_headers: requires a TLS config dict",
             ));
         };
-        Ok(VmValue::Dict(std::sync::Arc::new(
-            http_server_security_headers(config),
-        )))
+        Ok(VmValue::dict(http_server_security_headers(config)))
     });
 }
 
@@ -1066,9 +1069,9 @@ fn http_server_tls_config_value(
     terminate_tls: bool,
     scheme: &str,
     hsts: bool,
-    extra: BTreeMap<String, VmValue>,
+    extra: crate::value::DictMap,
 ) -> VmValue {
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.put_str("mode", mode);
     dict.insert("terminate_tls".to_string(), VmValue::Bool(terminate_tls));
     dict.put_str("scheme", scheme);
@@ -1076,11 +1079,11 @@ fn http_server_tls_config_value(
     for (key, value) in extra {
         dict.insert(key, value);
     }
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
-fn hsts_options(options: &BTreeMap<String, VmValue>) -> BTreeMap<String, VmValue> {
-    let mut hsts = BTreeMap::new();
+fn hsts_options(options: &crate::value::DictMap) -> crate::value::DictMap {
+    let mut hsts = crate::value::DictMap::new();
     hsts.insert(
         "hsts_max_age_seconds".to_string(),
         VmValue::Int(vm_get_int_option(
@@ -1104,10 +1107,10 @@ fn hsts_options(options: &BTreeMap<String, VmValue>) -> BTreeMap<String, VmValue
     hsts
 }
 
-fn http_server_security_headers(config: &BTreeMap<String, VmValue>) -> BTreeMap<String, VmValue> {
+fn http_server_security_headers(config: &crate::value::DictMap) -> crate::value::DictMap {
     let hsts_enabled = vm_get_bool_option(config, "hsts", false);
     if !hsts_enabled {
-        return BTreeMap::new();
+        return crate::value::DictMap::new();
     }
     let mut value = format!(
         "max-age={}",
@@ -1119,7 +1122,7 @@ fn http_server_security_headers(config: &BTreeMap<String, VmValue>) -> BTreeMap<
     if vm_get_bool_option(config, "hsts_preload", false) {
         value.push_str("; preload");
     }
-    BTreeMap::from([(
+    crate::value::DictMap::from_iter([(
         "strict-transport-security".to_string(),
         VmValue::String(std::sync::Arc::from(value)),
     )])
@@ -1158,16 +1161,12 @@ fn tls_hosts_arg(value: Option<&VmValue>) -> Result<Vec<String>, VmError> {
     }
 }
 
-pub(super) fn vm_get_int_option(
-    options: &BTreeMap<String, VmValue>,
-    key: &str,
-    default: i64,
-) -> i64 {
+pub(super) fn vm_get_int_option(options: &crate::value::DictMap, key: &str, default: i64) -> i64 {
     options.get(key).and_then(|v| v.as_int()).unwrap_or(default)
 }
 
 pub(super) fn vm_get_bool_option(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     key: &str,
     default: bool,
 ) -> bool {
@@ -1178,7 +1177,7 @@ pub(super) fn vm_get_bool_option(
 }
 
 pub(super) fn vm_get_int_option_prefer(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     canonical: &str,
     alias: &str,
     default: i64,
@@ -1191,7 +1190,7 @@ pub(super) fn vm_get_int_option_prefer(
 }
 
 pub(super) fn vm_get_optional_int_option(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     key: &str,
 ) -> Option<u64> {
     options
@@ -1200,7 +1199,7 @@ pub(super) fn vm_get_optional_int_option(
         .map(|value| value.max(0) as u64)
 }
 
-pub(super) fn string_option(options: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+pub(super) fn string_option(options: &crate::value::DictMap, key: &str) -> Option<String> {
     options
         .get(key)
         .map(|value| value.display())

--- a/crates/harn-vm/src/http/streaming.rs
+++ b/crates/harn-vm/src/http/streaming.rs
@@ -1,4 +1,4 @@
-use crate::value::VmDictExt;
+use crate::value::{DictRetain, VmDictExt};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::net::TcpStream;
@@ -60,7 +60,7 @@ struct FakeSseStream {
 
 pub(super) struct SseServerHandle {
     status: i64,
-    headers: BTreeMap<String, VmValue>,
+    headers: crate::value::DictMap,
     frames: VecDeque<String>,
     max_event_bytes: usize,
     max_buffered_events: usize,
@@ -196,7 +196,7 @@ fn close_websocket_servers() {
     });
 }
 
-fn transport_limit_option(options: &BTreeMap<String, VmValue>, key: &str, default: usize) -> usize {
+fn transport_limit_option(options: &crate::value::DictMap, key: &str, default: usize) -> usize {
     options
         .get(key)
         .and_then(|value| value.as_int())
@@ -218,20 +218,20 @@ fn receive_timeout_arg(args: &[VmValue], index: usize) -> u64 {
 fn timeout_event() -> VmValue {
     let mut dict = BTreeMap::new();
     dict.put_str("type", "timeout");
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn closed_event() -> VmValue {
     let mut dict = BTreeMap::new();
     dict.put_str("type", "close");
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn sse_server_closed_event() -> VmValue {
     let mut dict = BTreeMap::new();
     dict.put_str("type", "close");
     dict.insert("server_closed".to_string(), VmValue::Bool(true));
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn record_transport_call(call: TransportMockCall) {
@@ -300,7 +300,7 @@ fn sse_event_value(event: &MockStreamEvent) -> VmValue {
         "retry_ms".to_string(),
         event.retry_ms.map(VmValue::Int).unwrap_or(VmValue::Nil),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn sse_server_response_value(id: &str, handle: &SseServerHandle) -> VmValue {
@@ -308,10 +308,7 @@ fn sse_server_response_value(id: &str, handle: &SseServerHandle) -> VmValue {
     dict.put_str("id", id);
     dict.put_str("type", "sse_response");
     dict.insert("status".to_string(), VmValue::Int(handle.status));
-    dict.insert(
-        "headers".to_string(),
-        VmValue::Dict(std::sync::Arc::new(handle.headers.clone())),
-    );
+    dict.insert("headers".to_string(), VmValue::dict(handle.headers.clone()));
     dict.insert("body".to_string(), VmValue::Nil);
     dict.insert("streaming".to_string(), VmValue::Bool(true));
     dict.insert(
@@ -322,11 +319,11 @@ fn sse_server_response_value(id: &str, handle: &SseServerHandle) -> VmValue {
         "max_buffered_events".to_string(),
         VmValue::Int(handle.max_buffered_events as i64),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
-fn default_sse_response_headers() -> BTreeMap<String, VmValue> {
-    BTreeMap::from([
+fn default_sse_response_headers() -> crate::value::DictMap {
+    crate::value::DictMap::from_iter([
         (
             "content-type".to_string(),
             VmValue::String(std::sync::Arc::from("text/event-stream; charset=utf-8")),
@@ -346,7 +343,7 @@ fn default_sse_response_headers() -> BTreeMap<String, VmValue> {
     ])
 }
 
-fn sse_response_headers(options: &BTreeMap<String, VmValue>) -> BTreeMap<String, VmValue> {
+fn sse_response_headers(options: &crate::value::DictMap) -> crate::value::DictMap {
     let mut headers = default_sse_response_headers();
     if let Some(VmValue::Dict(custom)) = options.get("headers") {
         for (name, value) in custom.iter() {
@@ -392,7 +389,7 @@ fn push_sse_multiline_field(frame: &mut String, field: &str, value: &str) {
 
 pub(super) fn vm_sse_event_frame(
     event: &VmValue,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<String, VmError> {
     let mut frame = String::new();
     let mut has_event_payload = false;
@@ -504,9 +501,7 @@ fn push_sse_comment(frame: &mut String, comment: &str) {
     }
 }
 
-pub(super) fn vm_sse_server_response(
-    options: &BTreeMap<String, VmValue>,
-) -> Result<VmValue, VmError> {
+pub(super) fn vm_sse_server_response(options: &crate::value::DictMap) -> Result<VmValue, VmError> {
     let id = next_transport_handle("sse-server");
     let status = options
         .get("status")
@@ -554,10 +549,7 @@ fn sse_server_status_value(id: &str, handle: &SseServerHandle) -> VmValue {
     let mut dict = BTreeMap::new();
     dict.put_str("id", id);
     dict.insert("status".to_string(), VmValue::Int(handle.status));
-    dict.insert(
-        "headers".to_string(),
-        VmValue::Dict(std::sync::Arc::new(handle.headers.clone())),
-    );
+    dict.insert("headers".to_string(), VmValue::dict(handle.headers.clone()));
     dict.insert(
         "buffered_events".to_string(),
         VmValue::Int(handle.frames.len() as i64),
@@ -592,7 +584,7 @@ fn sse_server_status_value(id: &str, handle: &SseServerHandle) -> VmValue {
         "max_buffered_events".to_string(),
         VmValue::Int(handle.max_buffered_events as i64),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 pub(super) fn vm_sse_server_status(stream_id: &str) -> Result<VmValue, VmError> {
@@ -608,7 +600,7 @@ pub(super) fn vm_sse_server_status(stream_id: &str) -> Result<VmValue, VmError> 
 pub(super) fn vm_sse_server_send(
     stream_id: &str,
     event: &VmValue,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     let frame = vm_sse_event_frame(event, options)?;
     SSE_SERVER_HANDLES.with(|handles| {
@@ -811,12 +803,12 @@ fn sse_server_mock_frame_value(frame: &str) -> VmValue {
         let mut dict = BTreeMap::new();
         dict.put_str("type", "comment");
         dict.put_str("comment", comments.join("\n"));
-        VmValue::Dict(std::sync::Arc::new(dict))
+        VmValue::dict(dict)
     };
     if let VmValue::Dict(dict) = &mut value {
         let mut owned = (**dict).clone();
         owned.put_str("raw", frame);
-        value = VmValue::Dict(std::sync::Arc::new(owned));
+        value = VmValue::dict(owned);
     }
     value
 }
@@ -826,7 +818,7 @@ fn real_sse_event_value(event: SseEvent) -> VmValue {
         SseEvent::Open => {
             let mut dict = BTreeMap::new();
             dict.put_str("type", "open");
-            VmValue::Dict(std::sync::Arc::new(dict))
+            VmValue::dict(dict)
         }
         SseEvent::Message(message) => {
             let retry_ms = message.retry.map(|retry| retry.as_millis() as i64);
@@ -883,13 +875,13 @@ fn transport_mock_call_value(call: &TransportMockCall) -> VmValue {
             .map(|data| VmValue::String(std::sync::Arc::from(data)))
             .unwrap_or(VmValue::Nil),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 pub(super) async fn vm_sse_connect(
     method: &str,
     url: &str,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     let id = next_transport_handle("sse");
     let max_events =
@@ -1010,7 +1002,7 @@ pub(super) async fn vm_sse_receive(stream_id: &str, timeout_ms: u64) -> Result<V
                 stream.opened = true;
                 let mut dict = BTreeMap::new();
                 dict.put_str("type", "open");
-                return Ok(VmValue::Dict(std::sync::Arc::new(dict)));
+                return Ok(VmValue::dict(dict));
             }
             let Some(event) = stream.events.pop_front() else {
                 stream.closed = true;

--- a/crates/harn-vm/src/http/streaming/websocket.rs
+++ b/crates/harn-vm/src/http/streaming/websocket.rs
@@ -140,7 +140,7 @@ fn closed_event_with(code: Option<u16>, reason: Option<String>) -> VmValue {
     if let Some(reason) = reason {
         dict.put_str("reason", reason);
     }
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn ws_event_value(message: MockWsMessage) -> VmValue {
@@ -163,7 +163,7 @@ fn ws_event_value(message: MockWsMessage) -> VmValue {
             );
         }
     }
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn real_ws_event_value(message: WsMessage) -> VmValue {
@@ -202,7 +202,7 @@ fn real_ws_event_value(message: WsMessage) -> VmValue {
     }
 }
 
-fn websocket_route_from_options(path: &str, options: &BTreeMap<String, VmValue>) -> WebSocketRoute {
+fn websocket_route_from_options(path: &str, options: &crate::value::DictMap) -> WebSocketRoute {
     let bearer_token = options.get("auth").and_then(|auth| match auth {
         VmValue::Dict(dict) => dict.get("bearer").map(|value| value.display()),
         other => {
@@ -233,7 +233,7 @@ fn websocket_route_from_options(path: &str, options: &BTreeMap<String, VmValue>)
 
 pub(super) fn vm_websocket_server(
     bind: &str,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     let listener = TcpListener::bind(bind)
         .map_err(|error| vm_error(format!("websocket_server: bind failed: {error}")))?;
@@ -292,13 +292,13 @@ pub(super) fn vm_websocket_server(
     dict.put_str("id", id);
     dict.put_str("addr", addr);
     dict.put_str("url", url);
-    Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+    Ok(VmValue::dict(dict))
 }
 
 pub(super) fn vm_websocket_route(
     server_id: &str,
     path: &str,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     let routes = WEBSOCKET_SERVERS.with(|servers| {
         servers
@@ -387,14 +387,14 @@ fn register_accepted_websocket(event: WebSocketServerEvent) -> Result<VmValue, V
     metadata.put_str("peer", peer);
     metadata.insert(
         "headers".to_string(),
-        VmValue::Dict(std::sync::Arc::new(
+        VmValue::dict(
             headers
                 .into_iter()
                 .map(|(name, value)| (name, VmValue::String(std::sync::Arc::from(value))))
-                .collect(),
-        )),
+                .collect::<crate::value::DictMap>(),
+        ),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(metadata)))
+    Ok(VmValue::dict(metadata))
 }
 
 pub(super) fn vm_websocket_server_close(server_id: &str) -> Result<VmValue, VmError> {
@@ -606,7 +606,7 @@ fn websocket_connection_thread(
 
 pub(super) async fn vm_websocket_connect(
     url: &str,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     let id = next_transport_handle("websocket");
     let max_messages =
@@ -690,7 +690,7 @@ pub(super) async fn vm_websocket_connect(
 /// Permanent failures (DNS, refused, TLS, protocol) bypass the retry.
 async fn connect_with_retry(
     url: &str,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     timeout_ms: u64,
 ) -> Result<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
@@ -747,7 +747,7 @@ fn is_transient_connect_error(message: &str) -> bool {
 
 fn websocket_message_from_vm(
     value: VmValue,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<MockWsMessage, VmError> {
     let message_type = options
         .get("type")
@@ -792,7 +792,7 @@ fn websocket_message_from_vm(
 
 fn websocket_client_request(
     url: &str,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<tokio_tungstenite::tungstenite::http::Request<()>, VmError> {
     let mut request = url
         .into_client_request()
@@ -909,7 +909,7 @@ fn mock_ws_message_from_real(message: WsMessage) -> MockWsMessage {
 pub(super) async fn vm_websocket_send(
     socket_id: &str,
     value: VmValue,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     let message = websocket_message_from_vm(value, options)?;
     let socket = WEBSOCKET_HANDLES.with(|handles| {

--- a/crates/harn-vm/src/http/tests.rs
+++ b/crates/harn-vm/src/http/tests.rs
@@ -18,7 +18,6 @@ use rcgen::generate_simple_self_signed;
 use rustls::pki_types::PrivatePkcs8KeyDer;
 use rustls::{ServerConfig, ServerConnection, StreamOwned};
 use sha2::{Digest, Sha256};
-use std::collections::BTreeMap;
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::sync::{Arc, Once};
@@ -73,7 +72,7 @@ async fn typed_mock_api_drives_http_request_retries() {
     let result = vm_execute_http_request(
         "GET",
         "https://api.example.com/retry",
-        &BTreeMap::from([
+        &crate::value::DictMap::from_iter([
             ("retries".to_string(), VmValue::Int(1)),
             ("backoff".to_string(), VmValue::Int(0)),
         ]),
@@ -97,10 +96,10 @@ async fn http_mock_records_normalized_headers_and_final_query_url() {
         "https://api.example.com/items?api_key=secret&limit=2",
         vec![HttpMockResponse::new(200, "ok")],
     );
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         (
             "headers".to_string(),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            VmValue::dict(crate::value::DictMap::from_iter([
                 (
                     "Authorization".to_string(),
                     VmValue::String(std::sync::Arc::from("Bearer secret")),
@@ -109,17 +108,17 @@ async fn http_mock_records_normalized_headers_and_final_query_url() {
                     "X-Trace".to_string(),
                     VmValue::String(std::sync::Arc::from("trace-1")),
                 ),
-            ]))),
+            ])),
         ),
         (
             "query".to_string(),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            VmValue::dict(crate::value::DictMap::from_iter([
                 (
                     "api_key".to_string(),
                     VmValue::String(std::sync::Arc::from("secret")),
                 ),
                 ("limit".to_string(), VmValue::Int(2)),
-            ]))),
+            ])),
         ),
     ]);
 
@@ -148,7 +147,7 @@ async fn http_mock_records_normalized_headers_and_final_query_url() {
 
 #[test]
 fn mock_call_headers_redact_sensitive_values() {
-    let headers = BTreeMap::from([
+    let headers = crate::value::DictMap::from_iter([
         (
             "authorization".to_string(),
             VmValue::String(std::sync::Arc::from("Bearer secret")),
@@ -198,10 +197,10 @@ async fn multipart_requests_are_mock_visible() {
         "https://api.example.com/upload",
         vec![HttpMockResponse::new(201, "uploaded")],
     );
-    let options = BTreeMap::from([(
+    let options = crate::value::DictMap::from_iter([(
         "multipart".to_string(),
         VmValue::List(std::sync::Arc::new(vec![
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            VmValue::dict(crate::value::DictMap::from_iter([
                 (
                     "name".to_string(),
                     VmValue::String(std::sync::Arc::from("meta")),
@@ -210,8 +209,8 @@ async fn multipart_requests_are_mock_visible() {
                     "value".to_string(),
                     VmValue::String(std::sync::Arc::from("hello")),
                 ),
-            ]))),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            ])),
+            VmValue::dict(crate::value::DictMap::from_iter([
                 (
                     "name".to_string(),
                     VmValue::String(std::sync::Arc::from("blob")),
@@ -228,7 +227,7 @@ async fn multipart_requests_are_mock_visible() {
                     "value".to_string(),
                     VmValue::Bytes(std::sync::Arc::new(vec![0, 1, 2, 3])),
                 ),
-            ]))),
+            ])),
         ])),
     )]);
 
@@ -261,9 +260,12 @@ async fn http_stream_mock_reads_in_chunks() {
         vec![HttpMockResponse::new(200, "stream-body")],
     );
 
-    let handle = vm_http_stream_open("https://api.example.com/stream", &BTreeMap::new())
-        .await
-        .expect("stream open");
+    let handle = vm_http_stream_open(
+        "https://api.example.com/stream",
+        &crate::value::DictMap::new(),
+    )
+    .await
+    .expect("stream open");
     let stream_id = handle.display();
     let info = vm_http_stream_info(&stream_id).expect("stream info");
     let info = info.as_dict().expect("info dict");
@@ -298,7 +300,7 @@ async fn http_download_mock_writes_file() {
     let response = vm_http_download(
         "https://api.example.com/download",
         &path.display().to_string(),
-        &BTreeMap::new(),
+        &crate::value::DictMap::new(),
     )
     .await
     .expect("download response");
@@ -328,12 +330,12 @@ async fn http_download_mock_retries_retryable_status() {
     let response = vm_http_download(
         "https://api.example.com/download-retry",
         &path.display().to_string(),
-        &BTreeMap::from([(
+        &crate::value::DictMap::from_iter([(
             "retry".to_string(),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            VmValue::dict(crate::value::DictMap::from_iter([
                 ("max".to_string(), VmValue::Int(1)),
                 ("backoff_ms".to_string(), VmValue::Int(0)),
-            ]))),
+            ])),
         )]),
     )
     .await
@@ -363,7 +365,7 @@ async fn http_download_mock_enforces_max_response_bytes() {
     let error = vm_http_download(
         "https://api.example.com/download-too-large",
         &path.display().to_string(),
-        &BTreeMap::from([("max_response_bytes".to_string(), VmValue::Int(3))]),
+        &crate::value::DictMap::from_iter([("max_response_bytes".to_string(), VmValue::Int(3))]),
     )
     .await
     .expect_err("oversized mock body should fail");
@@ -402,7 +404,7 @@ async fn http_download_oversize_stream_preserves_existing_file() {
     let error = vm_http_download(
         &format!("http://127.0.0.1:{port}/oversize"),
         &path.display().to_string(),
-        &BTreeMap::from([("max_response_bytes".to_string(), VmValue::Int(1))]),
+        &crate::value::DictMap::from_iter([("max_response_bytes".to_string(), VmValue::Int(1))]),
     )
     .await
     .expect_err("oversized stream should fail");
@@ -436,14 +438,14 @@ async fn http_proxy_routes_requests_through_configured_proxy() {
         })
         .await;
 
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         (
             "proxy".to_string(),
             VmValue::String(std::sync::Arc::from(proxy.base_url().to_string())),
         ),
         (
             "proxy_auth".to_string(),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            VmValue::dict(crate::value::DictMap::from_iter([
                 (
                     "user".to_string(),
                     VmValue::String(std::sync::Arc::from("user")),
@@ -452,7 +454,7 @@ async fn http_proxy_routes_requests_through_configured_proxy() {
                     "pass".to_string(),
                     VmValue::String(std::sync::Arc::from("pass")),
                 ),
-            ]))),
+            ])),
         ),
         ("timeout_ms".to_string(), VmValue::Int(1_000)),
     ]);
@@ -504,9 +506,9 @@ async fn custom_tls_ca_bundle_and_pin_allow_request() {
         );
     });
 
-    let options = BTreeMap::from([(
+    let options = crate::value::DictMap::from_iter([(
         "tls".to_string(),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "ca_bundle_path".to_string(),
                 VmValue::String(std::sync::Arc::from(cert_path.display().to_string())),
@@ -517,7 +519,7 @@ async fn custom_tls_ca_bundle_and_pin_allow_request() {
                     std::sync::Arc::from(pin),
                 )])),
             ),
-        ]))),
+        ])),
     )]);
     let response =
         vm_execute_http_request("GET", &format!("https://localhost:{port}/secure"), &options)
@@ -564,9 +566,9 @@ async fn custom_tls_pin_mismatch_is_rejected() {
         );
     });
 
-    let options = BTreeMap::from([(
+    let options = crate::value::DictMap::from_iter([(
         "tls".to_string(),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "ca_bundle_path".to_string(),
                 VmValue::String(std::sync::Arc::from(cert_path.display().to_string())),
@@ -577,7 +579,7 @@ async fn custom_tls_pin_mismatch_is_rejected() {
                     std::sync::Arc::from("deadbeef"),
                 )])),
             ),
-        ]))),
+        ])),
     )]);
     let error =
         vm_execute_http_request("GET", &format!("https://localhost:{port}/secure"), &options)
@@ -642,7 +644,7 @@ fn write_http_response_generic<T: Write>(
 #[test]
 fn formats_sse_event_fields_and_multiline_data() {
     let frame = vm_sse_event_frame(
-        &VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        &VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "event".to_string(),
                 VmValue::String(std::sync::Arc::from("progress")),
@@ -656,8 +658,8 @@ fn formats_sse_event_fields_and_multiline_data() {
                 VmValue::String(std::sync::Arc::from("evt-1")),
             ),
             ("retry_ms".to_string(), VmValue::Int(2500)),
-        ]))),
-        &BTreeMap::new(),
+        ])),
+        &crate::value::DictMap::new(),
     )
     .expect("event frame");
     assert_eq!(
@@ -669,11 +671,11 @@ fn formats_sse_event_fields_and_multiline_data() {
 #[test]
 fn rejects_sse_event_control_fields_with_newlines() {
     let err = vm_sse_event_frame(
-        &VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        &VmValue::dict(crate::value::DictMap::from_iter([(
             "event".to_string(),
             VmValue::String(std::sync::Arc::from("bad\nname")),
-        )]))),
-        &BTreeMap::new(),
+        )])),
+        &crate::value::DictMap::new(),
     )
     .expect_err("newline should reject");
     assert!(err.to_string().contains("event must not contain newlines"));
@@ -682,7 +684,7 @@ fn rejects_sse_event_control_fields_with_newlines() {
 #[test]
 fn server_sse_mock_client_observes_heartbeat_disconnect_and_cancel() {
     reset_http_state();
-    let response = vm_sse_server_response(&BTreeMap::from([(
+    let response = vm_sse_server_response(&crate::value::DictMap::from_iter([(
         "max_buffered_events".to_string(),
         VmValue::Int(4),
     )]))
@@ -692,7 +694,7 @@ fn server_sse_mock_client_observes_heartbeat_disconnect_and_cancel() {
     assert!(expect_bool(
         vm_sse_server_send(
             &stream_id,
-            &VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            &VmValue::dict(crate::value::DictMap::from_iter([
                 (
                     "event".to_string(),
                     VmValue::String(std::sync::Arc::from("progress")),
@@ -701,8 +703,8 @@ fn server_sse_mock_client_observes_heartbeat_disconnect_and_cancel() {
                     "data".to_string(),
                     VmValue::String(std::sync::Arc::from("50"))
                 ),
-            ]))),
-            &BTreeMap::new(),
+            ])),
+            &crate::value::DictMap::new(),
         )
         .expect("send")
     ));
@@ -734,12 +736,13 @@ fn server_sse_mock_client_observes_heartbeat_disconnect_and_cancel() {
         vm_sse_server_send(
             &stream_id,
             &VmValue::String(std::sync::Arc::from("late")),
-            &BTreeMap::new()
+            &crate::value::DictMap::new()
         )
         .expect("late send")
     ));
 
-    let cancelled = vm_sse_server_response(&BTreeMap::new()).expect("cancelled response");
+    let cancelled =
+        vm_sse_server_response(&crate::value::DictMap::new()).expect("cancelled response");
     let cancelled_id = handle_from_value(&cancelled, "test").expect("cancelled handle");
     assert!(expect_bool(
         vm_sse_server_cancel(
@@ -758,7 +761,7 @@ fn server_sse_mock_client_observes_heartbeat_disconnect_and_cancel() {
 #[test]
 fn server_sse_rejects_oversized_events() {
     reset_http_state();
-    let response = vm_sse_server_response(&BTreeMap::from([(
+    let response = vm_sse_server_response(&crate::value::DictMap::from_iter([(
         "max_event_bytes".to_string(),
         VmValue::Int(12),
     )]))
@@ -767,7 +770,7 @@ fn server_sse_rejects_oversized_events() {
     let err = vm_sse_server_send(
         &stream_id,
         &VmValue::String(std::sync::Arc::from("this is too large")),
-        &BTreeMap::new(),
+        &crate::value::DictMap::new(),
     )
     .expect_err("oversized event should reject");
     assert!(err.to_string().contains("max_event_bytes"));
@@ -804,9 +807,10 @@ async fn ssrf_guard_default_on_blocks_loopback() {
     let _scope = crate::egress::require_ssrf_guard_for_host();
 
     // No server needed: the request must be blocked before any connection.
-    let error = vm_execute_http_request("GET", "http://127.0.0.1:9/x", &BTreeMap::new())
-        .await
-        .expect_err("default-on blocks loopback");
+    let error =
+        vm_execute_http_request("GET", "http://127.0.0.1:9/x", &crate::value::DictMap::new())
+            .await
+            .expect_err("default-on blocks loopback");
     let msg = error.to_string();
     assert!(msg.contains("EgressBlocked"), "{msg}");
     assert!(msg.contains("disallowed address"), "{msg}");
@@ -835,7 +839,7 @@ async fn ssrf_guard_allow_loopback_hatch_permits_capture_server() {
     let response = vm_execute_http_request(
         "GET",
         &format!("http://127.0.0.1:{port}/ok"),
-        &BTreeMap::new(),
+        &crate::value::DictMap::new(),
     )
     .await
     .expect("hatch permits loopback");
@@ -865,7 +869,7 @@ async fn ssrf_guard_block_private_off_permits_capture_server() {
     let response = vm_execute_http_request(
         "GET",
         &format!("http://127.0.0.1:{port}/ok"),
-        &BTreeMap::new(),
+        &crate::value::DictMap::new(),
     )
     .await
     .expect("block_private:off permits loopback");

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -475,7 +475,6 @@ mod reset_leak_tests {
     //! the registry is empty again.
     use super::*;
     use crate::value::VmValue;
-    use std::collections::BTreeMap;
 
     #[test]
     fn reset_drains_agent_inbox() {
@@ -511,7 +510,7 @@ mod reset_leak_tests {
     #[test]
     fn reset_drains_routing_policy_registry() {
         llm::routing::clear_policy_registry();
-        let mut config: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut config: crate::value::DictMap = crate::value::DictMap::new();
         config.insert(
             "chain".to_string(),
             VmValue::List(std::sync::Arc::new(vec![VmValue::String(

--- a/crates/harn-vm/src/llm/agent_config.rs
+++ b/crates/harn-vm/src/llm/agent_config.rs
@@ -32,12 +32,12 @@ pub(crate) fn agent_feedback_message(kind: &str, content: &str) -> VmValue {
     if kind == PREFILL_ASSISTANT_FEEDBACK_KIND {
         msg.put_str("role", "assistant");
         msg.put_str("content", content);
-        return VmValue::Dict(std::sync::Arc::new(msg));
+        return VmValue::dict(msg);
     }
     let body = format!("<runtime_feedback kind=\"{kind}\">\n{content}\n</runtime_feedback>");
     msg.put_str("role", "user");
     msg.put_str("content", body);
-    VmValue::Dict(std::sync::Arc::new(msg))
+    VmValue::dict(msg)
 }
 
 fn system_prompt_transcript_metadata(system: Option<&String>) -> Option<serde_json::Value> {

--- a/crates/harn-vm/src/llm/agent_host_primitives.rs
+++ b/crates/harn-vm/src/llm/agent_host_primitives.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -89,13 +88,13 @@ async fn host_agent_capture_events_impl(
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
-    let mut envelope = std::collections::BTreeMap::new();
+    let mut envelope = crate::value::DictMap::new();
     envelope.insert("result".to_string(), result);
     envelope.insert(
         "events".to_string(),
         json_to_vm_value(&serde_json::Value::Array(events)),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(envelope)))
+    Ok(VmValue::dict(envelope))
 }
 
 fn agent_primitive_tools_arg(
@@ -130,12 +129,12 @@ fn agent_primitive_tools_value_arg(
 fn agent_primitive_options_value_arg(
     value: Option<VmValue>,
     label: &str,
-) -> Result<std::collections::BTreeMap<String, VmValue>, VmError> {
+) -> Result<crate::value::DictMap, VmError> {
     match value {
         Some(VmValue::Dict(options)) => {
             Ok(Arc::try_unwrap(options).unwrap_or_else(|options| options.as_ref().clone()))
         }
-        Some(VmValue::Nil) | None => Ok(std::collections::BTreeMap::new()),
+        Some(VmValue::Nil) | None => Ok(crate::value::DictMap::new()),
         Some(other) => Err(VmError::Runtime(format!(
             "{label}: options must be a dict or nil; got {}",
             other.type_name()
@@ -143,20 +142,14 @@ fn agent_primitive_options_value_arg(
     }
 }
 
-fn agent_primitive_option_str(
-    options: &std::collections::BTreeMap<String, VmValue>,
-    key: &str,
-) -> Option<String> {
+fn agent_primitive_option_str(options: &crate::value::DictMap, key: &str) -> Option<String> {
     match options.get(key)? {
         VmValue::Nil => None,
         value => Some(value.display()),
     }
 }
 
-fn agent_primitive_option_int(
-    options: &std::collections::BTreeMap<String, VmValue>,
-    key: &str,
-) -> Option<i64> {
+fn agent_primitive_option_int(options: &crate::value::DictMap, key: &str) -> Option<i64> {
     options.get(key)?.as_int()
 }
 
@@ -521,7 +514,7 @@ async fn host_agent_parse_tool_calls_impl(
     })))
 }
 
-fn agent_primitive_max_concurrent_tools(options: &BTreeMap<String, VmValue>) -> usize {
+fn agent_primitive_max_concurrent_tools(options: &crate::value::DictMap) -> usize {
     agent_primitive_option_int(options, "_max_concurrent_tools")
         .or_else(|| agent_primitive_option_int(options, "max_concurrent_tools"))
         .unwrap_or(1)
@@ -533,7 +526,7 @@ async fn host_agent_dispatch_tool_call_indexed<'a>(
     index: usize,
     call: VmValue,
     tools: Option<&'a VmValue>,
-    options: &'a BTreeMap<String, VmValue>,
+    options: &'a crate::value::DictMap,
 ) -> (usize, Result<VmValue, VmError>) {
     (
         index,
@@ -545,7 +538,7 @@ async fn host_agent_dispatch_tool_batch_capped(
     ctx: crate::vm::AsyncBuiltinCtx,
     calls: Vec<VmValue>,
     tools: Option<&VmValue>,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     cap: usize,
 ) -> Result<Vec<VmValue>, VmError> {
     let total = calls.len();
@@ -826,7 +819,7 @@ async fn host_agent_dispatch_tool_call(
     ctx: crate::vm::AsyncBuiltinCtx,
     call: VmValue,
     tools: Option<&VmValue>,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     let call = match call {
         VmValue::Dict(call) => call,
@@ -1299,7 +1292,8 @@ async fn host_agent_dispatch_tool_call(
     // Session-scoped MCP clients (from opts.mcp_servers) bypass the bridge.
     let session_mcp = {
         use std::collections::BTreeMap;
-        let mut clients: BTreeMap<String, crate::mcp::VmMcpClientHandle> = BTreeMap::new();
+        let mut clients: BTreeMap<String, crate::mcp::VmMcpClientHandle> =
+            std::collections::BTreeMap::new();
         if let Some(server_name) = agent_tools::mcp_server_for_tool(tools, &tool_name) {
             if let Some(handle) = agent_runtime::session_mcp_client(&session_id, &server_name) {
                 clients.insert(server_name, handle);
@@ -1641,7 +1635,8 @@ async fn host_mcp_bootstrap_impl(
         }
     };
 
-    let mut clients: BTreeMap<String, crate::mcp::VmMcpClientHandle> = BTreeMap::new();
+    let mut clients: BTreeMap<String, crate::mcp::VmMcpClientHandle> =
+        std::collections::BTreeMap::new();
     let mut tools_added: Vec<serde_json::Value> = Vec::new();
     let mut server_infos: Vec<serde_json::Value> = Vec::new();
     let mut errors: Vec<serde_json::Value> = Vec::new();
@@ -1830,7 +1825,7 @@ async fn host_agent_reminder_providers_fire_impl(
 mod security_gate_tests {
     use super::{tool_descriptor_for, trifecta_gate_reason, upgrade_to_trifecta_ask};
     use crate::value::VmValue;
-    use std::collections::BTreeMap;
+
     use std::sync::Arc;
 
     fn allow_decision() -> crate::orchestration::PolicyEvaluation {
@@ -1966,18 +1961,18 @@ mod security_gate_tests {
 
     #[test]
     fn tool_descriptor_extracts_description_and_schema_changed() {
-        let mut tool = BTreeMap::new();
+        let mut tool = crate::value::DictMap::new();
         tool.insert("name".to_string(), vm_str("linear__create"));
         tool.insert("description".to_string(), vm_str("Create an issue"));
         tool.insert("_mcp_server".to_string(), vm_str("linear"));
         tool.insert("_schema_changed".to_string(), VmValue::Bool(true));
         let catalog = {
-            let mut dict = BTreeMap::new();
+            let mut dict = crate::value::DictMap::new();
             dict.insert(
                 "tools".to_string(),
-                VmValue::List(Arc::new(vec![VmValue::Dict(Arc::new(tool))])),
+                VmValue::List(Arc::new(vec![VmValue::dict(tool)])),
             );
-            VmValue::Dict(Arc::new(dict))
+            VmValue::dict(dict)
         };
 
         let descriptor = tool_descriptor_for(Some(&catalog), "linear__create").expect("descriptor");

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -1587,12 +1587,12 @@ mod retry_tests {
         // (mirrors the `tools` registry the request used).
         fn run_tool_registry() -> VmValue {
             let dict = |pairs: &[(&str, VmValue)]| -> VmValue {
-                VmValue::Dict(std::sync::Arc::new(
+                VmValue::dict(
                     pairs
                         .iter()
                         .map(|(k, v)| ((*k).to_string(), v.clone()))
-                        .collect(),
-                ))
+                        .collect::<crate::value::DictMap>(),
+                )
             };
             let s = |v: &str| VmValue::String(std::sync::Arc::from(v));
             let run_tool = dict(&[
@@ -1871,32 +1871,28 @@ mod retry_tests {
 
     #[test]
     fn llm_error_kind_dict_gates_retry() {
-        let transient = VmError::Thrown(VmValue::Dict(std::sync::Arc::new(
-            std::collections::BTreeMap::from([
-                (
-                    "kind".to_string(),
-                    VmValue::String(std::sync::Arc::from("transient")),
-                ),
-                (
-                    "reason".to_string(),
-                    VmValue::String(std::sync::Arc::from("network_error")),
-                ),
-            ]),
-        )));
+        let transient = VmError::Thrown(VmValue::dict(std::collections::BTreeMap::from([
+            (
+                "kind".to_string(),
+                VmValue::String(std::sync::Arc::from("transient")),
+            ),
+            (
+                "reason".to_string(),
+                VmValue::String(std::sync::Arc::from("network_error")),
+            ),
+        ])));
         assert!(is_retryable_llm_error(&transient));
 
-        let terminal = VmError::Thrown(VmValue::Dict(std::sync::Arc::new(
-            std::collections::BTreeMap::from([
-                (
-                    "kind".to_string(),
-                    VmValue::String(std::sync::Arc::from("terminal")),
-                ),
-                (
-                    "reason".to_string(),
-                    VmValue::String(std::sync::Arc::from("context_overflow")),
-                ),
-            ]),
-        )));
+        let terminal = VmError::Thrown(VmValue::dict(std::collections::BTreeMap::from([
+            (
+                "kind".to_string(),
+                VmValue::String(std::sync::Arc::from("terminal")),
+            ),
+            (
+                "reason".to_string(),
+                VmValue::String(std::sync::Arc::from("context_overflow")),
+            ),
+        ])));
         assert!(!is_retryable_llm_error(&terminal));
     }
 

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -122,7 +122,7 @@ impl Drop for SessionPolicyGuard {
 
 thread_local! {
     static AGENT_HOST_SESSIONS: RefCell<BTreeMap<String, AgentHostSession>> =
-        const { RefCell::new(BTreeMap::new()) };
+        const { RefCell::new(std::collections::BTreeMap::new()) };
 }
 
 pub(crate) fn reset_agent_session_host_state() {
@@ -161,10 +161,10 @@ pub(crate) fn session_taint_snapshot(session_id: &str) -> Vec<crate::security::T
     .unwrap_or_default()
 }
 
-fn opts_dict(value: Option<&VmValue>) -> BTreeMap<String, VmValue> {
+fn opts_dict(value: Option<&VmValue>) -> crate::value::DictMap {
     match value {
         Some(VmValue::Dict(d)) => (**d).clone(),
-        _ => BTreeMap::new(),
+        _ => crate::value::DictMap::new(),
     }
 }
 
@@ -190,14 +190,14 @@ fn dict_get<'a>(value: &'a VmValue, key: &str) -> Option<&'a VmValue> {
     }
 }
 
-fn opt_str(map: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn opt_str(map: &crate::value::DictMap, key: &str) -> Option<String> {
     map.get(key).and_then(|v| match v {
         VmValue::String(s) => Some(s.to_string()),
         _ => None,
     })
 }
 
-fn opt_int(map: &BTreeMap<String, VmValue>, key: &str) -> Option<i64> {
+fn opt_int(map: &crate::value::DictMap, key: &str) -> Option<i64> {
     map.get(key).and_then(|v| match v {
         VmValue::Int(i) => Some(*i),
         VmValue::Float(f) => Some(*f as i64),
@@ -205,14 +205,14 @@ fn opt_int(map: &BTreeMap<String, VmValue>, key: &str) -> Option<i64> {
     })
 }
 
-fn opt_json(map: &BTreeMap<String, VmValue>, key: &str) -> Option<serde_json::Value> {
+fn opt_json(map: &crate::value::DictMap, key: &str) -> Option<serde_json::Value> {
     map.get(key)
         .filter(|value| !matches!(value, VmValue::Nil))
         .map(vm_to_json)
 }
 
 fn initial_user_content(
-    opts_map: &BTreeMap<String, VmValue>,
+    opts_map: &crate::value::DictMap,
     fallback_message: &str,
 ) -> serde_json::Value {
     opt_json(opts_map, "initial_user_content")
@@ -363,7 +363,7 @@ async fn host_agent_session_init(
         daemon_state: None,
         daemon_snapshot_path: None,
         resumed_iterations,
-        daemon_watch_state: BTreeMap::new(),
+        daemon_watch_state: std::collections::BTreeMap::new(),
         daemon_idle_backoff_ms: 100,
         host_bridge,
         last_llm_stop_reason: None,
@@ -406,7 +406,7 @@ async fn host_agent_session_init(
     )
     .await?;
 
-    let mut control = BTreeMap::new();
+    let mut control = crate::value::DictMap::new();
     control.put_str("session_id", resolved);
     control.put_str("task", message);
     control.insert(
@@ -421,7 +421,7 @@ async fn host_agent_session_init(
         VmValue::Int(max_verify_attempts),
     );
     control.insert("done".to_string(), VmValue::Bool(false));
-    Ok(VmValue::Dict(std::sync::Arc::new(control)))
+    Ok(VmValue::dict(control))
 }
 
 enum AutonomyCheck {
@@ -431,7 +431,7 @@ enum AutonomyCheck {
 }
 
 async fn check_autonomy_budget(
-    opts_map: &BTreeMap<String, VmValue>,
+    opts_map: &crate::value::DictMap,
     session_id: &str,
 ) -> Result<AutonomyCheck, VmError> {
     let Some(config) =
@@ -523,7 +523,7 @@ fn agent_init_control_done(
     system: Option<&str>,
     result: VmValue,
 ) -> VmValue {
-    let mut control = BTreeMap::new();
+    let mut control = crate::value::DictMap::new();
     control.put_str("session_id", session_id);
     control.put_str("task", task);
     control.insert(
@@ -536,7 +536,7 @@ fn agent_init_control_done(
     control.insert("max_verify_attempts".to_string(), VmValue::Int(0));
     control.insert("done".to_string(), VmValue::Bool(true));
     control.insert("result".to_string(), result);
-    VmValue::Dict(std::sync::Arc::new(control))
+    VmValue::dict(control)
 }
 
 /// Tear down a Harn-driven agent session and emit the final result dict.
@@ -906,10 +906,10 @@ fn assistant_message_from_llm_result(llm_result: &VmValue) -> VmValue {
         .map(vm_to_json)
         .collect::<Vec<_>>();
     if native_calls_json.is_empty() {
-        let mut msg = BTreeMap::new();
+        let mut msg = crate::value::DictMap::new();
         msg.put_str("role", "assistant");
         msg.put_str("content", text);
-        return VmValue::Dict(std::sync::Arc::new(msg));
+        return VmValue::dict(msg);
     }
 
     let thinking = dict_get(llm_result, "thinking").map(|v| v.display());
@@ -993,7 +993,7 @@ fn tool_result_message_for_provider(
     tool_call_id: &str,
     observation: &str,
 ) -> VmValue {
-    let mut msg = BTreeMap::new();
+    let mut msg = crate::value::DictMap::new();
     // A text-channel tool_format (`text` or `json`) carries tool results back
     // as an ordinary `user` message — there is no provider tool-result role on
     // the text channel. `native` uses the provider's tool_result/tool role.
@@ -1014,7 +1014,7 @@ fn tool_result_message_for_provider(
         }
     }
     msg.put_str("content", observation);
-    VmValue::Dict(std::sync::Arc::new(msg))
+    VmValue::dict(msg)
 }
 
 /// Recover the plan artifact from a dispatched emit_plan/update_plan result.
@@ -1286,10 +1286,10 @@ fn host_agent_session_record_usage_builtin(
         ),
     )
     .map_err(VmError::Runtime)?;
-    let mut out = BTreeMap::new();
+    let mut out = crate::value::DictMap::new();
     out.insert("tokens_used".to_string(), VmValue::Int(totals.0));
     out.insert("cost_usd".to_string(), VmValue::Float(totals.1));
-    Ok(VmValue::Dict(std::sync::Arc::new(out)))
+    Ok(VmValue::dict(out))
 }
 
 /// Deterministic "should the loop auto-continue this truncated turn?" gate.
@@ -1348,13 +1348,13 @@ fn host_agent_session_drain_feedback_builtin(
     let drained = crate::orchestration::agent_inbox::drain(&session_id)
         .into_iter()
         .map(|entry| {
-            let mut item = BTreeMap::new();
+            let mut item = crate::value::DictMap::new();
             item.put_str("kind", entry.kind);
             item.put_str("content", entry.content);
             item.put_str("source", entry.source);
             item.insert("sequence".to_string(), VmValue::Int(entry.sequence as i64));
             item.insert("ts_ms".to_string(), VmValue::Int(entry.ts_ms));
-            VmValue::Dict(std::sync::Arc::new(item))
+            VmValue::dict(item)
         })
         .collect::<Vec<_>>();
     Ok(VmValue::List(std::sync::Arc::new(drained)))
@@ -1374,10 +1374,10 @@ fn host_agent_session_totals_builtin(
     let totals = with_session(&session_id, HOST_SESSION_TOTALS, |session| {
         Ok((session.tokens_used, session.cost_used))
     })?;
-    let mut out = BTreeMap::new();
+    let mut out = crate::value::DictMap::new();
     out.insert("tokens_used".to_string(), VmValue::Int(totals.0));
     out.insert("cost_usd".to_string(), VmValue::Float(totals.1));
-    Ok(VmValue::Dict(std::sync::Arc::new(out)))
+    Ok(VmValue::dict(out))
 }
 
 /// Append a runtime-feedback note to the session as a synthetic user turn.
@@ -1511,9 +1511,9 @@ fn host_agent_session_active_skills_builtin(
     let list = ids
         .into_iter()
         .map(|id| {
-            let mut entry = BTreeMap::new();
+            let mut entry = crate::value::DictMap::new();
             entry.put_str("id", id);
-            VmValue::Dict(std::sync::Arc::new(entry))
+            VmValue::dict(entry)
         })
         .collect();
     Ok(VmValue::List(std::sync::Arc::new(list)))
@@ -2997,21 +2997,21 @@ async fn host_autonomy_budget_check(
         .map(|value| value.display())
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| format!("agent_session_{}", now_id()));
-    let mut opts = BTreeMap::new();
+    let mut opts = crate::value::DictMap::new();
     if let Some(config) = args.get(1) {
         opts.insert("autonomy_budget".to_string(), config.clone());
     }
     match check_autonomy_budget(&opts, &session_id).await? {
         AutonomyCheck::Denied(result) => {
-            let mut out = BTreeMap::new();
+            let mut out = crate::value::DictMap::new();
             out.insert("approved".to_string(), VmValue::Bool(false));
             out.insert("denial_result".to_string(), result);
-            Ok(VmValue::Dict(std::sync::Arc::new(out)))
+            Ok(VmValue::dict(out))
         }
         AutonomyCheck::Approved(_) | AutonomyCheck::NoBudget => {
-            let mut out = BTreeMap::new();
+            let mut out = crate::value::DictMap::new();
             out.insert("approved".to_string(), VmValue::Bool(true));
-            Ok(VmValue::Dict(std::sync::Arc::new(out)))
+            Ok(VmValue::dict(out))
         }
     }
 }
@@ -3027,7 +3027,7 @@ async fn host_autonomy_budget_check(
 /// returning, so the caller never has to worry about leaked policy
 /// state.
 pub(crate) fn install_session_policy_guard(
-    opts_map: &BTreeMap<String, VmValue>,
+    opts_map: &crate::value::DictMap,
 ) -> Result<SessionPolicyGuard, VmError> {
     let mut installed = InstalledPolicies::default();
     match install_session_policies_inner(opts_map, &mut installed) {
@@ -3040,7 +3040,7 @@ pub(crate) fn install_session_policy_guard(
 }
 
 fn install_session_policies_inner(
-    opts_map: &BTreeMap<String, VmValue>,
+    opts_map: &crate::value::DictMap,
     installed: &mut InstalledPolicies,
 ) -> Result<(), VmError> {
     if let Some(requested) = parse_capability_policy(opts_map.get("policy"))? {
@@ -3111,7 +3111,7 @@ fn parse_capability_policy(value: Option<&VmValue>) -> Result<Option<CapabilityP
 /// can pass `_nested_kind` and `_nested_label` to refine the audit and
 /// error wording; we default to `agent_loop` + the session id.
 fn install_session_nested_budget(
-    opts_map: &BTreeMap<String, VmValue>,
+    opts_map: &crate::value::DictMap,
     session_id: &str,
 ) -> Result<NestedExecutionGuard, VmError> {
     let requested = parse_capability_policy(opts_map.get("policy"))?;

--- a/crates/harn-vm/src/llm/agent_session_host_tests.rs
+++ b/crates/harn-vm/src/llm/agent_session_host_tests.rs
@@ -6,7 +6,6 @@ use super::{
     last_assistant_text, text_has_tool_call_prefix, tool_result_message_for_provider,
     truncated_tool_call_should_continue, vm_to_json,
 };
-use std::collections::BTreeMap;
 
 #[test]
 fn model_less_turn_is_flagged_as_no_llm_call() {
@@ -53,7 +52,7 @@ fn native_tool_calls_replay_with_openai_wire_shape() {
 
 #[test]
 fn initial_user_content_preserves_multimodal_blocks() {
-    let mut opts = BTreeMap::new();
+    let mut opts = crate::value::DictMap::new();
     opts.insert(
         "initial_user_content".to_string(),
         crate::stdlib::json_to_vm_value(&json!([
@@ -75,7 +74,7 @@ fn initial_user_content_preserves_multimodal_blocks() {
 
 #[test]
 fn initial_user_content_falls_back_to_text_message() {
-    let opts = BTreeMap::new();
+    let opts = crate::value::DictMap::new();
 
     assert_eq!(
         initial_user_content(&opts, "hello"),
@@ -353,7 +352,6 @@ mod nested_budget_tests {
         push_execution_policy, CapabilityPolicy,
     };
     use crate::value::{VmDictExt, VmError, VmValue};
-    use std::collections::BTreeMap;
 
     use super::super::{build_nested_budget_denial, install_session_nested_budget};
     use super::vm_to_json;
@@ -375,7 +373,7 @@ mod nested_budget_tests {
         };
         push_execution_policy(parent);
 
-        let opts_map = BTreeMap::new();
+        let opts_map = crate::value::DictMap::new();
         let session_id = empty_session_id();
         let error = install_session_nested_budget(&opts_map, &session_id).unwrap_err();
         match error {
@@ -397,7 +395,7 @@ mod nested_budget_tests {
             ..Default::default()
         });
 
-        let opts_map = BTreeMap::new();
+        let opts_map = crate::value::DictMap::new();
         let guard = install_session_nested_budget(&opts_map, "child").unwrap();
         assert_eq!(guard.parent_limit, Some(3));
         assert_eq!(guard.child_limit, Some(2));
@@ -414,7 +412,7 @@ mod nested_budget_tests {
             ..Default::default()
         });
 
-        let mut opts_map = BTreeMap::new();
+        let mut opts_map = crate::value::DictMap::new();
         opts_map.put_str("_nested_kind", "sub_agent_run");
         opts_map.put_str("_nested_label", "research-worker");
         let error = install_session_nested_budget(&opts_map, "ignored").unwrap_err();
@@ -442,7 +440,7 @@ mod nested_budget_tests {
             ..Default::default()
         });
 
-        let mut opts_map = BTreeMap::new();
+        let mut opts_map = crate::value::DictMap::new();
         opts_map.insert(
             "policy".to_string(),
             policy_value(&CapabilityPolicy {

--- a/crates/harn-vm/src/llm/agent_tools.rs
+++ b/crates/harn-vm/src/llm/agent_tools.rs
@@ -499,7 +499,7 @@ pub(super) fn mcp_server_for_tool(tools_val: Option<&VmValue>, tool_name: &str) 
         _ => return None,
     };
     for tool in tools_list.iter() {
-        let entry: &std::collections::BTreeMap<String, VmValue> = match tool {
+        let entry: &crate::value::DictMap = match tool {
             VmValue::Dict(d) => d,
             _ => continue,
         };
@@ -548,7 +548,7 @@ pub(super) fn declared_executor_for_tool(
         _ => return None,
     };
     for tool in tools_list.iter() {
-        let entry: &std::collections::BTreeMap<String, VmValue> = match tool {
+        let entry: &crate::value::DictMap = match tool {
             VmValue::Dict(d) => d,
             _ => continue,
         };
@@ -577,7 +577,7 @@ fn declared_mcp_server_for_tool(tools_val: Option<&VmValue>, tool_name: &str) ->
         _ => return None,
     };
     for tool in tools_list.iter() {
-        let entry: &std::collections::BTreeMap<String, VmValue> = match tool {
+        let entry: &crate::value::DictMap = match tool {
             VmValue::Dict(d) => d,
             _ => continue,
         };
@@ -599,7 +599,7 @@ fn declared_mcp_tool_name_for_tool(tools_val: Option<&VmValue>, tool_name: &str)
         _ => return None,
     };
     for tool in tools_list.iter() {
-        let entry: &std::collections::BTreeMap<String, VmValue> = match tool {
+        let entry: &crate::value::DictMap = match tool {
             VmValue::Dict(d) => d,
             _ => continue,
         };
@@ -625,7 +625,7 @@ pub(super) fn find_tool_handler(
         _ => return None,
     };
     for tool in tools_list.iter() {
-        let entry: &std::collections::BTreeMap<String, VmValue> = match tool {
+        let entry: &crate::value::DictMap = match tool {
             VmValue::Dict(d) => d,
             _ => continue,
         };
@@ -652,7 +652,7 @@ mod tests {
 
     use super::*;
     use crate::value::VmDictExt;
-    use std::collections::BTreeMap;
+
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
     use tokio::sync::Mutex;
@@ -768,22 +768,22 @@ mod tests {
         assert_eq!(extract_missing_params("Tool call is missing a name."), None);
     }
 
-    fn tools_dict(entries: Vec<(&str, BTreeMap<String, VmValue>)>) -> VmValue {
+    fn tools_dict(entries: Vec<(&str, crate::value::DictMap)>) -> VmValue {
         let list: Vec<VmValue> = entries
             .into_iter()
             .map(|(name, mut entry)| {
                 entry
                     .entry("name".to_string())
                     .or_insert_with(|| VmValue::String(std::sync::Arc::from(name.to_string())));
-                VmValue::Dict(std::sync::Arc::new(entry))
+                VmValue::dict(entry)
             })
             .collect();
-        let mut dict = BTreeMap::new();
+        let mut dict = crate::value::DictMap::new();
         dict.insert(
             "tools".to_string(),
             VmValue::List(std::sync::Arc::new(list)),
         );
-        VmValue::Dict(std::sync::Arc::new(dict))
+        VmValue::dict(dict)
     }
 
     #[test]
@@ -873,7 +873,7 @@ mod tests {
         // mcp_list_tools tags every entry with `_mcp_server`. The
         // helper picks that up so the dispatch site can tag the
         // executor as `McpServer { server_name }`.
-        let mut entry = BTreeMap::new();
+        let mut entry = crate::value::DictMap::new();
         entry.put_str("_mcp_server", "linear");
         let tools = tools_dict(vec![("create_issue", entry)]);
         assert_eq!(
@@ -886,23 +886,20 @@ mod tests {
     fn mcp_server_for_tool_finds_nested_function_annotation() {
         // OpenAI-shape tools nest `_mcp_server` inside a `function`
         // sub-dict; the search must drill down a level.
-        let mut function = BTreeMap::new();
+        let mut function = crate::value::DictMap::new();
         function.put_str("name", "create_issue");
         function.put_str("_mcp_server", "linear");
-        let mut entry = BTreeMap::new();
-        entry.insert(
-            "function".to_string(),
-            VmValue::Dict(std::sync::Arc::new(function)),
-        );
+        let mut entry = crate::value::DictMap::new();
+        entry.insert("function".to_string(), VmValue::dict(function));
         // The outer entry has no `name` — fall back to function.name.
-        let mut dict = BTreeMap::new();
+        let mut dict = crate::value::DictMap::new();
         dict.insert(
             "tools".to_string(),
             VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
                 std::sync::Arc::new(entry),
             )])),
         );
-        let tools = VmValue::Dict(std::sync::Arc::new(dict));
+        let tools = VmValue::dict(dict);
         assert_eq!(
             mcp_server_for_tool(Some(&tools), "create_issue"),
             Some("linear".to_string())
@@ -911,7 +908,7 @@ mod tests {
 
     #[test]
     fn mcp_server_for_tool_returns_none_for_plain_tool() {
-        let tools = tools_dict(vec![("read", BTreeMap::new())]);
+        let tools = tools_dict(vec![("read", crate::value::DictMap::new())]);
         assert!(mcp_server_for_tool(Some(&tools), "read").is_none());
         assert!(mcp_server_for_tool(Some(&tools), "missing").is_none());
         assert!(mcp_server_for_tool(None, "read").is_none());
@@ -965,7 +962,7 @@ mod tests {
             1,
         );
         let bridge = Arc::new(bridge);
-        let mut entry = BTreeMap::new();
+        let mut entry = crate::value::DictMap::new();
         entry.put_str("_mcp_server", "linear");
         let tools = tools_dict(vec![("create_issue", entry)]);
         let args = serde_json::json!({});
@@ -1003,7 +1000,7 @@ mod tests {
             1,
         );
         let bridge = Arc::new(bridge);
-        let mut entry = BTreeMap::new();
+        let mut entry = crate::value::DictMap::new();
         entry.put_str("executor", "host_bridge");
         entry.put_str("host_capability", "interaction.ask");
         let tools = tools_dict(vec![("ask_user", entry)]);
@@ -1024,7 +1021,7 @@ mod tests {
         // Provider-native tools must never reach a runtime backend.
         // The dispatcher rejects with ProviderNative as the executor so
         // the ACP event reflects "model already executed this".
-        let mut entry = BTreeMap::new();
+        let mut entry = crate::value::DictMap::new();
         entry.put_str("executor", "provider_native");
         let tools = tools_dict(vec![("tool_search", entry)]);
         let outcome = dispatch_tool_execution(
@@ -1051,7 +1048,7 @@ mod tests {
             1,
         );
         let bridge = Arc::new(bridge);
-        let mut entry = BTreeMap::new();
+        let mut entry = crate::value::DictMap::new();
         entry.put_str("executor", "mcp_server");
         entry.put_str("mcp_server", "github");
         let tools = tools_dict(vec![("github_search_issues", entry)]);

--- a/crates/harn-vm/src/llm/api/completion.rs
+++ b/crates/harn-vm/src/llm/api/completion.rs
@@ -4,7 +4,6 @@
 //! user message and re-enters the chat path.
 
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 
 use crate::value::{VmError, VmValue};
 
@@ -273,7 +272,7 @@ async fn vm_call_completion_fallback(
 ) -> Result<LlmResult, VmError> {
     let mut fallback_opts = opts.clone();
     let has_suffix = suffix.is_some_and(|s| !s.is_empty());
-    let mut bindings = BTreeMap::new();
+    let mut bindings = crate::value::DictMap::new();
     bindings.put_str("prefix", prefix);
     bindings.insert("has_suffix".to_string(), VmValue::Bool(has_suffix));
     bindings.put_str("suffix", suffix.unwrap_or_default());

--- a/crates/harn-vm/src/llm/api/result.rs
+++ b/crates/harn-vm/src/llm/api/result.rs
@@ -2,7 +2,6 @@
 //! values, plus the mock-provider completion response.
 
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 
 use super::telemetry::ProviderTelemetry;
 use crate::value::VmValue;
@@ -66,7 +65,7 @@ pub(crate) struct LlmResult {
     pub telemetry: ProviderTelemetry,
 }
 
-fn build_usage_dict(result: &LlmResult) -> BTreeMap<String, VmValue> {
+fn build_usage_dict(result: &LlmResult) -> crate::value::DictMap {
     let cache_hit_ratio = crate::llm::cost::cache_hit_ratio(
         result.input_tokens,
         result.cache_read_tokens,
@@ -79,7 +78,7 @@ fn build_usage_dict(result: &LlmResult) -> BTreeMap<String, VmValue> {
         result.cache_write_tokens,
     );
 
-    let mut usage = BTreeMap::new();
+    let mut usage = crate::value::DictMap::new();
     usage.insert(
         "input_tokens".to_string(),
         VmValue::Int(result.input_tokens),
@@ -129,7 +128,7 @@ pub(crate) fn vm_build_llm_result(
 ) -> VmValue {
     use crate::stdlib::json_to_vm_value;
 
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.put_str("text", result.text.as_str());
     dict.put_str("model", result.model.as_str());
     dict.put_str("provider", result.provider.as_str());
@@ -174,10 +173,7 @@ pub(crate) fn vm_build_llm_result(
     if let Some(ref telemetry_dict) = telemetry_dict {
         usage.insert("provider_telemetry".to_string(), telemetry_dict.clone());
     }
-    dict.insert(
-        "usage".to_string(),
-        VmValue::Dict(std::sync::Arc::new(usage)),
-    );
+    dict.insert("usage".to_string(), VmValue::dict(usage));
     if let Some(telemetry_dict) = telemetry_dict {
         dict.insert("provider_telemetry".to_string(), telemetry_dict);
     }
@@ -320,7 +316,7 @@ pub(crate) fn vm_build_llm_result(
         );
     }
 
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 pub(super) fn mock_completion_response(prefix: &str, suffix: Option<&str>) -> LlmResult {

--- a/crates/harn-vm/src/llm/api/schema_stream.rs
+++ b/crates/harn-vm/src/llm/api/schema_stream.rs
@@ -200,11 +200,8 @@ pub(crate) fn aborted_result_value(abort: &SchemaStreamAbort) -> VmValue {
     dict.insert("input_tokens".to_string(), VmValue::Int(0));
     dict.insert("output_tokens".to_string(), VmValue::Int(0));
     dict.insert("data".to_string(), VmValue::Nil);
-    dict.insert(
-        "schema_stream_aborted".to_string(),
-        VmValue::Dict(std::sync::Arc::new(meta)),
-    );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    dict.insert("schema_stream_aborted".to_string(), VmValue::dict(meta));
+    VmValue::dict(dict)
 }
 
 #[cfg(test)]

--- a/crates/harn-vm/src/llm/api/telemetry.rs
+++ b/crates/harn-vm/src/llm/api/telemetry.rs
@@ -16,7 +16,6 @@
 //!   eval scripts can route on it without re-deriving provider names.
 
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 
 use crate::value::VmValue;
 
@@ -294,7 +293,7 @@ impl ProviderTelemetry {
         if self.is_empty() {
             return None;
         }
-        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut dict: crate::value::DictMap = crate::value::DictMap::new();
         if !self.source.is_empty() {
             dict.put_str("source", self.source.as_str());
         }
@@ -329,7 +328,7 @@ impl ProviderTelemetry {
         if let Some(ref request_id) = self.request_id {
             dict.put_str("request_id", request_id.as_str());
         }
-        Some(VmValue::Dict(std::sync::Arc::new(dict)))
+        Some(VmValue::dict(dict))
     }
 }
 
@@ -391,13 +390,13 @@ fn ms_or_round(value: Option<&serde_json::Value>) -> Option<u64> {
     value.as_f64().map(|n| n.round().max(0.0) as u64)
 }
 
-fn insert_opt_u64(dict: &mut BTreeMap<String, VmValue>, key: &str, value: Option<u64>) {
+fn insert_opt_u64(dict: &mut crate::value::DictMap, key: &str, value: Option<u64>) {
     if let Some(value) = value {
         dict.insert(key.to_string(), VmValue::Int(value as i64));
     }
 }
 
-fn insert_opt_i64(dict: &mut BTreeMap<String, VmValue>, key: &str, value: Option<i64>) {
+fn insert_opt_i64(dict: &mut crate::value::DictMap, key: &str, value: Option<i64>) {
     if let Some(value) = value {
         dict.insert(key.to_string(), VmValue::Int(value));
     }

--- a/crates/harn-vm/src/llm/autonomy_budget.rs
+++ b/crates/harn-vm/src/llm/autonomy_budget.rs
@@ -37,7 +37,7 @@ struct CounterEntry {
 
 thread_local! {
     static AUTONOMY_COUNTERS: RefCell<BTreeMap<String, CounterEntry>> =
-        const { RefCell::new(BTreeMap::new()) };
+        const { RefCell::new(std::collections::BTreeMap::new()) };
 }
 
 pub(crate) fn reset_autonomy_budget_state() {
@@ -108,7 +108,7 @@ pub(crate) fn snapshot(key: &str) -> (u64, u64) {
 }
 
 pub(crate) fn parse_autonomy_budget(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     default_key: &str,
     label: &str,
 ) -> Result<Option<AgentAutonomyBudget>, VmError> {
@@ -356,10 +356,10 @@ mod tests {
 
     #[test]
     fn missing_caps_returns_none() {
-        let mut opts = BTreeMap::new();
+        let mut opts = crate::value::DictMap::new();
         opts.insert(
             "autonomy_budget".to_string(),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::new())),
+            VmValue::dict(crate::value::DictMap::new()),
         );
         let parsed = parse_autonomy_budget(Some(&opts), "session-1", "agent_loop").expect("parse");
         assert!(parsed.is_none());

--- a/crates/harn-vm/src/llm/cache.rs
+++ b/crates/harn-vm/src/llm/cache.rs
@@ -100,8 +100,8 @@ const CACHE_BUILTINS: &[&VmBuiltinDef] = &[
     &LLM_CACHE_KEY_BUILTIN_DEF,
 ];
 
-fn cache_envelope_base(options: &CacheOptions) -> BTreeMap<String, VmValue> {
-    let mut envelope = BTreeMap::new();
+fn cache_envelope_base(options: &CacheOptions) -> crate::value::DictMap {
+    let mut envelope = crate::value::DictMap::new();
     envelope.put_str("backend", options.backend.name());
     envelope.put_str("namespace", options.namespace.clone());
     envelope
@@ -123,7 +123,7 @@ fn cache_get_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
     if let Some(value) = hit {
         envelope.insert("value".to_string(), crate::stdlib::json_to_vm_value(&value));
     }
-    Ok(VmValue::Dict(std::sync::Arc::new(envelope)))
+    Ok(VmValue::dict(envelope))
 }
 
 /// Persist a cache value with TTL and LRU eviction.
@@ -147,7 +147,7 @@ fn cache_put_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
     let mut envelope = cache_envelope_base(&options);
     envelope.insert("stored".to_string(), VmValue::Bool(true));
     envelope.put_str("key", key);
-    Ok(VmValue::Dict(std::sync::Arc::new(envelope)))
+    Ok(VmValue::dict(envelope))
 }
 
 /// Clear one persistent cache namespace.
@@ -188,7 +188,7 @@ fn cache_stats_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
         snapshot.hits as f64 / total as f64
     };
     dict.insert("hit_rate".to_string(), VmValue::Float(hit_rate));
-    Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+    Ok(VmValue::dict(dict))
 }
 
 fn saturating_u64_to_i64(value: u64) -> i64 {
@@ -244,7 +244,7 @@ fn llm_cache_key_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue,
         .map(super::helpers::vm_value_to_json)
         .unwrap_or(serde_json::Value::Null);
 
-    let mut identity = BTreeMap::new();
+    let mut identity = std::collections::BTreeMap::new();
     identity.insert("max_tokens", serde_json::json!(max_tokens));
     identity.insert("model", serde_json::Value::String(model));
     identity.insert("prompt", prompt);
@@ -407,7 +407,7 @@ fn parse_backend(value: &str) -> Result<CacheBackend, VmError> {
     }
 }
 
-fn read_string_field(dict: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<String> {
+fn read_string_field(dict: Option<&crate::value::DictMap>, key: &str) -> Option<String> {
     dict.and_then(|dict| dict.get(key))
         .and_then(|value| match value {
             VmValue::String(text) if !text.is_empty() => Some(text.to_string()),
@@ -416,7 +416,7 @@ fn read_string_field(dict: Option<&BTreeMap<String, VmValue>>, key: &str) -> Opt
 }
 
 fn read_duration_field(
-    dict: Option<&BTreeMap<String, VmValue>>,
+    dict: Option<&crate::value::DictMap>,
     key: &str,
 ) -> Option<Result<u64, VmError>> {
     dict.and_then(|dict| dict.get(key))
@@ -433,7 +433,7 @@ fn read_duration_field(
 }
 
 fn read_usize_field(
-    dict: Option<&BTreeMap<String, VmValue>>,
+    dict: Option<&crate::value::DictMap>,
     key: &str,
 ) -> Option<Result<usize, VmError>> {
     dict.and_then(|dict| dict.get(key))
@@ -839,7 +839,7 @@ fn canonicalize_json_value(value: &serde_json::Value) -> serde_json::Value {
 
 thread_local! {
     static ACCESS_CLOCK: RefCell<BTreeMap<String, i64>> =
-        const { RefCell::new(BTreeMap::new()) };
+        const { RefCell::new(std::collections::BTreeMap::new()) };
 }
 
 fn access_clock_key(options: &CacheOptions) -> String {
@@ -873,7 +873,7 @@ struct MemEntry {
 
 thread_local! {
     static MEM_STORE: RefCell<BTreeMap<String, MemNamespace>> =
-        const { RefCell::new(BTreeMap::new()) };
+        const { RefCell::new(std::collections::BTreeMap::new()) };
 }
 
 #[derive(Default)]
@@ -951,7 +951,7 @@ struct MetricsStore {
 }
 
 thread_local! {
-    static METRICS: RefCell<MetricsStore> = const { RefCell::new(MetricsStore { by_namespace: BTreeMap::new() }) };
+    static METRICS: RefCell<MetricsStore> = const { RefCell::new(MetricsStore { by_namespace: std::collections::BTreeMap::new() }) };
 }
 
 fn metrics_key(options: &CacheOptions) -> String {

--- a/crates/harn-vm/src/llm/cache_tests.rs
+++ b/crates/harn-vm/src/llm/cache_tests.rs
@@ -255,15 +255,15 @@ mod cache_key_identity_tests {
         }
     }
 
-    fn base_options() -> std::collections::BTreeMap<String, VmValue> {
-        let mut map = std::collections::BTreeMap::new();
+    fn base_options() -> crate::value::DictMap {
+        let mut map = crate::value::DictMap::new();
         map.insert("provider".to_string(), VmValue::String(Arc::from("mock")));
         map.insert("model".to_string(), VmValue::String(Arc::from("mock")));
         map
     }
 
-    fn dict(map: std::collections::BTreeMap<String, VmValue>) -> VmValue {
-        VmValue::Dict(Arc::new(map))
+    fn dict(map: crate::value::DictMap) -> VmValue {
+        VmValue::dict(map)
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/call.rs
+++ b/crates/harn-vm/src/llm/call.rs
@@ -16,7 +16,7 @@ use super::{
 };
 
 thread_local! {
-    static IN_FLIGHT_LLM_CALLS: RefCell<BTreeMap<String, InFlightLlmCall>> = const { RefCell::new(BTreeMap::new()) };
+    static IN_FLIGHT_LLM_CALLS: RefCell<BTreeMap<String, InFlightLlmCall>> = const { RefCell::new(std::collections::BTreeMap::new()) };
 }
 
 #[derive(Clone, Debug)]
@@ -178,9 +178,7 @@ pub(crate) enum SchemaNudge {
     Disabled,
 }
 
-pub(crate) fn parse_schema_nudge(
-    options: &Option<std::collections::BTreeMap<String, VmValue>>,
-) -> SchemaNudge {
+pub(crate) fn parse_schema_nudge(options: &Option<crate::value::DictMap>) -> SchemaNudge {
     let Some(opts) = options.as_ref() else {
         return SchemaNudge::Auto;
     };
@@ -412,7 +410,7 @@ pub(crate) fn build_llm_error_dict(err: &VmError, provider: &str, model: &str) -
             .or_insert_with(|| VmValue::String(std::sync::Arc::from(message.as_str())));
         dict.put_str("provider", provider);
         dict.put_str("model", model);
-        return VmValue::Dict(std::sync::Arc::new(dict));
+        return VmValue::dict(dict);
     }
     let mut dict = std::collections::BTreeMap::new();
     dict.put_str("category", category.as_str());
@@ -424,7 +422,7 @@ pub(crate) fn build_llm_error_dict(err: &VmError, provider: &str, model: &str) -
     }
     dict.put_str("provider", provider);
     dict.put_str("model", model);
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn llm_error_message(err: &VmError) -> String {
@@ -442,7 +440,7 @@ fn llm_error_message(err: &VmError) -> String {
 pub(crate) async fn execute_llm_call(
     ctx: Option<&crate::vm::AsyncBuiltinCtx>,
     opts: api::LlmCallOptions,
-    options: Option<std::collections::BTreeMap<String, VmValue>>,
+    options: Option<crate::value::DictMap>,
     bridge: Option<&Arc<crate::bridge::HostBridge>>,
 ) -> Result<VmValue, VmError> {
     // Publish the resolved provider/model facts for the introspection
@@ -491,7 +489,7 @@ async fn execute_routing_schema_retry_loop(
     ctx: Option<&crate::vm::AsyncBuiltinCtx>,
     policy: Arc<routing::RoutingPolicyConfig>,
     mut opts: api::LlmCallOptions,
-    options: Option<std::collections::BTreeMap<String, VmValue>>,
+    options: Option<crate::value::DictMap>,
     bridge: Option<&Arc<crate::bridge::HostBridge>>,
 ) -> Result<SchemaLoopOutcome, VmError> {
     let _ = structural_experiments::apply_structural_experiment(ctx, &mut opts, None).await?;
@@ -606,11 +604,8 @@ fn attach_routing_block(
         "session_cost_usd".to_string(),
         VmValue::Float(trace.session_cost_usd),
     );
-    dict.insert(
-        "routing".to_string(),
-        VmValue::Dict(std::sync::Arc::new(routing_dict)),
-    );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    dict.insert("routing".to_string(), VmValue::dict(routing_dict));
+    VmValue::dict(dict)
 }
 
 /// Outcome of the schema-retry loop, exposing both the final attempt's
@@ -639,7 +634,7 @@ pub(crate) struct SchemaLoopOutcome {
 pub(crate) async fn execute_schema_retry_loop(
     ctx: Option<&crate::vm::AsyncBuiltinCtx>,
     mut opts: api::LlmCallOptions,
-    options: Option<std::collections::BTreeMap<String, VmValue>>,
+    options: Option<crate::value::DictMap>,
     bridge: Option<&Arc<crate::bridge::HostBridge>>,
 ) -> Result<SchemaLoopOutcome, VmError> {
     let _ = structural_experiments::apply_structural_experiment(ctx, &mut opts, None).await?;
@@ -786,7 +781,7 @@ pub(super) fn llm_safe_envelope_ok(response: VmValue) -> VmValue {
     dict.insert("ok".to_string(), VmValue::Bool(true));
     dict.insert("response".to_string(), response);
     dict.insert("error".to_string(), VmValue::Nil);
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 pub(super) fn llm_safe_envelope_err(err: &VmError) -> VmValue {
@@ -800,7 +795,7 @@ pub(super) fn llm_safe_envelope_err(err: &VmError) -> VmValue {
         dict.insert("ok".to_string(), VmValue::Bool(false));
         dict.insert("response".to_string(), VmValue::Nil);
         dict.insert("error".to_string(), VmValue::Dict(d.clone()));
-        return VmValue::Dict(std::sync::Arc::new(dict));
+        return VmValue::dict(dict);
     }
     let category = crate::value::error_to_category(err);
     let message = llm_error_message(err);
@@ -813,11 +808,8 @@ pub(super) fn llm_safe_envelope_err(err: &VmError) -> VmValue {
     let mut dict = std::collections::BTreeMap::new();
     dict.insert("ok".to_string(), VmValue::Bool(false));
     dict.insert("response".to_string(), VmValue::Nil);
-    dict.insert(
-        "error".to_string(),
-        VmValue::Dict(std::sync::Arc::new(err_dict)),
-    );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    dict.insert("error".to_string(), VmValue::dict(err_dict));
+    VmValue::dict(dict)
 }
 
 /// Rewrite `(prompt, schema, options?)` — the ergonomic
@@ -891,7 +883,7 @@ pub(crate) fn rewrite_structured_args(args: Vec<VmValue>) -> Result<Vec<VmValue>
             fmt.put_str("kind", "json_schema");
             fmt.insert("schema".to_string(), schema);
             fmt.insert("strict".to_string(), VmValue::Bool(true));
-            VmValue::Dict(std::sync::Arc::new(fmt))
+            VmValue::dict(fmt)
         });
     options
         .entry("response_format".to_string())
@@ -903,7 +895,7 @@ pub(crate) fn rewrite_structured_args(args: Vec<VmValue>) -> Result<Vec<VmValue>
     Ok(vec![
         prompt,
         system.unwrap_or(VmValue::Nil),
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ])
 }
 
@@ -925,7 +917,7 @@ pub(crate) fn structured_safe_envelope_ok(data: VmValue) -> VmValue {
     dict.insert("ok".to_string(), VmValue::Bool(true));
     dict.insert("data".to_string(), data);
     dict.insert("error".to_string(), VmValue::Nil);
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 pub(crate) fn structured_safe_envelope_err(err: &VmError) -> VmValue {
@@ -934,7 +926,7 @@ pub(crate) fn structured_safe_envelope_err(err: &VmError) -> VmValue {
         dict.insert("ok".to_string(), VmValue::Bool(false));
         dict.insert("data".to_string(), VmValue::Nil);
         dict.insert("error".to_string(), VmValue::Dict(d.clone()));
-        return VmValue::Dict(std::sync::Arc::new(dict));
+        return VmValue::dict(dict);
     }
     let category = crate::value::error_to_category(err);
     let message = llm_error_message(err);
@@ -947,11 +939,8 @@ pub(crate) fn structured_safe_envelope_err(err: &VmError) -> VmValue {
     let mut dict = std::collections::BTreeMap::new();
     dict.insert("ok".to_string(), VmValue::Bool(false));
     dict.insert("data".to_string(), VmValue::Nil);
-    dict.insert(
-        "error".to_string(),
-        VmValue::Dict(std::sync::Arc::new(err_dict)),
-    );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    dict.insert("error".to_string(), VmValue::dict(err_dict));
+    VmValue::dict(dict)
 }
 
 #[cfg(test)]
@@ -970,16 +959,14 @@ mod schema_stream_abort_retry_tests {
     //! reason verbatim, so callers see why the retry happened rather
     //! than a generic stream failure.
 
-    use std::collections::BTreeMap;
-
     use super::*;
     use crate::llm::fake::{
         install_fake_llm_script, FakeLlmEvent, FakeLlmScript, FakeLlmTurn, FakeStopReason,
     };
     use crate::llm::trace::{peek_agent_trace, reset_agent_trace_state, AgentTraceEvent};
 
-    fn options_with_retries(retries: i64) -> BTreeMap<String, VmValue> {
-        let mut opts = BTreeMap::new();
+    fn options_with_retries(retries: i64) -> crate::value::DictMap {
+        let mut opts = crate::value::DictMap::new();
         opts.insert("schema_retries".to_string(), VmValue::Int(retries));
         opts
     }
@@ -1014,7 +1001,7 @@ mod schema_stream_abort_retry_tests {
     fn fake_routing_policy() -> Arc<routing::RoutingPolicyConfig> {
         routing::clear_policy_registry();
         let chain = VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
-            std::sync::Arc::new(BTreeMap::from([
+            std::sync::Arc::new(crate::value::DictMap::from_iter([
                 (
                     "provider".to_string(),
                     VmValue::String(std::sync::Arc::from("fake")),
@@ -1025,9 +1012,12 @@ mod schema_stream_abort_retry_tests {
                 ),
             ])),
         )]));
-        let tagged = routing::build_routing_policy(&BTreeMap::from([("chain".to_string(), chain)]))
-            .expect("routing policy validates");
-        let options = BTreeMap::from([("routing".to_string(), tagged)]);
+        let tagged = routing::build_routing_policy(&crate::value::DictMap::from_iter([(
+            "chain".to_string(),
+            chain,
+        )]))
+        .expect("routing policy validates");
+        let options = crate::value::DictMap::from_iter([("routing".to_string(), tagged)]);
         routing::extract_routing_policy(Some(&options))
             .expect("routing policy extracts")
             .expect("routing policy present")
@@ -1042,10 +1032,10 @@ mod schema_stream_abort_retry_tests {
     fn structured_output_truncation_detected_case_insensitively() {
         let opts = api::options::base_opts("fake");
         for spelling in ["max_tokens", "MAX_TOKENS", "length", "LENGTH"] {
-            let dict = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            let dict = VmValue::dict(crate::value::DictMap::from_iter([(
                 "stop_reason".to_string(),
                 VmValue::String(std::sync::Arc::from(spelling)),
-            )])));
+            )]));
             let errors = structured_output_errors(&dict, &opts);
             assert!(
                 errors.iter().any(|e| e.contains("hit the token limit")),
@@ -1053,10 +1043,10 @@ mod schema_stream_abort_retry_tests {
             );
         }
         // A non-truncation stop_reason must NOT add the token-limit error.
-        let dict = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        let dict = VmValue::dict(crate::value::DictMap::from_iter([(
             "stop_reason".to_string(),
             VmValue::String(std::sync::Arc::from("stop")),
-        )])));
+        )]));
         let errors = structured_output_errors(&dict, &opts);
         assert!(
             !errors.iter().any(|e| e.contains("hit the token limit")),

--- a/crates/harn-vm/src/llm/compass_router.rs
+++ b/crates/harn-vm/src/llm/compass_router.rs
@@ -46,8 +46,6 @@
 //! - `harn.compass.fell_back` — rewrite considered but not provably
 //!   equivalent, so the original freeform call ran.
 
-use std::collections::BTreeMap;
-
 use serde_json::{Map as JsonMap, Value as JsonValue};
 
 use crate::stdlib::observability::{emit_instrument, MetricInstrument};
@@ -655,7 +653,7 @@ pub(crate) fn routing_event(
 
 /// Convert an agent-loop options map into the JSON the config reader and
 /// router consume.
-pub(crate) fn options_to_json(options: &BTreeMap<String, crate::value::VmValue>) -> JsonValue {
+pub(crate) fn options_to_json(options: &crate::value::DictMap) -> JsonValue {
     JsonValue::Object(
         options
             .iter()

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -1,5 +1,4 @@
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 
 use crate::llm_config;
 use crate::stdlib::json_to_vm_value;
@@ -184,11 +183,11 @@ fn llm_model_defaults_builtin(args: &[VmValue], _out: &mut String) -> Result<VmV
         ));
     }
     let params = llm_config::model_params(&model_id);
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     for (k, v) in &params {
         dict.insert(k.clone(), toml_value_to_vm_value(v));
     }
-    Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+    Ok(VmValue::dict(dict))
 }
 
 /// Return the fully-merged llm_call options for `opts`. Requires opts.model.
@@ -230,7 +229,7 @@ fn llm_resolved_options_builtin(args: &[VmValue], _out: &mut String) -> Result<V
     }
     out.put_str("provider", final_provider);
     out.put_str("model", resolved_id);
-    Ok(VmValue::Dict(std::sync::Arc::new(out)))
+    Ok(VmValue::dict(out))
 }
 
 /// Apply Harn's provider-aware reasoning_policy/thinking_policy defaults to an llm_call option dict.
@@ -246,7 +245,7 @@ fn llm_apply_reasoning_policy_builtin(
         VmError::Runtime("llm_apply_reasoning_policy: opts must be a dict".to_string())
     })?;
     let out = super::reasoning_policy::apply_policy_to_vm_options(opts)?;
-    Ok(VmValue::Dict(std::sync::Arc::new(out)))
+    Ok(VmValue::dict(out))
 }
 
 fn toml_value_to_vm_value(value: &toml::Value) -> VmValue {
@@ -261,11 +260,11 @@ fn toml_value_to_vm_value(value: &toml::Value) -> VmValue {
             VmValue::List(std::sync::Arc::new(list))
         }
         toml::Value::Table(table) => {
-            let mut dict = BTreeMap::new();
+            let mut dict = crate::value::DictMap::new();
             for (k, v) in table {
                 dict.insert(k.clone(), toml_value_to_vm_value(v));
             }
-            VmValue::Dict(std::sync::Arc::new(dict))
+            VmValue::dict(dict)
         }
     }
 }
@@ -298,11 +297,11 @@ fn llm_pick_model_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue
         )
     };
 
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.put_str("id", id.clone());
     dict.put_str("provider", provider);
     dict.put_str("tier", llm_config::model_tier(&id));
-    Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+    Ok(VmValue::dict(dict))
 }
 
 /// Pick a different-family reviewer model for review, critique, or plan review.
@@ -430,7 +429,7 @@ pub(crate) fn llm_provider_status_value() -> VmValue {
 
     let mut entries = Vec::with_capacity(names.len());
     for name in names {
-        let mut entry = BTreeMap::new();
+        let mut entry = crate::value::DictMap::new();
         entry.put_str("name", name.clone());
 
         // Providers with `auth_style = "none"` (e.g. local Ollama) and
@@ -462,7 +461,7 @@ pub(crate) fn llm_provider_status_value() -> VmValue {
         };
         entry.insert("available".to_string(), VmValue::Bool(available));
         entry.put_str("credential_status", credential_status);
-        entries.push(VmValue::Dict(std::sync::Arc::new(entry)));
+        entries.push(VmValue::dict(entry));
     }
     VmValue::List(std::sync::Arc::new(entries))
 }
@@ -581,13 +580,13 @@ fn llm_config_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
             }
         }
         None => {
-            let mut dict = BTreeMap::new();
+            let mut dict = crate::value::DictMap::new();
             for name in llm_config::provider_names() {
                 if let Some(pdef) = llm_config::provider_config(&name) {
                     dict.insert(name.clone(), provider_def_to_vm_value(Some(&name), &pdef));
                 }
             }
-            Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+            Ok(VmValue::dict(dict))
         }
     }
 }
@@ -599,7 +598,7 @@ enum RateLimitField<T> {
 }
 
 fn rate_limit_u64_option(
-    opts: &BTreeMap<String, VmValue>,
+    opts: &crate::value::DictMap,
     key: &str,
 ) -> Result<RateLimitField<u64>, VmError> {
     let Some(value) = opts.get(key) else {
@@ -617,7 +616,7 @@ fn rate_limit_u64_option(
 }
 
 fn rate_limit_u32_option(
-    opts: &BTreeMap<String, VmValue>,
+    opts: &crate::value::DictMap,
     key: &str,
 ) -> Result<RateLimitField<u32>, VmError> {
     match rate_limit_u64_option(opts, key)? {
@@ -869,7 +868,7 @@ fn provider_region_value(provider_name: Option<&str>) -> Option<VmValue> {
         "bedrock" => crate::llm::providers::bedrock::current_env_region(),
         _ => None,
     };
-    let mut region = BTreeMap::new();
+    let mut region = crate::value::DictMap::new();
     region.put_str("override_key", "region");
     region.insert(
         "envs".to_string(),
@@ -882,7 +881,7 @@ fn provider_region_value(provider_name: Option<&str>) -> Option<VmValue> {
             None => VmValue::Nil,
         },
     );
-    Some(VmValue::Dict(std::sync::Arc::new(region)))
+    Some(VmValue::dict(region))
 }
 
 /// Convert a ProviderDef to a VmValue dict for the llm_config builtin.
@@ -890,7 +889,7 @@ fn provider_def_to_vm_value(
     provider_name: Option<&str>,
     pdef: &llm_config::ProviderDef,
 ) -> VmValue {
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.put_opt_str("display_name", pdef.display_name.as_deref());
     dict.put_opt_str("icon", pdef.icon.as_deref());
     dict.put_opt_str("protocol", pdef.protocol.as_deref());
@@ -936,14 +935,11 @@ fn provider_def_to_vm_value(
     }
     dict.put_opt_str("auth_header", pdef.auth_header.as_deref());
     if !pdef.extra_headers.is_empty() {
-        let mut headers = BTreeMap::new();
+        let mut headers = crate::value::DictMap::new();
         for (k, v) in &pdef.extra_headers {
             headers.insert(k.clone(), VmValue::String(std::sync::Arc::from(v.as_str())));
         }
-        dict.insert(
-            "extra_headers".to_string(),
-            VmValue::Dict(std::sync::Arc::new(headers)),
-        );
+        dict.insert("extra_headers".to_string(), VmValue::dict(headers));
     }
     if !pdef.features.is_empty() {
         let features: Vec<VmValue> = pdef
@@ -979,7 +975,7 @@ fn provider_def_to_vm_value(
     if let Some(latency) = pdef.latency_p50_ms {
         dict.insert("latency_p50_ms".to_string(), VmValue::Int(latency as i64));
     }
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn string_list_to_vm_value(items: Vec<String>) -> VmValue {
@@ -992,7 +988,7 @@ fn string_list_to_vm_value(items: Vec<String>) -> VmValue {
 }
 
 fn resolved_model_to_vm_value(resolved: &llm_config::ResolvedModel) -> VmValue {
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.put_str("id", resolved.id.as_str());
     dict.put_str("provider", resolved.provider.as_str());
     dict.insert(
@@ -1007,7 +1003,7 @@ fn resolved_model_to_vm_value(resolved: &llm_config::ResolvedModel) -> VmValue {
     dict.put_str("tier", resolved.tier.as_str());
     dict.put_str("family", resolved.family.as_str());
     dict.put_str("lineage", resolved.lineage.as_str());
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn model_info_to_vm_value(resolved: &llm_config::ResolvedModel) -> VmValue {
@@ -1036,7 +1032,7 @@ fn model_info_to_vm_value(resolved: &llm_config::ResolvedModel) -> VmValue {
         "auth_available".to_string(),
         VmValue::Bool(llm_config::provider_key_available(&resolved.provider)),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 pub(crate) fn capabilities_to_vm_value(
@@ -1044,7 +1040,7 @@ pub(crate) fn capabilities_to_vm_value(
     model: &str,
     caps: &super::capabilities::Capabilities,
 ) -> VmValue {
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.put_str("provider", provider);
     dict.put_str("model", model);
     dict.insert("native_tools".to_string(), VmValue::Bool(caps.native_tools));
@@ -1299,7 +1295,7 @@ pub(crate) fn capabilities_to_vm_value(
     );
     dict.insert(
         "auto_reasoning_overrides".to_string(),
-        VmValue::Dict(std::sync::Arc::new(
+        VmValue::dict(
             caps.auto_reasoning_overrides
                 .iter()
                 .map(|(task, mode)| {
@@ -1308,8 +1304,8 @@ pub(crate) fn capabilities_to_vm_value(
                         VmValue::String(std::sync::Arc::from(mode.clone())),
                     )
                 })
-                .collect(),
-        )),
+                .collect::<crate::value::DictMap>(),
+        ),
     );
     // Accelerated-serving ("fast mode") tier, read from the catalog so
     // callers can branch on `llm_call(..., { fast: true })` support without
@@ -1327,7 +1323,7 @@ pub(crate) fn capabilities_to_vm_value(
         ),
     );
     if let Some(fast_mode) = fast_mode {
-        let mut fast = BTreeMap::new();
+        let mut fast = crate::value::DictMap::new();
         fast.put_str("param", fast_mode.param.as_str());
         fast.put_str("value", fast_mode.value.as_str());
         fast.insert(
@@ -1353,16 +1349,13 @@ pub(crate) fn capabilities_to_vm_value(
                 .map(VmValue::Float)
                 .unwrap_or(VmValue::Nil),
         );
-        dict.insert(
-            "fast_mode".to_string(),
-            VmValue::Dict(std::sync::Arc::new(fast)),
-        );
+        dict.insert("fast_mode".to_string(), VmValue::dict(fast));
     }
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.put_str("id", id);
     dict.put_str("name", model.name.as_str());
     dict.put_str("provider", model.provider.as_str());
@@ -1495,15 +1488,12 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
         "strengths".to_string(),
         string_list_to_vm_value(model.strengths.clone()),
     );
-    let benchmarks: BTreeMap<String, VmValue> = model
+    let benchmarks: crate::value::DictMap = model
         .benchmarks
         .iter()
         .map(|(key, value)| (key.clone(), VmValue::Float(*value)))
         .collect();
-    dict.insert(
-        "benchmarks".to_string(),
-        VmValue::Dict(std::sync::Arc::new(benchmarks)),
-    );
+    dict.insert("benchmarks".to_string(), VmValue::dict(benchmarks));
     dict.insert(
         "fast_mode".to_string(),
         model
@@ -1512,7 +1502,7 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
             .map(fast_mode_to_vm_value)
             .unwrap_or(VmValue::Nil),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn rate_limits_to_vm_value(rate_limits: &llm_config::RateLimitsDef) -> VmValue {
@@ -1524,7 +1514,7 @@ fn architecture_to_vm_value(architecture: &llm_config::ModelArchitectureDef) -> 
 }
 
 fn pricing_to_vm_value(pricing: &llm_config::ModelPricing) -> VmValue {
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.insert(
         "input_per_mtok".to_string(),
         VmValue::Float(pricing.input_per_mtok),
@@ -1547,11 +1537,11 @@ fn pricing_to_vm_value(pricing: &llm_config::ModelPricing) -> VmValue {
             .map(VmValue::Float)
             .unwrap_or(VmValue::Nil),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn fast_mode_to_vm_value(fast: &llm_config::FastModeDef) -> VmValue {
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.put_str("param", fast.param.as_str());
     dict.put_str("value", fast.value.as_str());
     dict.insert(
@@ -1588,11 +1578,11 @@ fn fast_mode_to_vm_value(fast: &llm_config::FastModeDef) -> VmValue {
             .map(|note| VmValue::String(std::sync::Arc::from(note)))
             .unwrap_or(VmValue::Nil),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn provider_catalog_to_vm_value() -> VmValue {
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
 
     let mut providers = Vec::new();
     for name in llm_config::provider_names() {
@@ -1602,7 +1592,7 @@ fn provider_catalog_to_vm_value() -> VmValue {
                 _ => unreachable!("provider_def_to_vm_value returns a dict"),
             };
             provider.put_str("name", name.clone());
-            providers.push(VmValue::Dict(std::sync::Arc::new(provider)));
+            providers.push(VmValue::dict(provider));
         }
     }
     dict.insert(
@@ -1636,17 +1626,14 @@ fn provider_catalog_to_vm_value() -> VmValue {
     let qc_defaults = llm_config::qc_defaults()
         .into_iter()
         .map(|(provider, model)| (provider, VmValue::String(std::sync::Arc::from(model))))
-        .collect();
-    dict.insert(
-        "qc_defaults".to_string(),
-        VmValue::Dict(std::sync::Arc::new(qc_defaults)),
-    );
+        .collect::<crate::value::DictMap>();
+    dict.insert("qc_defaults".to_string(), VmValue::dict(qc_defaults));
 
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn alias_def_to_vm_value(name: &str, alias: &llm_config::AliasDef) -> VmValue {
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.put_str("name", name);
     dict.put_str("id", alias.id.as_str());
     dict.put_str("provider", alias.provider.as_str());
@@ -1658,7 +1645,7 @@ fn alias_def_to_vm_value(name: &str, alias: &llm_config::AliasDef) -> VmValue {
             .map(|format| VmValue::String(std::sync::Arc::from(format)))
             .unwrap_or(VmValue::Nil),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn healthcheck_model_arg(args: &[VmValue]) -> Option<String> {
@@ -1684,7 +1671,7 @@ fn healthcheck_model_arg(args: &[VmValue]) -> Option<String> {
 }
 
 fn readiness_result(readiness: &super::ModelReadiness) -> VmValue {
-    let mut meta = BTreeMap::new();
+    let mut meta = crate::value::DictMap::new();
     meta.put_str("category", readiness.category.as_str());
     meta.put_str("provider", readiness.provider.as_str());
     meta.put_str("model", readiness.model.as_str());
@@ -1720,16 +1707,13 @@ fn readiness_result(readiness: &super::ModelReadiness) -> VmValue {
 fn healthcheck_result_with_meta(
     valid: bool,
     message: &str,
-    meta: BTreeMap<String, VmValue>,
+    meta: crate::value::DictMap,
 ) -> VmValue {
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.insert("valid".to_string(), VmValue::Bool(valid));
     dict.put_str("message", message);
-    dict.insert(
-        "metadata".to_string(),
-        VmValue::Dict(std::sync::Arc::new(meta)),
-    );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    dict.insert("metadata".to_string(), VmValue::dict(meta));
+    VmValue::dict(dict)
 }
 
 #[cfg(test)]
@@ -1737,14 +1721,14 @@ mod tests {
     use super::*;
 
     fn build_dict(entries: Vec<(&str, VmValue)>) -> VmValue {
-        let mut map = BTreeMap::new();
+        let mut map = crate::value::DictMap::new();
         for (k, v) in entries {
             map.insert(k.to_string(), v);
         }
-        VmValue::Dict(std::sync::Arc::new(map))
+        VmValue::dict(map)
     }
 
-    fn expect_int(dict: &BTreeMap<String, VmValue>, key: &str, want: i64) {
+    fn expect_int(dict: &crate::value::DictMap, key: &str, want: i64) {
         match dict.get(key) {
             Some(VmValue::Int(value)) => assert_eq!(*value, want, "{key}"),
             other => panic!("expected Int({want}) for {key}, got {other:?}"),
@@ -1906,7 +1890,7 @@ mod tests {
         let _guard = crate::llm::env_guard();
         llm_config::clear_user_overrides();
         let mut overlay = llm_config::ProvidersConfig::default();
-        let mut model_defaults = BTreeMap::new();
+        let mut model_defaults = std::collections::BTreeMap::new();
         model_defaults.insert(
             "fake-resolved-options-model".to_string(),
             toml::Value::Float(0.5),
@@ -1943,7 +1927,7 @@ mod tests {
         let _guard = crate::llm::env_guard();
         llm_config::clear_user_overrides();
         let mut overlay = llm_config::ProvidersConfig::default();
-        let mut model_defaults = BTreeMap::new();
+        let mut model_defaults = std::collections::BTreeMap::new();
         model_defaults.insert("temperature".to_string(), toml::Value::Float(0.5));
         overlay
             .model_defaults
@@ -2043,11 +2027,10 @@ mod tests {
         )
         .expect("builtin returned error");
         let opus = opus.as_dict().expect("expected dict");
-        let expect_str =
-            |dict: &BTreeMap<String, VmValue>, key: &str, want: &str| match dict.get(key) {
-                Some(VmValue::String(s)) => assert_eq!(s.as_ref(), want, "{key}"),
-                other => panic!("expected String for {key}, got {other:?}"),
-            };
+        let expect_str = |dict: &crate::value::DictMap, key: &str, want: &str| match dict.get(key) {
+            Some(VmValue::String(s)) => assert_eq!(s.as_ref(), want, "{key}"),
+            other => panic!("expected String for {key}, got {other:?}"),
+        };
         assert!(matches!(
             opus.get("fast_mode_supported"),
             Some(VmValue::Bool(true))

--- a/crates/harn-vm/src/llm/conversation.rs
+++ b/crates/harn-vm/src/llm/conversation.rs
@@ -1,5 +1,4 @@
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 
 use crate::value::{VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity, VmBuiltinMetadata};
@@ -32,7 +31,7 @@ const CLEAR_REMINDER_KEYS: &[&str] = &["id", "tag", "dedupe_key"];
 fn require_transcript<'a>(
     args: &'a [VmValue],
     context: &str,
-) -> Result<&'a BTreeMap<String, VmValue>, VmError> {
+) -> Result<&'a crate::value::DictMap, VmError> {
     match args.first() {
         Some(VmValue::Dict(d))
             if d.get("_type").map(|v| v.display()).as_deref() == Some("transcript") =>
@@ -420,7 +419,7 @@ pub(crate) fn register_conversation_builtins(vm: &mut Vm) {
             .collect::<Vec<_>>()
             .join("\n");
 
-        let mut bindings = BTreeMap::new();
+        let mut bindings = crate::value::DictMap::new();
         bindings.put_str("prompt", prompt_override);
         bindings.put_str("formatted", formatted);
         let user_message = crate::stdlib::template::render_stdlib_prompt_asset(
@@ -453,13 +452,13 @@ pub(crate) fn register_conversation_builtins(vm: &mut Vm) {
             transcript_state(transcript),
         ) {
             VmValue::Dict(d) => (*d).clone(),
-            _ => BTreeMap::new(),
+            _ => crate::value::DictMap::new(),
         };
         compacted.insert(
             "archived_messages".to_string(),
             VmValue::Int(archived_count as i64),
         );
-        Ok(VmValue::Dict(std::sync::Arc::new(compacted)))
+        Ok(VmValue::dict(compacted))
     });
 
     vm.register_builtin("add_message", |args, _out| match args.first() {
@@ -513,12 +512,12 @@ pub(crate) fn register_conversation_builtins(vm: &mut Vm) {
         Some(VmValue::List(list)) => {
             let tool_use_id = args.get(1).map(|a| a.display()).unwrap_or_default();
             let result_content = args.get(2).map(|a| a.display()).unwrap_or_default();
-            let mut msg = BTreeMap::new();
+            let mut msg = crate::value::DictMap::new();
             msg.put_str("role", "tool_result");
             msg.put_str("tool_use_id", tool_use_id);
             msg.put_str("content", result_content);
             let mut new_messages = (**list).clone();
-            new_messages.push(VmValue::Dict(std::sync::Arc::new(msg)));
+            new_messages.push(VmValue::dict(msg));
             Ok(VmValue::List(std::sync::Arc::new(new_messages)))
         }
         Some(VmValue::Dict(d))
@@ -526,12 +525,12 @@ pub(crate) fn register_conversation_builtins(vm: &mut Vm) {
         {
             let tool_use_id = args.get(1).map(|a| a.display()).unwrap_or_default();
             let result_content = args.get(2).map(|a| a.display()).unwrap_or_default();
-            let mut msg = BTreeMap::new();
+            let mut msg = crate::value::DictMap::new();
             msg.put_str("role", "tool_result");
             msg.put_str("tool_use_id", tool_use_id);
             msg.put_str("content", result_content);
             let mut new_messages = transcript_message_list(d)?;
-            new_messages.push(VmValue::Dict(std::sync::Arc::new(msg)));
+            new_messages.push(VmValue::dict(msg));
             Ok(rebuild_transcript(
                 d,
                 new_messages,
@@ -547,14 +546,14 @@ pub(crate) fn register_conversation_builtins(vm: &mut Vm) {
     });
 }
 
-fn transcript_state(transcript: &BTreeMap<String, VmValue>) -> Option<&str> {
+fn transcript_state(transcript: &crate::value::DictMap) -> Option<&str> {
     transcript.get("state").and_then(|value| match value {
         VmValue::String(text) if !text.is_empty() => Some(text.as_ref()),
         _ => None,
     })
 }
 
-fn transcript_extra_events(transcript: &BTreeMap<String, VmValue>) -> Vec<VmValue> {
+fn transcript_extra_events(transcript: &crate::value::DictMap) -> Vec<VmValue> {
     transcript
         .get("events")
         .and_then(|events| match events {
@@ -576,7 +575,7 @@ fn transcript_extra_events(transcript: &BTreeMap<String, VmValue>) -> Vec<VmValu
 }
 
 fn rebuild_transcript(
-    transcript: &BTreeMap<String, VmValue>,
+    transcript: &crate::value::DictMap,
     messages: Vec<VmValue>,
     summary: Option<String>,
     assets: Vec<VmValue>,
@@ -596,7 +595,7 @@ fn rebuild_transcript(
 }
 
 fn rebuild_transcript_with_preserved_events(
-    transcript: &BTreeMap<String, VmValue>,
+    transcript: &crate::value::DictMap,
     messages: Vec<VmValue>,
     summary: Option<String>,
     assets: Vec<VmValue>,
@@ -680,7 +679,7 @@ fn transcript_inject_reminder_builtin(args: &[VmValue]) -> Result<VmValue, VmErr
         reminder_lifecycle_payload(transcript_id.as_deref(), &reminder),
     );
 
-    Ok(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    Ok(VmValue::dict(crate::value::DictMap::from_iter([
         ("transcript".to_string(), next),
         (
             "reminder_id".to_string(),
@@ -690,7 +689,7 @@ fn transcript_inject_reminder_builtin(args: &[VmValue]) -> Result<VmValue, VmErr
             "deduped_count".to_string(),
             VmValue::Int(deduped_reminder_ids.len() as i64),
         ),
-    ]))))
+    ])))
 }
 
 fn transcript_clear_reminders_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
@@ -736,17 +735,17 @@ fn transcript_clear_reminders_builtin(args: &[VmValue]) -> Result<VmValue, VmErr
         emit_reminder_lifecycle_event(REMINDER_EXPIRED_EVENT_KIND, payload);
     }
 
-    Ok(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    Ok(VmValue::dict(crate::value::DictMap::from_iter([
         ("transcript".to_string(), next),
         ("removed_count".to_string(), VmValue::Int(removed_count)),
-    ]))))
+    ])))
 }
 
 fn require_reminder_options<'a>(
     args: &'a [VmValue],
     index: usize,
     context: &str,
-) -> Result<&'a BTreeMap<String, VmValue>, VmError> {
+) -> Result<&'a crate::value::DictMap, VmError> {
     match args.get(index) {
         Some(VmValue::Dict(dict)) => Ok(dict),
         Some(other) => Err(reminder_code_error(
@@ -764,7 +763,7 @@ fn require_reminder_options<'a>(
 
 fn ensure_known_reminder_keys(
     context: &str,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     allowed: &[&str],
 ) -> Result<(), VmError> {
     let unknown = options
@@ -784,7 +783,7 @@ fn ensure_known_reminder_keys(
 }
 
 fn parse_inject_reminder_options(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     context: &str,
 ) -> Result<SystemReminder, VmError> {
     Ok(SystemReminder {
@@ -813,7 +812,7 @@ struct ClearReminderSelector {
 }
 
 impl ClearReminderSelector {
-    fn matches(&self, reminder: &BTreeMap<String, VmValue>) -> bool {
+    fn matches(&self, reminder: &crate::value::DictMap) -> bool {
         if let Some(expected) = self.id.as_deref() {
             if reminder_string_field(reminder, "id").as_deref() != Some(expected) {
                 return false;
@@ -837,7 +836,7 @@ impl ClearReminderSelector {
 }
 
 fn parse_clear_reminder_selector(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     context: &str,
 ) -> Result<ClearReminderSelector, VmError> {
     let selector = ClearReminderSelector {
@@ -856,7 +855,7 @@ fn parse_clear_reminder_selector(
 }
 
 fn required_reminder_string(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     key: &str,
     context: &str,
 ) -> Result<String, VmError> {
@@ -876,7 +875,7 @@ fn required_reminder_string(
 }
 
 fn optional_reminder_string(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     key: &str,
     context: &str,
 ) -> Result<Option<String>, VmError> {
@@ -898,10 +897,7 @@ fn optional_reminder_string(
     }
 }
 
-fn reminder_tags(
-    options: &BTreeMap<String, VmValue>,
-    context: &str,
-) -> Result<Vec<String>, VmError> {
+fn reminder_tags(options: &crate::value::DictMap, context: &str) -> Result<Vec<String>, VmError> {
     match options.get("tags") {
         None | Some(VmValue::Nil) => Ok(Vec::new()),
         Some(VmValue::List(values)) => {
@@ -937,7 +933,7 @@ fn reminder_tags(
 }
 
 fn optional_reminder_bool(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     key: &str,
     context: &str,
 ) -> Result<Option<bool>, VmError> {
@@ -953,7 +949,7 @@ fn optional_reminder_bool(
 }
 
 fn optional_reminder_ttl(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     context: &str,
 ) -> Result<Option<i64>, VmError> {
     match options.get("ttl_turns") {
@@ -976,7 +972,7 @@ fn optional_reminder_ttl(
 }
 
 fn optional_reminder_propagate(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     context: &str,
 ) -> Result<Option<ReminderPropagate>, VmError> {
     optional_reminder_string(options, "propagate", context)?
@@ -994,7 +990,7 @@ fn optional_reminder_propagate(
 }
 
 fn optional_reminder_role_hint(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     context: &str,
 ) -> Result<Option<ReminderRoleHint>, VmError> {
     optional_reminder_string(options, "role_hint", context)?
@@ -1012,7 +1008,7 @@ fn optional_reminder_role_hint(
         .transpose()
 }
 
-fn reminder_payload(event: &VmValue) -> Option<&BTreeMap<String, VmValue>> {
+fn reminder_payload(event: &VmValue) -> Option<&crate::value::DictMap> {
     let event = event.as_dict()?;
     if event.get("kind").map(|value| value.display()).as_deref() != Some(SYSTEM_REMINDER_EVENT_KIND)
     {
@@ -1021,7 +1017,7 @@ fn reminder_payload(event: &VmValue) -> Option<&BTreeMap<String, VmValue>> {
     event.get("reminder").and_then(VmValue::as_dict)
 }
 
-fn reminder_string_field(reminder: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn reminder_string_field(reminder: &crate::value::DictMap, key: &str) -> Option<String> {
     match reminder.get(key) {
         Some(VmValue::String(value)) if !value.is_empty() => Some(value.to_string()),
         _ => None,
@@ -1048,12 +1044,12 @@ mod tests {
     }
 
     fn dict(entries: Vec<(&str, VmValue)>) -> VmValue {
-        VmValue::Dict(std::sync::Arc::new(
+        VmValue::dict(
             entries
                 .into_iter()
                 .map(|(key, value)| (key.to_string(), value))
-                .collect(),
-        ))
+                .collect::<crate::value::DictMap>(),
+        )
     }
 
     fn strings(values: &[&str]) -> VmValue {

--- a/crates/harn-vm/src/llm/cost.rs
+++ b/crates/harn-vm/src/llm/cost.rs
@@ -212,7 +212,7 @@ fn integer_value(value: &VmValue, key: &str) -> Result<i64, VmError> {
 }
 
 fn parse_budget_fields(
-    fields: &BTreeMap<String, VmValue>,
+    fields: &crate::value::DictMap,
     envelope: &mut LlmBudgetEnvelope,
 ) -> Result<(), VmError> {
     if let Some(value) = fields.get("max_cost_usd") {
@@ -231,7 +231,7 @@ fn parse_budget_fields(
 }
 
 pub(crate) fn parse_budget_envelope(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<Option<LlmBudgetEnvelope>, VmError> {
     let Some(options) = options else {
         return Ok(None);
@@ -374,7 +374,7 @@ pub(crate) fn budget_exceeded_error(
             limit_kind.as_str(),
         ),
     );
-    VmError::Thrown(VmValue::Dict(std::sync::Arc::new(dict)))
+    VmError::Thrown(VmValue::dict(dict))
 }
 
 pub(crate) fn budget_exceeded_limit(
@@ -722,7 +722,7 @@ pub(crate) fn register_cost_builtins(vm: &mut Vm) {
         result.insert("input_tokens".to_string(), VmValue::Int(total_input));
         result.insert("output_tokens".to_string(), VmValue::Int(total_output));
         result.insert("call_count".to_string(), VmValue::Int(call_count));
-        Ok(VmValue::Dict(std::sync::Arc::new(result)))
+        Ok(VmValue::dict(result))
     });
 
     vm.register_builtin("llm_budget", |args, _out| {
@@ -815,7 +815,7 @@ fn pricing_detail_to_vm_value(provider: &str, model: &str, detail: &PricingDetai
             .unwrap_or(VmValue::Nil),
     );
     dict.put_str("source", detail.source.as_str());
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn resolve_pricing_args(args: &[VmValue]) -> (String, String) {
@@ -1034,7 +1034,7 @@ fn llm_compare_costs_builtin(args: &[VmValue], _out: &mut String) -> Result<VmVa
         );
         row.insert("calls".to_string(), VmValue::Int(calls));
         row.insert("pricing_known".to_string(), VmValue::Bool(detail.is_some()));
-        rows.push((projection, VmValue::Dict(std::sync::Arc::new(row))));
+        rows.push((projection, VmValue::dict(row)));
     }
 
     rows.sort_by(|left, right| match (left.0, right.0) {
@@ -1081,7 +1081,7 @@ fn tokenizer_info_to_vm_value(model: &str, info: super::token_count::TokenizerIn
             .map(|encoder| VmValue::String(std::sync::Arc::from(encoder)))
             .unwrap_or(VmValue::Nil),
     );
-    VmValue::Dict(std::sync::Arc::new(result))
+    VmValue::dict(result)
 }
 
 #[cfg(test)]

--- a/crates/harn-vm/src/llm/cost_route.rs
+++ b/crates/harn-vm/src/llm/cost_route.rs
@@ -1,13 +1,12 @@
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 
 use crate::value::{VmError, VmValue};
 
 tokio::task_local! {
-    static COST_ROUTE_STACK: Vec<BTreeMap<String, VmValue>>;
+    static COST_ROUTE_STACK: Vec<crate::value::DictMap>;
 }
 
-fn strategy_text(config: &BTreeMap<String, VmValue>) -> Option<String> {
+fn strategy_text(config: &crate::value::DictMap) -> Option<String> {
     config
         .get("fallback_strategy")
         .or_else(|| config.get("strategy"))
@@ -15,7 +14,7 @@ fn strategy_text(config: &BTreeMap<String, VmValue>) -> Option<String> {
         .filter(|value| !value.trim().is_empty())
 }
 
-fn quality_text(config: &BTreeMap<String, VmValue>) -> String {
+fn quality_text(config: &crate::value::DictMap) -> String {
     config
         .get("quality")
         .or_else(|| config.get("min_quality"))
@@ -30,7 +29,7 @@ fn route_policy_dict(
     prefer: Option<VmValue>,
     strategy: Option<String>,
 ) -> VmValue {
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.put_str("mode", mode);
     if let Some(target) = target {
         dict.put_str("target", target);
@@ -41,16 +40,16 @@ fn route_policy_dict(
     if let Some(strategy) = strategy {
         dict.put_str("strategy", strategy);
     }
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
-fn merge_budget_aliases(options: &mut BTreeMap<String, VmValue>) {
+fn merge_budget_aliases(options: &mut crate::value::DictMap) {
     let Some(budget_usd) = options.get("budget_usd").cloned() else {
         return;
     };
     let mut budget = match options.get("budget") {
         Some(VmValue::Dict(existing)) => existing.as_ref().clone(),
-        _ => BTreeMap::new(),
+        _ => crate::value::DictMap::new(),
     };
     budget
         .entry("max_cost_usd".to_string())
@@ -58,13 +57,10 @@ fn merge_budget_aliases(options: &mut BTreeMap<String, VmValue>) {
     options
         .entry("max_cost_usd".to_string())
         .or_insert(budget_usd);
-    options.insert(
-        "budget".to_string(),
-        VmValue::Dict(std::sync::Arc::new(budget)),
-    );
+    options.insert("budget".to_string(), VmValue::dict(budget));
 }
 
-fn normalize_config(mut config: BTreeMap<String, VmValue>) -> BTreeMap<String, VmValue> {
+fn normalize_config(mut config: crate::value::DictMap) -> crate::value::DictMap {
     merge_budget_aliases(&mut config);
     if config.contains_key("route_policy") {
         return config;
@@ -101,11 +97,11 @@ fn merge_budget(inherited: Option<&VmValue>, explicit: Option<&VmValue>) -> Opti
     let mut merged = match inherited {
         Some(VmValue::Dict(dict)) => dict.as_ref().clone(),
         Some(value) => {
-            let mut dict = BTreeMap::new();
+            let mut dict = crate::value::DictMap::new();
             dict.insert("max_cost_usd".to_string(), value.clone());
             dict
         }
-        None => BTreeMap::new(),
+        None => crate::value::DictMap::new(),
     };
     if let Some(VmValue::Dict(dict)) = explicit {
         for (key, value) in dict.iter() {
@@ -114,15 +110,15 @@ fn merge_budget(inherited: Option<&VmValue>, explicit: Option<&VmValue>) -> Opti
     } else if let Some(value) = explicit {
         merged.insert("max_cost_usd".to_string(), value.clone());
     }
-    (!merged.is_empty()).then(|| VmValue::Dict(std::sync::Arc::new(merged)))
+    (!merged.is_empty()).then(|| VmValue::dict(merged))
 }
 
 pub(crate) fn merge_context_options(
-    explicit: Option<BTreeMap<String, VmValue>>,
-) -> Option<BTreeMap<String, VmValue>> {
+    explicit: Option<crate::value::DictMap>,
+) -> Option<crate::value::DictMap> {
     let inherited = COST_ROUTE_STACK
         .try_with(|stack| {
-            let mut merged = BTreeMap::new();
+            let mut merged = crate::value::DictMap::new();
             for frame in stack.iter() {
                 for (key, value) in frame {
                     merged.insert(key.clone(), value.clone());

--- a/crates/harn-vm/src/llm/daemon.rs
+++ b/crates/harn-vm/src/llm/daemon.rs
@@ -88,7 +88,7 @@ pub(crate) fn persist_snapshot(path: &str, snapshot: &DaemonSnapshot) -> Result<
 }
 
 pub(crate) fn parse_daemon_loop_config(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> DaemonLoopConfig {
     let Some(options) = options else {
         return DaemonLoopConfig::default();

--- a/crates/harn-vm/src/llm/helpers/blocks.rs
+++ b/crates/harn-vm/src/llm/helpers/blocks.rs
@@ -24,7 +24,7 @@ pub(super) fn normalize_message_blocks(content: Option<&VmValue>, role: &str) ->
             )]
         }
         Some(VmValue::Nil) | None => Vec::new(),
-        Some(other) => vec![VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        Some(other) => vec![VmValue::dict(BTreeMap::from([
             (
                 "type".to_string(),
                 VmValue::String(std::sync::Arc::from("text")),
@@ -37,13 +37,13 @@ pub(super) fn normalize_message_blocks(content: Option<&VmValue>, role: &str) ->
                 "visibility".to_string(),
                 VmValue::String(std::sync::Arc::from(default_visibility)),
             ),
-        ])))],
+        ]))],
     }
 }
 
 fn normalize_transcript_block(block: &VmValue, default_visibility: &str) -> VmValue {
     let mut normalized = block.as_dict().cloned().unwrap_or_else(|| {
-        BTreeMap::from([(
+        crate::value::DictMap::from_iter([(
             "text".to_string(),
             VmValue::String(std::sync::Arc::from(block.display())),
         )])
@@ -54,7 +54,7 @@ fn normalize_transcript_block(block: &VmValue, default_visibility: &str) -> VmVa
     if !normalized.contains_key("visibility") {
         normalized.put_str("visibility", default_visibility);
     }
-    VmValue::Dict(std::sync::Arc::new(normalized))
+    VmValue::dict(normalized)
 }
 
 pub(super) fn overall_visibility(blocks: &[VmValue], default_visibility: &str) -> String {
@@ -119,7 +119,7 @@ pub(super) fn render_blocks_text(blocks: &[VmValue]) -> String {
     parts.join(" ")
 }
 
-fn render_assetish_label(kind: &str, dict: &BTreeMap<String, VmValue>) -> String {
+fn render_assetish_label(kind: &str, dict: &crate::value::DictMap) -> String {
     let label = dict
         .get("name")
         .or_else(|| dict.get("title"))

--- a/crates/harn-vm/src/llm/helpers/messages.rs
+++ b/crates/harn-vm/src/llm/helpers/messages.rs
@@ -77,7 +77,7 @@ pub(crate) fn vm_message_value(role: &str, content: VmValue) -> VmValue {
     let mut msg = BTreeMap::new();
     msg.put_str("role", role);
     msg.insert("content".to_string(), content);
-    VmValue::Dict(std::sync::Arc::new(msg))
+    VmValue::dict(msg)
 }
 
 pub(crate) fn json_messages_to_vm(msg_list: &[serde_json::Value]) -> Vec<VmValue> {
@@ -113,7 +113,7 @@ pub(crate) fn json_messages_to_vm(msg_list: &[serde_json::Value]) -> Vec<VmValue
                             result.put_str("role", "tool_result");
                             result.put_str("tool_use_id", tool_use_id);
                             result.put_str("content", content);
-                            return Some(VmValue::Dict(std::sync::Arc::new(result)));
+                            return Some(VmValue::dict(result));
                         }
                     }
                 }

--- a/crates/harn-vm/src/llm/helpers/mod.rs
+++ b/crates/harn-vm/src/llm/helpers/mod.rs
@@ -5,8 +5,6 @@ mod options;
 mod provider;
 mod transcript;
 
-use std::collections::BTreeMap;
-
 use crate::value::VmValue;
 
 pub(crate) use messages::{
@@ -59,7 +57,7 @@ pub(super) const TRANSCRIPT_ASSET_TYPE: &str = "transcript_asset";
 pub(super) const TRANSCRIPT_VERSION: i64 = 2;
 
 /// Convert a VmValue dict to serde_json::Value for API payloads.
-pub(crate) fn vm_value_dict_to_json(dict: &BTreeMap<String, VmValue>) -> serde_json::Value {
+pub(crate) fn vm_value_dict_to_json(dict: &crate::value::DictMap) -> serde_json::Value {
     let mut map = serde_json::Map::new();
     for (k, v) in dict {
         map.insert(k.clone(), vm_value_to_json(v));
@@ -90,7 +88,7 @@ pub fn vm_value_to_json(val: &VmValue) -> serde_json::Value {
 mod tests {
     use super::*;
     use crate::value::VmDictExt;
-    use std::collections::BTreeMap;
+
     use std::rc::Rc;
 
     #[test]
@@ -164,7 +162,7 @@ mod tests {
         // `anthropic/claude-sonnet-4-6` is a catalog alias that resolves
         // to the openrouter provider. With LOCAL_LLM_BASE_URL set the
         // pre-fix code would have returned "local".
-        let opts = Some(BTreeMap::from([(
+        let opts = Some(crate::value::DictMap::from_iter([(
             "model".to_string(),
             VmValue::String(std::sync::Arc::from("anthropic/claude-sonnet-4-6")),
         )]));
@@ -172,7 +170,7 @@ mod tests {
 
         // An unknown id with no catalog hit still falls into "local"
         // so users with a custom local server keep working.
-        let opts_unknown = Some(BTreeMap::from([(
+        let opts_unknown = Some(crate::value::DictMap::from_iter([(
             "model".to_string(),
             VmValue::String(std::sync::Arc::from("my-custom-local-tag")),
         )]));
@@ -201,7 +199,7 @@ mod tests {
 
     #[test]
     fn vm_messages_to_json_preserves_tool_message_fields() {
-        let message = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        let message = VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "role".to_string(),
                 VmValue::String(std::sync::Arc::from("tool")),
@@ -214,7 +212,7 @@ mod tests {
                 "content".to_string(),
                 VmValue::String(std::sync::Arc::from("ok")),
             ),
-        ])));
+        ]));
 
         let json = vm_messages_to_json(&[message]).expect("message json");
         assert_eq!(json[0]["role"], "tool");
@@ -233,10 +231,10 @@ mod tests {
         }
 
         let transcript = new_transcript_with(None, Vec::new(), None, None);
-        let options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        let options = VmValue::dict(crate::value::DictMap::from_iter([(
             "transcript".to_string(),
             transcript,
-        )])));
+        )]));
         let err = extract_llm_options(&[
             VmValue::String(std::sync::Arc::from("")),
             VmValue::Nil,
@@ -281,7 +279,7 @@ mod tests {
         }
         reset_provider_key_cache();
 
-        let options = Some(BTreeMap::from([(
+        let options = Some(crate::value::DictMap::from_iter([(
             "model_tier".to_string(),
             VmValue::String(std::sync::Arc::from("small")),
         )]));
@@ -326,7 +324,7 @@ mod tests {
         }
         reset_provider_key_cache();
 
-        let options = Some(BTreeMap::from([(
+        let options = Some(crate::value::DictMap::from_iter([(
             "model_tier".to_string(),
             VmValue::String(std::sync::Arc::from("small")),
         )]));
@@ -399,19 +397,19 @@ mod tests {
         }
         reset_provider_key_cache();
 
-        let mut opts: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut opts: crate::value::DictMap = crate::value::DictMap::new();
         opts.put_str("provider", "auto");
         opts.put_str("model", "local:gemma-4-e4b-it");
         assert_eq!(vm_resolve_provider(&Some(opts)), "ollama");
 
         // Case-insensitive: "AUTO" should behave the same.
-        let mut opts2: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut opts2: crate::value::DictMap = crate::value::DictMap::new();
         opts2.put_str("provider", "AUTO");
         opts2.put_str("model", "local:foo/bar");
         assert_eq!(vm_resolve_provider(&Some(opts2)), "ollama");
 
         // Explicit non-auto provider still wins.
-        let mut opts3: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut opts3: crate::value::DictMap = crate::value::DictMap::new();
         opts3.put_str("provider", "anthropic");
         opts3.put_str("model", "local:foo");
         assert_eq!(vm_resolve_provider(&Some(opts3)), "anthropic");
@@ -452,7 +450,7 @@ mod tests {
         let sink = Rc::new(crate::events::CollectorSink::new());
         crate::events::add_event_sink(sink.clone());
 
-        let opts = BTreeMap::from([
+        let opts = crate::value::DictMap::from_iter([
             (
                 "provider".to_string(),
                 VmValue::String(std::sync::Arc::from("auto")),
@@ -602,7 +600,7 @@ mod tests {
         // Call-site `model:` option must win — scripts opting into a
         // specific model should not be silently overridden by an ACP
         // pin meant only for "no-option" calls.
-        let mut explicit_opts: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut explicit_opts: crate::value::DictMap = crate::value::DictMap::new();
         explicit_opts.put_str("model", "gpt-4o-mini");
         explicit_opts.put_str("provider", "openai");
         let opts = Some(explicit_opts);

--- a/crates/harn-vm/src/llm/helpers/opt_get.rs
+++ b/crates/harn-vm/src/llm/helpers/opt_get.rs
@@ -1,19 +1,17 @@
-use std::collections::BTreeMap;
-
 use crate::value::VmValue;
 
-pub(crate) fn opt_str(options: &Option<BTreeMap<String, VmValue>>, key: &str) -> Option<String> {
+pub(crate) fn opt_str(options: &Option<crate::value::DictMap>, key: &str) -> Option<String> {
     match options.as_ref()?.get(key)? {
         VmValue::Nil => None,
         value => Some(value.display()),
     }
 }
 
-pub(crate) fn opt_int(options: &Option<BTreeMap<String, VmValue>>, key: &str) -> Option<i64> {
+pub(crate) fn opt_int(options: &Option<crate::value::DictMap>, key: &str) -> Option<i64> {
     options.as_ref()?.get(key)?.as_int()
 }
 
-pub(crate) fn opt_float(options: &Option<BTreeMap<String, VmValue>>, key: &str) -> Option<f64> {
+pub(crate) fn opt_float(options: &Option<crate::value::DictMap>, key: &str) -> Option<f64> {
     options.as_ref()?.get(key).and_then(|v| match v {
         VmValue::Float(f) => Some(*f),
         VmValue::Int(i) => Some(*i as f64),
@@ -21,7 +19,7 @@ pub(crate) fn opt_float(options: &Option<BTreeMap<String, VmValue>>, key: &str) 
     })
 }
 
-pub(crate) fn opt_bool(options: &Option<BTreeMap<String, VmValue>>, key: &str) -> bool {
+pub(crate) fn opt_bool(options: &Option<crate::value::DictMap>, key: &str) -> bool {
     options
         .as_ref()
         .and_then(|o| o.get(key))
@@ -32,7 +30,6 @@ pub(crate) fn opt_bool(options: &Option<BTreeMap<String, VmValue>>, key: &str) -
 #[cfg(test)]
 mod tests {
     use crate::value::VmDictExt;
-    use std::collections::BTreeMap;
 
     use crate::value::VmValue;
 
@@ -40,7 +37,7 @@ mod tests {
 
     #[test]
     fn opt_str_treats_nil_as_unset() {
-        let mut options = BTreeMap::new();
+        let mut options = crate::value::DictMap::new();
         options.insert("path".to_string(), VmValue::Nil);
 
         assert_eq!(opt_str(&Some(options), "path"), None);
@@ -48,7 +45,7 @@ mod tests {
 
     #[test]
     fn opt_str_preserves_string_values() {
-        let mut options = BTreeMap::new();
+        let mut options = crate::value::DictMap::new();
         options.put_str("path", "transcripts");
 
         assert_eq!(

--- a/crates/harn-vm/src/llm/helpers/options/defaults.rs
+++ b/crates/harn-vm/src/llm/helpers/options/defaults.rs
@@ -6,7 +6,7 @@ use crate::value::VmDictExt;
 /// is a no-op when the user explicitly passed `model:`. The budget
 /// merge is non-destructive: only fields the call site didn't already
 /// set are filled in, so a tighter explicit ceiling always wins.
-pub(super) fn apply_active_step_defaults(options: &mut Option<BTreeMap<String, VmValue>>) {
+pub(super) fn apply_active_step_defaults(options: &mut Option<crate::value::DictMap>) {
     let user_supplied_model = options
         .as_ref()
         .map(|o| o.contains_key("model"))
@@ -21,7 +21,7 @@ pub(super) fn apply_active_step_defaults(options: &mut Option<BTreeMap<String, V
     if step_default.is_none() && step_budget.is_none() {
         return;
     }
-    let opts = options.get_or_insert_with(BTreeMap::new);
+    let opts = options.get_or_insert_with(crate::value::DictMap::new);
     if let Some(model_name) = step_default {
         opts.put_str("model", model_name);
     }
@@ -31,9 +31,9 @@ pub(super) fn apply_active_step_defaults(options: &mut Option<BTreeMap<String, V
             // budget envelope so the existing accumulator + projection
             // machinery short-circuits a call that would obviously
             // exceed the step's ceiling.
-            let mut step_budget_dict: BTreeMap<String, VmValue> = match opts.get("budget") {
+            let mut step_budget_dict: crate::value::DictMap = match opts.get("budget") {
                 Some(VmValue::Dict(existing)) => (**existing).clone(),
-                _ => BTreeMap::new(),
+                _ => crate::value::DictMap::new(),
             };
             if let Some(max_tokens) = max_tokens {
                 step_budget_dict
@@ -45,10 +45,7 @@ pub(super) fn apply_active_step_defaults(options: &mut Option<BTreeMap<String, V
                     .entry("max_cost_usd".to_string())
                     .or_insert_with(|| VmValue::Float(max_usd));
             }
-            opts.insert(
-                "budget".to_string(),
-                VmValue::Dict(std::sync::Arc::new(step_budget_dict)),
-            );
+            opts.insert("budget".to_string(), VmValue::dict(step_budget_dict));
         }
     }
 }
@@ -63,16 +60,16 @@ pub(super) fn toml_value_to_vm_value(value: &toml::Value) -> VmValue {
         toml::Value::Array(items) => VmValue::List(std::sync::Arc::new(
             items.iter().map(toml_value_to_vm_value).collect(),
         )),
-        toml::Value::Table(table) => VmValue::Dict(std::sync::Arc::new(
+        toml::Value::Table(table) => VmValue::dict(
             table
                 .iter()
                 .map(|(key, value)| (key.clone(), toml_value_to_vm_value(value)))
-                .collect(),
-        )),
+                .collect::<crate::value::DictMap>(),
+        ),
     }
 }
 
-pub(super) fn model_role_option(options: &Option<BTreeMap<String, VmValue>>) -> Option<String> {
+pub(super) fn model_role_option(options: &Option<crate::value::DictMap>) -> Option<String> {
     options
         .as_ref()
         .and_then(|opts| opts.get("model_role").or_else(|| opts.get("role")))
@@ -82,7 +79,7 @@ pub(super) fn model_role_option(options: &Option<BTreeMap<String, VmValue>>) -> 
         .filter(|value| !value.is_empty())
 }
 
-pub(super) fn apply_model_role_defaults(options: &mut Option<BTreeMap<String, VmValue>>) {
+pub(super) fn apply_model_role_defaults(options: &mut Option<crate::value::DictMap>) {
     let Some(role) = model_role_option(options) else {
         return;
     };
@@ -90,7 +87,7 @@ pub(super) fn apply_model_role_defaults(options: &mut Option<BTreeMap<String, Vm
     if defaults.is_empty() {
         return;
     }
-    let opts = options.get_or_insert_with(BTreeMap::new);
+    let opts = options.get_or_insert_with(crate::value::DictMap::new);
     for (key, value) in defaults {
         if key == "model_role" || key == "role" {
             continue;

--- a/crates/harn-vm/src/llm/helpers/options/extract.rs
+++ b/crates/harn-vm/src/llm/helpers/options/extract.rs
@@ -666,7 +666,7 @@ pub(crate) fn extract_llm_options(
 }
 
 pub(crate) fn opt_str_list(
-    options: &Option<BTreeMap<String, VmValue>>,
+    options: &Option<crate::value::DictMap>,
     key: &str,
 ) -> Option<Vec<String>> {
     let val = options.as_ref()?.get(key)?;

--- a/crates/harn-vm/src/llm/helpers/options/mod.rs
+++ b/crates/harn-vm/src/llm/helpers/options/mod.rs
@@ -31,7 +31,6 @@ mod routing_tests;
 
 // Shared imports re-exported across the whole `options` subtree so each
 // submodule only needs `use super::*;`.
-pub(super) use std::collections::BTreeMap;
 
 pub(super) use crate::stdlib::xml::escape_xml_text;
 pub(super) use crate::value::{VmError, VmValue};

--- a/crates/harn-vm/src/llm/helpers/options/output.rs
+++ b/crates/harn-vm/src/llm/helpers/options/output.rs
@@ -6,7 +6,7 @@ use super::*;
 /// Harn cannot parse but that is known to forward `tool_search` +
 /// `defer_loading` unchanged.
 pub(super) fn provider_overrides_force_native(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     provider: &str,
 ) -> bool {
     let Some(options) = options else { return false };
@@ -29,7 +29,7 @@ pub(super) fn classify_native_shape(
 }
 
 pub(super) fn parse_api_mode_option(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<crate::llm::api::LlmApiMode, VmError> {
     let Some(raw) = options.and_then(|o| o.get("api_mode").or_else(|| o.get("api"))) else {
         return Ok(crate::llm::api::LlmApiMode::ChatCompletions);
@@ -64,7 +64,7 @@ pub(super) fn enforce_responses_provider_gate(
 }
 
 pub(super) fn parse_provider_tools_option(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<Vec<serde_json::Value>, VmError> {
     let Some(raw) = options.and_then(|o| o.get("provider_tools").or_else(|| o.get("hosted_tools")))
     else {
@@ -96,7 +96,7 @@ pub(super) fn parse_provider_tools_option(
 }
 
 pub(super) fn opt_bool_field(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     key: &str,
 ) -> Result<Option<bool>, VmError> {
     match options.and_then(|o| o.get(key)) {
@@ -109,7 +109,7 @@ pub(super) fn opt_bool_field(
 }
 
 pub(super) fn opt_responses_store_field(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<Option<bool>, VmError> {
     if let Some(value) = opt_bool_field(options, "response_store")? {
         return Ok(Some(value));
@@ -151,7 +151,7 @@ pub(super) fn unsupported_option_error(option: &str, provider: &str, model: &str
     ))))
 }
 
-pub(super) fn option_is_enabled(options: Option<&BTreeMap<String, VmValue>>, key: &str) -> bool {
+pub(super) fn option_is_enabled(options: Option<&crate::value::DictMap>, key: &str) -> bool {
     options
         .and_then(|o| o.get(key))
         .is_some_and(|value| value.is_truthy())
@@ -170,7 +170,7 @@ pub(super) fn parse_output_format_kind(raw: &str) -> Result<&'static str, VmErro
 }
 
 pub(super) fn parse_output_format_option(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     legacy_response_format: Option<&str>,
     legacy_json_schema: Option<&serde_json::Value>,
 ) -> Result<crate::llm::api::OutputFormat, VmError> {

--- a/crates/harn-vm/src/llm/helpers/options/output_format_tests.rs
+++ b/crates/harn-vm/src/llm/helpers/options/output_format_tests.rs
@@ -4,20 +4,18 @@ use crate::value::VmDictExt;
 
 #[test]
 fn parses_explicit_json_schema_output_format() {
-    let mut fmt = BTreeMap::new();
+    let mut fmt = crate::value::DictMap::new();
     fmt.put_str("kind", "json_schema");
     fmt.insert(
         "schema".to_string(),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        VmValue::dict(crate::value::DictMap::from_iter([(
             "type".to_string(),
             VmValue::String(std::sync::Arc::from("object")),
-        )]))),
+        )])),
     );
     fmt.insert("strict".to_string(), VmValue::Bool(false));
-    let options = BTreeMap::from([(
-        "output_format".to_string(),
-        VmValue::Dict(std::sync::Arc::new(fmt)),
-    )]);
+    let options =
+        crate::value::DictMap::from_iter([("output_format".to_string(), VmValue::dict(fmt))]);
 
     let parsed = parse_output_format_option(Some(&options), None, None).expect("output_format");
 
@@ -34,8 +32,12 @@ fn parses_explicit_json_schema_output_format() {
 fn legacy_response_format_and_json_schema_map_to_typed_output_format() {
     let schema = serde_json::json!({"type": "object"});
 
-    let parsed = parse_output_format_option(Some(&BTreeMap::new()), Some("json"), Some(&schema))
-        .expect("legacy output format");
+    let parsed = parse_output_format_option(
+        Some(&crate::value::DictMap::new()),
+        Some("json"),
+        Some(&schema),
+    )
+    .expect("legacy output format");
 
     assert_eq!(
         parsed,

--- a/crates/harn-vm/src/llm/helpers/options/reminder_render_tests.rs
+++ b/crates/harn-vm/src/llm/helpers/options/reminder_render_tests.rs
@@ -94,7 +94,7 @@ fn local_fallback_renders_plain_system_text() {
 
 #[test]
 fn system_text_reminders_are_excluded_from_system_string() {
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         (
             "system_prompt_parts".to_string(),
             VmValue::String(std::sync::Arc::from("parts")),
@@ -131,12 +131,12 @@ fn s(text: &str) -> VmValue {
 }
 
 fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(
+    VmValue::dict(
         pairs
             .iter()
             .map(|(k, v)| (k.to_string(), v.clone()))
-            .collect(),
-    ))
+            .collect::<crate::value::DictMap>(),
+    )
 }
 
 fn list(items: Vec<VmValue>) -> VmValue {
@@ -145,7 +145,7 @@ fn list(items: Vec<VmValue>) -> VmValue {
 
 #[test]
 fn full_host_option_ordering_is_faithful() {
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         ("system_preamble".to_string(), s("P")),
         ("system_prefix".to_string(), s("X")),
         ("system_context".to_string(), s("C")),
@@ -174,7 +174,7 @@ fn system_string_is_byte_stable_across_changing_reminder_sets() {
     // the live reminder set. Turn N has no reminders; turn N+1 fires a
     // token-pressure reminder. The assembled `system` string must be
     // byte-identical so the non-Anthropic prefix cache stays warm.
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         ("system_prompt_parts".to_string(), s("parts")),
         ("system_appendix".to_string(), s("appendix")),
     ]);
@@ -276,7 +276,7 @@ fn multiple_system_text_reminders_coalesce_into_one_trailing_message() {
 
 #[test]
 fn dict_part_position_override_moves_to_after() {
-    let options = BTreeMap::from([(
+    let options = crate::value::DictMap::from_iter([(
         "system_prompt_parts".to_string(),
         dict(&[("content", s("moved")), ("position", s("after"))]),
     )]);
@@ -288,7 +288,7 @@ fn dict_part_position_override_moves_to_after() {
 
 #[test]
 fn dict_part_with_title_renders_heading() {
-    let options = BTreeMap::from([(
+    let options = crate::value::DictMap::from_iter([(
         "system_prompt_parts".to_string(),
         dict(&[("content", s("body")), ("title", s("Title"))]),
     )]);
@@ -300,7 +300,7 @@ fn dict_part_with_title_renders_heading() {
 
 #[test]
 fn list_parts_expand_in_declaration_order() {
-    let options = BTreeMap::from([(
+    let options = crate::value::DictMap::from_iter([(
         "system_prompt_parts".to_string(),
         list(vec![s("one"), s("two")]),
     )]);
@@ -312,7 +312,7 @@ fn list_parts_expand_in_declaration_order() {
 
 #[test]
 fn nil_system_arg_falls_back_to_opts_system() {
-    let options = BTreeMap::from([("system".to_string(), s("fromopts"))]);
+    let options = crate::value::DictMap::from_iter([("system".to_string(), s("fromopts"))]);
     let prompt = compose_system_prompt(None, Some(&options))
         .expect("system prompt")
         .expect("non-empty prompt");
@@ -322,7 +322,7 @@ fn nil_system_arg_falls_back_to_opts_system() {
 #[test]
 fn tool_guidance_is_injected_only_when_the_tool_is_present() {
     // Tool carrying `guidance` → instruction auto-included after primary.
-    let with_guidance = BTreeMap::from([(
+    let with_guidance = crate::value::DictMap::from_iter([(
         "tools".to_string(),
         list(vec![dict(&[
             ("name", s("todo")),
@@ -342,7 +342,7 @@ fn tool_guidance_is_injected_only_when_the_tool_is_present() {
     );
 
     // Same tool without `guidance`, or a different tool set → no fragment.
-    let no_guidance = BTreeMap::from([(
+    let no_guidance = crate::value::DictMap::from_iter([(
         "tools".to_string(),
         list(vec![dict(&[
             ("name", s("read")),
@@ -357,7 +357,7 @@ fn tool_guidance_is_injected_only_when_the_tool_is_present() {
 
 #[test]
 fn assemble_records_provenance_for_every_fragment() {
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         ("system_prompt_parts".to_string(), s("parts")),
         (
             "tools".to_string(),
@@ -392,7 +392,7 @@ fn fragment(id: &str, body: &str) -> VmValue {
 fn system_fragments_expand_in_place_of_the_single_primary() {
     // The decomposed channel yields the same bytes as the equivalent
     // joined-string primary, while keeping each part individually traced.
-    let decomposed = BTreeMap::from([
+    let decomposed = crate::value::DictMap::from_iter([
         ("system_prefix".to_string(), s("X")),
         (
             "_system_fragments".to_string(),
@@ -405,7 +405,7 @@ fn system_fragments_expand_in_place_of_the_single_primary() {
         ("system_appendix".to_string(), s("A")),
     ]);
     let joined = "base\n\n## Active skills\n\nKeep going until done.";
-    let baseline = BTreeMap::from([
+    let baseline = crate::value::DictMap::from_iter([
         ("system_prefix".to_string(), s("X")),
         ("system_appendix".to_string(), s("A")),
     ]);
@@ -435,7 +435,7 @@ fn system_fragments_expand_in_place_of_the_single_primary() {
 fn system_fragments_supersede_the_system_arg() {
     // When the channel is present, the `system` arg / `opts.system` no
     // longer contributes a primary fragment — the channel owns that block.
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         ("system".to_string(), s("ignored opts.system")),
         (
             "_system_fragments".to_string(),
@@ -452,7 +452,8 @@ fn system_fragments_supersede_the_system_arg() {
 fn empty_system_fragments_yield_no_primary() {
     // An empty list still claims the primary block: the agent computed zero
     // non-empty parts, so the `system` arg must not leak back in.
-    let options = BTreeMap::from([("_system_fragments".to_string(), list(vec![]))]);
+    let options =
+        crate::value::DictMap::from_iter([("_system_fragments".to_string(), list(vec![]))]);
     let prompt = compose_system_prompt(Some("should not appear".to_string()), Some(&options))
         .expect("system prompt");
     assert_eq!(prompt, None);
@@ -460,7 +461,7 @@ fn empty_system_fragments_yield_no_primary() {
 
 #[test]
 fn system_fragments_honor_per_part_tool_gating() {
-    let options = BTreeMap::from([(
+    let options = crate::value::DictMap::from_iter([(
         "_system_fragments".to_string(),
         list(vec![dict(&[
             ("id", s("primary:todo_nudge")),
@@ -482,7 +483,7 @@ fn system_fragments_honor_per_part_tool_gating() {
 
 #[test]
 fn system_fragments_can_target_the_tail_bucket() {
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         (
             "_system_fragments".to_string(),
             list(vec![
@@ -514,7 +515,7 @@ fn system_fragments_can_target_the_tail_bucket() {
 
 #[test]
 fn system_fragments_reject_unknown_bucket() {
-    let options = BTreeMap::from([(
+    let options = crate::value::DictMap::from_iter([(
         "_system_fragments".to_string(),
         list(vec![dict(&[
             ("id", s("primary:bad")),
@@ -531,7 +532,7 @@ fn system_fragments_reject_unknown_bucket() {
 
 #[test]
 fn context_profile_fragments_join_prompt_explain_provenance() {
-    let options = BTreeMap::from([(
+    let options = crate::value::DictMap::from_iter([(
         "context_profile".to_string(),
         dict(&[
             ("caps", list(vec![s("remote.github")])),

--- a/crates/harn-vm/src/llm/helpers/options/routing.rs
+++ b/crates/harn-vm/src/llm/helpers/options/routing.rs
@@ -88,7 +88,7 @@ pub(super) fn vm_string_list(value: &VmValue) -> Vec<String> {
 }
 
 pub(super) fn parse_route_policy_option(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<crate::llm::api::LlmRoutePolicy, VmError> {
     use crate::llm::api::LlmRoutePolicy;
     let Some(raw) = options.and_then(|o| o.get("route_policy")) else {
@@ -153,9 +153,7 @@ pub(super) fn parse_route_policy_option(
     }
 }
 
-pub(super) fn parse_fallback_chain_option(
-    options: Option<&BTreeMap<String, VmValue>>,
-) -> Vec<String> {
+pub(super) fn parse_fallback_chain_option(options: Option<&crate::value::DictMap>) -> Vec<String> {
     let Some(raw) = options.and_then(|o| o.get("fallback_chain")) else {
         return Vec::new();
     };
@@ -183,7 +181,7 @@ pub(super) fn parse_fallback_chain_option(
 }
 
 pub(super) fn parse_equivalent_failover_option(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     provider: &str,
     model: &str,
     explicit_routing_policy: bool,

--- a/crates/harn-vm/src/llm/helpers/options/routing_tests.rs
+++ b/crates/harn-vm/src/llm/helpers/options/routing_tests.rs
@@ -105,7 +105,7 @@ fn test_equivalent_model(provider: &str, group: &str) -> ModelDef {
         tier: Some("mid".to_string()),
         open_weight: Some(true),
         strengths: Vec::new(),
-        benchmarks: BTreeMap::new(),
+        benchmarks: std::collections::BTreeMap::new(),
         family: Some("test-equivalent-family".to_string()),
         lineage: None,
         complementary_with: Vec::new(),
@@ -148,7 +148,7 @@ fn install_equivalent_routes() {
 }
 
 fn extract_with_policy(policy: &str) -> crate::llm::api::LlmCallOptions {
-    let mut options = BTreeMap::new();
+    let mut options = crate::value::DictMap::new();
     options.put_str("route_policy", policy);
     options.insert(
         "fallback_chain".to_string(),
@@ -159,7 +159,7 @@ fn extract_with_policy(policy: &str) -> crate::llm::api::LlmCallOptions {
     extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ])
     .expect("options")
 }
@@ -182,17 +182,17 @@ fn cheapest_over_quality_selects_lowest_cost_available_candidate() {
 }
 
 fn extract_with_options(
-    opts: BTreeMap<String, VmValue>,
+    opts: crate::value::DictMap,
 ) -> Result<crate::llm::api::LlmCallOptions, VmError> {
     extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(opts)),
+        VmValue::dict(opts),
     ])
 }
 
-fn model_role_options(role: &str) -> BTreeMap<String, VmValue> {
-    BTreeMap::from([(
+fn model_role_options(role: &str) -> crate::value::DictMap {
+    crate::value::DictMap::from_iter([(
         "model_role".to_string(),
         VmValue::String(std::sync::Arc::from(role.to_string())),
     )])
@@ -220,7 +220,7 @@ fn model_role_defaults_fill_missing_llm_options() {
     let mut overlay = ProvidersConfig::default();
     overlay.model_roles.insert(
         "merge".to_string(),
-        BTreeMap::from([
+        std::collections::BTreeMap::from_iter([
             (
                 "provider".to_string(),
                 toml::Value::String("mock".to_string()),
@@ -255,7 +255,7 @@ fn explicit_options_win_over_model_role_defaults() {
     let mut overlay = ProvidersConfig::default();
     overlay.model_roles.insert(
         "merge".to_string(),
-        BTreeMap::from([
+        std::collections::BTreeMap::from_iter([
             (
                 "provider".to_string(),
                 toml::Value::String("mock".to_string()),
@@ -310,7 +310,7 @@ fn model_role_aliases_do_not_override_exact_role_defaults() {
     let mut overlay = ProvidersConfig::default();
     overlay.model_roles.insert(
         "fast_apply".to_string(),
-        BTreeMap::from([
+        std::collections::BTreeMap::from_iter([
             (
                 "provider".to_string(),
                 toml::Value::String("mock".to_string()),
@@ -323,7 +323,7 @@ fn model_role_aliases_do_not_override_exact_role_defaults() {
     );
     overlay.model_roles.insert(
         "merge".to_string(),
-        BTreeMap::from([
+        std::collections::BTreeMap::from_iter([
             (
                 "provider".to_string(),
                 toml::Value::String("mock".to_string()),
@@ -379,7 +379,7 @@ fn model_role_config_keys_normalize_like_call_options() {
     let mut overlay = ProvidersConfig::default();
     overlay.model_roles.insert(
         "fast-apply".to_string(),
-        BTreeMap::from([
+        std::collections::BTreeMap::from_iter([
             (
                 "provider".to_string(),
                 toml::Value::String("mock".to_string()),
@@ -403,8 +403,8 @@ fn model_role_config_keys_normalize_like_call_options() {
     super::super::reset_provider_key_cache();
 }
 
-fn fast_options(model: &str) -> BTreeMap<String, VmValue> {
-    let mut options = BTreeMap::new();
+fn fast_options(model: &str) -> crate::value::DictMap {
+    let mut options = crate::value::DictMap::new();
     options.put_str("model", model);
     options.insert("fast".to_string(), VmValue::Bool(true));
     options
@@ -461,7 +461,7 @@ fn fastest_over_quality_selects_lowest_latency_available_candidate() {
 #[test]
 fn preference_list_cheapest_first_sets_route_fallbacks() {
     install_test_routes();
-    let mut policy = BTreeMap::new();
+    let mut policy = crate::value::DictMap::new();
     policy.put_str("mode", "preference_list");
     policy.put_str("strategy", "cheapest_first");
     policy.insert(
@@ -471,15 +471,12 @@ fn preference_list_cheapest_first_sets_route_fallbacks() {
             VmValue::String(std::sync::Arc::from("cheap-mid")),
         ])),
     );
-    let mut options = BTreeMap::new();
-    options.insert(
-        "route_policy".to_string(),
-        VmValue::Dict(std::sync::Arc::new(policy)),
-    );
+    let mut options = crate::value::DictMap::new();
+    options.insert("route_policy".to_string(), VmValue::dict(policy));
     let opts = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ])
     .expect("options");
 
@@ -495,9 +492,9 @@ fn preference_list_cheapest_first_sets_route_fallbacks() {
 #[test]
 fn equivalent_failover_builds_catalog_backed_routing_policy() {
     install_equivalent_routes();
-    let mut failover = BTreeMap::new();
+    let mut failover = crate::value::DictMap::new();
     failover.insert("max_routes".to_string(), VmValue::Int(2));
-    let opts = extract_with_options(BTreeMap::from([
+    let opts = extract_with_options(crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("primary")),
@@ -506,10 +503,7 @@ fn equivalent_failover_builds_catalog_backed_routing_policy() {
             "model".to_string(),
             VmValue::String(std::sync::Arc::from("primary-model")),
         ),
-        (
-            "equivalent_failover".to_string(),
-            VmValue::Dict(std::sync::Arc::new(failover)),
-        ),
+        ("equivalent_failover".to_string(), VmValue::dict(failover)),
     ]))
     .expect("options");
 
@@ -536,7 +530,7 @@ fn equivalent_failover_builds_catalog_backed_routing_policy() {
 fn equivalent_failover_rejects_explicit_routing_policy() {
     install_equivalent_routes();
     let chain = VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
-        std::sync::Arc::new(BTreeMap::from([
+        std::sync::Arc::new(crate::value::DictMap::from_iter([
             (
                 "provider".to_string(),
                 VmValue::String(std::sync::Arc::from("primary")),
@@ -547,11 +541,13 @@ fn equivalent_failover_rejects_explicit_routing_policy() {
             ),
         ])),
     )]));
-    let routing =
-        crate::llm::routing::build_routing_policy(&BTreeMap::from([("chain".to_string(), chain)]))
-            .expect("routing policy");
+    let routing = crate::llm::routing::build_routing_policy(&crate::value::DictMap::from_iter([(
+        "chain".to_string(),
+        chain,
+    )]))
+    .expect("routing policy");
 
-    let err = match extract_with_options(BTreeMap::from([
+    let err = match extract_with_options(crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("primary")),
@@ -590,20 +586,20 @@ fn always_policy_accepts_provider_model_selector() {
 
 #[test]
 fn thinking_dict_enabled_false_disables_thinking() {
-    let mut options = BTreeMap::new();
+    let mut options = crate::value::DictMap::new();
     options.put_str("provider", "mock");
     options.put_str("model", "gpt-5.4");
     options.insert(
         "thinking".to_string(),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        VmValue::dict(crate::value::DictMap::from_iter([(
             "enabled".to_string(),
             VmValue::Bool(false),
-        )]))),
+        )])),
     );
     let opts = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ])
     .expect("options");
     assert!(opts.thinking.is_disabled());
@@ -611,23 +607,23 @@ fn thinking_dict_enabled_false_disables_thinking() {
 
 #[test]
 fn thinking_dict_enabled_budget_parses_typed_config() {
-    let mut options = BTreeMap::new();
+    let mut options = crate::value::DictMap::new();
     options.put_str("provider", "mock");
     options.put_str("model", "claude-opus-4-6");
     options.insert(
         "thinking".to_string(),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "mode".to_string(),
                 VmValue::String(std::sync::Arc::from("enabled".to_string())),
             ),
             ("budget_tokens".to_string(), VmValue::Int(8000)),
-        ]))),
+        ])),
     );
     let opts = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ])
     .expect("options");
     assert_eq!(
@@ -644,7 +640,7 @@ fn thinking_dict_enabled_budget_parses_typed_config() {
 
 #[test]
 fn anthropic_beta_features_parse_and_dedupe_with_interleaved_flag() {
-    let mut options = BTreeMap::new();
+    let mut options = crate::value::DictMap::new();
     options.put_str("provider", "mock");
     options.put_str("model", "claude-opus-4-6");
     options.insert(
@@ -663,7 +659,7 @@ fn anthropic_beta_features_parse_and_dedupe_with_interleaved_flag() {
     let opts = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ])
     .expect("options");
     assert_eq!(
@@ -677,7 +673,7 @@ fn anthropic_beta_features_parse_and_dedupe_with_interleaved_flag() {
 
 #[test]
 fn anthropic_beta_features_reject_invalid_header_names() {
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("mock".to_string())),
@@ -695,7 +691,7 @@ fn anthropic_beta_features_reject_invalid_header_names() {
     let err = match extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ]) {
         Ok(_) => panic!("invalid beta feature should fail before transport"),
         Err(err) => err,
@@ -705,12 +701,12 @@ fn anthropic_beta_features_reject_invalid_header_names() {
 
 #[test]
 fn thinking_effort_parses_typed_level() {
-    let mut options = BTreeMap::new();
+    let mut options = crate::value::DictMap::new();
     options.put_str("provider", "mock");
     options.put_str("model", "o3");
     options.insert(
         "thinking".to_string(),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "mode".to_string(),
                 VmValue::String(std::sync::Arc::from("effort".to_string())),
@@ -719,12 +715,12 @@ fn thinking_effort_parses_typed_level() {
                 "level".to_string(),
                 VmValue::String(std::sync::Arc::from("high".to_string())),
             ),
-        ]))),
+        ])),
     );
     let opts = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ])
     .expect("options");
     assert_eq!(
@@ -736,7 +732,7 @@ fn thinking_effort_parses_typed_level() {
 }
 
 fn unsupported_local_options(extra: Vec<(&str, VmValue)>) -> VmError {
-    let mut options = BTreeMap::from([
+    let mut options = crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("local".to_string())),
@@ -752,7 +748,7 @@ fn unsupported_local_options(extra: Vec<(&str, VmValue)>) -> VmError {
     match extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ]) {
         Ok(_) => panic!("unsupported option should fail"),
         Err(err) => err,
@@ -776,7 +772,7 @@ fn assert_unsupported_local_option(option: &str, extra: Vec<(&str, VmValue)>) {
 
 fn one_tool_list() -> VmValue {
     VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
-        std::sync::Arc::new(BTreeMap::from([
+        std::sync::Arc::new(crate::value::DictMap::from_iter([
             (
                 "name".to_string(),
                 VmValue::String(std::sync::Arc::from("lookup")),
@@ -787,7 +783,7 @@ fn one_tool_list() -> VmValue {
             ),
             (
                 "parameters".to_string(),
-                VmValue::Dict(std::sync::Arc::new(BTreeMap::new())),
+                VmValue::dict(crate::value::DictMap::new()),
             ),
         ])),
     )]))
@@ -865,7 +861,7 @@ fn tool_choice_accepted_on_text_tool_routes() {
     crate::llm_config::clear_user_overrides();
     super::super::reset_provider_key_cache();
 
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("ollama".to_string())),
@@ -882,7 +878,7 @@ fn tool_choice_accepted_on_text_tool_routes() {
     extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ])
     .expect("tool_choice accepted on text-format routes");
 }
@@ -893,7 +889,7 @@ fn text_tool_format_does_not_emit_native_provider_tools() {
     crate::llm_config::clear_user_overrides();
     super::super::reset_provider_key_cache();
 
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("ollama".to_string())),
@@ -911,7 +907,7 @@ fn text_tool_format_does_not_emit_native_provider_tools() {
     let opts = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ])
     .expect("text-format tools accepted");
 
@@ -921,7 +917,7 @@ fn text_tool_format_does_not_emit_native_provider_tools() {
 
 #[test]
 fn standalone_reasoning_effort_maps_to_thinking_effort_when_supported() {
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("mock".to_string())),
@@ -939,7 +935,7 @@ fn standalone_reasoning_effort_maps_to_thinking_effort_when_supported() {
     let opts = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ])
     .expect("supported reasoning_effort");
 
@@ -953,7 +949,7 @@ fn standalone_reasoning_effort_maps_to_thinking_effort_when_supported() {
 
 #[test]
 fn standalone_reasoning_effort_accepts_minimal_when_supported() {
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("mock".to_string())),
@@ -971,7 +967,7 @@ fn standalone_reasoning_effort_accepts_minimal_when_supported() {
     let opts = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ])
     .expect("minimal reasoning_effort");
 
@@ -985,7 +981,7 @@ fn standalone_reasoning_effort_accepts_minimal_when_supported() {
 
 #[test]
 fn reasoning_policy_maps_to_provider_aware_thinking_when_explicit() {
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("mock".to_string())),
@@ -1003,7 +999,7 @@ fn reasoning_policy_maps_to_provider_aware_thinking_when_explicit() {
     let opts = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ])
     .expect("reasoning_policy");
 
@@ -1023,7 +1019,7 @@ fn session_pinned_reasoning_policy_is_llm_call_default() {
     crate::agent_sessions::set_pinned_reasoning_policy(&session_id, Some("high".to_string()))
         .expect("set policy");
     let _session_guard = crate::agent_sessions::enter_current_session(session_id);
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("mock".to_string())),
@@ -1037,7 +1033,7 @@ fn session_pinned_reasoning_policy_is_llm_call_default() {
     let opts = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ])
     .expect("session reasoning_policy");
 
@@ -1061,7 +1057,7 @@ fn explicit_thinking_wins_over_session_pinned_reasoning_policy() {
     crate::agent_sessions::set_pinned_reasoning_policy(&session_id, Some("high".to_string()))
         .expect("set policy");
     let _session_guard = crate::agent_sessions::enter_current_session(session_id);
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("mock".to_string())),
@@ -1076,7 +1072,7 @@ fn explicit_thinking_wins_over_session_pinned_reasoning_policy() {
     let opts = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ])
     .expect("explicit thinking");
 
@@ -1092,7 +1088,7 @@ fn standalone_reasoning_effort_accepts_none_and_xhigh_when_supported() {
         ("none", crate::llm::api::ReasoningEffort::None),
         ("xhigh", crate::llm::api::ReasoningEffort::XHigh),
     ] {
-        let options = BTreeMap::from([
+        let options = crate::value::DictMap::from_iter([
             (
                 "provider".to_string(),
                 VmValue::String(std::sync::Arc::from("mock".to_string())),
@@ -1110,7 +1106,7 @@ fn standalone_reasoning_effort_accepts_none_and_xhigh_when_supported() {
         let opts = extract_llm_options(&[
             VmValue::String(std::sync::Arc::from("hello".to_string())),
             VmValue::Nil,
-            VmValue::Dict(std::sync::Arc::new(options)),
+            VmValue::dict(options),
         ])
         .expect("reasoning_effort");
 
@@ -1131,7 +1127,7 @@ fn standalone_reasoning_effort_rejects_cerebras_gpt_oss_unsupported_levels() {
         ),
         (
             "thinking",
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            VmValue::dict(crate::value::DictMap::from_iter([
                 (
                     "mode".to_string(),
                     VmValue::String(std::sync::Arc::from("effort".to_string())),
@@ -1140,10 +1136,10 @@ fn standalone_reasoning_effort_rejects_cerebras_gpt_oss_unsupported_levels() {
                     "level".to_string(),
                     VmValue::String(std::sync::Arc::from("minimal".to_string())),
                 ),
-            ]))),
+            ])),
         ),
     ] {
-        let options = BTreeMap::from([
+        let options = crate::value::DictMap::from_iter([
             (
                 "provider".to_string(),
                 VmValue::String(std::sync::Arc::from("cerebras".to_string())),
@@ -1170,7 +1166,7 @@ fn standalone_reasoning_effort_rejects_cerebras_gpt_oss_unsupported_levels() {
 
 #[test]
 fn standalone_reasoning_effort_none_disables_thinking_without_effort_capability() {
-    let options = BTreeMap::from([
+    let options = crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("local".to_string())),
@@ -1188,7 +1184,7 @@ fn standalone_reasoning_effort_none_disables_thinking_without_effort_capability(
     let opts = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("hello".to_string())),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ])
     .expect("reasoning_effort none should be universally accepted");
 
@@ -1233,7 +1229,7 @@ thinking_modes = ["effort"]
 
 #[test]
 fn image_content_sets_vision_and_requires_capability() {
-    let image_block = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    let image_block = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "type".to_string(),
             VmValue::String(std::sync::Arc::from("image")),
@@ -1246,8 +1242,8 @@ fn image_content_sets_vision_and_requires_capability() {
             "media_type".to_string(),
             VmValue::String(std::sync::Arc::from("image/png")),
         ),
-    ])));
-    let message = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    ]));
+    let message = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "role".to_string(),
             VmValue::String(std::sync::Arc::from("user")),
@@ -1256,8 +1252,8 @@ fn image_content_sets_vision_and_requires_capability() {
             "content".to_string(),
             VmValue::List(std::sync::Arc::new(vec![image_block])),
         ),
-    ])));
-    let options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    ]));
+    let options = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("mock")),
@@ -1270,7 +1266,7 @@ fn image_content_sets_vision_and_requires_capability() {
             "messages".to_string(),
             VmValue::List(std::sync::Arc::new(vec![message.clone()])),
         ),
-    ])));
+    ]));
     let opts = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("")),
         VmValue::Nil,
@@ -1279,7 +1275,7 @@ fn image_content_sets_vision_and_requires_capability() {
     .unwrap();
     assert!(opts.vision);
 
-    let bad_options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    let bad_options = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("mock")),
@@ -1292,7 +1288,7 @@ fn image_content_sets_vision_and_requires_capability() {
             "messages".to_string(),
             VmValue::List(std::sync::Arc::new(vec![message])),
         ),
-    ])));
+    ]));
     let err = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("")),
         VmValue::Nil,
@@ -1302,7 +1298,7 @@ fn image_content_sets_vision_and_requires_capability() {
     .expect("non-vision model should reject image content");
     assert!(err.to_string().contains("option `vision` is not supported"));
 
-    let url_image = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    let url_image = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "type".to_string(),
             VmValue::String(std::sync::Arc::from("image")),
@@ -1315,8 +1311,8 @@ fn image_content_sets_vision_and_requires_capability() {
             "media_type".to_string(),
             VmValue::String(std::sync::Arc::from("image/png")),
         ),
-    ])));
-    let url_message = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    ]));
+    let url_message = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "role".to_string(),
             VmValue::String(std::sync::Arc::from("user")),
@@ -1325,8 +1321,8 @@ fn image_content_sets_vision_and_requires_capability() {
             "content".to_string(),
             VmValue::List(std::sync::Arc::new(vec![url_image])),
         ),
-    ])));
-    let ollama_options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    ]));
+    let ollama_options = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("ollama")),
@@ -1339,7 +1335,7 @@ fn image_content_sets_vision_and_requires_capability() {
             "messages".to_string(),
             VmValue::List(std::sync::Arc::new(vec![url_message])),
         ),
-    ])));
+    ]));
     let err = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("")),
         VmValue::Nil,
@@ -1352,7 +1348,7 @@ fn image_content_sets_vision_and_requires_capability() {
 
 #[test]
 fn pdf_and_audio_content_require_capabilities() {
-    let pdf_block = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    let pdf_block = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "type".to_string(),
             VmValue::String(std::sync::Arc::from("pdf")),
@@ -1361,8 +1357,8 @@ fn pdf_and_audio_content_require_capabilities() {
             "file_id".to_string(),
             VmValue::String(std::sync::Arc::from("file_123")),
         ),
-    ])));
-    let audio_block = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    ]));
+    let audio_block = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "type".to_string(),
             VmValue::String(std::sync::Arc::from("audio")),
@@ -1375,8 +1371,8 @@ fn pdf_and_audio_content_require_capabilities() {
             "media_type".to_string(),
             VmValue::String(std::sync::Arc::from("audio/wav")),
         ),
-    ])));
-    let message = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    ]));
+    let message = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "role".to_string(),
             VmValue::String(std::sync::Arc::from("user")),
@@ -1385,8 +1381,8 @@ fn pdf_and_audio_content_require_capabilities() {
             "content".to_string(),
             VmValue::List(std::sync::Arc::new(vec![pdf_block, audio_block])),
         ),
-    ])));
-    let options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    ]));
+    let options = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("mock")),
@@ -1399,7 +1395,7 @@ fn pdf_and_audio_content_require_capabilities() {
             "messages".to_string(),
             VmValue::List(std::sync::Arc::new(vec![message.clone()])),
         ),
-    ])));
+    ]));
     let opts = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("")),
         VmValue::Nil,
@@ -1410,7 +1406,7 @@ fn pdf_and_audio_content_require_capabilities() {
         .anthropic_beta_features
         .contains(&crate::stdlib::files::ANTHROPIC_FILES_API_BETA.to_string()));
 
-    let bad_options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    let bad_options = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("mock")),
@@ -1423,7 +1419,7 @@ fn pdf_and_audio_content_require_capabilities() {
             "messages".to_string(),
             VmValue::List(std::sync::Arc::new(vec![message])),
         ),
-    ])));
+    ]));
     let err = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("")),
         VmValue::Nil,
@@ -1444,7 +1440,7 @@ video_supported = true
 "#,
     )
     .expect("capability override");
-    let video_block = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    let video_block = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "type".to_string(),
             VmValue::String(std::sync::Arc::from("video")),
@@ -1457,8 +1453,8 @@ video_supported = true
             "media_type".to_string(),
             VmValue::String(std::sync::Arc::from("video/mp4")),
         ),
-    ])));
-    let message = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    ]));
+    let message = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "role".to_string(),
             VmValue::String(std::sync::Arc::from("user")),
@@ -1467,8 +1463,8 @@ video_supported = true
             "content".to_string(),
             VmValue::List(std::sync::Arc::new(vec![video_block])),
         ),
-    ])));
-    let options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    ]));
+    let options = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("local")),
@@ -1481,7 +1477,7 @@ video_supported = true
             "messages".to_string(),
             VmValue::List(std::sync::Arc::new(vec![message.clone()])),
         ),
-    ])));
+    ]));
     extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("")),
         VmValue::Nil,
@@ -1490,7 +1486,7 @@ video_supported = true
     .expect("video-capable route should accept video content");
     crate::llm::capabilities::clear_user_overrides();
 
-    let bad_options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    let bad_options = VmValue::dict(crate::value::DictMap::from_iter([
         (
             "provider".to_string(),
             VmValue::String(std::sync::Arc::from("mock")),
@@ -1503,7 +1499,7 @@ video_supported = true
             "messages".to_string(),
             VmValue::List(std::sync::Arc::new(vec![message])),
         ),
-    ])));
+    ]));
     let err = extract_llm_options(&[
         VmValue::String(std::sync::Arc::from("")),
         VmValue::Nil,

--- a/crates/harn-vm/src/llm/helpers/options/system_prompt.rs
+++ b/crates/harn-vm/src/llm/helpers/options/system_prompt.rs
@@ -35,24 +35,21 @@ pub(super) fn system_prompt_position(
     }
 }
 
-pub(super) fn enabled_system_prompt_part(part: &BTreeMap<String, VmValue>) -> bool {
+pub(super) fn enabled_system_prompt_part(part: &crate::value::DictMap) -> bool {
     !matches!(
         part.get("enabled"),
         Some(VmValue::Bool(false) | VmValue::Nil)
     )
 }
 
-pub(super) fn system_prompt_part_content(part: &BTreeMap<String, VmValue>) -> Option<String> {
+pub(super) fn system_prompt_part_content(part: &crate::value::DictMap) -> Option<String> {
     part.get("content")
         .or_else(|| part.get("text"))
         .or_else(|| part.get("prompt"))
         .map(VmValue::display)
 }
 
-pub(super) fn render_system_prompt_part(
-    content: String,
-    part: &BTreeMap<String, VmValue>,
-) -> String {
+pub(super) fn render_system_prompt_part(content: String, part: &crate::value::DictMap) -> String {
     let title = part
         .get("label")
         .or_else(|| part.get("title"))
@@ -171,14 +168,14 @@ pub(crate) fn system_prompt_event_metadata(system: &str) -> serde_json::Value {
 
 pub(crate) fn compose_system_prompt(
     system: Option<String>,
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<Option<String>, VmError> {
     compose_system_prompt_with_reminders(system, options, &[])
 }
 
 pub(super) fn compose_system_prompt_with_reminders(
     system: Option<String>,
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     rendered_reminders: &[RenderedReminder],
 ) -> Result<Option<String>, VmError> {
     Ok(assemble_system_prompt(system, options, rendered_reminders)?.system)
@@ -193,7 +190,7 @@ pub(super) fn compose_system_prompt_with_reminders(
 /// [`compose_system_prompt_with_reminders`] is the thin string-only wrapper.
 pub(crate) fn assemble_system_prompt(
     system: Option<String>,
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     rendered_reminders: &[RenderedReminder],
 ) -> Result<crate::llm::prompt::AssembledPrompt, VmError> {
     use crate::llm::prompt::{assemble, FragmentBucket, PromptFragment};
@@ -290,7 +287,7 @@ pub(crate) fn assemble_system_prompt(
 /// Names of the tools active for this call, read from the `tools` option
 /// (either a list of tool dicts or a `{tools: [...]}` registry).
 pub(super) fn tool_names_from_options(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> std::collections::BTreeSet<String> {
     let mut names = std::collections::BTreeSet::new();
     let Some(list) = options.and_then(|options| tool_entry_list(options.get("tools"))) else {
@@ -327,7 +324,7 @@ pub(super) fn tool_entry_list(value: Option<&VmValue>) -> Option<Vec<VmValue>> {
 /// on the tool's own presence so instruction and tool can never drift.
 pub(super) fn append_tool_guidance_fragments(
     fragments: &mut Vec<crate::llm::prompt::PromptFragment>,
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) {
     use crate::llm::prompt::{FragmentBucket, PromptFragment};
     let Some(list) = options.and_then(|options| tool_entry_list(options.get("tools"))) else {
@@ -376,7 +373,7 @@ pub(super) fn append_tool_guidance_fragments(
 /// present: the agent computed zero non-empty parts, so there is no primary.
 pub(super) fn append_decomposed_primary_fragments(
     fragments: &mut Vec<crate::llm::prompt::PromptFragment>,
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<bool, VmError> {
     use crate::llm::prompt::{FragmentBucket, PromptFragment};
     let Some(VmValue::List(items)) = options.and_then(|options| options.get("_system_fragments"))
@@ -436,7 +433,7 @@ pub(super) fn append_decomposed_primary_fragments(
 /// for direct `llm_call` / `prompt_explain` users that pass `context_profile`.
 pub(super) fn append_context_profile_fragments(
     fragments: &mut Vec<crate::llm::prompt::PromptFragment>,
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) {
     use crate::llm::prompt::{FragmentBucket, PromptFragment};
     let Some(profile) = options
@@ -492,7 +489,7 @@ pub(super) fn append_context_profile_fragments(
 }
 
 pub(super) fn assemble_ctx(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> crate::llm::prompt::AssembleCtx {
     crate::llm::prompt::AssembleCtx {
         tool_names: tool_names_from_options(options),
@@ -501,7 +498,7 @@ pub(super) fn assemble_ctx(
 }
 
 pub(super) fn caps_from_options(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> std::collections::BTreeSet<String> {
     let mut caps = std::collections::BTreeSet::new();
     let Some(options) = options else {

--- a/crates/harn-vm/src/llm/helpers/options/thinking.rs
+++ b/crates/harn-vm/src/llm/helpers/options/thinking.rs
@@ -29,7 +29,7 @@ pub(super) fn parse_reasoning_effort(
 }
 
 pub(super) fn parse_reasoning_effort_option(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<Option<crate::llm::api::ReasoningEffort>, VmError> {
     let Some(raw) = options.and_then(|o| o.get("reasoning_effort")) else {
         return Ok(None);
@@ -73,7 +73,7 @@ pub(super) fn parse_thinking_budget(raw: Option<&VmValue>) -> Result<Option<u32>
 ///   `{budget_tokens: N}` => enabled with a budget
 ///   `{enabled: false}` / `false` / `nil` => disabled
 pub(super) fn parse_thinking_option(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<crate::llm::api::ThinkingConfig, VmError> {
     use crate::llm::api::ThinkingConfig;
 
@@ -201,7 +201,7 @@ pub(super) fn validate_reasoning_effort_level_supported(
 }
 
 pub(super) fn parse_anthropic_beta_features_option(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     thinking: &crate::llm::api::ThinkingConfig,
     provider: &str,
     model: &str,

--- a/crates/harn-vm/src/llm/helpers/options/tool_search.rs
+++ b/crates/harn-vm/src/llm/helpers/options/tool_search.rs
@@ -19,7 +19,7 @@ pub(super) enum ToolSearchResolution {
 ///     Non-string strategies are Harn-side custom scorers, so they force
 ///     client-mode resolution.
 pub(super) fn parse_tool_search_option(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<Option<crate::llm::api::ToolSearchConfig>, VmError> {
     use crate::llm::api::{ToolSearchConfig, ToolSearchMode, ToolSearchVariant};
 

--- a/crates/harn-vm/src/llm/helpers/provider.rs
+++ b/crates/harn-vm/src/llm/helpers/provider.rs
@@ -242,7 +242,7 @@ fn resolve_available_tier_model(
     requested
 }
 
-pub(crate) fn vm_resolve_provider(options: &Option<BTreeMap<String, VmValue>>) -> String {
+pub(crate) fn vm_resolve_provider(options: &Option<crate::value::DictMap>) -> String {
     use crate::llm_config;
 
     // Explicit option wins, except "auto" which means "run the normal
@@ -339,10 +339,7 @@ pub(crate) fn vm_resolve_provider(options: &Option<BTreeMap<String, VmValue>>) -
     default
 }
 
-pub(crate) fn vm_resolve_model(
-    options: &Option<BTreeMap<String, VmValue>>,
-    provider: &str,
-) -> String {
+pub(crate) fn vm_resolve_model(options: &Option<crate::value::DictMap>, provider: &str) -> String {
     use crate::llm_config;
 
     if let Some(raw) = options

--- a/crates/harn-vm/src/llm/helpers/transcript.rs
+++ b/crates/harn-vm/src/llm/helpers/transcript.rs
@@ -271,7 +271,7 @@ impl SystemReminder {
 }
 
 pub(crate) fn transcript_message_list(
-    transcript: &BTreeMap<String, VmValue>,
+    transcript: &crate::value::DictMap,
 ) -> Result<Vec<VmValue>, VmError> {
     match transcript.get("messages") {
         Some(VmValue::List(list)) => Ok((**list).clone()),
@@ -283,7 +283,7 @@ pub(crate) fn transcript_message_list(
 }
 
 pub(crate) fn transcript_asset_list(
-    transcript: &BTreeMap<String, VmValue>,
+    transcript: &crate::value::DictMap,
 ) -> Result<Vec<VmValue>, VmError> {
     match transcript.get("assets") {
         Some(VmValue::List(list)) => Ok((**list).clone()),
@@ -294,18 +294,18 @@ pub(crate) fn transcript_asset_list(
     }
 }
 
-fn transcript_string_field(transcript: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn transcript_string_field(transcript: &crate::value::DictMap, key: &str) -> Option<String> {
     transcript.get(key).and_then(|v| match v {
         VmValue::String(s) if !s.is_empty() => Some(s.to_string()),
         _ => None,
     })
 }
 
-pub(crate) fn transcript_summary_text(transcript: &BTreeMap<String, VmValue>) -> Option<String> {
+pub(crate) fn transcript_summary_text(transcript: &crate::value::DictMap) -> Option<String> {
     transcript_string_field(transcript, "summary")
 }
 
-pub(crate) fn transcript_id(transcript: &BTreeMap<String, VmValue>) -> Option<String> {
+pub(crate) fn transcript_id(transcript: &crate::value::DictMap) -> Option<String> {
     transcript_string_field(transcript, "id")
 }
 
@@ -385,7 +385,7 @@ pub(crate) fn new_transcript_with_event_prefix(
     if let Some(state) = state {
         transcript.put_str("state", state);
     }
-    VmValue::Dict(std::sync::Arc::new(transcript))
+    VmValue::dict(transcript)
 }
 
 pub(crate) fn transcript_event_from_message(message: &VmValue) -> VmValue {
@@ -435,7 +435,7 @@ pub(crate) fn transcript_event_from_message(message: &VmValue) -> VmValue {
         "blocks".to_string(),
         VmValue::List(std::sync::Arc::new(blocks)),
     );
-    VmValue::Dict(std::sync::Arc::new(event))
+    VmValue::dict(event)
 }
 
 pub(crate) fn transcript_events_from_messages(messages: &[VmValue]) -> Vec<VmValue> {
@@ -503,7 +503,7 @@ pub(crate) fn transcript_event(
     event.insert(
         "blocks".to_string(),
         VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
-            std::sync::Arc::new(BTreeMap::from([
+            std::sync::Arc::new(crate::value::DictMap::from_iter([
                 (
                     "type".to_string(),
                     VmValue::String(std::sync::Arc::from("text")),
@@ -525,7 +525,7 @@ pub(crate) fn transcript_event(
             crate::stdlib::json_to_vm_value(&metadata),
         );
     }
-    VmValue::Dict(std::sync::Arc::new(event))
+    VmValue::dict(event)
 }
 
 pub(crate) fn normalize_transcript_asset(value: &VmValue) -> VmValue {
@@ -543,13 +543,13 @@ pub(crate) fn normalize_transcript_asset(value: &VmValue) -> VmValue {
     if value.as_dict().is_none() {
         asset.insert(
             "storage".to_string(),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            VmValue::dict(BTreeMap::from([(
                 "path".to_string(),
                 VmValue::String(std::sync::Arc::from(value.display())),
-            )]))),
+            )])),
         );
     }
-    VmValue::Dict(std::sync::Arc::new(asset))
+    VmValue::dict(asset)
 }
 
 pub(crate) fn is_transcript_value(value: &VmValue) -> bool {
@@ -588,7 +588,7 @@ pub(crate) fn transcript_reminder_event(reminder: &SystemReminder) -> VmValue {
         "reminder".to_string(),
         crate::stdlib::json_to_vm_value(&reminder_json),
     );
-    VmValue::Dict(std::sync::Arc::new(event))
+    VmValue::dict(event)
 }
 
 #[derive(Clone, Debug, Default)]
@@ -663,13 +663,10 @@ pub(crate) fn apply_reminder_post_turn(transcript: &VmValue, turn: i64) -> Remin
     if !expired.is_empty() {
         let mut lifecycle = BTreeMap::new();
         lifecycle.insert("last_post_turn".to_string(), VmValue::Int(turn));
-        next.insert(
-            "reminder_lifecycle".to_string(),
-            VmValue::Dict(std::sync::Arc::new(lifecycle)),
-        );
+        next.insert("reminder_lifecycle".to_string(), VmValue::dict(lifecycle));
     }
     ReminderPostTurnReport {
-        transcript: Some(VmValue::Dict(std::sync::Arc::new(next))),
+        transcript: Some(VmValue::dict(next)),
         decremented_count,
         expired,
         remaining_count,
@@ -854,7 +851,7 @@ fn lifecycle_transcript_event(
         payload_key.to_string(),
         crate::stdlib::json_to_vm_value(payload),
     );
-    VmValue::Dict(std::sync::Arc::new(event))
+    VmValue::dict(event)
 }
 
 pub(crate) fn reminder_from_vm_value(value: &VmValue) -> SystemReminder {
@@ -1000,7 +997,7 @@ pub(crate) fn replace_reminder_payload(event: &VmValue, reminder: &SystemReminde
     let mut dict = event.as_dict().cloned().unwrap_or_default();
     dict.insert("reminder".to_string(), reminder_value.clone());
     dict.insert("metadata".to_string(), reminder_value);
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn string_value(value: &VmValue) -> Option<String> {
@@ -1104,7 +1101,7 @@ mod tests {
                 })),
             ),
         ]);
-        let event = transcript_event_from_message(&VmValue::Dict(std::sync::Arc::new(dict)));
+        let event = transcript_event_from_message(&VmValue::dict(dict));
         let event_dict = event.as_dict().expect("event is dict");
         assert_eq!(
             event_dict.get("kind").map(|v| v.display()).as_deref(),
@@ -1327,15 +1324,13 @@ mod tests {
         ];
 
         for (kind, slot, payload) in cases {
-            let event = transcript_event_from_message(&VmValue::Dict(std::sync::Arc::new(
-                BTreeMap::from([
-                    (
-                        "kind".to_string(),
-                        VmValue::String(std::sync::Arc::from(kind)),
-                    ),
-                    (slot.to_string(), crate::stdlib::json_to_vm_value(&payload)),
-                ]),
-            )));
+            let event = transcript_event_from_message(&VmValue::dict(BTreeMap::from([
+                (
+                    "kind".to_string(),
+                    VmValue::String(std::sync::Arc::from(kind)),
+                ),
+                (slot.to_string(), crate::stdlib::json_to_vm_value(&payload)),
+            ])));
             let dict = event.as_dict().expect("event is dict");
             assert_eq!(dict.get("kind").map(|v| v.display()).as_deref(), Some(kind));
             assert_eq!(

--- a/crates/harn-vm/src/llm/introspection.rs
+++ b/crates/harn-vm/src/llm/introspection.rs
@@ -120,7 +120,7 @@ pub fn snapshot_to_vm_value(snapshot: Option<&RuntimeIntrospectionSnapshot>) -> 
         dict.insert("context_window".to_string(), VmValue::Nil);
         dict.insert("runtime_context_window".to_string(), VmValue::Nil);
         dict.insert("capabilities".to_string(), VmValue::Nil);
-        return VmValue::Dict(std::sync::Arc::new(dict));
+        return VmValue::dict(dict);
     };
     dict.put_str("provider", snap.provider.as_str());
     dict.put_str("model", snap.model.as_str());
@@ -147,7 +147,7 @@ pub fn snapshot_to_vm_value(snapshot: Option<&RuntimeIntrospectionSnapshot>) -> 
             .unwrap_or(VmValue::Nil),
     );
     dict.insert("capabilities".to_string(), snap.capabilities.clone());
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 /// Tool names registered by `runtime_introspection_tools`. Kept in

--- a/crates/harn-vm/src/llm/mock.rs
+++ b/crates/harn-vm/src/llm/mock.rs
@@ -511,7 +511,7 @@ fn mock_error_to_vm_error(err: &MockError) -> VmError {
                 VmValue::Int(retry_after_ms as i64),
             );
         }
-        return VmError::Thrown(VmValue::Dict(std::sync::Arc::new(dict)));
+        return VmError::Thrown(VmValue::dict(dict));
     }
 
     VmError::CategorizedError {

--- a/crates/harn-vm/src/llm/mock_builtins.rs
+++ b/crates/harn-vm/src/llm/mock_builtins.rs
@@ -187,10 +187,7 @@ fn llm_mock_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
     Ok(VmValue::Nil)
 }
 
-fn optional_display_field(
-    dict: &std::collections::BTreeMap<String, VmValue>,
-    key: &str,
-) -> Option<String> {
+fn optional_display_field(dict: &crate::value::DictMap, key: &str) -> Option<String> {
     match dict.get(key) {
         None | Some(VmValue::Nil) => None,
         Some(value) => Some(value.display()),
@@ -294,7 +291,7 @@ fn llm_mock_calls_builtin(_args: &[VmValue], _out: &mut String) -> Result<VmValu
                 "max_tool_calls".to_string(),
                 c.max_tool_calls.map(VmValue::Int).unwrap_or(VmValue::Nil),
             );
-            VmValue::Dict(std::sync::Arc::new(dict))
+            VmValue::dict(dict)
         })
         .collect();
     Ok(VmValue::List(std::sync::Arc::new(result)))

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -211,7 +211,7 @@ pub mod bench_internals {
 
     pub fn llm_options_roundtrip_probe(
         args: &[VmValue],
-        options: &Option<std::collections::BTreeMap<String, VmValue>>,
+        options: &Option<crate::value::DictMap>,
     ) -> Result<usize, VmError> {
         let resolved_provider = helpers::vm_resolve_provider(options);
         let extracted = extract_llm_options(args)?;
@@ -824,7 +824,7 @@ mod tests {
         let opts = base_opts();
         let mut map = std::collections::BTreeMap::new();
         map.put_str("name", "Ada");
-        let data = VmValue::Dict(std::sync::Arc::new(map));
+        let data = VmValue::dict(map);
         let errors = compute_validation_errors(&data, &opts);
         assert!(errors.is_empty(), "schema should pass: {errors:?}");
     }
@@ -834,7 +834,7 @@ mod tests {
         let opts = base_opts();
         let mut map = std::collections::BTreeMap::new();
         map.insert("name".to_string(), VmValue::Int(42));
-        let data = VmValue::Dict(std::sync::Arc::new(map));
+        let data = VmValue::dict(map);
         let errors = compute_validation_errors(&data, &opts);
         assert!(!errors.is_empty(), "schema should fail");
         assert!(errors.join(" ").contains("string"));
@@ -842,7 +842,7 @@ mod tests {
 
     #[test]
     fn structured_output_errors_report_missing_json() {
-        let result = VmValue::Dict(std::sync::Arc::new(std::collections::BTreeMap::from([
+        let result = VmValue::dict(std::collections::BTreeMap::from([
             (
                 "text".to_string(),
                 VmValue::String(std::sync::Arc::from("Analyzing the task")),
@@ -857,7 +857,7 @@ mod tests {
                 "stop_reason".to_string(),
                 VmValue::String(std::sync::Arc::from("length")),
             ),
-        ])));
+        ]));
 
         let errors = structured_output_errors(&result, &base_opts());
         assert!(errors.iter().any(|err| err.contains("parseable JSON")));

--- a/crates/harn-vm/src/llm/permissions.rs
+++ b/crates/harn-vm/src/llm/permissions.rs
@@ -331,14 +331,14 @@ fn parse_pattern_list(value: &VmValue, label: &str) -> Result<Vec<String>, VmErr
     }
 }
 
-fn is_path_scope_matcher(map: &BTreeMap<String, VmValue>) -> bool {
+fn is_path_scope_matcher(map: &crate::value::DictMap) -> bool {
     map.get("type")
         .or_else(|| map.get("kind"))
         .is_some_and(|value| value.display() == "path_scope")
 }
 
 fn parse_path_scope_matcher(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     label: &str,
 ) -> Result<PathScopeMatcher, VmError> {
     let arg_keys = match map
@@ -1152,7 +1152,7 @@ fn permission_request_value(
             VmValue::Bool(false),
         ])),
     );
-    VmValue::Dict(std::sync::Arc::new(request))
+    VmValue::dict(request)
 }
 
 async fn emit_tier_promotion_if_needed(

--- a/crates/harn-vm/src/llm/reasoning_policy.rs
+++ b/crates/harn-vm/src/llm/reasoning_policy.rs
@@ -5,8 +5,6 @@
 //! user-facing policy vocabulary (`auto`, `off`, `low`, ...), lowering it
 //! into the canonical [`ThinkingConfig`] that providers already understand.
 
-use std::collections::BTreeMap;
-
 use crate::llm::api::{ReasoningEffort, ThinkingConfig};
 use crate::llm::capabilities::Capabilities;
 use crate::value::{VmError, VmValue};
@@ -45,7 +43,7 @@ pub fn policy_values() -> &'static [&'static str] {
 }
 
 pub(crate) fn resolve_for_llm_call(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     provider: &str,
     model: &str,
     caps: &Capabilities,
@@ -54,8 +52,8 @@ pub(crate) fn resolve_for_llm_call(
 }
 
 pub(crate) fn apply_policy_to_vm_options(
-    opts: &BTreeMap<String, VmValue>,
-) -> Result<BTreeMap<String, VmValue>, VmError> {
+    opts: &crate::value::DictMap,
+) -> Result<crate::value::DictMap, VmError> {
     if caller_set_reasoning(Some(opts)) {
         return Ok(opts.clone());
     }
@@ -80,7 +78,7 @@ pub(crate) fn apply_policy_to_vm_options(
 }
 
 fn resolve_policy(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     provider: &str,
     model: &str,
     caps: &Capabilities,
@@ -133,7 +131,7 @@ fn resolve_policy(
 }
 
 fn selected_policy(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     default_policy: Option<&str>,
 ) -> Result<Option<String>, VmError> {
     if let Some(value) = options.and_then(|opts| {
@@ -150,7 +148,7 @@ fn selected_policy(
     default_policy.map(normalize_policy_str_vm).transpose()
 }
 
-fn caller_set_reasoning(options: Option<&BTreeMap<String, VmValue>>) -> bool {
+fn caller_set_reasoning(options: Option<&crate::value::DictMap>) -> bool {
     let Some(opts) = options else {
         return false;
     };
@@ -200,7 +198,7 @@ fn normalize_policy_str(raw: &str) -> Result<String, String> {
     ))
 }
 
-fn reasoning_scale(options: Option<&BTreeMap<String, VmValue>>) -> Result<String, VmError> {
+fn reasoning_scale(options: Option<&crate::value::DictMap>) -> Result<String, VmError> {
     let raw = options
         .and_then(|opts| {
             opts.get("reasoning_scale")
@@ -220,7 +218,7 @@ fn reasoning_scale(options: Option<&BTreeMap<String, VmValue>>) -> Result<String
     )))
 }
 
-fn reasoning_task(options: Option<&BTreeMap<String, VmValue>>) -> Result<String, VmError> {
+fn reasoning_task(options: Option<&crate::value::DictMap>) -> Result<String, VmError> {
     let raw = options.and_then(|opts| {
         opts.get("reasoning_task")
             .or_else(|| opts.get("task_kind"))
@@ -351,7 +349,7 @@ fn budget_for_reasoning_level(level: &str) -> u32 {
     }
 }
 
-fn resolved_route_from_options(opts: &BTreeMap<String, VmValue>) -> Option<(String, String)> {
+fn resolved_route_from_options(opts: &crate::value::DictMap) -> Option<(String, String)> {
     let model = opts.get("model")?.display();
     if model.trim().is_empty() {
         return None;
@@ -372,12 +370,12 @@ fn resolved_route_from_options(opts: &BTreeMap<String, VmValue>) -> Option<(Stri
 
 fn thinking_to_vm_value(thinking: &ThinkingConfig) -> VmValue {
     match thinking {
-        ThinkingConfig::Disabled => VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        ThinkingConfig::Disabled => VmValue::dict(crate::value::DictMap::from_iter([(
             "mode".to_string(),
             VmValue::String(std::sync::Arc::from("disabled")),
-        )]))),
+        )])),
         ThinkingConfig::Enabled { budget_tokens } => {
-            let mut dict = BTreeMap::from([(
+            let mut dict = crate::value::DictMap::from_iter([(
                 "mode".to_string(),
                 VmValue::String(std::sync::Arc::from("enabled")),
             )]);
@@ -387,13 +385,13 @@ fn thinking_to_vm_value(thinking: &ThinkingConfig) -> VmValue {
                     VmValue::Int(*budget_tokens as i64),
                 );
             }
-            VmValue::Dict(std::sync::Arc::new(dict))
+            VmValue::dict(dict)
         }
-        ThinkingConfig::Adaptive => VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        ThinkingConfig::Adaptive => VmValue::dict(crate::value::DictMap::from_iter([(
             "mode".to_string(),
             VmValue::String(std::sync::Arc::from("adaptive")),
-        )]))),
-        ThinkingConfig::Effort { level } => VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        )])),
+        ThinkingConfig::Effort { level } => VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "mode".to_string(),
                 VmValue::String(std::sync::Arc::from("effort")),
@@ -402,12 +400,12 @@ fn thinking_to_vm_value(thinking: &ThinkingConfig) -> VmValue {
                 "level".to_string(),
                 VmValue::String(std::sync::Arc::from(level.as_str())),
             ),
-        ]))),
+        ])),
     }
 }
 
 fn application_metadata_to_vm_value(application: &ReasoningPolicyApplication) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    VmValue::dict(crate::value::DictMap::from_iter([
         (
             "policy".to_string(),
             VmValue::String(std::sync::Arc::from(application.policy.clone())),
@@ -432,20 +430,20 @@ fn application_metadata_to_vm_value(application: &ReasoningPolicyApplication) ->
             "model".to_string(),
             VmValue::String(std::sync::Arc::from(application.model.clone())),
         ),
-    ])))
+    ]))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn apply(opts: BTreeMap<String, VmValue>) -> BTreeMap<String, VmValue> {
+    fn apply(opts: crate::value::DictMap) -> crate::value::DictMap {
         apply_policy_to_vm_options(&opts).expect("policy")
     }
 
     #[test]
     fn high_policy_maps_to_effort_for_openai_reasoning_models() {
-        let opts = BTreeMap::from([
+        let opts = crate::value::DictMap::from_iter([
             (
                 "provider".to_string(),
                 VmValue::String(std::sync::Arc::from("openai")),
@@ -476,7 +474,7 @@ mod tests {
 
     #[test]
     fn off_policy_floors_to_low_for_cerebras_gpt_oss() {
-        let opts = BTreeMap::from([
+        let opts = crate::value::DictMap::from_iter([
             (
                 "provider".to_string(),
                 VmValue::String(std::sync::Arc::from("cerebras")),
@@ -524,7 +522,7 @@ mod tests {
         // to neutralize the Qwen3 tool-call/thinking regression at the
         // data layer. Previously this lived as a hard-coded
         // `local_qwen_route` branch in resolve_policy.
-        let opts = BTreeMap::from([
+        let opts = crate::value::DictMap::from_iter([
             (
                 "provider".to_string(),
                 VmValue::String(std::sync::Arc::from("ollama")),
@@ -569,7 +567,7 @@ mod tests {
         // openrouter qwen rules (matching qwen/qwen3.6-35b-a3b — the
         // exact model whose 5+ minute single-turn finalize bug
         // motivated this work).
-        let opts = BTreeMap::from([
+        let opts = crate::value::DictMap::from_iter([
             (
                 "provider".to_string(),
                 VmValue::String(std::sync::Arc::from("openrouter")),
@@ -604,7 +602,7 @@ mod tests {
         // is `auto`. A caller who explicitly asks for `high` reasoning
         // is acknowledged regardless of the per-route default — the
         // override declares the auto default, not a ceiling.
-        let opts = BTreeMap::from([
+        let opts = crate::value::DictMap::from_iter([
             (
                 "provider".to_string(),
                 VmValue::String(std::sync::Arc::from("openrouter")),
@@ -651,7 +649,7 @@ auto_reasoning_overrides = { agent = "off" }
 "#,
         )
         .expect("override toml");
-        let opts = BTreeMap::from([
+        let opts = crate::value::DictMap::from_iter([
             (
                 "provider".to_string(),
                 VmValue::String(std::sync::Arc::from("acme")),
@@ -683,7 +681,7 @@ auto_reasoning_overrides = { agent = "off" }
 
     #[test]
     fn explicit_thinking_wins_over_policy() {
-        let opts = BTreeMap::from([
+        let opts = crate::value::DictMap::from_iter([
             (
                 "provider".to_string(),
                 VmValue::String(std::sync::Arc::from("openai")),

--- a/crates/harn-vm/src/llm/reminder_providers.rs
+++ b/crates/harn-vm/src/llm/reminder_providers.rs
@@ -1,7 +1,7 @@
 //! System reminder provider registry and canonical provider implementations.
 
 use std::cell::RefCell;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use serde_json::Value as JsonValue;
@@ -10,7 +10,7 @@ use harn_parser::diagnostic_codes::Code;
 
 use crate::llm::helpers::{ReminderPropagate, ReminderRoleHint, ReminderSource, SystemReminder};
 use crate::orchestration::{HookEffect, HookEvent, ReminderSpec};
-use crate::value::{VmClosure, VmError, VmValue};
+use crate::value::{VmClosure, VmError};
 
 const TOKEN_PRESSURE_ID: &str = "token_pressure";
 const IDLE_NUDGE_ID: &str = "idle_nudge";
@@ -1617,7 +1617,7 @@ fn json_bool(value: &JsonValue, key: &str) -> Option<bool> {
     value.get(key).and_then(JsonValue::as_bool)
 }
 
-pub(crate) fn options_map_to_json(options: &BTreeMap<String, VmValue>) -> JsonValue {
+pub(crate) fn options_map_to_json(options: &crate::value::DictMap) -> JsonValue {
     JsonValue::Object(
         options
             .iter()

--- a/crates/harn-vm/src/llm/rerank.rs
+++ b/crates/harn-vm/src/llm/rerank.rs
@@ -76,7 +76,7 @@ async fn self_certainty_builtin(
     let opts = super::helpers::extract_llm_options(&[
         VmValue::String(std::sync::Arc::from(prompt)),
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(call_options)),
+        VmValue::dict(call_options),
     ])?;
     let result = super::api::vm_call_llm_full(&opts).await?;
     if result.logprobs.is_empty() {

--- a/crates/harn-vm/src/llm/routing.rs
+++ b/crates/harn-vm/src/llm/routing.rs
@@ -296,7 +296,7 @@ fn runtime_error(message: String) -> VmError {
     VmError::Thrown(VmValue::String(std::sync::Arc::from(message)))
 }
 
-fn parse_label(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<String, VmError> {
+fn parse_label(dict: &crate::value::DictMap, key: &str) -> Result<String, VmError> {
     match dict.get(key) {
         Some(VmValue::String(s)) => Ok(s.to_string()),
         Some(VmValue::Nil) | None => Ok(String::new()),
@@ -307,7 +307,7 @@ fn parse_label(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<String, Vm
     }
 }
 
-fn parse_pos_u64(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<u64>, VmError> {
+fn parse_pos_u64(dict: &crate::value::DictMap, key: &str) -> Result<Option<u64>, VmError> {
     match dict.get(key) {
         Some(VmValue::Nil) | None => Ok(None),
         Some(VmValue::Int(n)) if *n >= 0 => Ok(Some(*n as u64)),
@@ -319,11 +319,11 @@ fn parse_pos_u64(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<u
     }
 }
 
-fn parse_pos_usize(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<usize>, VmError> {
+fn parse_pos_usize(dict: &crate::value::DictMap, key: &str) -> Result<Option<usize>, VmError> {
     parse_pos_u64(dict, key).map(|opt| opt.map(|v| v as usize))
 }
 
-fn parse_pos_f64(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<f64>, VmError> {
+fn parse_pos_f64(dict: &crate::value::DictMap, key: &str) -> Result<Option<f64>, VmError> {
     match dict.get(key) {
         Some(VmValue::Nil) | None => Ok(None),
         Some(VmValue::Int(n)) if *n >= 0 => Ok(Some(*n as f64)),
@@ -335,7 +335,7 @@ fn parse_pos_f64(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<f
     }
 }
 
-fn parse_string_list(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Vec<String>, VmError> {
+fn parse_string_list(dict: &crate::value::DictMap, key: &str) -> Result<Vec<String>, VmError> {
     match dict.get(key) {
         Some(VmValue::Nil) | None => Ok(Vec::new()),
         Some(VmValue::List(items)) => {
@@ -362,7 +362,7 @@ fn parse_string_list(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Vec<
     }
 }
 
-fn parse_status_list(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Vec<u16>, VmError> {
+fn parse_status_list(dict: &crate::value::DictMap, key: &str) -> Result<Vec<u16>, VmError> {
     let Some(value) = dict.get(key) else {
         return Ok(Vec::new());
     };
@@ -578,7 +578,7 @@ fn parse_observe(value: Option<&VmValue>) -> Result<ObserveRules, VmError> {
 /// Validate a user-facing config dict and return a tagged copy. The
 /// tag (`__routing_policy__: true`) is what `llm_call` looks for when
 /// it decides whether to dispatch through the routing executor.
-pub(crate) fn build_routing_policy(config: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
+pub(crate) fn build_routing_policy(config: &crate::value::DictMap) -> Result<VmValue, VmError> {
     let chain_value = config.get("chain").ok_or_else(|| {
         runtime_error("routing_policy: `chain` is required (list of {provider, model})".to_string())
     })?;
@@ -652,7 +652,7 @@ pub(crate) fn build_routing_policy(config: &BTreeMap<String, VmValue>) -> Result
     };
     let handle = intern_policy(parsed);
     summary.insert(HANDLE_KEY.to_string(), VmValue::Int(handle as i64));
-    Ok(VmValue::Dict(std::sync::Arc::new(summary)))
+    Ok(VmValue::dict(summary))
 }
 
 fn chain_summary_value(chain: &[ChainLink]) -> VmValue {
@@ -671,7 +671,7 @@ fn chain_summary_value(chain: &[ChainLink]) -> VmValue {
             if let Some(region) = &link.region {
                 dict.put_str("region", region.clone());
             }
-            VmValue::Dict(std::sync::Arc::new(dict))
+            VmValue::dict(dict)
         })
         .collect();
     VmValue::List(std::sync::Arc::new(items))
@@ -703,7 +703,7 @@ fn failover_value(failover: &FailoverRules) -> VmValue {
     if let Some(max) = failover.max_attempts {
         dict.insert("max_attempts".to_string(), VmValue::Int(max as i64));
     }
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn latency_value(latency: &LatencyRules) -> VmValue {
@@ -714,7 +714,7 @@ fn latency_value(latency: &LatencyRules) -> VmValue {
     if let Some(ms) = latency.race_after_ms {
         dict.insert("race_after_ms".to_string(), VmValue::Int(ms as i64));
     }
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn budget_value(budget: &BudgetRules) -> VmValue {
@@ -726,7 +726,7 @@ fn budget_value(budget: &BudgetRules) -> VmValue {
         dict.insert("session_usd".to_string(), VmValue::Float(v));
     }
     dict.put_str("on_exceed", budget.on_exceed_or_abort().as_str());
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn observe_value(observe: &ObserveRules) -> VmValue {
@@ -734,7 +734,7 @@ fn observe_value(observe: &ObserveRules) -> VmValue {
     if let Some(event) = &observe.emit_event {
         dict.put_str("emit_event", event.clone());
     }
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 /// Pull the parsed config off a dict produced by `routing_policy(...)`.
@@ -742,7 +742,7 @@ fn observe_value(observe: &ObserveRules) -> VmValue {
 /// the historical resolution path; returns an error when the tag is
 /// present but the handle is missing (corruption indicator).
 pub(crate) fn extract_routing_policy(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<Option<Arc<RoutingPolicyConfig>>, VmError> {
     let Some(opts) = options else {
         return Ok(None);
@@ -1909,10 +1909,7 @@ pub(crate) fn trace_to_vm_attempts(trace: &RoutingTrace) -> VmValue {
                 if let Some(status) = error.status {
                     err_dict.insert("status".to_string(), VmValue::Int(status as i64));
                 }
-                dict.insert(
-                    "error".to_string(),
-                    VmValue::Dict(std::sync::Arc::new(err_dict)),
-                );
+                dict.insert("error".to_string(), VmValue::dict(err_dict));
             }
             if let Some(outcome) = attempt.verifier_outcome {
                 dict.put_str("verifier_outcome", outcome.as_str());
@@ -1929,7 +1926,7 @@ pub(crate) fn trace_to_vm_attempts(trace: &RoutingTrace) -> VmValue {
                         if let Some(reason) = &signal.reason {
                             sig_dict.put_str("reason", reason.clone());
                         }
-                        VmValue::Dict(std::sync::Arc::new(sig_dict))
+                        VmValue::dict(sig_dict)
                     })
                     .collect();
                 dict.insert(
@@ -1937,7 +1934,7 @@ pub(crate) fn trace_to_vm_attempts(trace: &RoutingTrace) -> VmValue {
                     VmValue::List(std::sync::Arc::new(signals)),
                 );
             }
-            VmValue::Dict(std::sync::Arc::new(dict))
+            VmValue::dict(dict)
         })
         .collect();
     VmValue::List(std::sync::Arc::new(items))
@@ -1947,7 +1944,7 @@ pub(crate) fn trace_to_vm_attempts(trace: &RoutingTrace) -> VmValue {
 mod tests {
     use super::*;
 
-    fn dict(items: &[(&str, VmValue)]) -> BTreeMap<String, VmValue> {
+    fn dict(items: &[(&str, VmValue)]) -> crate::value::DictMap {
         items
             .iter()
             .map(|(k, v)| (k.to_string(), v.clone()))
@@ -1962,15 +1959,15 @@ mod tests {
                 "chain",
                 VmValue::List(std::sync::Arc::new(vec![
                     VmValue::String(std::sync::Arc::from("mock:mock")),
-                    VmValue::Dict(std::sync::Arc::new(dict(&[
+                    VmValue::dict(dict(&[
                         ("provider", VmValue::String(std::sync::Arc::from("mock"))),
                         ("model", VmValue::String(std::sync::Arc::from("mock-2"))),
-                    ]))),
+                    ])),
                 ])),
             ),
             (
                 "failover",
-                VmValue::Dict(std::sync::Arc::new(dict(&[
+                VmValue::dict(dict(&[
                     (
                         "on_status",
                         VmValue::List(std::sync::Arc::new(vec![
@@ -1979,14 +1976,14 @@ mod tests {
                         ])),
                     ),
                     ("max_attempts", VmValue::Int(2)),
-                ]))),
+                ])),
             ),
             (
                 "budget",
-                VmValue::Dict(std::sync::Arc::new(dict(&[
+                VmValue::dict(dict(&[
                     ("per_call_usd", VmValue::Float(0.5)),
                     ("on_exceed", VmValue::String(std::sync::Arc::from("abort"))),
-                ]))),
+                ])),
             ),
         ]);
         let tagged = build_routing_policy(&config).expect("validates");
@@ -2009,14 +2006,14 @@ mod tests {
             "chain",
             VmValue::List(std::sync::Arc::new(vec![
                 // Link 0: explicit region override.
-                VmValue::Dict(std::sync::Arc::new(dict(&[
+                VmValue::dict(dict(&[
                     ("provider", VmValue::String(std::sync::Arc::from("bedrock"))),
                     (
                         "model",
                         VmValue::String(std::sync::Arc::from("anthropic.claude-3-5-sonnet-v2:0")),
                     ),
                     ("region", VmValue::String(std::sync::Arc::from("eu-west-1"))),
-                ]))),
+                ])),
                 // Link 1: no region -> falls back to env at call time.
                 VmValue::String(std::sync::Arc::from("mock:mock")),
             ])),
@@ -2080,10 +2077,10 @@ mod tests {
             ),
             (
                 "failover",
-                VmValue::Dict(std::sync::Arc::new(dict(&[(
+                VmValue::dict(dict(&[(
                     "on_status",
                     VmValue::List(std::sync::Arc::new(vec![VmValue::Int(42)])),
-                )]))),
+                )])),
             ),
         ]);
         let err = build_routing_policy(&config).unwrap_err();

--- a/crates/harn-vm/src/llm/routing_verifier.rs
+++ b/crates/harn-vm/src/llm/routing_verifier.rs
@@ -425,7 +425,7 @@ fn runtime_error(message: String) -> VmError {
     VmError::Thrown(VmValue::String(std::sync::Arc::from(message)))
 }
 
-fn parse_string(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<String>, VmError> {
+fn parse_string(dict: &crate::value::DictMap, key: &str) -> Result<Option<String>, VmError> {
     match dict.get(key) {
         Some(VmValue::Nil) | None => Ok(None),
         Some(VmValue::String(s)) => Ok(Some(s.to_string())),
@@ -436,7 +436,7 @@ fn parse_string(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<St
     }
 }
 
-fn parse_bool(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<bool>, VmError> {
+fn parse_bool(dict: &crate::value::DictMap, key: &str) -> Result<Option<bool>, VmError> {
     match dict.get(key) {
         Some(VmValue::Nil) | None => Ok(None),
         Some(VmValue::Bool(b)) => Ok(Some(*b)),
@@ -447,7 +447,7 @@ fn parse_bool(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<bool
     }
 }
 
-fn parse_pos_usize(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<usize>, VmError> {
+fn parse_pos_usize(dict: &crate::value::DictMap, key: &str) -> Result<Option<usize>, VmError> {
     match dict.get(key) {
         Some(VmValue::Nil) | None => Ok(None),
         Some(VmValue::Int(n)) if *n >= 0 => Ok(Some(*n as usize)),
@@ -459,7 +459,7 @@ fn parse_pos_usize(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<Option
 }
 
 fn parse_regex_list(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
     key: &str,
 ) -> Result<(Vec<Regex>, Vec<String>), VmError> {
     let value = match dict.get(key) {
@@ -533,7 +533,7 @@ fn parse_command(value: Option<&VmValue>) -> Result<Vec<String>, VmError> {
     }
 }
 
-fn parse_on_fail(dict: &BTreeMap<String, VmValue>, default: FailMode) -> Result<FailMode, VmError> {
+fn parse_on_fail(dict: &crate::value::DictMap, default: FailMode) -> Result<FailMode, VmError> {
     match dict.get("on_fail") {
         Some(VmValue::Nil) | None => Ok(default),
         Some(VmValue::String(s)) => FailMode::parse(s),
@@ -705,7 +705,7 @@ pub(crate) fn verifiers_summary(verifiers: &[Verifier]) -> VmValue {
                     FailMode::Escalate => "escalate",
                 },
             );
-            VmValue::Dict(std::sync::Arc::new(dict))
+            VmValue::dict(dict)
         })
         .collect();
     VmValue::List(std::sync::Arc::new(items))
@@ -715,7 +715,7 @@ pub(crate) fn verifiers_summary(verifiers: &[Verifier]) -> VmValue {
 mod tests {
     use super::*;
 
-    fn dict(items: &[(&str, VmValue)]) -> BTreeMap<String, VmValue> {
+    fn dict(items: &[(&str, VmValue)]) -> crate::value::DictMap {
         items
             .iter()
             .map(|(k, v)| (k.to_string(), v.clone()))

--- a/crates/harn-vm/src/llm/schema_recover.rs
+++ b/crates/harn-vm/src/llm/schema_recover.rs
@@ -44,7 +44,6 @@
 //! wants to recover the schema-shaped payload after the fact.
 
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use serde_json::Value as JsonValue;
@@ -277,7 +276,7 @@ fn try_regex_recover(
         _ => return Ok(None),
     };
 
-    let mut recovered: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut recovered: crate::value::DictMap = crate::value::DictMap::new();
     let mut any = false;
     for (field, field_schema) in properties.iter() {
         let field_type = field_type_name(field_schema);
@@ -293,7 +292,7 @@ fn try_regex_recover(
     if !any {
         return Ok(None);
     }
-    let candidate = VmValue::Dict(std::sync::Arc::new(recovered));
+    let candidate = VmValue::dict(recovered);
     let result = schema_result_value(&candidate, schema, apply_defaults);
     match extract_validation_outcome(&result) {
         Ok(data) => Ok(Some(data)),
@@ -482,29 +481,29 @@ fn field_allows_null(field_schema: &VmValue) -> bool {
 #[derive(Clone)]
 struct LlmRepairConfig {
     enabled: bool,
-    overrides: BTreeMap<String, VmValue>,
+    overrides: crate::value::DictMap,
 }
 
-fn parse_llm_repair_config(opts: &Option<BTreeMap<String, VmValue>>) -> LlmRepairConfig {
+fn parse_llm_repair_config(opts: &Option<crate::value::DictMap>) -> LlmRepairConfig {
     let Some(opts) = opts.as_ref() else {
         return LlmRepairConfig {
             enabled: true,
-            overrides: BTreeMap::new(),
+            overrides: crate::value::DictMap::new(),
         };
     };
     let raw = opts.get("llm_repair");
     match raw {
         None => LlmRepairConfig {
             enabled: true,
-            overrides: BTreeMap::new(),
+            overrides: crate::value::DictMap::new(),
         },
         Some(VmValue::Nil) => LlmRepairConfig {
             enabled: true,
-            overrides: BTreeMap::new(),
+            overrides: crate::value::DictMap::new(),
         },
         Some(VmValue::Bool(b)) => LlmRepairConfig {
             enabled: *b,
-            overrides: BTreeMap::new(),
+            overrides: crate::value::DictMap::new(),
         },
         Some(VmValue::Dict(d)) => {
             let enabled = match d.get("enabled") {
@@ -513,7 +512,7 @@ fn parse_llm_repair_config(opts: &Option<BTreeMap<String, VmValue>>) -> LlmRepai
                 Some(VmValue::Nil) => true,
                 Some(_) => true,
             };
-            let mut overrides: BTreeMap<String, VmValue> = (**d).clone();
+            let mut overrides: crate::value::DictMap = (**d).clone();
             overrides.remove("enabled");
             LlmRepairConfig { enabled, overrides }
         }
@@ -521,12 +520,12 @@ fn parse_llm_repair_config(opts: &Option<BTreeMap<String, VmValue>>) -> LlmRepai
         // rather than throwing — recovery is best-effort.
         Some(_) => LlmRepairConfig {
             enabled: false,
-            overrides: BTreeMap::new(),
+            overrides: crate::value::DictMap::new(),
         },
     }
 }
 
-fn opt_bool_field(opts: &Option<BTreeMap<String, VmValue>>, key: &str) -> bool {
+fn opt_bool_field(opts: &Option<crate::value::DictMap>, key: &str) -> bool {
     matches!(
         opts.as_ref().and_then(|o| o.get(key)),
         Some(VmValue::Bool(true))
@@ -546,7 +545,7 @@ async fn run_llm_repair(
     text: &str,
     schema: &VmValue,
     repair: &LlmRepairConfig,
-    base_opts: &Option<BTreeMap<String, VmValue>>,
+    base_opts: &Option<crate::value::DictMap>,
     bridge: Option<&Arc<crate::bridge::HostBridge>>,
 ) -> Result<Option<VmValue>, String> {
     let prompt = build_repair_prompt(text, schema);
@@ -557,7 +556,7 @@ async fn run_llm_repair(
         // System slot — the prompt carries instructions inline so the
         // repair pass works regardless of any caller-set system text.
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(merged_options)),
+        VmValue::dict(merged_options),
     ];
     let opts = extract_llm_options(&args).map_err(|e| e.to_string())?;
     let outcome = execute_schema_retry_loop(None, opts.clone(), merged_dict, bridge)
@@ -583,7 +582,7 @@ async fn run_llm_repair(
 
 fn build_repair_prompt(raw_text: &str, schema: &VmValue) -> String {
     let schema_text = schema_to_compact_json(schema);
-    let mut bindings = BTreeMap::new();
+    let mut bindings = crate::value::DictMap::new();
     bindings.put_str("schema_text", schema_text);
     bindings.put_str("raw_text", raw_text);
     crate::stdlib::template::render_stdlib_prompt_asset(
@@ -599,11 +598,11 @@ fn schema_to_compact_json(schema: &VmValue) -> String {
 }
 
 fn merge_repair_options(
-    base: Option<&BTreeMap<String, VmValue>>,
-    overrides: &BTreeMap<String, VmValue>,
+    base: Option<&crate::value::DictMap>,
+    overrides: &crate::value::DictMap,
     schema: &VmValue,
-) -> BTreeMap<String, VmValue> {
-    let mut merged: BTreeMap<String, VmValue> = base.cloned().unwrap_or_default();
+) -> crate::value::DictMap {
+    let mut merged: crate::value::DictMap = base.cloned().unwrap_or_default();
     // The repair pass is always single-shot inside schema_recover —
     // burning the caller's `schema_retries` budget here would amplify
     // cost and the outer recovery cascade has already done what it
@@ -620,11 +619,11 @@ fn merge_repair_options(
     merged
         .entry("output_format".to_string())
         .or_insert_with(|| {
-            let mut fmt = BTreeMap::new();
+            let mut fmt = crate::value::DictMap::new();
             fmt.put_str("kind", "json_schema");
             fmt.insert("schema".to_string(), schema.clone());
             fmt.insert("strict".to_string(), VmValue::Bool(true));
-            VmValue::Dict(std::sync::Arc::new(fmt))
+            VmValue::dict(fmt)
         });
     merged
         .entry("output_validation".to_string())
@@ -645,7 +644,7 @@ fn envelope_success(
     attempts: usize,
     repaired: bool,
 ) -> VmValue {
-    let mut env = BTreeMap::new();
+    let mut env = crate::value::DictMap::new();
     env.insert("ok".to_string(), VmValue::Bool(true));
     env.insert("data".to_string(), data);
     env.put_str("raw_text", raw_text);
@@ -654,7 +653,7 @@ fn envelope_success(
     env.insert("attempts".to_string(), VmValue::Int(attempts as i64));
     env.put_str("stage", stage);
     env.insert("repaired".to_string(), VmValue::Bool(repaired));
-    VmValue::Dict(std::sync::Arc::new(env))
+    VmValue::dict(env)
 }
 
 fn envelope_failure(
@@ -664,7 +663,7 @@ fn envelope_failure(
     error_message: &str,
     attempts: usize,
 ) -> VmValue {
-    let mut env = BTreeMap::new();
+    let mut env = crate::value::DictMap::new();
     env.insert("ok".to_string(), VmValue::Bool(false));
     env.insert("data".to_string(), VmValue::Nil);
     env.put_str("raw_text", raw_text);
@@ -673,7 +672,7 @@ fn envelope_failure(
     env.insert("attempts".to_string(), VmValue::Int(attempts as i64));
     env.put_str("stage", stage);
     env.insert("repaired".to_string(), VmValue::Bool(false));
-    VmValue::Dict(std::sync::Arc::new(env))
+    VmValue::dict(env)
 }
 
 #[cfg(test)]
@@ -682,31 +681,25 @@ mod tests {
     use crate::value::VmDictExt;
 
     fn person_schema() -> VmValue {
-        let mut name = BTreeMap::new();
+        let mut name = crate::value::DictMap::new();
         name.put_str("type", "string");
-        let mut age = BTreeMap::new();
+        let mut age = crate::value::DictMap::new();
         age.put_str("type", "integer");
-        let mut active = BTreeMap::new();
+        let mut active = crate::value::DictMap::new();
         active.put_str("type", "boolean");
-        let mut props = BTreeMap::new();
-        props.insert("name".to_string(), VmValue::Dict(std::sync::Arc::new(name)));
-        props.insert("age".to_string(), VmValue::Dict(std::sync::Arc::new(age)));
-        props.insert(
-            "active".to_string(),
-            VmValue::Dict(std::sync::Arc::new(active)),
-        );
+        let mut props = crate::value::DictMap::new();
+        props.insert("name".to_string(), VmValue::dict(name));
+        props.insert("age".to_string(), VmValue::dict(age));
+        props.insert("active".to_string(), VmValue::dict(active));
         let required = VmValue::List(std::sync::Arc::new(vec![
             VmValue::String(std::sync::Arc::from("name")),
             VmValue::String(std::sync::Arc::from("age")),
         ]));
-        let mut schema = BTreeMap::new();
+        let mut schema = crate::value::DictMap::new();
         schema.put_str("type", "object");
-        schema.insert(
-            "properties".to_string(),
-            VmValue::Dict(std::sync::Arc::new(props)),
-        );
+        schema.insert("properties".to_string(), VmValue::dict(props));
         schema.insert("required".to_string(), required);
-        VmValue::Dict(std::sync::Arc::new(schema))
+        VmValue::dict(schema)
     }
 
     #[test]
@@ -815,46 +808,40 @@ mod tests {
 
     #[test]
     fn regex_recover_skips_when_schema_is_not_object() {
-        let mut scalar = BTreeMap::new();
+        let mut scalar = crate::value::DictMap::new();
         scalar.put_str("type", "string");
-        let schema = VmValue::Dict(std::sync::Arc::new(scalar));
+        let schema = VmValue::dict(scalar);
         let outcome = try_regex_recover("hello", &schema, false).unwrap();
         assert!(outcome.is_none());
     }
 
     #[test]
     fn coerce_handles_unquoted_string_with_trailing_punct() {
-        let mut field = BTreeMap::new();
+        let mut field = crate::value::DictMap::new();
         field.put_str("type", "string");
-        let v =
-            coerce_scalar("Ada,", "string", &VmValue::Dict(std::sync::Arc::new(field))).unwrap();
+        let v = coerce_scalar("Ada,", "string", &VmValue::dict(field)).unwrap();
         assert_eq!(v.display(), "Ada");
     }
 
     #[test]
     fn coerce_handles_escaped_quotes_in_string() {
-        let mut field = BTreeMap::new();
+        let mut field = crate::value::DictMap::new();
         field.put_str("type", "string");
-        let v = coerce_scalar(
-            "he said \\\"hi\\\"",
-            "string",
-            &VmValue::Dict(std::sync::Arc::new(field)),
-        )
-        .unwrap();
+        let v = coerce_scalar("he said \\\"hi\\\"", "string", &VmValue::dict(field)).unwrap();
         assert_eq!(v.display(), "he said \"hi\"");
     }
 
     #[test]
     fn coerce_rejects_null_for_non_nullable_string() {
-        let mut field = BTreeMap::new();
+        let mut field = crate::value::DictMap::new();
         field.put_str("type", "string");
-        let v = coerce_scalar("null", "string", &VmValue::Dict(std::sync::Arc::new(field)));
+        let v = coerce_scalar("null", "string", &VmValue::dict(field));
         assert!(v.is_none());
     }
 
     #[test]
     fn parse_repair_config_disable_via_bool() {
-        let mut opts = BTreeMap::new();
+        let mut opts = crate::value::DictMap::new();
         opts.insert("llm_repair".to_string(), VmValue::Bool(false));
         let cfg = parse_llm_repair_config(&Some(opts));
         assert!(!cfg.enabled);
@@ -868,14 +855,11 @@ mod tests {
 
     #[test]
     fn parse_repair_config_dict_extracts_overrides() {
-        let mut repair = BTreeMap::new();
+        let mut repair = crate::value::DictMap::new();
         repair.put_str("model", "local:fix");
         repair.insert("max_tokens".to_string(), VmValue::Int(400));
-        let mut opts = BTreeMap::new();
-        opts.insert(
-            "llm_repair".to_string(),
-            VmValue::Dict(std::sync::Arc::new(repair)),
-        );
+        let mut opts = crate::value::DictMap::new();
+        opts.insert("llm_repair".to_string(), VmValue::dict(repair));
         let cfg = parse_llm_repair_config(&Some(opts));
         assert!(cfg.enabled);
         assert_eq!(
@@ -891,11 +875,11 @@ mod tests {
     #[test]
     fn merge_repair_caps_schema_retries_and_installs_schema() {
         let schema = person_schema();
-        let mut base = BTreeMap::new();
+        let mut base = crate::value::DictMap::new();
         base.insert("schema_retries".to_string(), VmValue::Int(7));
         base.insert("llm_repair".to_string(), VmValue::Bool(true));
         base.insert("apply_defaults".to_string(), VmValue::Bool(true));
-        let merged = merge_repair_options(Some(&base), &BTreeMap::new(), &schema);
+        let merged = merge_repair_options(Some(&base), &crate::value::DictMap::new(), &schema);
         assert_eq!(
             merged.get("schema_retries").and_then(VmValue::as_int),
             Some(0)
@@ -915,9 +899,9 @@ mod tests {
     #[test]
     fn merge_repair_overrides_win_over_base() {
         let schema = person_schema();
-        let mut base = BTreeMap::new();
+        let mut base = crate::value::DictMap::new();
         base.put_str("model", "base:big");
-        let mut overrides = BTreeMap::new();
+        let mut overrides = crate::value::DictMap::new();
         overrides.put_str("model", "override:small");
         let merged = merge_repair_options(Some(&base), &overrides, &schema);
         assert_eq!(
@@ -997,12 +981,12 @@ mod tests {
     #[tokio::test]
     async fn schema_recover_failure_when_repair_disabled_and_unrecoverable() {
         let schema = person_schema();
-        let mut opts = BTreeMap::new();
+        let mut opts = crate::value::DictMap::new();
         opts.insert("llm_repair".to_string(), VmValue::Bool(false));
         let args = vec![
             VmValue::String(std::sync::Arc::from("nothing useful here at all")),
             schema,
-            VmValue::Dict(std::sync::Arc::new(opts)),
+            VmValue::dict(opts),
         ];
         let env = schema_recover_impl(args, None).await.unwrap();
         let dict = env.as_dict().unwrap();

--- a/crates/harn-vm/src/llm/skill_score.rs
+++ b/crates/harn-vm/src/llm/skill_score.rs
@@ -70,14 +70,14 @@ pub(crate) async fn score_skill_registry(
         score_via_bridge(bridge.as_deref(), &skills, &task, &working_files, strategy).await?;
 
     let scored_values = scored.into_iter().map(candidate_to_vm).collect();
-    Ok(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+    Ok(VmValue::dict(BTreeMap::from([(
         "scored".to_string(),
         VmValue::List(std::sync::Arc::new(scored_values)),
-    )]))))
+    )])))
 }
 
 fn candidate_to_vm(candidate: SkillCandidate) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    VmValue::dict(BTreeMap::from([
         (
             "id".to_string(),
             VmValue::String(std::sync::Arc::from(candidate.id.clone())),
@@ -95,7 +95,7 @@ fn candidate_to_vm(candidate: SkillCandidate) -> VmValue {
             "reason".to_string(),
             VmValue::String(std::sync::Arc::from(candidate.trigger)),
         ),
-    ])))
+    ]))
 }
 
 fn extract_skills(registry: &VmValue) -> Vec<VmValue> {

--- a/crates/harn-vm/src/llm/stream_builtins.rs
+++ b/crates/harn-vm/src/llm/stream_builtins.rs
@@ -76,7 +76,7 @@ fn llm_stream_chunk(
             .map(|reason| VmValue::String(std::sync::Arc::from(reason.to_string())))
             .unwrap_or(VmValue::Nil),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 async fn forward_llm_stream_delta(
@@ -263,7 +263,7 @@ mod tests {
         vec![
             VmValue::String(Arc::from("hello".to_string())),
             VmValue::Nil,
-            VmValue::Dict(Arc::new(options)),
+            VmValue::dict(options),
         ]
     }
 

--- a/crates/harn-vm/src/llm/structural_experiments.rs
+++ b/crates/harn-vm/src/llm/structural_experiments.rs
@@ -1,5 +1,4 @@
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 
 use crate::value::{VmError, VmValue};
 
@@ -36,7 +35,7 @@ pub(crate) struct AppliedStructuralExperiment {
 const STRUCTURAL_EXPERIMENT_ENV: &str = "HARN_STRUCTURAL_EXPERIMENT";
 
 pub(crate) fn parse_structural_experiment_option(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<Option<StructuralExperimentConfig>, VmError> {
     let explicit = options.and_then(|dict| dict.get("structural_experiment"));
     match explicit {
@@ -63,7 +62,7 @@ pub(crate) fn parse_structural_experiment_option(
 }
 
 fn parse_structural_experiment_dict(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
 ) -> Result<Option<StructuralExperimentConfig>, VmError> {
     let label = dict
         .get("label")
@@ -296,7 +295,7 @@ pub(crate) async fn apply_structural_experiment(
                         "structural_experiment requires an async builtin VM context".to_string(),
                     )
                 })?;
-            let mut ctx = BTreeMap::new();
+            let mut ctx = crate::value::DictMap::new();
             ctx.insert(
                 "messages".to_string(),
                 VmValue::List(std::sync::Arc::new(
@@ -325,8 +324,7 @@ pub(crate) async fn apply_structural_experiment(
             interpret_closure_result(
                 &current_messages,
                 current_system.as_deref(),
-                &vm.call_closure_pub(closure, &[VmValue::Dict(std::sync::Arc::new(ctx))])
-                    .await?,
+                &vm.call_closure_pub(closure, &[VmValue::dict(ctx)]).await?,
                 &config,
             )?
         }
@@ -440,7 +438,7 @@ fn apply_builtin_experiment(
         BuiltInStructuralExperiment::ChainOfDraft => {
             if let Some(index) = latest_string_user_message_index(&messages) {
                 if let Some(content) = message_text(&messages[index]).map(str::to_string) {
-                    let mut bindings = BTreeMap::new();
+                    let mut bindings = crate::value::DictMap::new();
                     bindings.put_str("content", content);
                     let rendered = crate::stdlib::template::render_stdlib_prompt_asset(
                         "llm/prompts/structural_chain_of_draft.harn.prompt",

--- a/crates/harn-vm/src/llm/structured_envelope.rs
+++ b/crates/harn-vm/src/llm/structured_envelope.rs
@@ -27,7 +27,6 @@
 //! since there is no raw text to salvage.
 
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::value::{VmError, VmValue};
@@ -218,14 +217,14 @@ fn apply_prompt_mode_structured_transport(args: &mut [VmValue]) {
         let mut dict = options.as_dict().cloned().unwrap_or_default();
         dict.put_str("output_format", "text");
         dict.put_str("response_format", "text");
-        *options = VmValue::Dict(std::sync::Arc::new(dict));
+        *options = VmValue::dict(dict);
     }
 }
 
 fn prompt_with_schema_contract(prompt: &str, schema: &VmValue) -> String {
     let schema_json = serde_json::to_string_pretty(&vm_value_to_json(schema))
         .unwrap_or_else(|_| schema.display());
-    let mut bindings = BTreeMap::new();
+    let mut bindings = crate::value::DictMap::new();
     bindings.put_str("prompt", prompt);
     bindings.put_str("schema_json", schema_json);
     crate::stdlib::template::render_stdlib_prompt_asset(
@@ -250,14 +249,14 @@ fn classify_main_failure(outcome: &SchemaLoopOutcome) -> EnvelopeFailureKind {
 /// Returned-`{enabled, ...overrides}`-dict-or-`nil` repair config.
 struct RepairConfig {
     enabled: bool,
-    overrides: BTreeMap<String, VmValue>,
+    overrides: crate::value::DictMap,
 }
 
 fn take_repair_config(args: &mut [VmValue]) -> Option<RepairConfig> {
     let options = args.get_mut(2)?;
     let mut new_dict = options.as_dict()?.clone();
     let raw = new_dict.remove("repair")?;
-    *options = VmValue::Dict(std::sync::Arc::new(new_dict));
+    *options = VmValue::dict(new_dict);
     parse_repair_value(&raw)
 }
 
@@ -266,7 +265,7 @@ fn parse_repair_value(raw: &VmValue) -> Option<RepairConfig> {
         VmValue::Nil => None,
         VmValue::Bool(b) => Some(RepairConfig {
             enabled: *b,
-            overrides: BTreeMap::new(),
+            overrides: crate::value::DictMap::new(),
         }),
         VmValue::Dict(d) => {
             let enabled = match d.get("enabled") {
@@ -276,7 +275,7 @@ fn parse_repair_value(raw: &VmValue) -> Option<RepairConfig> {
                 Some(VmValue::Bool(true)) => true,
                 Some(_) => true, // Tolerant: any truthy value enables it.
             };
-            let mut overrides: BTreeMap<String, VmValue> = (**d).clone();
+            let mut overrides: crate::value::DictMap = (**d).clone();
             overrides.remove("enabled");
             Some(RepairConfig { enabled, overrides })
         }
@@ -290,7 +289,7 @@ fn parse_repair_value(raw: &VmValue) -> Option<RepairConfig> {
 async fn run_repair_pass(
     main_outcome: &SchemaLoopOutcome,
     repair: &RepairConfig,
-    base_options: Option<&BTreeMap<String, VmValue>>,
+    base_options: Option<&crate::value::DictMap>,
     bridge: Option<&Arc<crate::bridge::HostBridge>>,
 ) -> Option<VmValue> {
     let prompt = build_repair_prompt(&main_outcome.raw_text, &main_outcome.errors);
@@ -306,7 +305,7 @@ async fn run_repair_pass(
         VmValue::String(std::sync::Arc::from(prompt.as_str())),
         // System slot — the prompt carries instructions inline.
         VmValue::Nil,
-        VmValue::Dict(std::sync::Arc::new(merged_options)),
+        VmValue::dict(merged_options),
     ];
     let opts = extract_llm_options(&args).ok()?;
     let outcome = execute_schema_retry_loop(None, opts, merged_dict, bridge)
@@ -325,7 +324,7 @@ fn build_repair_prompt(raw_text: &str, errors: &[String]) -> String {
     } else {
         errors.join("; ")
     };
-    let mut bindings = BTreeMap::new();
+    let mut bindings = crate::value::DictMap::new();
     bindings.put_str("errors_line", errors_line);
     bindings.put_str("raw_text", raw_text);
     crate::stdlib::template::render_stdlib_prompt_asset(
@@ -336,9 +335,9 @@ fn build_repair_prompt(raw_text: &str, errors: &[String]) -> String {
 }
 
 fn merge_repair_options(
-    base: Option<&BTreeMap<String, VmValue>>,
-    overrides: &BTreeMap<String, VmValue>,
-) -> BTreeMap<String, VmValue> {
+    base: Option<&crate::value::DictMap>,
+    overrides: &crate::value::DictMap,
+) -> crate::value::DictMap {
     let mut merged = base.cloned().unwrap_or_default();
     // The repair pass runs a single shot: do not multiply schema
     // retries from the main call (cost amplification) and do not let
@@ -383,7 +382,7 @@ fn envelope_success(outcome: &SchemaLoopOutcome, repaired: bool) -> VmValue {
     let usage = build_usage_dict(outcome);
     let (model, provider) = result_model_provider(outcome);
 
-    let mut env = BTreeMap::new();
+    let mut env = crate::value::DictMap::new();
     env.insert("ok".to_string(), VmValue::Bool(true));
     env.insert("data".to_string(), data);
     env.put_str("raw_text", outcome.raw_text.as_str());
@@ -398,7 +397,7 @@ fn envelope_success(outcome: &SchemaLoopOutcome, repaired: bool) -> VmValue {
     env.insert("usage".to_string(), usage);
     env.put_str("model", model.as_str());
     env.put_str("provider", provider.as_str());
-    VmValue::Dict(std::sync::Arc::new(env))
+    VmValue::dict(env)
 }
 
 fn envelope_failure(
@@ -415,7 +414,7 @@ fn envelope_failure(
         outcome.errors.join("; ")
     };
 
-    let mut env = BTreeMap::new();
+    let mut env = crate::value::DictMap::new();
     env.insert("ok".to_string(), VmValue::Bool(false));
     env.insert("data".to_string(), VmValue::Nil);
     env.put_str("raw_text", outcome.raw_text.as_str());
@@ -430,7 +429,7 @@ fn envelope_failure(
     env.insert("usage".to_string(), usage);
     env.put_str("model", model.as_str());
     env.put_str("provider", provider.as_str());
-    VmValue::Dict(std::sync::Arc::new(env))
+    VmValue::dict(env)
 }
 
 fn envelope_from_transport_error(err: &VmError, provider: &str, model: &str) -> VmValue {
@@ -444,7 +443,7 @@ fn envelope_from_transport_error(err: &VmError, provider: &str, model: &str) -> 
             .unwrap_or_else(|| err.to_string()),
         _ => err.to_string(),
     };
-    let mut env = BTreeMap::new();
+    let mut env = crate::value::DictMap::new();
     env.insert("ok".to_string(), VmValue::Bool(false));
     env.insert("data".to_string(), VmValue::Nil);
     env.put_str("raw_text", "");
@@ -453,13 +452,10 @@ fn envelope_from_transport_error(err: &VmError, provider: &str, model: &str) -> 
     env.insert("attempts".to_string(), VmValue::Int(0));
     env.insert("repaired".to_string(), VmValue::Bool(false));
     env.insert("extracted_json".to_string(), VmValue::Bool(false));
-    env.insert(
-        "usage".to_string(),
-        VmValue::Dict(std::sync::Arc::new(empty_usage_dict())),
-    );
+    env.insert("usage".to_string(), VmValue::dict(empty_usage_dict()));
     env.put_str("model", model);
     env.put_str("provider", provider);
-    VmValue::Dict(std::sync::Arc::new(env))
+    VmValue::dict(env)
 }
 
 fn envelope_from_arg_error(err: &VmError) -> VmValue {
@@ -469,8 +465,8 @@ fn envelope_from_arg_error(err: &VmError) -> VmValue {
     envelope_from_transport_error(err, "", "")
 }
 
-fn empty_usage_dict() -> BTreeMap<String, VmValue> {
-    let mut usage = BTreeMap::new();
+fn empty_usage_dict() -> crate::value::DictMap {
+    let mut usage = crate::value::DictMap::new();
     usage.insert("input_tokens".to_string(), VmValue::Int(0));
     usage.insert("output_tokens".to_string(), VmValue::Int(0));
     usage.insert("cache_read_tokens".to_string(), VmValue::Int(0));
@@ -484,7 +480,7 @@ fn empty_usage_dict() -> BTreeMap<String, VmValue> {
 fn build_usage_dict(outcome: &SchemaLoopOutcome) -> VmValue {
     let dict = match outcome.vm_result.as_dict() {
         Some(d) => d,
-        None => return VmValue::Dict(std::sync::Arc::new(empty_usage_dict())),
+        None => return VmValue::dict(empty_usage_dict()),
     };
     if let Some(VmValue::Dict(usage)) = dict.get("usage") {
         return VmValue::Dict(usage.clone());
@@ -503,7 +499,7 @@ fn build_usage_dict(outcome: &SchemaLoopOutcome) -> VmValue {
             usage.insert(key.to_string(), v.clone());
         }
     }
-    VmValue::Dict(std::sync::Arc::new(usage))
+    VmValue::dict(usage)
 }
 
 fn result_model_provider(outcome: &SchemaLoopOutcome) -> (String, String) {
@@ -592,34 +588,34 @@ mod tests {
             VmValue::Nil
         ]));
         // Already prompt-mode text transport -> do NOT re-degrade.
-        let mut text_opts = BTreeMap::new();
+        let mut text_opts = crate::value::DictMap::new();
         text_opts.put_str("output_format", "text");
         assert!(!structured_request_uses_response_format(&[
             VmValue::Nil,
             VmValue::Nil,
-            VmValue::Dict(std::sync::Arc::new(text_opts)),
+            VmValue::dict(text_opts),
         ]));
         // json_object still sends a response_format -> degradable.
-        let mut json_object_opts = BTreeMap::new();
+        let mut json_object_opts = crate::value::DictMap::new();
         json_object_opts.put_str("output_format", "json_object");
         assert!(structured_request_uses_response_format(&[
             VmValue::Nil,
             VmValue::Nil,
-            VmValue::Dict(std::sync::Arc::new(json_object_opts)),
+            VmValue::dict(json_object_opts),
         ]));
     }
 
     #[test]
     fn merge_repair_caps_schema_retries_and_drops_nested_repair() {
-        let mut base = BTreeMap::new();
+        let mut base = crate::value::DictMap::new();
         base.put_str("provider", "auto");
         base.insert("schema_retries".to_string(), VmValue::Int(5));
         base.insert(
             "repair".to_string(),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::new())),
+            VmValue::dict(crate::value::DictMap::new()),
         );
         let overrides = {
-            let mut o = BTreeMap::new();
+            let mut o = crate::value::DictMap::new();
             o.put_str("model", "local:fix");
             o
         };
@@ -647,34 +643,33 @@ mod tests {
         let bool_false = parse_repair_value(&VmValue::Bool(false)).unwrap();
         assert!(!bool_false.enabled);
         let dict_no_enabled =
-            parse_repair_value(&VmValue::Dict(std::sync::Arc::new(BTreeMap::new()))).unwrap();
+            parse_repair_value(&VmValue::dict(crate::value::DictMap::new())).unwrap();
         assert!(dict_no_enabled.enabled);
-        let mut disabled = BTreeMap::new();
+        let mut disabled = crate::value::DictMap::new();
         disabled.insert("enabled".to_string(), VmValue::Bool(false));
-        let dict_disabled =
-            parse_repair_value(&VmValue::Dict(std::sync::Arc::new(disabled))).unwrap();
+        let dict_disabled = parse_repair_value(&VmValue::dict(disabled)).unwrap();
         assert!(!dict_disabled.enabled);
     }
 
     #[test]
     fn prompt_mode_structured_transport_keeps_harn_side_validation() {
-        let schema = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        let schema = VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "type".to_string(),
                 VmValue::String(std::sync::Arc::from("object")),
             ),
             (
                 "properties".to_string(),
-                VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+                VmValue::dict(crate::value::DictMap::from_iter([(
                     "pass".to_string(),
-                    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+                    VmValue::dict(crate::value::DictMap::from_iter([(
                         "type".to_string(),
                         VmValue::String(std::sync::Arc::from("boolean")),
-                    )]))),
-                )]))),
+                    )])),
+                )])),
             ),
-        ])));
-        let options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        ]));
+        let options = VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "provider".to_string(),
                 VmValue::String(std::sync::Arc::from("ollama")),
@@ -686,7 +681,7 @@ mod tests {
                 // prompt-mode. (ollama gemma4/devstral now declare format_kw support.)
                 VmValue::String(std::sync::Arc::from("llava:latest")),
             ),
-        ])));
+        ]));
         let mut args = crate::llm::rewrite_structured_args(vec![
             VmValue::String(std::sync::Arc::from("Return a completion verdict.")),
             schema,

--- a/crates/harn-vm/src/llm/tool_conformance.rs
+++ b/crates/harn-vm/src/llm/tool_conformance.rs
@@ -811,14 +811,11 @@ fn probe_tool_registry() -> VmValue {
         vm_str("The marker value to echo."),
     );
     let mut params = BTreeMap::new();
-    params.insert(
-        "value".to_string(),
-        VmValue::Dict(std::sync::Arc::new(value_param)),
-    );
+    params.insert("value".to_string(), VmValue::dict(value_param));
     let tool = vm_dict(&[
         ("name", vm_str(TOOL_PROBE_TOOL_NAME)),
         ("description", vm_str("Echo the probe marker exactly.")),
-        ("parameters", VmValue::Dict(std::sync::Arc::new(params))),
+        ("parameters", VmValue::dict(params)),
     ]);
     vm_dict(&[("tools", VmValue::List(std::sync::Arc::new(vec![tool])))])
 }
@@ -832,7 +829,7 @@ fn vm_dict(pairs: &[(&str, VmValue)]) -> VmValue {
     for (key, value) in pairs {
         map.insert((*key).to_string(), value.clone());
     }
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn has_raw_model_tool_tag(content: &str) -> bool {

--- a/crates/harn-vm/src/llm/tools/json_schema.rs
+++ b/crates/harn-vm/src/llm/tools/json_schema.rs
@@ -157,9 +157,7 @@ pub(crate) fn json_schema_to_type_expr(
     }
 }
 
-pub(super) fn vm_build_json_schema(
-    params: Option<&std::collections::BTreeMap<String, VmValue>>,
-) -> serde_json::Value {
+pub(super) fn vm_build_json_schema(params: Option<&crate::value::DictMap>) -> serde_json::Value {
     let mut properties = serde_json::Map::new();
     let mut required = Vec::new();
 

--- a/crates/harn-vm/src/llm/tools/params.rs
+++ b/crates/harn-vm/src/llm/tools/params.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use super::components::ComponentRegistry;
 use super::json_schema::json_schema_to_type_expr;
 use super::type_expr::TypeExpr;
@@ -13,7 +11,7 @@ use crate::value::VmValue;
 /// lift into TypeExpr. The `root_json` is the whole tool-registry converted
 /// to JSON so `$ref` pointers can resolve against it.
 pub(super) fn extract_params_from_vm_dict(
-    td: &BTreeMap<String, VmValue>,
+    td: &crate::value::DictMap,
     root_json: &serde_json::Value,
     registry: &mut ComponentRegistry,
 ) -> Vec<ToolParamSchema> {
@@ -64,8 +62,8 @@ pub(super) fn extract_params_from_vm_dict(
 /// canonical VmValue → JSON conversion (re-exported via `super::vm_value_to_json`
 /// at the top of this file). We wrap the dict contents in `VmValue::Dict` so
 /// the single shared conversion path handles every field uniformly.
-fn vm_dict_to_json(dict: &BTreeMap<String, VmValue>) -> serde_json::Value {
-    super::super::vm_value_to_json(&VmValue::Dict(std::sync::Arc::new(dict.clone())))
+fn vm_dict_to_json(dict: &crate::value::DictMap) -> serde_json::Value {
+    super::super::vm_value_to_json(&VmValue::dict(dict.clone()))
 }
 
 #[derive(Clone, Debug, serde::Serialize)]
@@ -96,7 +94,7 @@ pub(super) fn extract_examples(
 }
 
 /// Pull examples from a VmValue dict, same dual-key convention.
-pub(super) fn extract_examples_vm(pdef: &BTreeMap<String, VmValue>) -> Vec<serde_json::Value> {
+pub(super) fn extract_examples_vm(pdef: &crate::value::DictMap) -> Vec<serde_json::Value> {
     if let Some(VmValue::List(items)) = pdef.get("examples") {
         return items.iter().map(super::super::vm_value_to_json).collect();
     }

--- a/crates/harn-vm/src/llm/tools/tests/mod.rs
+++ b/crates/harn-vm/src/llm/tools/tests/mod.rs
@@ -30,7 +30,7 @@ pub(super) fn vm_dict(pairs: &[(&str, VmValue)]) -> VmValue {
     for (key, value) in pairs {
         map.insert((*key).to_string(), value.clone());
     }
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 pub(super) fn vm_str(s: &str) -> VmValue {
@@ -121,7 +121,7 @@ pub(super) fn sample_tool_registry() -> VmValue {
     let edit_tool = vm_dict(&[
         ("name", vm_str("edit")),
         ("description", vm_str("Precise code edit.")),
-        ("parameters", VmValue::Dict(std::sync::Arc::new(params))),
+        ("parameters", VmValue::dict(params)),
     ]);
 
     // run tool
@@ -136,7 +136,7 @@ pub(super) fn sample_tool_registry() -> VmValue {
     let run_tool = vm_dict(&[
         ("name", vm_str("run")),
         ("description", vm_str("Run a shell command.")),
-        ("parameters", VmValue::Dict(std::sync::Arc::new(run_params))),
+        ("parameters", VmValue::dict(run_params)),
     ]);
 
     vm_dict(&[("tools", vm_list(vec![edit_tool, run_tool]))])
@@ -155,10 +155,7 @@ pub(super) fn defer_loading_registry() -> VmValue {
     let eager = vm_dict(&[
         ("name", vm_str("look")),
         ("description", vm_str("Read file contents")),
-        (
-            "parameters",
-            VmValue::Dict(std::sync::Arc::new(eager_params)),
-        ),
+        ("parameters", VmValue::dict(eager_params)),
     ]);
 
     let mut deferred_params = BTreeMap::new();
@@ -166,10 +163,7 @@ pub(super) fn defer_loading_registry() -> VmValue {
     let deferred = vm_dict(&[
         ("name", vm_str("deploy")),
         ("description", vm_str("Deploy the app")),
-        (
-            "parameters",
-            VmValue::Dict(std::sync::Arc::new(deferred_params)),
-        ),
+        ("parameters", VmValue::dict(deferred_params)),
         ("defer_loading", vm_bool(true)),
     ]);
 

--- a/crates/harn-vm/src/llm/tools/tests/native_tools.rs
+++ b/crates/harn-vm/src/llm/tools/tests/native_tools.rs
@@ -59,10 +59,7 @@ fn vm_tools_to_native_emits_namespace_for_openai_compat() {
     let deferred = vm_dict(&[
         ("name", vm_str("deploy")),
         ("description", vm_str("Deploy the app")),
-        (
-            "parameters",
-            super::VmValue::Dict(std::sync::Arc::new(deferred_params)),
-        ),
+        ("parameters", super::VmValue::dict(deferred_params)),
         ("defer_loading", vm_bool(true)),
         ("namespace", vm_str("ops")),
     ]);
@@ -168,10 +165,7 @@ fn vm_tools_to_native_normalizes_nested_harn_type_aliases() {
     let tool = vm_dict(&[
         ("name", vm_str("rank")),
         ("description", vm_str("Rank results")),
-        (
-            "parameters",
-            super::VmValue::Dict(std::sync::Arc::new(params)),
-        ),
+        ("parameters", super::VmValue::dict(params)),
     ]);
     let registry = vm_list(vec![tool]);
 
@@ -212,10 +206,7 @@ fn vm_tools_to_native_preserves_json_schema_required_arrays() {
     let tool = vm_dict(&[
         ("name", vm_str("submit")),
         ("description", vm_str("Submit payload")),
-        (
-            "parameters",
-            super::VmValue::Dict(std::sync::Arc::new(params)),
-        ),
+        ("parameters", super::VmValue::dict(params)),
     ]);
     let registry = vm_list(vec![tool]);
 

--- a/crates/harn-vm/src/llm/transcript_stats.rs
+++ b/crates/harn-vm/src/llm/transcript_stats.rs
@@ -95,21 +95,21 @@ fn events_list(transcript: &VmValue) -> Vec<VmValue> {
         .unwrap_or_default()
 }
 
-fn list_field(dict: &BTreeMap<String, VmValue>, key: &str) -> Vec<VmValue> {
+fn list_field(dict: &crate::value::DictMap, key: &str) -> Vec<VmValue> {
     match dict.get(key) {
         Some(VmValue::List(list)) => (**list).clone(),
         _ => Vec::new(),
     }
 }
 
-fn string_field(dict: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn string_field(dict: &crate::value::DictMap, key: &str) -> Option<String> {
     match dict.get(key) {
         Some(VmValue::String(s)) => Some(s.to_string()),
         _ => None,
     }
 }
 
-fn count_tool_calls(msg: &BTreeMap<String, VmValue>) -> i64 {
+fn count_tool_calls(msg: &crate::value::DictMap) -> i64 {
     match msg.get("tool_calls") {
         Some(VmValue::List(list)) => list.len() as i64,
         _ => 0,
@@ -146,7 +146,7 @@ fn stats_to_vm(stats: &TranscriptStats) -> VmValue {
         "visible_event_count".to_string(),
         VmValue::Int(stats.visible_event_count),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 #[cfg(test)]

--- a/crates/harn-vm/src/mcp/builtins.rs
+++ b/crates/harn-vm/src/mcp/builtins.rs
@@ -279,7 +279,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
             if let Some(card) = entry.card {
                 dict.put_str("card", card.as_str());
             }
-            out.push(VmValue::Dict(std::sync::Arc::new(dict)));
+            out.push(VmValue::dict(dict));
         }
         Ok(VmValue::List(std::sync::Arc::new(out)))
     });
@@ -464,7 +464,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
                 json_to_vm_value(&cache_hints_to_json(cache_hints.iter())),
             );
         }
-        Ok(VmValue::Dict(std::sync::Arc::new(info)))
+        Ok(VmValue::dict(info))
     });
 
     vm.register_async_builtin("mcp_disconnect", |_ctx, args| async move {
@@ -648,7 +648,7 @@ pub(crate) fn mcp_roots_builtin(_args: &[VmValue], _out: &mut String) -> Result<
 }
 
 pub(crate) fn register_harn_mcp_namespace(vm: &mut Vm) {
-    let mcp_namespace = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    let mcp_namespace = VmValue::dict(BTreeMap::from([
         (
             "_namespace".to_string(),
             VmValue::String(std::sync::Arc::from("harn.mcp")),
@@ -701,10 +701,10 @@ pub(crate) fn register_harn_mcp_namespace(vm: &mut Vm) {
             "status".to_string(),
             VmValue::BuiltinRef(std::sync::Arc::from("harn.mcp.status")),
         ),
-    ])));
+    ]));
     vm.set_global(
         "harn",
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        VmValue::dict(BTreeMap::from([
             (
                 "_namespace".to_string(),
                 VmValue::String(std::sync::Arc::from("harn")),
@@ -714,7 +714,7 @@ pub(crate) fn register_harn_mcp_namespace(vm: &mut Vm) {
                 VmValue::BuiltinRef(std::sync::Arc::from("harn.mcp.roots")),
             ),
             ("mcp".to_string(), mcp_namespace),
-        ]))),
+        ])),
     );
 }
 
@@ -850,7 +850,7 @@ pub(crate) fn register_supervised_mcp_host_builtins(vm: &mut Vm) {
                     "cache_entries".to_string(),
                     VmValue::Int(s.cache_entries as i64),
                 );
-                VmValue::Dict(std::sync::Arc::new(dict))
+                VmValue::dict(dict)
             })
             .collect();
         Ok(VmValue::List(std::sync::Arc::new(list)))

--- a/crates/harn-vm/src/mcp/tests.rs
+++ b/crates/harn-vm/src/mcp/tests.rs
@@ -902,7 +902,7 @@ fn test_vm_value_to_serde_string() {
 fn test_vm_value_to_serde_dict() {
     let mut map = BTreeMap::new();
     map.insert("key".to_string(), VmValue::Int(42));
-    let val = VmValue::Dict(std::sync::Arc::new(map));
+    let val = VmValue::dict(map);
     let json = vm_value_to_serde(&val);
     assert_eq!(json, serde_json::json!({"key": 42}));
 }

--- a/crates/harn-vm/src/mcp_elicit.rs
+++ b/crates/harn-vm/src/mcp_elicit.rs
@@ -19,7 +19,7 @@
 
 use crate::value::VmDictExt;
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -218,7 +218,7 @@ pub(crate) fn envelope_from_response(
         )))));
     }
 
-    let mut envelope: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut envelope: crate::value::DictMap = crate::value::DictMap::new();
     envelope.put_str("action", action);
 
     if action == "accept" {
@@ -230,7 +230,7 @@ pub(crate) fn envelope_from_response(
         envelope.insert("content".to_string(), validated);
     }
 
-    Ok(VmValue::Dict(std::sync::Arc::new(envelope)))
+    Ok(VmValue::dict(envelope))
 }
 
 /// Validate the `content` field of an `accept` response against the
@@ -314,7 +314,7 @@ pub(crate) async fn dispatch_inbound_elicitation(
     // Build the params bundle dispatched to the host bridge / mock.
     // Includes the originating server name so a single host can route
     // by source, and copies the raw schema through unmodified.
-    let mut bridge_params: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut bridge_params: crate::value::DictMap = crate::value::DictMap::new();
     bridge_params.put_str("server", server_name);
     bridge_params.put_str("message", message.as_str());
     bridge_params.insert(

--- a/crates/harn-vm/src/mcp_file_upload.rs
+++ b/crates/harn-vm/src/mcp_file_upload.rs
@@ -144,17 +144,11 @@ fn status_value() -> VmValue {
     file_upload.put_str("wire_format", "x-mcp-file+rfc2397-data-uri");
 
     let mut experimental = BTreeMap::new();
-    experimental.insert(
-        "file_upload".to_string(),
-        VmValue::Dict(std::sync::Arc::new(file_upload)),
-    );
+    experimental.insert("file_upload".to_string(), VmValue::dict(file_upload));
 
     let mut root = BTreeMap::new();
-    root.insert(
-        "experimental".to_string(),
-        VmValue::Dict(std::sync::Arc::new(experimental)),
-    );
-    VmValue::Dict(std::sync::Arc::new(root))
+    root.insert("experimental".to_string(), VmValue::dict(experimental));
+    VmValue::dict(root)
 }
 
 fn ensure_enabled(name: &str) -> Result<(), VmError> {
@@ -205,17 +199,14 @@ fn file_input_schema(options: &VmValue) -> Result<VmValue, VmError> {
     let mut schema = BTreeMap::new();
     schema.put_str("type", "string");
     schema.put_str("format", "uri");
-    schema.insert(
-        X_MCP_FILE.to_string(),
-        VmValue::Dict(std::sync::Arc::new(descriptor)),
-    );
+    schema.insert(X_MCP_FILE.to_string(), VmValue::dict(descriptor));
     if let Some(title) = options.and_then(|opts| string_field(opts, "title")) {
         schema.put_str("title", title);
     }
     if let Some(description) = options.and_then(|opts| string_field(opts, "description")) {
         schema.put_str("description", description);
     }
-    Ok(VmValue::Dict(std::sync::Arc::new(schema)))
+    Ok(VmValue::dict(schema))
 }
 
 fn upload_file(args: &[VmValue]) -> Result<VmValue, VmError> {
@@ -644,21 +635,21 @@ fn redact_data_uri(raw: &str) -> String {
     format!("data:{media_type};redacted;sha256={}", &digest[..16])
 }
 
-fn string_field(map: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn string_field(map: &crate::value::DictMap, key: &str) -> Option<String> {
     match map.get(key) {
         Some(VmValue::String(value)) => Some(value.to_string()),
         _ => None,
     }
 }
 
-fn int_field(map: &BTreeMap<String, VmValue>, key: &str) -> Option<i64> {
+fn int_field(map: &crate::value::DictMap, key: &str) -> Option<i64> {
     match map.get(key) {
         Some(VmValue::Int(value)) => Some(*value),
         _ => None,
     }
 }
 
-fn optional_bool(map: &BTreeMap<String, VmValue>, key: &str) -> Option<bool> {
+fn optional_bool(map: &crate::value::DictMap, key: &str) -> Option<bool> {
     match map.get(key) {
         Some(VmValue::Bool(value)) => Some(*value),
         _ => None,
@@ -683,7 +674,7 @@ fn list_of_strings(
 }
 
 fn string_vec_field(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     key: &str,
     callee: &str,
 ) -> Result<Option<Vec<String>>, VmError> {
@@ -815,10 +806,7 @@ mod tests {
                 spec_revision: SPEC_REVISION.to_string(),
             });
         });
-        let options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
-            "max_size".to_string(),
-            VmValue::Int(-1),
-        )])));
+        let options = VmValue::dict(BTreeMap::from([("max_size".to_string(), VmValue::Int(-1))]));
         let err = file_input_schema(&options).expect_err("negative max_size should fail");
         assert!(err.to_string().contains("max_size must be non-negative"));
     }

--- a/crates/harn-vm/src/mcp_sampling.rs
+++ b/crates/harn-vm/src/mcp_sampling.rs
@@ -19,7 +19,6 @@
 //! <https://modelcontextprotocol.io/specification/2025-11-25/client/sampling>.
 
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 
 use serde_json::{json, Value as JsonValue};
 
@@ -69,7 +68,7 @@ struct SamplingRequest {
 enum ApprovalDecision {
     /// Approved — proceed with the listed `llm_call` option overrides
     /// merged on top of the request-derived defaults.
-    Accept(BTreeMap<String, VmValue>),
+    Accept(crate::value::DictMap),
     /// Declined — propagate as a JSON-RPC error to the server with the
     /// reason string the host supplied (or a default).
     Decline(String),
@@ -260,7 +259,7 @@ fn parse_sampling_request(params: &JsonValue) -> Result<SamplingRequest, String>
 ///   minimal embedder that just wants to force `provider: "mock"` can
 ///   return `{provider: "mock"}` without ceremony)
 async fn ask_host_approval(server_name: &str, params: &JsonValue) -> ApprovalDecision {
-    let mut bridge_params: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut bridge_params: crate::value::DictMap = crate::value::DictMap::new();
     bridge_params.put_str("server", server_name);
     bridge_params.insert("params".to_string(), json_to_vm_value(params));
 
@@ -286,7 +285,7 @@ fn coerce_bridge_response(value: VmValue) -> ApprovalDecision {
     match value {
         VmValue::Nil => ApprovalDecision::Decline("host bridge returned nil".into()),
         VmValue::Bool(false) => ApprovalDecision::Decline("host bridge declined".into()),
-        VmValue::Bool(true) => ApprovalDecision::Accept(BTreeMap::new()),
+        VmValue::Bool(true) => ApprovalDecision::Accept(crate::value::DictMap::new()),
         VmValue::Dict(dict) => {
             let map = dict.as_ref().clone();
             match map.get("action").and_then(|v| match v {
@@ -351,7 +350,7 @@ struct LlmOutcome {
 /// to a short string so the dispatcher can wrap them in JSON-RPC.
 async fn run_llm_call(
     parsed: &SamplingRequest,
-    overrides: BTreeMap<String, VmValue>,
+    overrides: crate::value::DictMap,
 ) -> Result<LlmOutcome, String> {
     let (vm_args, options_dict) = build_llm_call_args(parsed, overrides);
 
@@ -391,9 +390,9 @@ fn extract_assistant_outcome(result: &VmValue) -> Result<LlmOutcome, String> {
 /// for retry/tool-format settings that aren't on `LlmCallOptions`).
 fn build_llm_call_args(
     parsed: &SamplingRequest,
-    overrides: BTreeMap<String, VmValue>,
-) -> (Vec<VmValue>, BTreeMap<String, VmValue>) {
-    let mut options: BTreeMap<String, VmValue> = BTreeMap::new();
+    overrides: crate::value::DictMap,
+) -> (Vec<VmValue>, crate::value::DictMap) {
+    let mut options: crate::value::DictMap = crate::value::DictMap::new();
 
     // Translate the sampling messages into the VM `messages` shape
     // `extract_llm_options` accepts (a list of `{role, content}` dicts).
@@ -458,7 +457,7 @@ fn build_llm_call_args(
     let args = vec![
         VmValue::String(std::sync::Arc::from("")),
         system_value,
-        VmValue::Dict(std::sync::Arc::new(options.clone())),
+        VmValue::dict(options.clone()),
     ];
 
     (args, options)
@@ -514,6 +513,7 @@ fn build_spec_response(outcome: LlmOutcome, parsed: &SamplingRequest) -> JsonVal
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use crate::value::VmDictExt;
     use std::sync::Arc;
 
@@ -625,15 +625,12 @@ mod tests {
 
     #[test]
     fn coerce_bridge_response_accept_with_options() {
-        let mut dict = BTreeMap::new();
+        let mut dict = crate::value::DictMap::new();
         dict.put_str("action", "accept");
-        let mut options = BTreeMap::new();
+        let mut options = crate::value::DictMap::new();
         options.put_str("provider", "mock");
-        dict.insert(
-            "options".to_string(),
-            VmValue::Dict(std::sync::Arc::new(options)),
-        );
-        match coerce_bridge_response(VmValue::Dict(std::sync::Arc::new(dict))) {
+        dict.insert("options".to_string(), VmValue::dict(options));
+        match coerce_bridge_response(VmValue::dict(dict)) {
             ApprovalDecision::Accept(map) => {
                 assert_eq!(
                     map.get("provider").map(|v| v.display()).as_deref(),
@@ -646,10 +643,10 @@ mod tests {
 
     #[test]
     fn coerce_bridge_response_decline_with_message() {
-        let mut dict = BTreeMap::new();
+        let mut dict = crate::value::DictMap::new();
         dict.put_str("action", "decline");
         dict.put_str("message", "rate limit");
-        match coerce_bridge_response(VmValue::Dict(std::sync::Arc::new(dict))) {
+        match coerce_bridge_response(VmValue::dict(dict)) {
             ApprovalDecision::Decline(reason) => assert_eq!(reason, "rate limit"),
             other => panic!("expected decline, got {other:?}"),
         }
@@ -657,9 +654,9 @@ mod tests {
 
     #[test]
     fn coerce_bridge_response_bare_dict_is_overrides() {
-        let mut dict = BTreeMap::new();
+        let mut dict = crate::value::DictMap::new();
         dict.put_str("provider", "mock");
-        match coerce_bridge_response(VmValue::Dict(std::sync::Arc::new(dict))) {
+        match coerce_bridge_response(VmValue::dict(dict)) {
             ApprovalDecision::Accept(map) => {
                 assert_eq!(
                     map.get("provider").map(|v| v.display()).as_deref(),
@@ -748,7 +745,7 @@ mod tests {
     /// `HostMock` registration API while still exercising the bridge
     /// → llm_call path end-to-end.
     struct ApproveSamplingBridge {
-        overrides: BTreeMap<String, VmValue>,
+        overrides: crate::value::DictMap,
     }
 
     impl crate::stdlib::host::HostCallBridge for ApproveSamplingBridge {
@@ -756,16 +753,13 @@ mod tests {
             &self,
             capability: &str,
             operation: &str,
-            _params: &BTreeMap<String, VmValue>,
+            _params: &crate::value::DictMap,
         ) -> Result<Option<VmValue>, VmError> {
             if capability == "mcp" && operation == "sample" {
-                let mut envelope: BTreeMap<String, VmValue> = BTreeMap::new();
+                let mut envelope: crate::value::DictMap = crate::value::DictMap::new();
                 envelope.put_str("action", "accept");
-                envelope.insert(
-                    "options".to_string(),
-                    VmValue::Dict(std::sync::Arc::new(self.overrides.clone())),
-                );
-                Ok(Some(VmValue::Dict(std::sync::Arc::new(envelope))))
+                envelope.insert("options".to_string(), VmValue::dict(self.overrides.clone()));
+                Ok(Some(VmValue::dict(envelope)))
             } else {
                 Ok(None)
             }
@@ -802,7 +796,7 @@ mod tests {
 
         // Install an approving bridge that forces provider=mock so the
         // call resolves through MockProvider deterministically.
-        let mut overrides: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut overrides: crate::value::DictMap = crate::value::DictMap::new();
         overrides.put_str("provider", "mock");
         overrides.put_str("model", "mock-model");
         crate::stdlib::host::set_host_call_bridge(Arc::new(ApproveSamplingBridge { overrides }));

--- a/crates/harn-vm/src/mcp_server/register.rs
+++ b/crates/harn-vm/src/mcp_server/register.rs
@@ -356,7 +356,7 @@ fn completion_sources_from_dict(value: Option<&VmValue>) -> BTreeMap<String, Mcp
 }
 
 fn completion_source_from_argument_dict(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
 ) -> Option<McpCompletionSource> {
     let mut source = McpCompletionSource::default();
     for key in ["suggestions", "completions", "values"] {

--- a/crates/harn-vm/src/mcp_server/tests.rs
+++ b/crates/harn-vm/src/mcp_server/tests.rs
@@ -1,5 +1,4 @@
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::chunk::{Chunk, CompiledFunction};
@@ -46,17 +45,14 @@ fn test_params_to_json_schema_empty() {
 
 #[test]
 fn test_params_to_json_schema_with_params() {
-    let mut params = BTreeMap::new();
-    let mut param_def = BTreeMap::new();
+    let mut params = crate::value::DictMap::new();
+    let mut param_def = crate::value::DictMap::new();
     param_def.put_str("type", "string");
     param_def.put_str("description", "A file path");
     param_def.insert("required".to_string(), VmValue::Bool(true));
-    params.insert(
-        "path".to_string(),
-        VmValue::Dict(std::sync::Arc::new(param_def)),
-    );
+    params.insert("path".to_string(), VmValue::dict(param_def));
 
-    let schema = params_to_json_schema(Some(&VmValue::Dict(std::sync::Arc::new(params))));
+    let schema = params_to_json_schema(Some(&VmValue::dict(params)));
     assert_eq!(
         schema,
         serde_json::json!({
@@ -69,7 +65,7 @@ fn test_params_to_json_schema_with_params() {
 
 #[test]
 fn test_params_to_json_schema_preserves_file_input_descriptor() {
-    let mut file_descriptor = BTreeMap::new();
+    let mut file_descriptor = crate::value::DictMap::new();
     file_descriptor.insert(
         "accept".to_string(),
         VmValue::List(std::sync::Arc::new(vec![VmValue::String(
@@ -78,22 +74,16 @@ fn test_params_to_json_schema_preserves_file_input_descriptor() {
     );
     file_descriptor.insert("maxSize".to_string(), VmValue::Int(64));
 
-    let mut param_def = BTreeMap::new();
+    let mut param_def = crate::value::DictMap::new();
     param_def.put_str("type", "string");
     param_def.put_str("format", "uri");
-    param_def.insert(
-        "x-mcp-file".to_string(),
-        VmValue::Dict(std::sync::Arc::new(file_descriptor)),
-    );
+    param_def.insert("x-mcp-file".to_string(), VmValue::dict(file_descriptor));
     param_def.insert("required".to_string(), VmValue::Bool(true));
 
-    let mut params = BTreeMap::new();
-    params.insert(
-        "upload".to_string(),
-        VmValue::Dict(std::sync::Arc::new(param_def)),
-    );
+    let mut params = crate::value::DictMap::new();
+    params.insert("upload".to_string(), VmValue::dict(param_def));
 
-    let schema = params_to_json_schema(Some(&VmValue::Dict(std::sync::Arc::new(params))));
+    let schema = params_to_json_schema(Some(&VmValue::dict(params)));
     assert_eq!(schema["properties"]["upload"]["type"], "string");
     assert_eq!(schema["properties"]["upload"]["format"], "uri");
     assert_eq!(
@@ -106,9 +96,9 @@ fn test_params_to_json_schema_preserves_file_input_descriptor() {
 
 #[test]
 fn test_params_to_json_schema_simple_form() {
-    let mut params = BTreeMap::new();
+    let mut params = crate::value::DictMap::new();
     params.put_str("query", "string");
-    let schema = params_to_json_schema(Some(&VmValue::Dict(std::sync::Arc::new(params))));
+    let schema = params_to_json_schema(Some(&VmValue::dict(params)));
     assert_eq!(
         schema["properties"]["query"]["type"],
         serde_json::json!("string")
@@ -122,7 +112,7 @@ fn test_tool_registry_to_mcp_tools_invalid() {
 
 #[test]
 fn test_tool_registry_to_mcp_tools_empty() {
-    let mut registry = BTreeMap::new();
+    let mut registry = crate::value::DictMap::new();
     registry.insert(
         "_type".into(),
         VmValue::String(std::sync::Arc::from("tool_registry")),
@@ -131,7 +121,7 @@ fn test_tool_registry_to_mcp_tools_empty() {
         "tools".into(),
         VmValue::List(std::sync::Arc::new(Vec::new())),
     );
-    let result = tool_registry_to_mcp_tools(&VmValue::Dict(std::sync::Arc::new(registry)));
+    let result = tool_registry_to_mcp_tools(&VmValue::dict(registry));
     assert!(result.unwrap().is_empty());
 }
 
@@ -139,12 +129,12 @@ fn test_tool_registry_to_mcp_tools_empty() {
 fn test_tool_registry_to_mcp_tools_preserves_metadata() {
     let handler = VmValue::Closure(Arc::new(empty_closure("echo")));
 
-    let mut annotations = BTreeMap::new();
+    let mut annotations = crate::value::DictMap::new();
     annotations.insert("readOnlyHint".into(), VmValue::Bool(true));
     annotations.insert("idempotentHint".into(), VmValue::Bool(true));
 
-    let icon = VmValue::Dict(std::sync::Arc::new({
-        let mut icon = BTreeMap::new();
+    let icon = VmValue::dict({
+        let mut icon = crate::value::DictMap::new();
         icon.insert(
             "src".into(),
             VmValue::String(std::sync::Arc::from("https://example.com/tool.png")),
@@ -154,9 +144,9 @@ fn test_tool_registry_to_mcp_tools_preserves_metadata() {
             VmValue::String(std::sync::Arc::from("image/png")),
         );
         icon
-    }));
+    });
 
-    let mut tool = BTreeMap::new();
+    let mut tool = crate::value::DictMap::new();
     tool.insert("name".into(), VmValue::String(std::sync::Arc::from("echo")));
     tool.insert(
         "title".into(),
@@ -169,29 +159,26 @@ fn test_tool_registry_to_mcp_tools_preserves_metadata() {
     tool.insert("handler".into(), handler);
     tool.insert(
         "parameters".into(),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::new())),
+        VmValue::dict(crate::value::DictMap::new()),
     );
-    tool.insert(
-        "annotations".into(),
-        VmValue::Dict(std::sync::Arc::new(annotations)),
-    );
+    tool.insert("annotations".into(), VmValue::dict(annotations));
     tool.insert(
         "icons".into(),
         VmValue::List(std::sync::Arc::new(vec![icon])),
     );
     tool.insert(
         "outputSchema".into(),
-        VmValue::Dict(std::sync::Arc::new({
-            let mut schema = BTreeMap::new();
+        VmValue::dict({
+            let mut schema = crate::value::DictMap::new();
             schema.insert(
                 "type".into(),
                 VmValue::String(std::sync::Arc::from("string")),
             );
             schema
-        })),
+        }),
     );
 
-    let mut registry = BTreeMap::new();
+    let mut registry = crate::value::DictMap::new();
     registry.insert(
         "_type".into(),
         VmValue::String(std::sync::Arc::from("tool_registry")),
@@ -203,7 +190,7 @@ fn test_tool_registry_to_mcp_tools_preserves_metadata() {
         )])),
     );
 
-    let tools = tool_registry_to_mcp_tools(&VmValue::Dict(std::sync::Arc::new(registry))).unwrap();
+    let tools = tool_registry_to_mcp_tools(&VmValue::dict(registry)).unwrap();
     assert_eq!(tools[0].title.as_deref(), Some("Echo"));
     assert_eq!(tools[0].annotations.as_ref().unwrap()["readOnlyHint"], true);
     assert_eq!(
@@ -224,17 +211,17 @@ fn test_prompt_value_to_messages_string() {
 #[test]
 fn test_prompt_value_to_messages_list() {
     let items = vec![
-        VmValue::Dict(std::sync::Arc::new({
-            let mut d = BTreeMap::new();
+        VmValue::dict({
+            let mut d = crate::value::DictMap::new();
             d.insert("role".into(), VmValue::String(std::sync::Arc::from("user")));
             d.insert(
                 "content".into(),
                 VmValue::String(std::sync::Arc::from("hi")),
             );
             d
-        })),
-        VmValue::Dict(std::sync::Arc::new({
-            let mut d = BTreeMap::new();
+        }),
+        VmValue::dict({
+            let mut d = crate::value::DictMap::new();
             d.insert(
                 "role".into(),
                 VmValue::String(std::sync::Arc::from("assistant")),
@@ -244,7 +231,7 @@ fn test_prompt_value_to_messages_list() {
                 VmValue::String(std::sync::Arc::from("hello")),
             );
             d
-        })),
+        }),
     ];
     let msgs = prompt_value_to_messages(&VmValue::List(std::sync::Arc::new(items)));
     assert_eq!(msgs.len(), 2);
@@ -253,8 +240,8 @@ fn test_prompt_value_to_messages_list() {
 
 #[test]
 fn test_prompt_value_to_messages_preserves_image_content() {
-    let items = vec![VmValue::Dict(std::sync::Arc::new({
-        let mut image = BTreeMap::new();
+    let items = vec![VmValue::dict({
+        let mut image = crate::value::DictMap::new();
         image.insert(
             "type".into(),
             VmValue::String(std::sync::Arc::from("image")),
@@ -268,11 +255,11 @@ fn test_prompt_value_to_messages_preserves_image_content() {
             VmValue::String(std::sync::Arc::from("image/png")),
         );
 
-        let mut message = BTreeMap::new();
+        let mut message = crate::value::DictMap::new();
         message.insert("role".into(), VmValue::String(std::sync::Arc::from("user")));
-        message.insert("content".into(), VmValue::Dict(std::sync::Arc::new(image)));
+        message.insert("content".into(), VmValue::dict(image));
         message
-    }))];
+    })];
     let msgs = prompt_value_to_messages(&VmValue::List(std::sync::Arc::new(items)));
     assert_eq!(msgs.len(), 1);
     assert_eq!(msgs[0]["content"]["type"], "image");
@@ -300,14 +287,14 @@ fn test_match_uri_template_no_match() {
 
 #[test]
 fn test_annotations_to_json() {
-    let mut d = BTreeMap::new();
+    let mut d = crate::value::DictMap::new();
     d.insert(
         "title".into(),
         VmValue::String(std::sync::Arc::from("My Tool")),
     );
     d.insert("readOnlyHint".into(), VmValue::Bool(true));
     d.insert("destructiveHint".into(), VmValue::Bool(false));
-    let json = annotations_to_json(&VmValue::Dict(std::sync::Arc::new(d))).unwrap();
+    let json = annotations_to_json(&VmValue::dict(d)).unwrap();
     assert_eq!(json["title"], "My Tool");
     assert_eq!(json["readOnlyHint"], true);
     assert_eq!(json["destructiveHint"], false);
@@ -315,8 +302,8 @@ fn test_annotations_to_json() {
 
 #[test]
 fn test_annotations_empty_returns_none() {
-    let d = BTreeMap::new();
-    assert!(annotations_to_json(&VmValue::Dict(std::sync::Arc::new(d))).is_none());
+    let d = crate::value::DictMap::new();
+    assert!(annotations_to_json(&VmValue::dict(d)).is_none());
 }
 
 #[tokio::test]
@@ -439,7 +426,7 @@ async fn server_advertises_elicitation_capability() {
 
 #[tokio::test]
 async fn server_completion_complete_returns_prompt_and_resource_suggestions() {
-    let mut resource_completions = BTreeMap::new();
+    let mut resource_completions = std::collections::BTreeMap::new();
     resource_completions.insert(
         "key".to_string(),
         McpCompletionSource {

--- a/crates/harn-vm/src/metadata.rs
+++ b/crates/harn-vm/src/metadata.rs
@@ -510,7 +510,7 @@ fn json_to_vm(jv: &serde_json::Value) -> VmValue {
             for (k, v) in map {
                 m.insert(k.clone(), json_to_vm(v));
             }
-            VmValue::Dict(std::sync::Arc::new(m))
+            VmValue::dict(m)
         }
     }
 }
@@ -520,7 +520,7 @@ fn namespace_fields_to_vm(fields: &BTreeMap<FieldKey, serde_json::Value>) -> VmV
     for (k, v) in fields {
         map.insert(k.clone(), json_to_vm(v));
     }
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn directory_metadata_to_vm(meta: &DirectoryMetadata) -> VmValue {
@@ -528,7 +528,7 @@ fn directory_metadata_to_vm(meta: &DirectoryMetadata) -> VmValue {
     for (ns, fields) in &meta.namespaces {
         namespaces.insert(ns.clone(), namespace_fields_to_vm(fields));
     }
-    VmValue::Dict(std::sync::Arc::new(namespaces))
+    VmValue::dict(namespaces)
 }
 
 fn normalize_directory_key(dir: &str) -> String {
@@ -620,14 +620,14 @@ impl Default for ScanOptions {
     }
 }
 
-fn bool_arg(map: &BTreeMap<String, VmValue>, key: &str, default: bool) -> bool {
+fn bool_arg(map: &crate::value::DictMap, key: &str, default: bool) -> bool {
     match map.get(key) {
         Some(VmValue::Bool(value)) => *value,
         _ => default,
     }
 }
 
-fn usize_arg(map: &BTreeMap<String, VmValue>, key: &str, default: usize) -> usize {
+fn usize_arg(map: &crate::value::DictMap, key: &str, default: usize) -> usize {
     match map.get(key) {
         Some(VmValue::Int(value)) if *value >= 0 => *value as usize,
         _ => default,
@@ -650,7 +650,7 @@ fn parse_scan_options(
     options
 }
 
-fn apply_scan_options_dict(options: &mut ScanOptions, dict: &BTreeMap<String, VmValue>) {
+fn apply_scan_options_dict(options: &mut ScanOptions, dict: &crate::value::DictMap) {
     if let Some(pattern) = dict.get("pattern").map(|value| value.display()) {
         if !pattern.is_empty() {
             options.pattern = Some(pattern);
@@ -749,7 +749,7 @@ fn metadata_get_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
                     for (k, v) in fields {
                         m.insert(k, json_to_vm(&v));
                     }
-                    Ok(VmValue::Dict(std::sync::Arc::new(m)))
+                    Ok(VmValue::dict(m))
                 }
                 None => Ok(VmValue::Nil),
             }
@@ -764,7 +764,7 @@ fn metadata_get_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
             if m.is_empty() {
                 Ok(VmValue::Nil)
             } else {
-                Ok(VmValue::Dict(std::sync::Arc::new(m)))
+                Ok(VmValue::dict(m))
             }
         }
     })
@@ -843,7 +843,7 @@ fn metadata_entries_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue,
                     item.insert("resolved".to_string(), directory_metadata_to_vm(&resolved));
                 }
             }
-            items.push(VmValue::Dict(std::sync::Arc::new(item)));
+            items.push(VmValue::dict(item));
         }
         Ok(VmValue::List(std::sync::Arc::new(items)))
     })
@@ -934,7 +934,7 @@ fn metadata_stale_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, 
             "tier2".to_string(),
             VmValue::List(std::sync::Arc::new(tier2_stale)),
         );
-        Ok(VmValue::Dict(std::sync::Arc::new(m)))
+        Ok(VmValue::dict(m))
     })
 }
 
@@ -1044,7 +1044,7 @@ fn metadata_status_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
             VmValue::List(std::sync::Arc::new(missing_content_hash)),
         );
         result.insert("stale".to_string(), stale);
-        Ok(VmValue::Dict(std::sync::Arc::new(result)))
+        Ok(VmValue::dict(result))
     })
 }
 
@@ -1210,7 +1210,7 @@ fn path_metadata_entries_impl(args: &[VmValue], _out: &mut String) -> Result<VmV
                 item.put_str("kind", "file");
                 item.put_str("path", path.as_str());
                 item.insert("local".to_string(), local);
-                items.push(VmValue::Dict(std::sync::Arc::new(item)));
+                items.push(VmValue::dict(item));
             }
         }
         if include_dirs {
@@ -1238,7 +1238,7 @@ fn path_metadata_entries_impl(args: &[VmValue], _out: &mut String) -> Result<VmV
                 item.put_str("path", normalize_directory_key(&dir));
                 item.insert("local".to_string(), local_value);
                 item.insert("resolved".to_string(), resolved_value);
-                items.push(VmValue::Dict(std::sync::Arc::new(item)));
+                items.push(VmValue::dict(item));
             }
         }
         Ok(VmValue::List(std::sync::Arc::new(items)))
@@ -1359,7 +1359,7 @@ fn metadata_stale_value(state: &MetadataState, base_dir: &Path) -> VmValue {
         "tier2".to_string(),
         VmValue::List(std::sync::Arc::new(tier2_stale)),
     );
-    VmValue::Dict(std::sync::Arc::new(m))
+    VmValue::dict(m)
 }
 
 fn scan_dir_recursive(
@@ -1411,7 +1411,7 @@ fn scan_dir_recursive(
         m.insert("modified".to_string(), VmValue::Int(mtime));
         m.insert("is_dir".to_string(), VmValue::Bool(meta.is_dir()));
         if (meta.is_dir() && options.include_dirs) || (!meta.is_dir() && options.include_files) {
-            results.push(VmValue::Dict(std::sync::Arc::new(m)));
+            results.push(VmValue::dict(m));
         }
         if meta.is_dir() {
             scan_dir_recursive(&entry.path(), base, options, results, depth + 1);

--- a/crates/harn-vm/src/orchestration/command_policy.rs
+++ b/crates/harn-vm/src/orchestration/command_policy.rs
@@ -49,7 +49,7 @@ pub struct CommandPolicyDecision {
 #[derive(Clone, Debug)]
 pub enum CommandPolicyPreflight {
     Proceed {
-        params: BTreeMap<String, VmValue>,
+        params: crate::value::DictMap,
         context: JsonValue,
         decisions: Vec<CommandPolicyDecision>,
     },
@@ -148,11 +148,8 @@ pub fn normalize_command_policy_value(config: &VmValue) -> Result<VmValue, VmErr
     normalized
         .entry("require_approval".to_string())
         .or_insert_with(|| VmValue::List(std::sync::Arc::new(Vec::new())));
-    parse_command_policy_value(
-        Some(&VmValue::Dict(std::sync::Arc::new(normalized.clone()))),
-        "command_policy",
-    )?;
-    Ok(VmValue::Dict(std::sync::Arc::new(normalized)))
+    parse_command_policy_value(Some(&VmValue::dict(normalized.clone())), "command_policy")?;
+    Ok(VmValue::dict(normalized))
 }
 
 pub fn command_risk_scan_value(ctx: &VmValue) -> Result<VmValue, VmError> {
@@ -218,7 +215,7 @@ pub fn command_llm_risk_scan_value(
 }
 
 pub async fn run_command_policy_preflight(
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
     caller: JsonValue,
 ) -> Result<CommandPolicyPreflight, VmError> {
     run_command_policy_preflight_with_ctx(None, params, caller).await
@@ -226,7 +223,7 @@ pub async fn run_command_policy_preflight(
 
 pub async fn run_command_policy_preflight_with_ctx(
     ctx: Option<&crate::vm::AsyncBuiltinCtx>,
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
     caller: JsonValue,
 ) -> Result<CommandPolicyPreflight, VmError> {
     let Some(policy) = current_command_policy() else {
@@ -440,7 +437,7 @@ pub async fn run_command_policy_preflight_with_ctx(
 }
 
 pub async fn run_command_policy_postflight(
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
     result: VmValue,
     pre_context: JsonValue,
     decisions: Vec<CommandPolicyDecision>,
@@ -450,7 +447,7 @@ pub async fn run_command_policy_postflight(
 
 pub async fn run_command_policy_postflight_with_ctx(
     ctx: Option<&crate::vm::AsyncBuiltinCtx>,
-    _params: &BTreeMap<String, VmValue>,
+    _params: &crate::value::DictMap,
     result: VmValue,
     pre_context: JsonValue,
     mut decisions: Vec<CommandPolicyDecision>,
@@ -489,7 +486,7 @@ pub async fn run_command_policy_postflight_with_ctx(
 }
 
 pub fn blocked_command_response(
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
     status: &str,
     message: &str,
     context: JsonValue,
@@ -520,14 +517,9 @@ pub fn blocked_command_response(
     result.put_str("audit_id", format!("audit_{command_id}"));
     result.insert(
         "request".to_string(),
-        VmValue::Dict(std::sync::Arc::new(redacted_vm_request(params))),
+        VmValue::dict(redacted_vm_request(params)),
     );
-    attach_policy_audit(
-        VmValue::Dict(std::sync::Arc::new(result)),
-        context,
-        decisions,
-        None,
-    )
+    attach_policy_audit(VmValue::dict(result), context, decisions, None)
 }
 
 fn attach_policy_audit(
@@ -551,7 +543,7 @@ fn attach_policy_audit(
         "command_policy".to_string(),
         crate::stdlib::json_to_vm_value(&audit),
     );
-    VmValue::Dict(std::sync::Arc::new(out))
+    VmValue::dict(out)
 }
 
 fn decision(
@@ -603,7 +595,7 @@ enum ParsedPreHookAction {
     Allow,
     Deny(String),
     RequireApproval(String, Option<JsonValue>),
-    Rewrite(BTreeMap<String, VmValue>),
+    Rewrite(crate::value::DictMap),
     DryRun(String),
     ExplainOnly(String),
 }
@@ -702,10 +694,8 @@ fn parse_post_hook_action(
                             .get("content")
                             .map(|v| v.display())
                             .unwrap_or_else(|| {
-                                crate::llm::vm_value_to_json(&VmValue::Dict(std::sync::Arc::new(
-                                    feedback.clone(),
-                                )))
-                                .to_string()
+                                crate::llm::vm_value_to_json(&VmValue::dict(feedback.clone()))
+                                    .to_string()
                             });
                     crate::orchestration::agent_inbox::push(
                         &session_id,
@@ -733,8 +723,8 @@ fn parse_post_hook_action(
 }
 
 fn apply_command_rewrite(
-    params: &mut BTreeMap<String, VmValue>,
-    rewrite: &BTreeMap<String, VmValue>,
+    params: &mut crate::value::DictMap,
+    rewrite: &crate::value::DictMap,
 ) -> Result<(), VmError> {
     for (key, value) in rewrite {
         match key.as_str() {
@@ -753,7 +743,7 @@ fn apply_command_rewrite(
 }
 
 fn command_context_json(
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
     policy: &CommandPolicy,
     caller: JsonValue,
 ) -> JsonValue {
@@ -796,7 +786,7 @@ fn command_context_json(
     })
 }
 
-fn command_request_json(params: &BTreeMap<String, VmValue>) -> JsonValue {
+fn command_request_json(params: &crate::value::DictMap) -> JsonValue {
     let mode = string_field_raw(params, "mode")
         .or_else(|| params.get("argv").map(|_| "argv".to_string()))
         .unwrap_or_else(|| "shell".to_string());
@@ -1167,7 +1157,7 @@ fn inline_output_for_scan(value: Option<&JsonValue>) -> String {
         .unwrap_or_default()
 }
 
-fn redacted_vm_request(params: &BTreeMap<String, VmValue>) -> BTreeMap<String, VmValue> {
+fn redacted_vm_request(params: &crate::value::DictMap) -> crate::value::DictMap {
     params
         .iter()
         .map(|(key, value)| {
@@ -1183,7 +1173,7 @@ fn redacted_vm_request(params: &BTreeMap<String, VmValue>) -> BTreeMap<String, V
         .collect()
 }
 
-fn string_field(map: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<String>, VmError> {
+fn string_field(map: &crate::value::DictMap, key: &str) -> Result<Option<String>, VmError> {
     match map.get(key) {
         None | Some(VmValue::Nil) => Ok(None),
         Some(VmValue::String(value)) => Ok(Some(value.to_string())),
@@ -1194,7 +1184,7 @@ fn string_field(map: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<Str
     }
 }
 
-fn string_field_raw(map: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn string_field_raw(map: &crate::value::DictMap, key: &str) -> Option<String> {
     match map.get(key) {
         Some(VmValue::String(value)) => Some(value.to_string()),
         _ => None,
@@ -1202,7 +1192,7 @@ fn string_field_raw(map: &BTreeMap<String, VmValue>, key: &str) -> Option<String
 }
 
 fn string_list_field(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     key: &str,
 ) -> Result<Option<Vec<String>>, VmError> {
     match map.get(key) {
@@ -1225,7 +1215,7 @@ fn string_list_field(
     }
 }
 
-fn bool_field(map: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<bool>, VmError> {
+fn bool_field(map: &crate::value::DictMap, key: &str) -> Result<Option<bool>, VmError> {
     match map.get(key) {
         None | Some(VmValue::Nil) => Ok(None),
         Some(VmValue::Bool(value)) => Ok(Some(*value)),
@@ -1237,7 +1227,7 @@ fn bool_field(map: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<bool>
 }
 
 fn closure_field(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     key: &str,
 ) -> Result<Option<Arc<VmClosure>>, VmError> {
     match map.get(key) {

--- a/crates/harn-vm/src/orchestration/compact_lifecycle.rs
+++ b/crates/harn-vm/src/orchestration/compact_lifecycle.rs
@@ -898,7 +898,7 @@ fn build_snapshot_asset(
     if let Some(source) = config.policy.instruction_source() {
         asset_metadata.put_str("instruction_source", source);
     }
-    let asset = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    let asset = VmValue::dict(BTreeMap::from([
         (
             "id".to_string(),
             VmValue::String(std::sync::Arc::from(format!(
@@ -919,11 +919,8 @@ fn build_snapshot_asset(
             VmValue::String(std::sync::Arc::from("internal")),
         ),
         ("data".to_string(), transcript.clone()),
-        (
-            "metadata".to_string(),
-            VmValue::Dict(std::sync::Arc::new(asset_metadata)),
-        ),
-    ])));
+        ("metadata".to_string(), VmValue::dict(asset_metadata)),
+    ]));
     normalize_transcript_asset(&asset)
 }
 
@@ -940,7 +937,7 @@ fn snapshot_asset_id_of(asset: &VmValue) -> String {
 /// `tool_result` events). This is the canonical filter used by every
 /// transcript-having compaction caller — keeping it in one place stops the
 /// trivial-but-load-bearing filter list from drifting per-callsite.
-pub fn transcript_compactable_events(transcript: &BTreeMap<String, VmValue>) -> Vec<VmValue> {
+pub fn transcript_compactable_events(transcript: &crate::value::DictMap) -> Vec<VmValue> {
     transcript
         .get("events")
         .and_then(|events| match events {
@@ -987,7 +984,7 @@ mod tests {
         event.put_str("kind", "system_reminder");
         event.put_str("role", "system");
         event.insert("reminder".to_string(), reminder_value);
-        VmValue::Dict(std::sync::Arc::new(event))
+        VmValue::dict(event)
     }
 
     #[test]

--- a/crates/harn-vm/src/orchestration/compaction.rs
+++ b/crates/harn-vm/src/orchestration/compaction.rs
@@ -1,7 +1,6 @@
 //! Auto-compaction — transcript size management strategies.
 
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
@@ -195,7 +194,7 @@ pub fn compaction_policy_option_keys() -> &'static [&'static str] {
 }
 
 pub fn compaction_policy_to_vm_value(policy: &CompactionPolicy) -> VmValue {
-    let mut map = BTreeMap::new();
+    let mut map = crate::value::DictMap::new();
     if let Some(instructions) = policy.instructions.as_ref() {
         map.put_str("instructions", instructions.clone());
     }
@@ -234,11 +233,11 @@ pub fn compaction_policy_to_vm_value(policy: &CompactionPolicy) -> VmValue {
     if let Some(author) = policy.author.as_ref() {
         map.put_str("author", author.clone());
     }
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 pub fn parse_compaction_policy_options(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     builtin: &str,
 ) -> Result<CompactionPolicy, VmError> {
     let mut policy = options
@@ -286,7 +285,7 @@ fn parse_compaction_policy_value(
 
 fn apply_compaction_policy_fields(
     policy: &mut CompactionPolicy,
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     builtin: &str,
 ) -> Result<(), VmError> {
     if let Some(value) = optional_policy_string(map, "instructions", builtin)? {
@@ -314,7 +313,7 @@ fn apply_compaction_policy_fields(
 }
 
 fn optional_policy_string(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Option<String>, VmError> {
@@ -336,7 +335,7 @@ fn optional_policy_string(
 }
 
 fn optional_policy_bool(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Option<bool>, VmError> {
@@ -850,7 +849,7 @@ fn render_llm_compaction_prompt(
     if policy.has_prompt_directives() && policy.extend_default_instructions == Some(false) {
         return render_replacement_compaction_prompt(policy, formatted, archived_count);
     }
-    let mut bindings = BTreeMap::new();
+    let mut bindings = crate::value::DictMap::new();
     bindings.put_str("formatted_messages", formatted);
     bindings.insert(
         "archived_count".to_string(),
@@ -877,7 +876,7 @@ fn render_replacement_compaction_prompt(
     archived_count: usize,
 ) -> Result<String, VmError> {
     let directives = policy.prompt_directives().unwrap_or_default();
-    let mut bindings = BTreeMap::new();
+    let mut bindings = crate::value::DictMap::new();
     bindings.put_str("directives", directives);
     bindings.put_str("formatted_messages", formatted);
     bindings.insert(

--- a/crates/harn-vm/src/orchestration/compaction_policy_registry.rs
+++ b/crates/harn-vm/src/orchestration/compaction_policy_registry.rs
@@ -402,7 +402,7 @@ pub fn to_auto_compact_config(policy: &CompactionPolicyDeclaration) -> super::Au
 /// mismatch so the builtin layer can surface a meaningful error.
 pub fn parse_policy_dict(
     builtin: &str,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
 ) -> Result<CompactionPolicyDeclaration, String> {
     let mut policy = CompactionPolicyDeclaration::default();
     if let Some(value) = dict.get("strategy") {
@@ -513,7 +513,7 @@ fn display_vm_error(error: &crate::value::VmError) -> String {
 }
 
 fn optional_usize(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Option<usize>, String> {
@@ -533,7 +533,7 @@ fn optional_usize(
 }
 
 fn optional_f64(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Option<f64>, String> {

--- a/crates/harn-vm/src/orchestration/hooks.rs
+++ b/crates/harn-vm/src/orchestration/hooks.rs
@@ -1,7 +1,6 @@
 //! Runtime lifecycle hooks — tool, agent-turn, and worker interception.
 
 use std::cell::RefCell;
-use std::collections::BTreeMap;
 use std::future::Future;
 use std::sync::Arc;
 
@@ -824,7 +823,7 @@ fn unsupported_reminder_event_error(event: HookEvent, context: &str) -> VmError 
 }
 
 fn required_reminder_spec_string(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     key: &str,
     context: &str,
 ) -> Result<String, VmError> {
@@ -842,7 +841,7 @@ fn required_reminder_spec_string(
 }
 
 fn optional_reminder_spec_string(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     key: &str,
     context: &str,
 ) -> Result<Option<String>, VmError> {
@@ -864,7 +863,7 @@ fn optional_reminder_spec_string(
 }
 
 fn optional_reminder_spec_bool(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     key: &str,
     context: &str,
 ) -> Result<Option<bool>, VmError> {
@@ -879,7 +878,7 @@ fn optional_reminder_spec_bool(
 }
 
 fn reminder_spec_tags(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     context: &str,
 ) -> Result<Vec<String>, VmError> {
     match options.get("tags") {
@@ -914,7 +913,7 @@ fn reminder_spec_tags(
 }
 
 fn optional_reminder_spec_ttl(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     context: &str,
 ) -> Result<Option<i64>, VmError> {
     match options.get("ttl_turns") {
@@ -932,7 +931,7 @@ fn optional_reminder_spec_ttl(
 }
 
 fn optional_reminder_spec_propagate(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     context: &str,
 ) -> Result<Option<ReminderPropagate>, VmError> {
     optional_reminder_spec_string(options, "propagate", context)?
@@ -950,7 +949,7 @@ fn optional_reminder_spec_propagate(
 }
 
 fn optional_reminder_spec_role_hint(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     context: &str,
 ) -> Result<Option<ReminderRoleHint>, VmError> {
     optional_reminder_spec_string(options, "role_hint", context)?
@@ -1013,7 +1012,7 @@ fn parse_reminder_spec(value: &VmValue, context: &str) -> Result<ReminderSpec, V
     })
 }
 
-fn looks_like_reminder_spec(map: &BTreeMap<String, VmValue>) -> bool {
+fn looks_like_reminder_spec(map: &crate::value::DictMap) -> bool {
     map.contains_key("body")
         && !map.contains_key("deny")
         && !map.contains_key("args")
@@ -1129,7 +1128,7 @@ fn action_value_after_effects(value: VmValue, default_action: VmValue) -> VmValu
             "deny" | "args" | "result" | "output" | "modify" | "block" | "decision" | "action"
         )
     }) {
-        VmValue::Dict(std::sync::Arc::new(action))
+        VmValue::dict(action)
     } else {
         default_action
     }
@@ -1773,12 +1772,12 @@ mod tests {
     }
 
     fn dict(entries: Vec<(&str, VmValue)>) -> VmValue {
-        VmValue::Dict(std::sync::Arc::new(
+        VmValue::dict(
             entries
                 .into_iter()
                 .map(|(key, value)| (key.to_string(), value))
-                .collect(),
-        ))
+                .collect::<crate::value::DictMap>(),
+        )
     }
 
     fn error_message(result: Result<Vec<HookEffect>, VmError>) -> String {

--- a/crates/harn-vm/src/orchestration/policy/mod.rs
+++ b/crates/harn-vm/src/orchestration/policy/mod.rs
@@ -566,7 +566,7 @@ pub fn redact_transcript_visibility(
         "events".to_string(),
         VmValue::List(std::sync::Arc::new(public_events)),
     );
-    Some(VmValue::Dict(std::sync::Arc::new(redacted)))
+    Some(VmValue::dict(redacted))
 }
 
 fn redact_public_message(message: &VmValue) -> Option<VmValue> {
@@ -610,7 +610,7 @@ fn redact_public_message(message: &VmValue) -> Option<VmValue> {
             redacted.put_str("text", public_text.join("\n"));
         }
     }
-    Some(VmValue::Dict(std::sync::Arc::new(redacted)))
+    Some(VmValue::dict(redacted))
 }
 
 fn redact_public_block(block: &VmValue) -> Option<VmValue> {

--- a/crates/harn-vm/src/orchestration/policy/nested_budget.rs
+++ b/crates/harn-vm/src/orchestration/policy/nested_budget.rs
@@ -15,8 +15,6 @@
 //! child execution, audited consistently, and the error surface is
 //! uniform.
 
-use std::collections::BTreeMap;
-
 use super::CapabilityPolicy;
 use crate::events::log_info_meta;
 use crate::orchestration::{current_execution_policy, pop_execution_policy, push_execution_policy};
@@ -173,7 +171,7 @@ pub fn enter_nested_execution_policy(
 /// stages, spawn_agent worker setup) use this rather than rewriting
 /// the dict-insert pattern.
 pub fn annotate_nested_execution_options(
-    options: &mut BTreeMap<String, VmValue>,
+    options: &mut crate::value::DictMap,
     kind: NestedExecutionKind,
     label: &str,
 ) {
@@ -206,7 +204,7 @@ fn emit_descent_event(
     child_limit: Option<usize>,
     rejected: bool,
 ) {
-    let mut metadata = BTreeMap::new();
+    let mut metadata = std::collections::BTreeMap::new();
     metadata.insert(
         "kind".to_string(),
         serde_json::Value::String(kind.as_str().to_string()),
@@ -380,7 +378,7 @@ mod tests {
         clear_execution_policy_stacks();
         let requested = CapabilityPolicy {
             tools: vec!["read_only".to_string()],
-            capabilities: std::collections::BTreeMap::from([(
+            capabilities: std::collections::BTreeMap::from_iter([(
                 "workspace".to_string(),
                 vec!["read_text".to_string()],
             )]),
@@ -411,7 +409,7 @@ mod tests {
         // a permissive carrier shadowing it.
         clear_execution_policy_stacks();
         let outer = CapabilityPolicy {
-            capabilities: std::collections::BTreeMap::from([(
+            capabilities: std::collections::BTreeMap::from_iter([(
                 "workspace".to_string(),
                 vec!["read_text".to_string()],
             )]),
@@ -467,7 +465,7 @@ mod tests {
 
     #[test]
     fn annotate_nested_execution_options_writes_canonical_keys() {
-        let mut options: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut options: crate::value::DictMap = crate::value::DictMap::new();
         annotate_nested_execution_options(
             &mut options,
             NestedExecutionKind::SubAgentRun,

--- a/crates/harn-vm/src/orchestration/stage_options.rs
+++ b/crates/harn-vm/src/orchestration/stage_options.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use serde::Deserialize;
 
 use super::WorkflowNode;
-use crate::value::{VmError, VmValue};
+use crate::value::VmError;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct WorkflowStageAgentOptions {
@@ -14,11 +14,11 @@ pub struct WorkflowStageAgentOptions {
 }
 
 impl WorkflowStageAgentOptions {
-    pub fn llm_options_vm_dict(&self) -> BTreeMap<String, VmValue> {
+    pub fn llm_options_vm_dict(&self) -> crate::value::DictMap {
         json_map_to_vm_dict(&self.llm_options)
     }
 
-    pub fn agent_loop_options_vm_dict(&self) -> BTreeMap<String, VmValue> {
+    pub fn agent_loop_options_vm_dict(&self) -> crate::value::DictMap {
         json_map_to_vm_dict(&self.agent_loop_options)
     }
 }
@@ -61,7 +61,7 @@ pub async fn prepare_workflow_stage_agent_options(
     Ok(prepared)
 }
 
-fn json_map_to_vm_dict(map: &BTreeMap<String, serde_json::Value>) -> BTreeMap<String, VmValue> {
+fn json_map_to_vm_dict(map: &BTreeMap<String, serde_json::Value>) -> crate::value::DictMap {
     map.iter()
         .map(|(key, value)| (key.clone(), crate::stdlib::json_to_vm_value(value)))
         .collect()

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -855,9 +855,7 @@ fn resolve_node_session_id(node: &WorkflowNode) -> String {
     format!("workflow_stage_{}", uuid::Uuid::now_v7())
 }
 
-fn raw_auto_compact_dict(
-    node: &WorkflowNode,
-) -> Option<&std::collections::BTreeMap<String, VmValue>> {
+fn raw_auto_compact_dict(node: &WorkflowNode) -> Option<&crate::value::DictMap> {
     node.raw_auto_compact
         .as_ref()
         .and_then(|value| value.as_dict())
@@ -880,14 +878,14 @@ fn raw_auto_compact_string(node: &WorkflowNode, key: &str) -> Option<String> {
         })
 }
 
-fn raw_model_policy_dict(node: &WorkflowNode) -> Option<&BTreeMap<String, VmValue>> {
+fn raw_model_policy_dict(node: &WorkflowNode) -> Option<&crate::value::DictMap> {
     node.raw_model_policy
         .as_ref()
         .and_then(|value| value.as_dict())
 }
 
 fn insert_json_vm_option<T: Serialize>(
-    options: &mut BTreeMap<String, VmValue>,
+    options: &mut crate::value::DictMap,
     key: &str,
     value: &T,
 ) -> Result<(), VmError> {
@@ -898,7 +896,7 @@ fn insert_json_vm_option<T: Serialize>(
     Ok(())
 }
 
-fn merge_raw_model_policy_options(options: &mut BTreeMap<String, VmValue>, node: &WorkflowNode) {
+fn merge_raw_model_policy_options(options: &mut crate::value::DictMap, node: &WorkflowNode) {
     if let Some(raw) = raw_model_policy_dict(node) {
         for (key, value) in raw {
             if !matches!(value, VmValue::Nil) {
@@ -908,7 +906,7 @@ fn merge_raw_model_policy_options(options: &mut BTreeMap<String, VmValue>, node:
     }
 }
 
-fn preserve_nested_command_policy(options: &mut BTreeMap<String, VmValue>, node: &WorkflowNode) {
+fn preserve_nested_command_policy(options: &mut crate::value::DictMap, node: &WorkflowNode) {
     if options.contains_key("command_policy") {
         return;
     }
@@ -933,7 +931,7 @@ fn stage_tools_value(node: &WorkflowNode) -> Option<VmValue> {
 }
 
 fn add_stage_tools_option(
-    options: &mut BTreeMap<String, VmValue>,
+    options: &mut crate::value::DictMap,
     tools_value: &Option<VmValue>,
     tool_names: &[String],
 ) {
@@ -950,7 +948,7 @@ fn workflow_stage_llm_options(
     tools_value: &Option<VmValue>,
     tool_names: &[String],
     stage_agent_options: &super::WorkflowStageAgentOptions,
-) -> BTreeMap<String, VmValue> {
+) -> crate::value::DictMap {
     let mut options = stage_agent_options.llm_options_vm_dict();
     merge_raw_model_policy_options(&mut options, node);
     options.put_str("session_id", stage_session_id);
@@ -959,10 +957,7 @@ fn workflow_stage_llm_options(
     options
 }
 
-fn add_workflow_agent_compaction_options(
-    options: &mut BTreeMap<String, VmValue>,
-    node: &WorkflowNode,
-) {
+fn add_workflow_agent_compaction_options(options: &mut crate::value::DictMap, node: &WorkflowNode) {
     if !node.auto_compact.enabled {
         options.insert("auto_compact".to_string(), VmValue::Bool(false));
         return;
@@ -1012,7 +1007,7 @@ fn workflow_stage_agent_loop_options(
     tools_value: &Option<VmValue>,
     tool_names: &[String],
     stage_agent_options: &super::WorkflowStageAgentOptions,
-) -> Result<BTreeMap<String, VmValue>, VmError> {
+) -> Result<crate::value::DictMap, VmError> {
     let mut options = stage_agent_options.agent_loop_options_vm_dict();
     merge_raw_model_policy_options(&mut options, node);
     if let Some(context) = crate::orchestration::current_workflow_skill_context() {
@@ -1055,8 +1050,8 @@ pub struct PreparedWorkflowStageNode {
     pub prompt: String,
     pub system: Option<String>,
     pub run_agent_loop: bool,
-    pub llm_options: BTreeMap<String, VmValue>,
-    pub agent_loop_options: BTreeMap<String, VmValue>,
+    pub llm_options: crate::value::DictMap,
+    pub agent_loop_options: crate::value::DictMap,
     pub result: Option<serde_json::Value>,
     pub selected: Vec<ArtifactRecord>,
     pub rendered_context: String,
@@ -1211,7 +1206,7 @@ pub async fn prepare_stage_node(
                 &stage_agent_options,
             )?
         } else {
-            BTreeMap::new()
+            crate::value::DictMap::new()
         };
         return Ok(PreparedWorkflowStageNode {
             prompt,
@@ -1233,8 +1228,8 @@ pub async fn prepare_stage_node(
         prompt,
         system: node.system.clone(),
         run_agent_loop: false,
-        llm_options: BTreeMap::new(),
-        agent_loop_options: BTreeMap::new(),
+        llm_options: crate::value::DictMap::new(),
+        agent_loop_options: crate::value::DictMap::new(),
         result: Some(result),
         selected,
         rendered_context,
@@ -1399,7 +1394,7 @@ pub async fn execute_stage_node(
                 .clone()
                 .map(|s| VmValue::String(std::sync::Arc::from(s)))
                 .unwrap_or(VmValue::Nil),
-            VmValue::Dict(std::sync::Arc::new(prepared.llm_options.clone())),
+            VmValue::dict(prepared.llm_options.clone()),
         ];
         let opts = extract_llm_options(&args)?;
         let result = vm_call_llm_full(&opts).await?;

--- a/crates/harn-vm/src/runtime_context.rs
+++ b/crates/harn-vm/src/runtime_context.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::collections::BTreeMap;
 
 use crate::value::{VmError, VmValue};
 
@@ -11,7 +10,7 @@ pub struct RuntimeContext {
     pub task_name: Option<String>,
     pub task_group_id: Option<String>,
     pub scope_id: Option<String>,
-    pub values: BTreeMap<String, VmValue>,
+    pub values: crate::value::DictMap,
 }
 
 impl RuntimeContext {
@@ -23,7 +22,7 @@ impl RuntimeContext {
             task_name: Some("root".to_string()),
             task_group_id: None,
             scope_id: None,
-            values: BTreeMap::new(),
+            values: crate::value::DictMap::new(),
         }
     }
 
@@ -126,9 +125,7 @@ pub(crate) fn dispatch_runtime_context_builtin(
 ) -> Option<Result<VmValue, VmError>> {
     match name {
         "runtime_context" | "task_current" => Some(Ok(runtime_context_value(vm))),
-        "runtime_context_values" => Some(Ok(VmValue::Dict(std::sync::Arc::new(
-            vm.runtime_context.values.clone(),
-        )))),
+        "runtime_context_values" => Some(Ok(VmValue::dict(vm.runtime_context.values.clone()))),
         "runtime_context_get" => Some(runtime_context_get(vm, args)),
         "runtime_context_set" => Some(runtime_context_set(vm, args)),
         "runtime_context_clear" => Some(runtime_context_clear(vm, args)),
@@ -200,7 +197,7 @@ pub(crate) fn runtime_context_value(vm: &crate::vm::Vm) -> VmValue {
             .and_then(|session| session.worker_id.clone())
     });
 
-    let mut values = BTreeMap::new();
+    let mut values = crate::value::DictMap::new();
     insert_string(
         &mut values,
         "task_id",
@@ -313,15 +310,15 @@ pub(crate) fn runtime_context_value(vm: &crate::vm::Vm) -> VmValue {
     insert_string(&mut values, "capacity_class", None);
     values.insert(
         "context_values".to_string(),
-        VmValue::Dict(std::sync::Arc::new(vm.runtime_context.values.clone())),
+        VmValue::dict(vm.runtime_context.values.clone()),
     );
     values.insert("cancelled".to_string(), VmValue::Bool(cancelled));
     values.insert("debug".to_string(), debug_context_value(vm, cancelled));
-    VmValue::Dict(std::sync::Arc::new(values))
+    VmValue::dict(values)
 }
 
 fn debug_context_value(vm: &crate::vm::Vm, cancelled: bool) -> VmValue {
-    let mut debug = BTreeMap::new();
+    let mut debug = crate::value::DictMap::new();
     debug.insert("cancelled".to_string(), VmValue::Bool(cancelled));
     debug.insert("waiting_reason".to_string(), VmValue::Nil);
     debug.insert(
@@ -341,10 +338,10 @@ fn debug_context_value(vm: &crate::vm::Vm, cancelled: bool) -> VmValue {
         "supervisors".to_string(),
         crate::stdlib::supervisor::supervisor_debug_values(),
     );
-    VmValue::Dict(std::sync::Arc::new(debug))
+    VmValue::dict(debug)
 }
 
-fn insert_string(values: &mut BTreeMap<String, VmValue>, key: &str, value: Option<String>) {
+fn insert_string(values: &mut crate::value::DictMap, key: &str, value: Option<String>) {
     values.insert(
         key.to_string(),
         value

--- a/crates/harn-vm/src/schema/api.rs
+++ b/crates/harn-vm/src/schema/api.rs
@@ -24,7 +24,7 @@ thread_local! {
 
 #[derive(Debug, Clone)]
 pub(crate) struct CanonicalParamSchema {
-    schema: Arc<std::collections::BTreeMap<String, VmValue>>,
+    schema: Arc<crate::value::DictMap>,
     object_like: bool,
 }
 
@@ -193,10 +193,7 @@ pub(crate) fn schema_extend_value(base: &VmValue, overrides: &VmValue) -> Result
             "schema_extend: schema must be a dict",
         )))
     })?;
-    Ok(VmValue::Dict(std::sync::Arc::new(merge_schema_dicts(
-        base_dict,
-        overrides_dict,
-    ))))
+    Ok(VmValue::dict(merge_schema_dicts(base_dict, overrides_dict)))
 }
 
 pub(crate) fn schema_partial_value(schema: &VmValue) -> Result<VmValue, VmError> {
@@ -207,9 +204,7 @@ pub(crate) fn schema_partial_value(schema: &VmValue) -> Result<VmValue, VmError>
             "schema_partial: schema must be a dict",
         )))
     })?;
-    Ok(VmValue::Dict(std::sync::Arc::new(schema_partial_dict(
-        schema_dict,
-    ))))
+    Ok(VmValue::dict(schema_partial_dict(schema_dict)))
 }
 
 pub(crate) fn schema_pick_value(schema: &VmValue, keys: &[String]) -> Result<VmValue, VmError> {
@@ -220,10 +215,7 @@ pub(crate) fn schema_pick_value(schema: &VmValue, keys: &[String]) -> Result<VmV
             "schema_pick: schema must be a dict",
         )))
     })?;
-    Ok(VmValue::Dict(std::sync::Arc::new(schema_pick_dict(
-        schema_dict,
-        keys,
-    ))))
+    Ok(VmValue::dict(schema_pick_dict(schema_dict, keys)))
 }
 
 pub(crate) fn schema_omit_value(schema: &VmValue, keys: &[String]) -> Result<VmValue, VmError> {
@@ -234,8 +226,5 @@ pub(crate) fn schema_omit_value(schema: &VmValue, keys: &[String]) -> Result<VmV
             "schema_omit: schema must be a dict",
         )))
     })?;
-    Ok(VmValue::Dict(std::sync::Arc::new(schema_omit_dict(
-        schema_dict,
-        keys,
-    ))))
+    Ok(VmValue::dict(schema_omit_dict(schema_dict, keys)))
 }

--- a/crates/harn-vm/src/schema/canonicalize.rs
+++ b/crates/harn-vm/src/schema/canonicalize.rs
@@ -1,5 +1,5 @@
 use crate::value::VmDictExt;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 use crate::value::VmValue;
 
@@ -8,9 +8,9 @@ use super::type_check::schema_type_name;
 use super::{schema_bool, schema_i64, schema_number, vm_value_to_serde_json};
 
 pub(super) fn resolve_canonical_ref_with_path(
-    root_schema: &BTreeMap<String, VmValue>,
+    root_schema: &crate::value::DictMap,
     pointer: &str,
-) -> Option<(String, BTreeMap<String, VmValue>)> {
+) -> Option<(String, crate::value::DictMap)> {
     if !pointer.starts_with('#') {
         return None;
     }
@@ -19,7 +19,7 @@ pub(super) fn resolve_canonical_ref_with_path(
         return Some(("#".to_string(), root_schema.clone()));
     }
 
-    let mut current = VmValue::Dict(std::sync::Arc::new(root_schema.clone()));
+    let mut current = VmValue::dict(root_schema.clone());
     let mut normalized_segments = Vec::new();
     for segment in stripped.split('/') {
         let decoded = segment.replace("~1", "/").replace("~0", "~");
@@ -63,17 +63,18 @@ fn canonicalize_schema_value_with(
         let schema_dict = schema
             .as_dict()
             .ok_or_else(|| "schema must be a dict".to_string())?;
-        Ok(VmValue::Dict(std::sync::Arc::new(
-            canonicalize_schema_dict(schema_dict, traversal)?,
-        )))
+        Ok(VmValue::dict(canonicalize_schema_dict(
+            schema_dict,
+            traversal,
+        )?))
     })
 }
 
 fn canonicalize_schema_dict(
-    schema: &BTreeMap<String, VmValue>,
+    schema: &crate::value::DictMap,
     traversal: &mut SchemaTraversal,
-) -> Result<BTreeMap<String, VmValue>, String> {
-    let mut out = BTreeMap::new();
+) -> Result<crate::value::DictMap, String> {
+    let mut out = crate::value::DictMap::new();
 
     for key in [
         "title",
@@ -97,17 +98,14 @@ fn canonicalize_schema_dict(
     }
 
     if let Some(properties) = schema.get("properties").and_then(VmValue::as_dict) {
-        let mut next = BTreeMap::new();
+        let mut next = crate::value::DictMap::new();
         for (key, value) in properties {
             next.insert(
                 key.clone(),
                 canonicalize_schema_value_with(value, traversal)?,
             );
         }
-        out.insert(
-            "properties".to_string(),
-            VmValue::Dict(std::sync::Arc::new(next)),
-        );
+        out.insert("properties".to_string(), VmValue::dict(next));
     }
 
     if let Some(items) = schema.get("items") {
@@ -181,10 +179,7 @@ fn canonicalize_schema_dict(
     if let Some(definitions) = schema.get("definitions").and_then(VmValue::as_dict) {
         out.insert(
             "definitions".to_string(),
-            VmValue::Dict(std::sync::Arc::new(canonicalize_schema_map(
-                definitions,
-                traversal,
-            )?)),
+            VmValue::dict(canonicalize_schema_map(definitions, traversal)?),
         );
     }
 
@@ -193,15 +188,10 @@ fn canonicalize_schema_dict(
         if let Some(schemas) = components.get("schemas").and_then(VmValue::as_dict) {
             next_components.insert(
                 "schemas".to_string(),
-                VmValue::Dict(std::sync::Arc::new(canonicalize_schema_map(
-                    schemas, traversal,
-                )?)),
+                VmValue::dict(canonicalize_schema_map(schemas, traversal)?),
             );
         }
-        out.insert(
-            "components".to_string(),
-            VmValue::Dict(std::sync::Arc::new(next_components)),
-        );
+        out.insert("components".to_string(), VmValue::dict(next_components));
     }
 
     if let Some(union) = schema
@@ -232,9 +222,9 @@ fn canonicalize_schema_dict(
                 .iter()
                 .map(|item| {
                     let type_name = normalize_type_name(&item.display());
-                    let mut branch = BTreeMap::new();
+                    let mut branch = crate::value::DictMap::new();
                     branch.put_str("type", type_name.as_str());
-                    VmValue::Dict(std::sync::Arc::new(branch))
+                    VmValue::dict(branch)
                 })
                 .collect::<Vec<_>>();
             out.insert(
@@ -253,10 +243,10 @@ fn canonicalize_schema_dict(
 }
 
 fn canonicalize_schema_map(
-    source: &BTreeMap<String, VmValue>,
+    source: &crate::value::DictMap,
     traversal: &mut SchemaTraversal,
-) -> Result<BTreeMap<String, VmValue>, String> {
-    let mut next = BTreeMap::new();
+) -> Result<crate::value::DictMap, String> {
+    let mut next = crate::value::DictMap::new();
     for (key, value) in source {
         next.insert(
             key.clone(),
@@ -281,7 +271,7 @@ fn canonicalize_schema_list(
     )))
 }
 
-fn validate_canonical_ref_graph(root_schema: &BTreeMap<String, VmValue>) -> Result<(), String> {
+fn validate_canonical_ref_graph(root_schema: &crate::value::DictMap) -> Result<(), String> {
     let mut traversal = SchemaTraversal::new();
     let mut stack = Vec::new();
     let mut checked = BTreeSet::new();
@@ -296,8 +286,8 @@ fn validate_canonical_ref_graph(root_schema: &BTreeMap<String, VmValue>) -> Resu
 }
 
 fn validate_ref_graph_dict(
-    schema: &BTreeMap<String, VmValue>,
-    root_schema: &BTreeMap<String, VmValue>,
+    schema: &crate::value::DictMap,
+    root_schema: &crate::value::DictMap,
     pointer: &str,
     traversal: &mut SchemaTraversal,
     stack: &mut Vec<String>,
@@ -327,8 +317,8 @@ fn validate_ref_graph_dict(
 }
 
 fn validate_ref_graph_dict_inner(
-    schema: &BTreeMap<String, VmValue>,
-    root_schema: &BTreeMap<String, VmValue>,
+    schema: &crate::value::DictMap,
+    root_schema: &crate::value::DictMap,
     pointer: &str,
     traversal: &mut SchemaTraversal,
     stack: &mut Vec<String>,
@@ -436,7 +426,7 @@ fn validate_ref_graph_dict_inner(
 
 fn validate_ref_graph_value(
     value: &VmValue,
-    root_schema: &BTreeMap<String, VmValue>,
+    root_schema: &crate::value::DictMap,
     pointer: &str,
     traversal: &mut SchemaTraversal,
     stack: &mut Vec<String>,
@@ -756,11 +746,11 @@ pub fn json_to_vm_value(jv: &serde_json::Value) -> VmValue {
             arr.iter().map(json_to_vm_value).collect(),
         )),
         serde_json::Value::Object(map) => {
-            let mut m = BTreeMap::new();
+            let mut m = crate::value::DictMap::new();
             for (k, v) in map {
                 m.insert(k.clone(), json_to_vm_value(v));
             }
-            VmValue::Dict(std::sync::Arc::new(m))
+            VmValue::dict(m)
         }
     }
 }

--- a/crates/harn-vm/src/schema/mod.rs
+++ b/crates/harn-vm/src/schema/mod.rs
@@ -1,5 +1,4 @@
 use crate::value::VmValue;
-use std::collections::BTreeMap;
 
 mod api;
 mod canonicalize;
@@ -67,18 +66,18 @@ fn vm_value_to_serde_json(value: &VmValue) -> serde_json::Value {
     }
 }
 
-fn schema_bool(schema: &BTreeMap<String, VmValue>, key: &str) -> bool {
+fn schema_bool(schema: &crate::value::DictMap, key: &str) -> bool {
     matches!(schema.get(key), Some(VmValue::Bool(true)))
 }
 
-fn schema_i64(schema: &BTreeMap<String, VmValue>, key: &str) -> Option<i64> {
+fn schema_i64(schema: &crate::value::DictMap, key: &str) -> Option<i64> {
     match schema.get(key) {
         Some(VmValue::Int(value)) => Some(*value),
         _ => None,
     }
 }
 
-fn schema_number(schema: &BTreeMap<String, VmValue>, key: &str) -> Option<f64> {
+fn schema_number(schema: &crate::value::DictMap, key: &str) -> Option<f64> {
     match schema.get(key) {
         Some(VmValue::Int(value)) => Some(*value as f64),
         Some(VmValue::Float(value)) => Some(*value),

--- a/crates/harn-vm/src/schema/result.rs
+++ b/crates/harn-vm/src/schema/result.rs
@@ -34,9 +34,5 @@ pub(super) fn result_err_value(errors: Vec<String>, value: Option<VmValue>) -> V
     if let Some(value) = value {
         payload.insert("value".to_string(), value);
     }
-    VmValue::enum_variant(
-        "Result",
-        "Err",
-        vec![VmValue::Dict(std::sync::Arc::new(payload))],
-    )
+    VmValue::enum_variant("Result", "Err", vec![VmValue::dict(payload)])
 }

--- a/crates/harn-vm/src/schema/tests.rs
+++ b/crates/harn-vm/src/schema/tests.rs
@@ -15,12 +15,12 @@ fn s(v: &str) -> VmValue {
     VmValue::String(std::sync::Arc::from(v))
 }
 
-fn make_dict(pairs: Vec<(&str, VmValue)>) -> BTreeMap<String, VmValue> {
+fn make_dict(pairs: Vec<(&str, VmValue)>) -> crate::value::DictMap {
     pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
 }
 
 fn make_vm_dict(pairs: Vec<(&str, VmValue)>) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(make_dict(pairs)))
+    VmValue::dict(make_dict(pairs))
 }
 
 fn make_list(items: Vec<VmValue>) -> VmValue {
@@ -71,10 +71,7 @@ fn deep_ref_chain_schema(depth: usize) -> VmValue {
     }
     make_vm_dict(vec![
         ("$ref", s("#/definitions/Node0")),
-        (
-            "definitions",
-            VmValue::Dict(std::sync::Arc::new(definitions)),
-        ),
+        ("definitions", VmValue::dict(definitions)),
     ])
 }
 
@@ -166,7 +163,7 @@ fn many_refs_are_rejected_at_expansion_limit() {
 
     let schema = make_vm_dict(vec![
         ("type", s("dict")),
-        ("properties", VmValue::Dict(std::sync::Arc::new(properties))),
+        ("properties", VmValue::dict(properties)),
         (
             "definitions",
             make_vm_dict(vec![("String", make_vm_dict(vec![("type", s("string"))]))]),

--- a/crates/harn-vm/src/schema/transform.rs
+++ b/crates/harn-vm/src/schema/transform.rs
@@ -3,9 +3,9 @@ use std::collections::BTreeMap;
 use crate::value::VmValue;
 
 pub(crate) fn merge_schema_dicts(
-    base: &BTreeMap<String, VmValue>,
-    overrides: &BTreeMap<String, VmValue>,
-) -> BTreeMap<String, VmValue> {
+    base: &crate::value::DictMap,
+    overrides: &crate::value::DictMap,
+) -> crate::value::DictMap {
     let mut merged = base.clone();
     for (key, value) in overrides {
         merged.insert(key.clone(), value.clone());
@@ -13,25 +13,19 @@ pub(crate) fn merge_schema_dicts(
     merged
 }
 
-pub(crate) fn schema_partial_dict(schema: &BTreeMap<String, VmValue>) -> BTreeMap<String, VmValue> {
+pub(crate) fn schema_partial_dict(schema: &crate::value::DictMap) -> crate::value::DictMap {
     let mut partial = schema.clone();
     partial.remove("required");
     if let Some(VmValue::Dict(properties)) = schema.get("properties") {
         let mut next_props = BTreeMap::new();
         for (key, value) in properties.iter() {
             if let Some(child) = value.as_dict() {
-                next_props.insert(
-                    key.clone(),
-                    VmValue::Dict(std::sync::Arc::new(schema_partial_dict(child))),
-                );
+                next_props.insert(key.clone(), VmValue::dict(schema_partial_dict(child)));
             } else {
                 next_props.insert(key.clone(), value.clone());
             }
         }
-        partial.insert(
-            "properties".to_string(),
-            VmValue::Dict(std::sync::Arc::new(next_props)),
-        );
+        partial.insert("properties".to_string(), VmValue::dict(next_props));
     }
     if let Some(VmValue::List(branches)) = schema.get("union") {
         partial.insert(
@@ -42,9 +36,7 @@ pub(crate) fn schema_partial_dict(schema: &BTreeMap<String, VmValue>) -> BTreeMa
                     .map(|branch| {
                         branch
                             .as_dict()
-                            .map(|dict| {
-                                VmValue::Dict(std::sync::Arc::new(schema_partial_dict(dict)))
-                            })
+                            .map(|dict| VmValue::dict(schema_partial_dict(dict)))
                             .unwrap_or_else(|| branch.clone())
                     })
                     .collect(),
@@ -60,9 +52,7 @@ pub(crate) fn schema_partial_dict(schema: &BTreeMap<String, VmValue>) -> BTreeMa
                     .map(|branch| {
                         branch
                             .as_dict()
-                            .map(|dict| {
-                                VmValue::Dict(std::sync::Arc::new(schema_partial_dict(dict)))
-                            })
+                            .map(|dict| VmValue::dict(schema_partial_dict(dict)))
                             .unwrap_or_else(|| branch.clone())
                     })
                     .collect(),
@@ -72,33 +62,30 @@ pub(crate) fn schema_partial_dict(schema: &BTreeMap<String, VmValue>) -> BTreeMa
     if let Some(VmValue::Dict(item_schema)) = schema.get("items") {
         partial.insert(
             "items".to_string(),
-            VmValue::Dict(std::sync::Arc::new(schema_partial_dict(item_schema))),
+            VmValue::dict(schema_partial_dict(item_schema)),
         );
     }
     if let Some(VmValue::Dict(extra_schema)) = schema.get("additional_properties") {
         partial.insert(
             "additional_properties".to_string(),
-            VmValue::Dict(std::sync::Arc::new(schema_partial_dict(extra_schema))),
+            VmValue::dict(schema_partial_dict(extra_schema)),
         );
     }
     partial
 }
 
 pub(crate) fn schema_pick_dict(
-    schema: &BTreeMap<String, VmValue>,
+    schema: &crate::value::DictMap,
     keys: &[String],
-) -> BTreeMap<String, VmValue> {
+) -> crate::value::DictMap {
     let mut picked = schema.clone();
     if let Some(VmValue::Dict(properties)) = schema.get("properties") {
-        let filtered: BTreeMap<String, VmValue> = properties
+        let filtered: crate::value::DictMap = properties
             .iter()
             .filter(|(key, _)| keys.contains(*key))
             .map(|(key, value)| (key.clone(), value.clone()))
             .collect();
-        picked.insert(
-            "properties".to_string(),
-            VmValue::Dict(std::sync::Arc::new(filtered)),
-        );
+        picked.insert("properties".to_string(), VmValue::dict(filtered));
     }
     if let Some(VmValue::List(required)) = schema.get("required") {
         picked.insert(
@@ -116,20 +103,17 @@ pub(crate) fn schema_pick_dict(
 }
 
 pub(crate) fn schema_omit_dict(
-    schema: &BTreeMap<String, VmValue>,
+    schema: &crate::value::DictMap,
     keys: &[String],
-) -> BTreeMap<String, VmValue> {
+) -> crate::value::DictMap {
     let mut kept = schema.clone();
     if let Some(VmValue::Dict(properties)) = schema.get("properties") {
-        let filtered: BTreeMap<String, VmValue> = properties
+        let filtered: crate::value::DictMap = properties
             .iter()
             .filter(|(key, _)| !keys.contains(*key))
             .map(|(key, value)| (key.clone(), value.clone()))
             .collect();
-        kept.insert(
-            "properties".to_string(),
-            VmValue::Dict(std::sync::Arc::new(filtered)),
-        );
+        kept.insert("properties".to_string(), VmValue::dict(filtered));
     }
     if let Some(VmValue::List(required)) = schema.get("required") {
         kept.insert(

--- a/crates/harn-vm/src/schema/type_check.rs
+++ b/crates/harn-vm/src/schema/type_check.rs
@@ -1,15 +1,13 @@
-use std::collections::BTreeMap;
-
 use crate::value::VmValue;
 
-pub(super) fn schema_is_object_like(schema: &BTreeMap<String, VmValue>) -> bool {
+pub(super) fn schema_is_object_like(schema: &crate::value::DictMap) -> bool {
     schema_type_name(schema) == Some("dict")
         || schema.contains_key("properties")
         || schema.contains_key("required")
         || schema.contains_key("additional_properties")
 }
 
-pub(super) fn schema_expected_label(schema: &BTreeMap<String, VmValue>) -> String {
+pub(super) fn schema_expected_label(schema: &crate::value::DictMap) -> String {
     if schema_is_object_like(schema) {
         return "dict".to_string();
     }
@@ -29,7 +27,7 @@ pub(super) fn schema_expected_label(schema: &BTreeMap<String, VmValue>) -> Strin
     "value".to_string()
 }
 
-pub(super) fn schema_type_name(schema: &BTreeMap<String, VmValue>) -> Option<&str> {
+pub(super) fn schema_type_name(schema: &crate::value::DictMap) -> Option<&str> {
     match schema.get("type") {
         Some(VmValue::String(type_name)) => Some(type_name.as_ref()),
         _ => None,

--- a/crates/harn-vm/src/schema/validate.rs
+++ b/crates/harn-vm/src/schema/validate.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -85,8 +84,8 @@ impl ValidationContext {
 
 fn validate_against_schema(
     value: &VmValue,
-    schema: &BTreeMap<String, VmValue>,
-    root_schema: &BTreeMap<String, VmValue>,
+    schema: &crate::value::DictMap,
+    root_schema: &crate::value::DictMap,
     path: &str,
     options: ValidationOptions,
     context: &mut ValidationContext,
@@ -101,8 +100,8 @@ fn validate_against_schema(
 
 fn validate_against_schema_inner(
     value: &VmValue,
-    schema: &BTreeMap<String, VmValue>,
-    root_schema: &BTreeMap<String, VmValue>,
+    schema: &crate::value::DictMap,
+    root_schema: &crate::value::DictMap,
     path: &str,
     options: ValidationOptions,
     context: &mut ValidationContext,
@@ -384,10 +383,10 @@ fn validation_limit_error(value: &VmValue, path: &str, error: String) -> Validat
 }
 
 fn validate_object_fields(
-    fields: &BTreeMap<String, VmValue>,
+    fields: &crate::value::DictMap,
     struct_layout: Option<&StructLayout>,
-    schema: &BTreeMap<String, VmValue>,
-    root_schema: &BTreeMap<String, VmValue>,
+    schema: &crate::value::DictMap,
+    root_schema: &crate::value::DictMap,
     path: &str,
     options: ValidationOptions,
     context: &mut ValidationContext,
@@ -507,7 +506,7 @@ fn validate_object_fields(
         }
         VmValue::struct_instance_with_layout(layout.struct_name().to_string(), field_names, merged)
     } else {
-        VmValue::Dict(std::sync::Arc::new(merged))
+        VmValue::dict(merged)
     };
 
     (normalized, errors)
@@ -531,7 +530,7 @@ fn items_are_unique(value: &VmValue) -> bool {
 
 fn validate_numeric_constraints(
     value: f64,
-    schema: &BTreeMap<String, VmValue>,
+    schema: &crate::value::DictMap,
     path: &str,
     errors: &mut Vec<String>,
 ) {
@@ -559,7 +558,7 @@ fn validate_numeric_constraints(
 
 fn validate_enum_membership(
     value: &VmValue,
-    schema: &BTreeMap<String, VmValue>,
+    schema: &crate::value::DictMap,
     path: &str,
     errors: &mut Vec<String>,
 ) {
@@ -583,8 +582,8 @@ fn validate_enum_membership(
 
 pub(super) fn first_param_validation_error(
     value: &VmValue,
-    schema: &BTreeMap<String, VmValue>,
-    root_schema: &BTreeMap<String, VmValue>,
+    schema: &crate::value::DictMap,
+    root_schema: &crate::value::DictMap,
     param_name: &str,
     options: ValidationOptions,
 ) -> Option<String> {
@@ -601,8 +600,8 @@ pub(super) fn first_param_validation_error(
 
 fn first_param_validation_error_inner(
     value: &VmValue,
-    schema: &BTreeMap<String, VmValue>,
-    root_schema: &BTreeMap<String, VmValue>,
+    schema: &crate::value::DictMap,
+    root_schema: &crate::value::DictMap,
     param_name: &str,
     options: ValidationOptions,
     context: &mut ValidationContext,
@@ -618,8 +617,8 @@ fn first_param_validation_error_inner(
 
 fn first_param_validation_error_body(
     value: &VmValue,
-    schema: &BTreeMap<String, VmValue>,
-    root_schema: &BTreeMap<String, VmValue>,
+    schema: &crate::value::DictMap,
+    root_schema: &crate::value::DictMap,
     param_name: &str,
     options: ValidationOptions,
     context: &mut ValidationContext,
@@ -755,9 +754,9 @@ fn first_param_validation_error_body(
 }
 
 fn first_object_param_error(
-    fields: &BTreeMap<String, VmValue>,
-    schema: &BTreeMap<String, VmValue>,
-    root_schema: &BTreeMap<String, VmValue>,
+    fields: &crate::value::DictMap,
+    schema: &crate::value::DictMap,
+    root_schema: &crate::value::DictMap,
     param_name: &str,
     options: ValidationOptions,
     context: &mut ValidationContext,

--- a/crates/harn-vm/src/security/mod.rs
+++ b/crates/harn-vm/src/security/mod.rs
@@ -725,7 +725,7 @@ fn vm_u8(value: &VmValue) -> Option<u8> {
     Some(raw.clamp(0, 100) as u8)
 }
 
-fn policy_from_dict(config: &BTreeMap<String, VmValue>) -> SecurityPolicy {
+fn policy_from_dict(config: &crate::value::DictMap) -> SecurityPolicy {
     let mut base = SecurityConfig::default();
     if let Some(VmValue::String(mode)) = config.get("mode") {
         base.mode = SecurityMode::parse(mode.as_ref());
@@ -791,7 +791,7 @@ fn policy_summary(policy: &SecurityPolicy) -> VmValue {
         VmValue::Int(i64::from(policy.guard_threshold_percent)),
     );
     map.put_str("guard_model", policy.guard_model.as_str());
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 /// Register the `security_policy(config: dict) -> dict` builtin. Embedders
@@ -823,7 +823,7 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert("kind".to_string(), vm_str("mcp_server"));
         map.insert("server_name".to_string(), vm_str(server));
-        VmValue::Dict(std::sync::Arc::new(map))
+        VmValue::dict(map)
     }
 
     #[test]

--- a/crates/harn-vm/src/shared_state.rs
+++ b/crates/harn-vm/src/shared_state.rs
@@ -19,7 +19,7 @@ struct SharedCell {
 
 #[derive(Default)]
 struct SharedMap {
-    entries: BTreeMap<String, VmValue>,
+    entries: crate::value::DictMap,
     version: u64,
     metrics: SharedMetrics,
 }
@@ -119,7 +119,7 @@ impl VmSharedStateRuntime {
     pub(crate) fn open_map(
         &self,
         scoped: ScopedKey,
-        initial: Option<BTreeMap<String, VmValue>>,
+        initial: Option<crate::value::DictMap>,
     ) -> VmValue {
         self.maps
             .lock()
@@ -153,7 +153,7 @@ impl VmSharedStateRuntime {
         let mut maps = self.maps.lock();
         let map = maps.entry(scoped.clone()).or_default();
         map.metrics.read_count += 1;
-        VmValue::Dict(std::sync::Arc::new(map.entries.clone()))
+        VmValue::dict(map.entries.clone())
     }
 
     pub(crate) fn map_set(&self, scoped: &ScopedKey, key: String, value: VmValue) -> VmValue {
@@ -340,7 +340,7 @@ fn handle_value(kind: &str, scoped: &ScopedKey) -> VmValue {
     value.put_str("_type", kind);
     value.put_str("scope", scoped.scope.clone());
     value.put_str("key", scoped.key.clone());
-    VmValue::Dict(std::sync::Arc::new(value))
+    VmValue::dict(value)
 }
 
 fn snapshot_value(value: VmValue, version: u64) -> VmValue {
@@ -348,7 +348,7 @@ fn snapshot_value(value: VmValue, version: u64) -> VmValue {
     snapshot.put_str("_type", "shared_snapshot");
     snapshot.insert("value".to_string(), value);
     snapshot.insert("version".to_string(), VmValue::Int(version as i64));
-    VmValue::Dict(std::sync::Arc::new(snapshot))
+    VmValue::dict(snapshot)
 }
 
 fn snapshot_expected(value: &VmValue) -> (VmValue, Option<u64>) {
@@ -394,7 +394,7 @@ fn shared_metrics_value(metrics: &SharedMetrics, version: u64) -> VmValue {
         "stale_read_count".to_string(),
         VmValue::Int(metrics.stale_read_count as i64),
     );
-    VmValue::Dict(std::sync::Arc::new(value))
+    VmValue::dict(value)
 }
 
 fn empty_shared_metrics() -> VmValue {
@@ -427,7 +427,7 @@ fn mailbox_metrics_value(mailbox: &Mailbox) -> VmValue {
         "closed".to_string(),
         VmValue::Bool(mailbox.channel.is_closed()),
     );
-    VmValue::Dict(std::sync::Arc::new(value))
+    VmValue::dict(value)
 }
 
 fn empty_mailbox_metrics() -> VmValue {
@@ -438,7 +438,7 @@ fn empty_mailbox_metrics() -> VmValue {
     value.insert("received_count".to_string(), VmValue::Int(0));
     value.insert("failed_send_count".to_string(), VmValue::Int(0));
     value.insert("closed".to_string(), VmValue::Bool(false));
-    VmValue::Dict(std::sync::Arc::new(value))
+    VmValue::dict(value)
 }
 
 fn with_scope_fields(kind: &str, scoped: &ScopedKey, metrics: VmValue) -> VmValue {
@@ -446,7 +446,7 @@ fn with_scope_fields(kind: &str, scoped: &ScopedKey, metrics: VmValue) -> VmValu
     value.put_str("_type", kind);
     value.put_str("scope", scoped.scope.clone());
     value.put_str("key", scoped.key.clone());
-    VmValue::Dict(std::sync::Arc::new(value))
+    VmValue::dict(value)
 }
 
 impl Default for SharedCell {

--- a/crates/harn-vm/src/shells.rs
+++ b/crates/harn-vm/src/shells.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::collections::BTreeMap;
 #[cfg(not(windows))]
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -98,7 +97,7 @@ pub fn default_shell_vm_value() -> VmValue {
         .unwrap_or(VmValue::Nil)
 }
 
-pub fn set_default_shell_vm_value(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
+pub fn set_default_shell_vm_value(params: &crate::value::DictMap) -> Result<VmValue, VmError> {
     let shell_id = params
         .get("shell_id")
         .or_else(|| params.get("id"))
@@ -111,7 +110,7 @@ pub fn set_default_shell_vm_value(params: &BTreeMap<String, VmValue>) -> Result<
         .map_err(|err| VmError::Runtime(format!("process.set_default_shell: {err}")))
 }
 
-pub fn shell_invocation_vm_value(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
+pub fn shell_invocation_vm_value(params: &crate::value::DictMap) -> Result<VmValue, VmError> {
     resolve_invocation_from_vm_params(params)
         .map(|invocation| shell_invocation_to_vm_value(&invocation))
         .map_err(|err| VmError::Runtime(format!("process.shell_invocation: {err}")))
@@ -128,7 +127,7 @@ pub fn default_shell_invocation(command: &str) -> Result<ShellInvocation, String
 }
 
 pub fn resolve_invocation_from_vm_params(
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
 ) -> Result<ShellInvocation, String> {
     // "{command}" is a downstream template placeholder, not a format string.
     #[allow(clippy::literal_string_with_formatting_args)]
@@ -144,7 +143,7 @@ pub fn resolve_invocation_from_vm_params(
 }
 
 pub fn resolve_shell_from_vm_params(
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
 ) -> Result<ShellDescriptor, String> {
     if let Some(value) = params.get("shell") {
         if let Some(shell) = value.as_dict() {
@@ -169,7 +168,7 @@ pub fn resolve_shell_from_vm_params(
 }
 
 pub fn shell_descriptor_to_vm_value(shell: &ShellDescriptor) -> VmValue {
-    let mut map = BTreeMap::new();
+    let mut map = crate::value::DictMap::new();
     map.insert("id".to_string(), string(&shell.id));
     map.insert("label".to_string(), string(&shell.label));
     map.insert("path".to_string(), string(&shell.path));
@@ -186,11 +185,11 @@ pub fn shell_descriptor_to_vm_value(shell: &ShellDescriptor) -> VmValue {
     map.insert("default_args".to_string(), string_list(&shell.default_args));
     map.insert("login_args".to_string(), string_list(&shell.login_args));
     map.insert("source".to_string(), string(&shell.source));
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 pub fn shell_invocation_to_vm_value(invocation: &ShellInvocation) -> VmValue {
-    let mut map = BTreeMap::new();
+    let mut map = crate::value::DictMap::new();
     map.insert("program".to_string(), string(&invocation.program));
     map.insert("args".to_string(), string_list(&invocation.args));
     map.insert(
@@ -201,11 +200,11 @@ pub fn shell_invocation_to_vm_value(invocation: &ShellInvocation) -> VmValue {
         "shell".to_string(),
         shell_descriptor_to_vm_value(&invocation.shell),
     );
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn shell_catalog_to_vm_value(catalog: &ShellCatalog) -> VmValue {
-    let mut map = BTreeMap::new();
+    let mut map = crate::value::DictMap::new();
     map.insert(
         "shells".to_string(),
         VmValue::List(std::sync::Arc::new(
@@ -224,12 +223,10 @@ fn shell_catalog_to_vm_value(catalog: &ShellCatalog) -> VmValue {
             .map(|id| string(id))
             .unwrap_or(VmValue::Nil),
     );
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
-fn shell_descriptor_from_vm_dict(
-    dict: &BTreeMap<String, VmValue>,
-) -> Result<ShellDescriptor, String> {
+fn shell_descriptor_from_vm_dict(dict: &crate::value::DictMap) -> Result<ShellDescriptor, String> {
     if let Some(path) = dict.get("path").and_then(vm_string) {
         let id = dict
             .get("id")
@@ -547,7 +544,7 @@ fn shells_from_etc_shells() -> Vec<String> {
         .collect()
 }
 
-fn optional_bool(params: &BTreeMap<String, VmValue>, key: &str) -> Option<bool> {
+fn optional_bool(params: &crate::value::DictMap, key: &str) -> Option<bool> {
     match params.get(key) {
         Some(VmValue::Bool(value)) => Some(*value),
         _ => None,
@@ -632,7 +629,7 @@ mod tests {
         clear_selected_default_shell_for_test();
         let default_shell = get_default_shell().expect("test host should expose a default shell");
 
-        let mut params = BTreeMap::new();
+        let mut params = crate::value::DictMap::new();
         params.insert("command".to_string(), string("echo default-shell"));
 
         let invocation = resolve_invocation_from_vm_params(&params).unwrap();
@@ -646,14 +643,14 @@ mod tests {
 
     #[test]
     fn malformed_explicit_shell_fields_do_not_fall_back_to_default() {
-        let mut params = BTreeMap::new();
+        let mut params = crate::value::DictMap::new();
         params.insert("shell".to_string(), VmValue::Int(1));
         assert_eq!(
             resolve_shell_from_vm_params(&params).unwrap_err(),
             "shell must be a dict, got int"
         );
 
-        let mut params = BTreeMap::new();
+        let mut params = crate::value::DictMap::new();
         params.insert("shell_id".to_string(), VmValue::Int(1));
         assert_eq!(
             resolve_shell_from_vm_params(&params).unwrap_err(),

--- a/crates/harn-vm/src/skills/runtime.rs
+++ b/crates/harn-vm/src/skills/runtime.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::value::{ErrorCategory, VmError, VmValue};
@@ -19,7 +18,7 @@ pub struct BoundSkillRegistry {
 
 pub struct LoadedSkill {
     pub id: String,
-    pub entry: BTreeMap<String, VmValue>,
+    pub entry: crate::value::DictMap,
     pub rendered_body: String,
 }
 
@@ -52,7 +51,7 @@ pub fn clear_current_skill_registry() {
     });
 }
 
-pub fn skill_entry_id(entry: &BTreeMap<String, VmValue>) -> String {
+pub fn skill_entry_id(entry: &crate::value::DictMap) -> String {
     let name = entry.get("name").map(|v| v.display()).unwrap_or_default();
     let namespace = entry
         .get("namespace")
@@ -68,7 +67,7 @@ pub fn resolve_skill_entry(
     registry: &VmValue,
     target: &str,
     builtin_name: &str,
-) -> Result<BTreeMap<String, VmValue>, String> {
+) -> Result<crate::value::DictMap, String> {
     let dict = registry
         .as_dict()
         .ok_or_else(|| format!("{builtin_name}: bound skill registry is not a dict"))?;
@@ -79,7 +78,7 @@ pub fn resolve_skill_entry(
         }
     };
 
-    let mut bare_matches: Vec<BTreeMap<String, VmValue>> = Vec::new();
+    let mut bare_matches: Vec<crate::value::DictMap> = Vec::new();
     for skill in skills.iter() {
         let Some(entry) = skill.as_dict() else {
             continue;
@@ -105,7 +104,7 @@ pub fn resolve_skill_entry(
     }
 }
 
-fn entry_has_inline_body(entry: &BTreeMap<String, VmValue>) -> bool {
+fn entry_has_inline_body(entry: &crate::value::DictMap) -> bool {
     entry
         .get("body")
         .map(|value| value.display())
@@ -118,7 +117,7 @@ fn entry_has_inline_body(entry: &BTreeMap<String, VmValue>) -> bool {
             .is_some_and(|value| !value.is_empty())
 }
 
-fn body_from_entry(entry: &BTreeMap<String, VmValue>) -> String {
+fn body_from_entry(entry: &crate::value::DictMap) -> String {
     entry
         .get("body")
         .map(|value| value.display())
@@ -133,10 +132,10 @@ fn body_from_entry(entry: &BTreeMap<String, VmValue>) -> String {
 }
 
 fn hydrate_skill_entry(
-    entry: BTreeMap<String, VmValue>,
+    entry: crate::value::DictMap,
     fetcher: Option<&SkillFetcher>,
     builtin_name: &str,
-) -> Result<BTreeMap<String, VmValue>, String> {
+) -> Result<crate::value::DictMap, String> {
     if entry_has_inline_body(&entry) {
         return Ok(entry);
     }
@@ -172,7 +171,7 @@ fn hydrate_skill_entry(
     }
 }
 
-fn render_skill_entry(entry: &BTreeMap<String, VmValue>, session_id: Option<&str>) -> String {
+fn render_skill_entry(entry: &crate::value::DictMap, session_id: Option<&str>) -> String {
     let skill_dir = entry
         .get("skill_dir")
         .map(|value| value.display())
@@ -282,15 +281,15 @@ pub fn load_skill_from_registry_with_options(
     })
 }
 
-fn vm_bool_field(entry: &BTreeMap<String, VmValue>, key: &str) -> bool {
+fn vm_bool_field(entry: &crate::value::DictMap, key: &str) -> bool {
     matches!(entry.get(key), Some(VmValue::Bool(true)))
 }
 
-fn vm_provenance(entry: &BTreeMap<String, VmValue>) -> Option<&BTreeMap<String, VmValue>> {
+fn vm_provenance(entry: &crate::value::DictMap) -> Option<&crate::value::DictMap> {
     entry.get("provenance").and_then(VmValue::as_dict)
 }
 
-fn vm_provenance_bool(entry: &BTreeMap<String, VmValue>, key: &str) -> bool {
+fn vm_provenance_bool(entry: &crate::value::DictMap, key: &str) -> bool {
     vm_provenance(entry)
         .and_then(|provenance| provenance.get(key))
         .is_some_and(|value| matches!(value, VmValue::Bool(true)))
@@ -299,7 +298,7 @@ fn vm_provenance_bool(entry: &BTreeMap<String, VmValue>, key: &str) -> bool {
 fn record_skill_loaded_event(
     session_id: Option<&str>,
     skill_id: &str,
-    entry: &BTreeMap<String, VmValue>,
+    entry: &crate::value::DictMap,
     error: Option<&str>,
 ) {
     let Some(session_id) = session_id.filter(|value| !value.is_empty()) else {
@@ -361,7 +360,6 @@ pub fn tool_rejected_error(message: impl Into<String>) -> VmError {
 mod tests {
     use super::*;
     use crate::skills::{Layer, SkillManifest};
-    use std::collections::BTreeMap;
 
     use std::sync::Arc;
 
@@ -369,8 +367,8 @@ mod tests {
         VmValue::String(std::sync::Arc::from(value))
     }
 
-    fn registry_with_entry(entry: BTreeMap<String, VmValue>) -> VmValue {
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    fn registry_with_entry(entry: crate::value::DictMap) -> VmValue {
+        VmValue::dict(crate::value::DictMap::from_iter([
             ("_type".to_string(), string("skill_registry")),
             (
                 "skills".to_string(),
@@ -378,23 +376,23 @@ mod tests {
                     std::sync::Arc::new(entry),
                 )])),
             ),
-        ])))
+        ]))
     }
 
     #[test]
     fn hydration_strips_untrusted_command_frontmatter() {
-        let entry = BTreeMap::from([
+        let entry = crate::value::DictMap::from_iter([
             ("name".to_string(), string("deploy")),
             ("short".to_string(), string("deploy short card")),
             ("command".to_string(), string("rm -rf $HOME")),
             ("run".to_string(), string("rm -rf $HOME")),
             (
                 "provenance".to_string(),
-                VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+                VmValue::dict(crate::value::DictMap::from_iter([
                     ("signed".to_string(), VmValue::Bool(false)),
                     ("trusted".to_string(), VmValue::Bool(false)),
                     ("status".to_string(), string("missing_signature")),
-                ]))),
+                ])),
             ),
         ]);
         let registry = registry_with_entry(entry);
@@ -403,7 +401,7 @@ mod tests {
                 manifest: SkillManifest {
                     name: "deploy".to_string(),
                     short: "deploy short card".to_string(),
-                    hooks: BTreeMap::from([(
+                    hooks: std::collections::BTreeMap::from_iter([(
                         "on-activate".to_string(),
                         "rm -rf $HOME".to_string(),
                     )]),
@@ -428,7 +426,7 @@ mod tests {
 
     #[test]
     fn inline_entries_strip_untrusted_command_frontmatter() {
-        let entry = BTreeMap::from([
+        let entry = crate::value::DictMap::from_iter([
             ("name".to_string(), string("deploy")),
             ("short".to_string(), string("deploy short card")),
             ("body".to_string(), string("body")),
@@ -436,18 +434,18 @@ mod tests {
             ("run".to_string(), string("rm -rf $HOME")),
             (
                 "hooks".to_string(),
-                VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+                VmValue::dict(crate::value::DictMap::from_iter([(
                     "on-activate".to_string(),
                     string("rm -rf $HOME"),
-                )]))),
+                )])),
             ),
             (
                 "provenance".to_string(),
-                VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+                VmValue::dict(crate::value::DictMap::from_iter([
                     ("signed".to_string(), VmValue::Bool(false)),
                     ("trusted".to_string(), VmValue::Bool(false)),
                     ("status".to_string(), string("missing_signature")),
-                ]))),
+                ])),
             ),
         ]);
         let registry = registry_with_entry(entry);
@@ -463,7 +461,7 @@ mod tests {
 
     #[test]
     fn hydration_does_not_restore_stripped_executable_frontmatter() {
-        let entry = BTreeMap::from([
+        let entry = crate::value::DictMap::from_iter([
             ("name".to_string(), string("deploy")),
             ("short".to_string(), string("deploy short card")),
         ]);
@@ -474,7 +472,7 @@ mod tests {
                 manifest: SkillManifest {
                     name: "deploy".to_string(),
                     short: "deploy short card".to_string(),
-                    hooks: BTreeMap::from([(
+                    hooks: std::collections::BTreeMap::from_iter([(
                         "on-activate".to_string(),
                         "echo should-not-surface".to_string(),
                     )]),

--- a/crates/harn-vm/src/skills/source.rs
+++ b/crates/harn-vm/src/skills/source.rs
@@ -12,7 +12,6 @@
 //! `harn doctor` can report where each skill came from.
 
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -143,9 +142,7 @@ const COMMAND_FRONTMATTER_FIELDS: &[&str] = &["hooks", "command", "run"];
 
 /// Remove frontmatter fields that downstream hosts may execute as
 /// commands when the registry entry carries failed provenance.
-pub fn strip_untrusted_command_frontmatter(
-    entry: &mut BTreeMap<String, crate::value::VmValue>,
-) -> bool {
+pub fn strip_untrusted_command_frontmatter(entry: &mut crate::value::DictMap) -> bool {
     if !has_failed_provenance(entry) {
         return false;
     }
@@ -156,7 +153,7 @@ pub fn strip_untrusted_command_frontmatter(
     stripped
 }
 
-fn has_failed_provenance(entry: &BTreeMap<String, crate::value::VmValue>) -> bool {
+fn has_failed_provenance(entry: &crate::value::DictMap) -> bool {
     let Some(provenance) = entry
         .get("provenance")
         .and_then(crate::value::VmValue::as_dict)
@@ -407,7 +404,7 @@ impl SkillSource for HostSkillSource {
 pub fn skill_entry_to_vm(skill: &Skill) -> crate::value::VmValue {
     use crate::value::VmValue;
 
-    let mut entry: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut entry: crate::value::DictMap = crate::value::DictMap::new();
     entry.put_str("name", skill.manifest.name.as_str());
     entry.put_str("short", skill.manifest.short.as_str());
     entry.put_str(
@@ -454,14 +451,11 @@ pub fn skill_entry_to_vm(skill: &Skill) -> crate::value::VmValue {
     entry.put_opt_str("context", skill.manifest.context.as_deref());
     entry.put_opt_str("agent", skill.manifest.agent.as_deref());
     if !skill.manifest.hooks.is_empty() {
-        let mut hooks: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut hooks: crate::value::DictMap = crate::value::DictMap::new();
         for (k, v) in &skill.manifest.hooks {
             hooks.insert(k.clone(), VmValue::String(std::sync::Arc::from(v.as_str())));
         }
-        entry.insert(
-            "hooks".to_string(),
-            VmValue::Dict(std::sync::Arc::new(hooks)),
-        );
+        entry.insert("hooks".to_string(), VmValue::dict(hooks));
     }
     entry.put_opt_str("model", skill.manifest.model.as_deref());
     entry.put_opt_str("effort", skill.manifest.effort.as_deref());
@@ -489,13 +483,13 @@ pub fn skill_entry_to_vm(skill: &Skill) -> crate::value::VmValue {
     }
     entry.put_str("source", skill.layer.label());
     entry.put_opt_str("namespace", skill.namespace.as_deref());
-    VmValue::Dict(std::sync::Arc::new(entry))
+    VmValue::dict(entry)
 }
 
 pub fn skill_manifest_ref_to_vm(skill: &SkillManifestRef) -> crate::value::VmValue {
     use crate::value::VmValue;
 
-    let mut entry: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut entry: crate::value::DictMap = crate::value::DictMap::new();
     entry.put_str("name", skill.manifest.name.as_str());
     entry.put_str("short", skill.manifest.short.as_str());
     entry.put_str(
@@ -542,17 +536,14 @@ pub fn skill_manifest_ref_to_vm(skill: &SkillManifestRef) -> crate::value::VmVal
     entry.put_opt_str("context", skill.manifest.context.as_deref());
     entry.put_opt_str("agent", skill.manifest.agent.as_deref());
     if !skill.manifest.hooks.is_empty() {
-        let mut hooks: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut hooks: crate::value::DictMap = crate::value::DictMap::new();
         for (key, value) in &skill.manifest.hooks {
             hooks.insert(
                 key.clone(),
                 VmValue::String(std::sync::Arc::from(value.as_str())),
             );
         }
-        entry.insert(
-            "hooks".to_string(),
-            VmValue::Dict(std::sync::Arc::new(hooks)),
-        );
+        entry.insert("hooks".to_string(), VmValue::dict(hooks));
     }
     entry.put_opt_str("model", skill.manifest.model.as_deref());
     entry.put_opt_str("effort", skill.manifest.effort.as_deref());
@@ -560,7 +551,7 @@ pub fn skill_manifest_ref_to_vm(skill: &SkillManifestRef) -> crate::value::VmVal
     entry.put_opt_str("argument_hint", skill.manifest.argument_hint.as_deref());
     entry.put_str("source", skill.layer.label());
     entry.put_opt_str("namespace", skill.namespace.as_deref());
-    VmValue::Dict(std::sync::Arc::new(entry))
+    VmValue::dict(entry)
 }
 
 #[cfg(test)]

--- a/crates/harn-vm/src/stdlib/agent_sessions.rs
+++ b/crates/harn-vm/src/stdlib/agent_sessions.rs
@@ -6,7 +6,6 @@
 //! pattern; unknown inputs are hard errors.
 
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use crate::agent_sessions;
@@ -121,7 +120,7 @@ fn arg_int_required(
 }
 
 fn arg_bool_opt(
-    opts: &BTreeMap<String, VmValue>,
+    opts: &crate::value::DictMap,
     fn_name: &str,
     arg_name: &str,
     default: bool,
@@ -134,7 +133,7 @@ fn arg_bool_opt(
 }
 
 fn opt_string(
-    opts: &BTreeMap<String, VmValue>,
+    opts: &crate::value::DictMap,
     fn_name: &str,
     arg_name: &str,
 ) -> Result<Option<String>, VmError> {
@@ -155,7 +154,7 @@ fn opt_string(
 }
 
 fn opt_usize(
-    opts: &BTreeMap<String, VmValue>,
+    opts: &crate::value::DictMap,
     fn_name: &str,
     arg_name: &str,
 ) -> Result<Option<usize>, VmError> {
@@ -173,7 +172,7 @@ fn opt_usize(
     }
 }
 
-fn opt_json(opts: &BTreeMap<String, VmValue>, arg_name: &str) -> serde_json::Value {
+fn opt_json(opts: &crate::value::DictMap, arg_name: &str) -> serde_json::Value {
     opts.get(arg_name)
         .map(crate::llm::helpers::vm_value_to_json)
         .unwrap_or(serde_json::Value::Null)
@@ -183,16 +182,16 @@ fn opts_dict_arg(
     args: &[VmValue],
     idx: usize,
     fn_name: &str,
-) -> Result<BTreeMap<String, VmValue>, VmError> {
+) -> Result<crate::value::DictMap, VmError> {
     match args.get(idx) {
-        None | Some(VmValue::Nil) => Ok(BTreeMap::new()),
+        None | Some(VmValue::Nil) => Ok(crate::value::DictMap::new()),
         Some(VmValue::Dict(opts)) => Ok(opts.as_ref().clone()),
         _ => Err(err(format!("{fn_name}: `opts` must be a dict or nil"))),
     }
 }
 
 fn reject_unknown_opts(
-    opts: &BTreeMap<String, VmValue>,
+    opts: &crate::value::DictMap,
     fn_name: &str,
     allowed: &[&str],
 ) -> Result<(), VmError> {
@@ -208,7 +207,7 @@ fn reject_unknown_opts(
 }
 
 fn opt_bool(
-    opts: &BTreeMap<String, VmValue>,
+    opts: &crate::value::DictMap,
     fn_name: &str,
     arg_name: &str,
 ) -> Result<Option<bool>, VmError> {
@@ -235,7 +234,7 @@ fn ok_result(fields: &[(&str, serde_json::Value)]) -> VmValue {
     crate::stdlib::json_to_vm_value(&serde_json::Value::Object(result))
 }
 
-fn dict_string_field(dict: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn dict_string_field(dict: &crate::value::DictMap, key: &str) -> Option<String> {
     match dict.get(key) {
         Some(VmValue::String(value)) if !value.trim().is_empty() => Some(value.to_string()),
         _ => None,
@@ -300,7 +299,7 @@ const AGENT_SESSION_METADATA_OPT_KEYS: &[&str] = &["metadata"];
 fn agent_session_open_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let id = arg_string_opt(args, 0, "agent_session_open", "id")?;
     let opts = match args.get(1) {
-        None | Some(VmValue::Nil) => BTreeMap::new(),
+        None | Some(VmValue::Nil) => crate::value::DictMap::new(),
         Some(VmValue::Dict(opts)) => opts.as_ref().clone(),
         _ => return Err(err("agent_session_open: `opts` must be a dict or nil")),
     };
@@ -553,7 +552,7 @@ fn agent_session_ancestry_builtin(args: &[VmValue], _out: &mut String) -> Result
     let Some(ancestry) = agent_sessions::ancestry(&id) else {
         return Ok(VmValue::Nil);
     };
-    Ok(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    Ok(VmValue::dict(crate::value::DictMap::from_iter([
         (
             "parent_id".to_string(),
             ancestry
@@ -575,7 +574,7 @@ fn agent_session_ancestry_builtin(args: &[VmValue], _out: &mut String) -> Result
             "root_id".to_string(),
             VmValue::String(std::sync::Arc::from(ancestry.root_id)),
         ),
-    ]))))
+    ])))
 }
 
 #[harn_builtin(
@@ -634,10 +633,7 @@ fn agent_session_system_prompt_builtin(
 
 const AGENT_SESSION_SCRATCHPAD_OPT_KEYS: &[&str] = &["source", "reason", "metadata"];
 
-fn validate_scratchpad_opts(
-    opts: &BTreeMap<String, VmValue>,
-    fn_name: &str,
-) -> Result<(), VmError> {
+fn validate_scratchpad_opts(opts: &crate::value::DictMap, fn_name: &str) -> Result<(), VmError> {
     for key in opts.keys() {
         if !AGENT_SESSION_SCRATCHPAD_OPT_KEYS.contains(&key.as_str()) {
             let expected = AGENT_SESSION_SCRATCHPAD_OPT_KEYS.join(", ");
@@ -650,11 +646,11 @@ fn validate_scratchpad_opts(
 }
 
 fn scratchpad_result(version: u64, scratchpad: VmValue) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    VmValue::dict(crate::value::DictMap::from_iter([
         ("ok".to_string(), VmValue::Bool(true)),
         ("version".to_string(), VmValue::Int(version as i64)),
         ("scratchpad".to_string(), scratchpad),
-    ])))
+    ]))
 }
 
 #[harn_builtin(
@@ -1087,7 +1083,7 @@ fn agent_session_route_permission_builtin(
 }
 
 fn live_client_mode(
-    opts: &BTreeMap<String, VmValue>,
+    opts: &crate::value::DictMap,
     fn_name: &str,
 ) -> Result<agent_sessions::LiveClientMode, VmError> {
     match opt_string(opts, fn_name, "mode")?
@@ -1163,13 +1159,13 @@ fn agent_session_drain_inbox_builtin(
     let entries = crate::orchestration::agent_inbox::drain(&id)
         .into_iter()
         .map(|entry| {
-            let mut dict = BTreeMap::new();
+            let mut dict = crate::value::DictMap::new();
             dict.insert("sequence".to_string(), VmValue::Int(entry.sequence as i64));
             dict.put_str("kind", entry.kind);
             dict.put_str("content", entry.content);
             dict.put_str("source", entry.source);
             dict.insert("ts_ms".to_string(), VmValue::Int(entry.ts_ms));
-            VmValue::Dict(std::sync::Arc::new(dict))
+            VmValue::dict(dict)
         })
         .collect::<Vec<_>>();
     Ok(VmValue::List(std::sync::Arc::new(entries)))
@@ -1294,7 +1290,7 @@ async fn agent_session_reanchor_builtin(
     )
     .map_err(|message| err(format!("agent_session_reanchor: {message}")))?;
     let opts = match args.get(2) {
-        None | Some(VmValue::Nil) => BTreeMap::new(),
+        None | Some(VmValue::Nil) => crate::value::DictMap::new(),
         Some(VmValue::Dict(d)) => d.as_ref().clone(),
         _ => return Err(err("agent_session_reanchor: `opts` must be a dict or nil")),
     };
@@ -1378,7 +1374,7 @@ async fn agent_session_compact_builtin(
     }
     let opts_dict = match args.get(1) {
         Some(VmValue::Dict(d)) => (**d).clone(),
-        None | Some(VmValue::Nil) => BTreeMap::new(),
+        None | Some(VmValue::Nil) => crate::value::DictMap::new(),
         _ => return Err(err("agent_session_compact: `opts` must be a dict or nil")),
     };
     let mut config = build_compact_config(&opts_dict)?;
@@ -1458,7 +1454,7 @@ const COMPACT_OPT_KEYS: &[&str] = &[
 ];
 
 fn build_compact_config(
-    opts: &BTreeMap<String, VmValue>,
+    opts: &crate::value::DictMap,
 ) -> Result<crate::orchestration::AutoCompactConfig, VmError> {
     for key in opts.keys() {
         if !COMPACT_OPT_KEYS.contains(&key.as_str()) {
@@ -1601,7 +1597,7 @@ async fn cancel_in_flight_tool_call_builtin(
         }
     }
 
-    let mut result = BTreeMap::new();
+    let mut result = crate::value::DictMap::new();
     result.put_str("status", final_status);
     result.put_str("call_id", call_id);
     result.insert(
@@ -1612,7 +1608,7 @@ async fn cancel_in_flight_tool_call_builtin(
             .unwrap_or(VmValue::Nil),
     );
     result.put_str("reason", reason);
-    Ok(VmValue::Dict(std::sync::Arc::new(result)))
+    Ok(VmValue::dict(result))
 }
 
 async fn push_cancellation_reminder(
@@ -1649,7 +1645,7 @@ async fn push_cancellation_reminder(
 }
 
 fn compact_usize_opt(
-    opts: &BTreeMap<String, VmValue>,
+    opts: &crate::value::DictMap,
     key: &'static str,
 ) -> Result<Option<usize>, VmError> {
     let Some(value) = opts.get(key) else {
@@ -1668,7 +1664,6 @@ fn compact_usize_opt(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
 
     use super::build_compact_config;
     use crate::value::VmValue;
@@ -1715,7 +1710,7 @@ mod tests {
             "tool_output_max_chars",
             "hard_limit_tokens",
         ] {
-            let mut opts = BTreeMap::new();
+            let mut opts = crate::value::DictMap::new();
             opts.insert(key.to_string(), VmValue::Int(-1));
             let err = build_compact_config(&opts).expect_err("negative option must fail");
             assert!(err.to_string().contains(key), "{err}");

--- a/crates/harn-vm/src/stdlib/agent_state.rs
+++ b/crates/harn-vm/src/stdlib/agent_state.rs
@@ -168,7 +168,7 @@ fn agent_state_handoff_impl(args: &[VmValue], _out: &mut String) -> Result<VmVal
 fn handle_from_args<'a>(
     args: &'a [VmValue],
     fn_name: &str,
-) -> Result<&'a BTreeMap<String, VmValue>, VmError> {
+) -> Result<&'a crate::value::DictMap, VmError> {
     let handle = args
         .first()
         .ok_or_else(|| VmError::Runtime(format!("{fn_name}: `handle` is required")))?;
@@ -256,7 +256,7 @@ fn resolve_root(root: &str) -> PathBuf {
     crate::stdlib::process::resolve_source_relative_path(root)
 }
 
-fn conflict_policy(options: Option<&BTreeMap<String, VmValue>>) -> Result<ConflictPolicy, VmError> {
+fn conflict_policy(options: Option<&crate::value::DictMap>) -> Result<ConflictPolicy, VmError> {
     let Some(options) = options else {
         return Ok(ConflictPolicy::Ignore);
     };
@@ -268,7 +268,7 @@ fn conflict_policy(options: Option<&BTreeMap<String, VmValue>>) -> Result<Confli
     ConflictPolicy::parse(&raw)
 }
 
-fn option_string(options: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<String> {
+fn option_string(options: Option<&crate::value::DictMap>, key: &str) -> Option<String> {
     options
         .and_then(|options| options.get(key))
         .map(VmValue::display)
@@ -276,7 +276,7 @@ fn option_string(options: Option<&BTreeMap<String, VmValue>>, key: &str) -> Opti
 }
 
 fn writer_identity(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     session_id: Option<&str>,
 ) -> WriterIdentity {
     let mutation = crate::orchestration::current_mutation_session();
@@ -337,7 +337,7 @@ fn handle_value(
     handle.put_str("handoff_key", HANDOFF_KEY);
     handle.put_str("conflict_policy", conflict_policy.as_str());
     handle.insert("writer".to_string(), writer_vm_value(writer));
-    VmValue::Dict(std::sync::Arc::new(handle))
+    VmValue::dict(handle)
 }
 
 fn writer_vm_value(writer: &WriterIdentity) -> VmValue {
@@ -374,10 +374,10 @@ fn writer_vm_value(writer: &WriterIdentity) -> VmValue {
             .map(|item| VmValue::String(std::sync::Arc::from(item.clone())))
             .unwrap_or(VmValue::Nil),
     );
-    VmValue::Dict(std::sync::Arc::new(value))
+    VmValue::dict(value)
 }
 
-fn scope_from_handle(handle: &BTreeMap<String, VmValue>) -> Result<BackendScope, VmError> {
+fn scope_from_handle(handle: &crate::value::DictMap) -> Result<BackendScope, VmError> {
     let root = handle
         .get("root")
         .map(VmValue::display)
@@ -394,7 +394,7 @@ fn scope_from_handle(handle: &BTreeMap<String, VmValue>) -> Result<BackendScope,
     })
 }
 
-fn writer_from_handle(handle: &BTreeMap<String, VmValue>) -> WriterIdentity {
+fn writer_from_handle(handle: &crate::value::DictMap) -> WriterIdentity {
     let writer = handle.get("writer").and_then(VmValue::as_dict);
     WriterIdentity {
         writer_id: option_string(writer, "writer_id"),
@@ -405,7 +405,7 @@ fn writer_from_handle(handle: &BTreeMap<String, VmValue>) -> WriterIdentity {
 }
 
 fn write_options_from_handle(
-    handle: &BTreeMap<String, VmValue>,
+    handle: &crate::value::DictMap,
 ) -> Result<BackendWriteOptions, VmError> {
     let policy = handle
         .get("conflict_policy")
@@ -418,7 +418,7 @@ fn write_options_from_handle(
 }
 
 fn enforce_conflict_policy(
-    handle: &BTreeMap<String, VmValue>,
+    handle: &crate::value::DictMap,
     outcome: &backend::BackendWriteOutcome,
 ) -> Result<(), VmError> {
     let Some(conflict) = &outcome.conflict else {

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -13,7 +13,7 @@ mod sub_agent;
 pub(super) mod workflow;
 
 use crate::value::VmDictExt;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -77,7 +77,7 @@ pub(super) struct SubAgentRunSpec {
     pub(super) name: String,
     pub(super) task: String,
     pub(super) system: Option<String>,
-    pub(super) options: BTreeMap<String, VmValue>,
+    pub(super) options: crate::value::DictMap,
     pub(super) returns_schema: Option<VmValue>,
     pub(super) session_id: String,
     pub(super) parent_session_id: Option<String>,

--- a/crates/harn-vm/src/stdlib/agents/replay.rs
+++ b/crates/harn-vm/src/stdlib/agents/replay.rs
@@ -1,5 +1,5 @@
 use crate::value::VmDictExt;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -251,7 +251,7 @@ pub(super) fn apply_worker_replay_config(
 
 pub(super) fn apply_workflow_replay_config(
     artifacts: &mut Vec<ArtifactRecord>,
-    options: &mut BTreeMap<String, VmValue>,
+    options: &mut crate::value::DictMap,
     carry: WorkerReplayCarry,
 ) {
     if !carry.artifacts.is_empty() {

--- a/crates/harn-vm/src/stdlib/agents/resume.rs
+++ b/crates/harn-vm/src/stdlib/agents/resume.rs
@@ -111,7 +111,7 @@ pub(super) fn parse_resume_options(args: &[VmValue]) -> WorkerResumeOptions {
 }
 
 pub(super) fn summary_message(summary: &str) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    VmValue::dict(BTreeMap::from([
         (
             "role".to_string(),
             VmValue::String(std::sync::Arc::from("user".to_string())),
@@ -120,7 +120,7 @@ pub(super) fn summary_message(summary: &str) -> VmValue {
             "content".to_string(),
             VmValue::String(std::sync::Arc::from(summary.to_string())),
         ),
-    ])))
+    ]))
 }
 
 pub(super) fn summary_only_resume_transcript(

--- a/crates/harn-vm/src/stdlib/agents/stop_handoff.rs
+++ b/crates/harn-vm/src/stdlib/agents/stop_handoff.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -136,7 +136,7 @@ pub(super) fn vm_value_i64(value: &VmValue) -> Option<i64> {
     }
 }
 
-pub(super) fn vm_options_token_budget(options: &BTreeMap<String, VmValue>) -> Option<i64> {
+pub(super) fn vm_options_token_budget(options: &crate::value::DictMap) -> Option<i64> {
     options
         .get("token_budget")
         .and_then(vm_value_i64)

--- a/crates/harn-vm/src/stdlib/agents/suspend_tests.rs
+++ b/crates/harn-vm/src/stdlib/agents/suspend_tests.rs
@@ -88,7 +88,7 @@ fn handle_value(worker_id: &str) -> VmValue {
 }
 
 fn message_value(role: &str, content: &str) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    VmValue::dict(crate::value::DictMap::from_iter([
         (
             "role".to_string(),
             VmValue::String(std::sync::Arc::from(role.to_string())),
@@ -97,7 +97,7 @@ fn message_value(role: &str, content: &str) -> VmValue {
             "content".to_string(),
             VmValue::String(std::sync::Arc::from(content.to_string())),
         ),
-    ])))
+    ]))
 }
 
 fn summary_status(summary: &VmValue) -> String {
@@ -119,9 +119,9 @@ async fn resume_agent_for_test(args: Vec<VmValue>) -> Result<VmValue, VmError> {
 }
 
 fn auto_resume_conditions(kind: &str) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+    VmValue::dict(crate::value::DictMap::from_iter([(
         "trigger".to_string(),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "kind".to_string(),
                 VmValue::String(std::sync::Arc::from(kind.to_string())),
@@ -130,15 +130,15 @@ fn auto_resume_conditions(kind: &str) -> VmValue {
                 "provider".to_string(),
                 VmValue::String(std::sync::Arc::from("github")),
             ),
-        ]))),
-    )])))
+        ])),
+    )]))
 }
 
 fn auto_resume_conditions_with_timeout(kind: &str, on_timeout: &str) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    VmValue::dict(crate::value::DictMap::from_iter([
         (
             "trigger".to_string(),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            VmValue::dict(crate::value::DictMap::from_iter([
                 (
                     "kind".to_string(),
                     VmValue::String(std::sync::Arc::from(kind.to_string())),
@@ -147,29 +147,29 @@ fn auto_resume_conditions_with_timeout(kind: &str, on_timeout: &str) -> VmValue 
                     "provider".to_string(),
                     VmValue::String(std::sync::Arc::from("github")),
                 ),
-            ]))),
+            ])),
         ),
         (
             "timeout".to_string(),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            VmValue::dict(crate::value::DictMap::from_iter([
                 ("duration_minutes".to_string(), VmValue::Int(1)),
                 (
                     "on_timeout".to_string(),
                     VmValue::String(std::sync::Arc::from(on_timeout.to_string())),
                 ),
-            ]))),
+            ])),
         ),
-    ])))
+    ]))
 }
 
 fn suspend_options(conditions: VmValue) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    VmValue::dict(crate::value::DictMap::from_iter([
         (
             "initiator".to_string(),
             VmValue::String(std::sync::Arc::from("self")),
         ),
         ("conditions".to_string(), conditions),
-    ])))
+    ]))
 }
 
 fn auto_resume_trigger_id(summary: &VmValue) -> String {
@@ -199,9 +199,9 @@ fn assert_error_code(error: VmError, code: Code) {
 
 #[test]
 fn resume_conditions_parse_round_trips_each_shape() {
-    let trigger = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+    let trigger = VmValue::dict(crate::value::DictMap::from_iter([(
         "trigger".to_string(),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "id".to_string(),
                 VmValue::String(std::sync::Arc::from("resume-review")),
@@ -220,40 +220,40 @@ fn resume_conditions_parse_round_trips_each_shape() {
             ),
             (
                 "match".to_string(),
-                VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+                VmValue::dict(crate::value::DictMap::from_iter([(
                     "events".to_string(),
                     VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                         std::sync::Arc::from("review.approved"),
                     )])),
-                )]))),
+                )])),
             ),
-        ]))),
-    )])));
+        ])),
+    )]));
     let trigger_json = crate::llm::vm_value_to_json(
         &parse_resume_conditions_value(Some(&trigger)).expect("parse trigger"),
     );
     assert_eq!(trigger_json["trigger"]["kind"], "review.approved");
 
-    let timeout = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+    let timeout = VmValue::dict(crate::value::DictMap::from_iter([(
         "timeout".to_string(),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        VmValue::dict(crate::value::DictMap::from_iter([
             ("duration_minutes".to_string(), VmValue::Int(15)),
             (
                 "on_timeout".to_string(),
                 VmValue::String(std::sync::Arc::from("resume_with_input")),
             ),
-        ]))),
-    )])));
+        ])),
+    )]));
     let timeout_json = crate::llm::vm_value_to_json(
         &parse_resume_conditions_value(Some(&timeout)).expect("parse timeout"),
     );
     assert_eq!(timeout_json["timeout"]["duration_minutes"], 15);
     assert_eq!(timeout_json["timeout"]["on_timeout"], "resume_with_input");
 
-    let event = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+    let event = VmValue::dict(crate::value::DictMap::from_iter([(
         "on_event".to_string(),
         VmValue::String(std::sync::Arc::from("operator.resume")),
-    )])));
+    )]));
     let event_json = crate::llm::vm_value_to_json(
         &parse_resume_conditions_value(Some(&event)).expect("parse event"),
     );
@@ -262,13 +262,13 @@ fn resume_conditions_parse_round_trips_each_shape() {
 
 #[test]
 fn resume_conditions_parse_reports_harn_sus_002_field() {
-    let invalid = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+    let invalid = VmValue::dict(crate::value::DictMap::from_iter([(
         "timeout".to_string(),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        VmValue::dict(crate::value::DictMap::from_iter([(
             "duration_minutes".to_string(),
             VmValue::Int(0),
-        )]))),
-    )])));
+        )])),
+    )]));
     let error = parse_resume_conditions_value(Some(&invalid)).expect_err("invalid timeout");
     assert!(
         error.to_string().contains("HARN-SUS-002")
@@ -276,13 +276,13 @@ fn resume_conditions_parse_reports_harn_sus_002_field() {
         "expected HARN-SUS-002 timeout field error, got: {error}"
     );
 
-    let unknown_timeout = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+    let unknown_timeout = VmValue::dict(crate::value::DictMap::from_iter([(
         "timeout".to_string(),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        VmValue::dict(crate::value::DictMap::from_iter([
             ("duration_minutes".to_string(), VmValue::Int(1)),
             ("extra".to_string(), VmValue::Bool(true)),
-        ]))),
-    )])));
+        ])),
+    )]));
     let unknown_timeout_error =
         parse_resume_conditions_value(Some(&unknown_timeout)).expect_err("unknown timeout key");
     assert!(
@@ -290,10 +290,10 @@ fn resume_conditions_parse_reports_harn_sus_002_field() {
         "expected HARN-SUS-002 timeout.extra field error, got: {unknown_timeout_error}"
     );
 
-    let invalid_event = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+    let invalid_event = VmValue::dict(crate::value::DictMap::from_iter([(
         "on_event".to_string(),
         VmValue::String(std::sync::Arc::from("bad channel")),
-    )])));
+    )]));
     let event_error =
         parse_resume_conditions_value(Some(&invalid_event)).expect_err("invalid event topic");
     assert!(
@@ -313,10 +313,10 @@ async fn suspended_subagent_snapshot_includes_active_suspension_metadata() {
         vec![
             handle_value(&worker_id),
             VmValue::String(std::sync::Arc::from("waiting on external review")),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            VmValue::dict(crate::value::DictMap::from_iter([(
                 "initiator".to_string(),
                 VmValue::String(std::sync::Arc::from("parent")),
-            )]))),
+            )])),
         ],
     )
     .await
@@ -634,7 +634,7 @@ async fn top_level_suspend_registers_auto_resume_trigger() {
             VmValue::String(std::sync::Arc::from("session-top-level-auto-resume")),
             VmValue::String(std::sync::Arc::from("continue the top-level task")),
             VmValue::Nil,
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::new())),
+            VmValue::dict(crate::value::DictMap::new()),
             VmValue::String(std::sync::Arc::from("waiting for review")),
             auto_resume_conditions("review.approved"),
         ],
@@ -689,7 +689,7 @@ async fn matching_trigger_event_auto_resumes_worker_and_unregisters() {
                 None,
                 "delivery-auto-resume",
                 None,
-                BTreeMap::new(),
+                std::collections::BTreeMap::new(),
                 crate::triggers::ProviderPayload::Extension(
                     crate::triggers::ExtensionProviderPayload {
                         provider: "github".to_string(),
@@ -828,13 +828,13 @@ async fn resume_can_drop_transcript_history_to_summary() {
 
     let resumed = resume_agent_for_test(vec![
         handle_value(&worker_id),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "input".to_string(),
                 VmValue::String(std::sync::Arc::from("fresh prompt")),
             ),
             ("continue_transcript".to_string(), VmValue::Bool(false)),
-        ]))),
+        ])),
     ])
     .await
     .expect("resume with transcript reset");
@@ -1096,10 +1096,10 @@ async fn suspend_resume_spans_carry_canonical_attribute_bag() {
         vec![
             handle_value(&worker_id),
             VmValue::String(std::sync::Arc::from("waiting on review")),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            VmValue::dict(crate::value::DictMap::from_iter([(
                 "initiator".to_string(),
                 VmValue::String(std::sync::Arc::from("triggered")),
-            )]))),
+            )])),
         ],
     )
     .await
@@ -1108,7 +1108,7 @@ async fn suspend_resume_spans_carry_canonical_attribute_bag() {
 
     resume_agent_for_test(vec![
         handle_value(&worker_id),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "input".to_string(),
                 VmValue::String(std::sync::Arc::from(
@@ -1116,7 +1116,7 @@ async fn suspend_resume_spans_carry_canonical_attribute_bag() {
                 )),
             ),
             ("continue_transcript".to_string(), VmValue::Bool(false)),
-        ]))),
+        ])),
     ])
     .await
     .expect("resume");
@@ -1256,10 +1256,10 @@ async fn agent_loop_returns_suspended_checkpoint_for_current_worker() {
         &[
             VmValue::String(std::sync::Arc::from("continue the task")),
             VmValue::Nil,
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            VmValue::dict(crate::value::DictMap::from_iter([(
                 "max_iterations".to_string(),
                 VmValue::Int(3),
-            )]))),
+            )])),
         ],
     )
     .await
@@ -1313,7 +1313,10 @@ async fn sub_agent_execution_preserves_suspended_loop_payload() {
             name: "worker-sub-agent-suspend".to_string(),
             task: "continue the task".to_string(),
             session_id: format!("session_{worker_id}"),
-            options: BTreeMap::from([("max_iterations".to_string(), VmValue::Int(3))]),
+            options: crate::value::DictMap::from_iter([(
+                "max_iterations".to_string(),
+                VmValue::Int(3),
+            )]),
             ..Default::default()
         },
     )
@@ -1447,10 +1450,10 @@ async fn raw_suspend_trigger_registration_reports_sus_007() {
     crate::triggers::clear_trigger_registry();
     crate::stdlib::triggers_stdlib::reset_auto_resume_timeouts();
     let (worker_id, dir) = seed_test_worker("worker-trigger-registration-error");
-    let invalid_trigger = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+    let invalid_trigger = VmValue::dict(crate::value::DictMap::from_iter([(
         "trigger".to_string(),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::new())),
-    )])));
+        VmValue::dict(crate::value::DictMap::new()),
+    )]));
 
     let err = suspend_agent_builtin(
         crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),

--- a/crates/harn-vm/src/stdlib/agents_daemon.rs
+++ b/crates/harn-vm/src/stdlib/agents_daemon.rs
@@ -69,7 +69,7 @@ struct DaemonSpawnSpec {
     persist_root: String,
     snapshot_path: String,
     event_queue_capacity: usize,
-    options: BTreeMap<String, VmValue>,
+    options: crate::value::DictMap,
 }
 
 struct DaemonState {
@@ -80,7 +80,7 @@ struct DaemonState {
     session_id: String,
     persist_root: String,
     snapshot_path: String,
-    options: BTreeMap<String, VmValue>,
+    options: crate::value::DictMap,
     bridge: Arc<HostBridge>,
     handle: Option<tokio::task::JoinHandle<Result<VmValue, VmError>>>,
     monitor_handle: Option<tokio::task::JoinHandle<()>>,
@@ -357,7 +357,7 @@ async fn daemon_resume_builtin(
         }
     };
     let spec = parse_spawn_spec(
-        &BTreeMap::from([
+        &crate::value::DictMap::from_iter([
             (
                 "name".to_string(),
                 VmValue::String(std::sync::Arc::from(meta.name.clone())),
@@ -374,10 +374,7 @@ async fn daemon_resume_builtin(
                 "session_id".to_string(),
                 VmValue::String(std::sync::Arc::from(meta.session_id.clone())),
             ),
-            (
-                "options".to_string(),
-                VmValue::Dict(std::sync::Arc::new(options.clone())),
-            ),
+            ("options".to_string(), VmValue::dict(options.clone())),
         ]),
         Some(meta.id.clone()),
         meta.system.clone(),
@@ -503,7 +500,7 @@ async fn daemon_resume_builtin(
     Ok(summary)
 }
 
-fn optional_string(dict: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn optional_string(dict: &crate::value::DictMap, key: &str) -> Option<String> {
     dict.get(key)
         .map(VmValue::display)
         .map(|value| value.trim().to_string())
@@ -526,7 +523,7 @@ struct DaemonPaths {
 }
 
 fn parse_spawn_spec(
-    config: &BTreeMap<String, VmValue>,
+    config: &crate::value::DictMap,
     explicit_id: Option<String>,
     explicit_system: Option<String>,
 ) -> Result<DaemonSpawnSpec, VmError> {
@@ -781,9 +778,7 @@ fn persist_daemon_meta(daemon: &DaemonState) -> Result<(), VmError> {
         prompt: daemon.prompt.clone(),
         system: daemon.system.clone(),
         session_id: daemon.session_id.clone(),
-        options: crate::llm::vm_value_to_json(&VmValue::Dict(std::sync::Arc::new(
-            daemon.options.clone(),
-        ))),
+        options: crate::llm::vm_value_to_json(&VmValue::dict(daemon.options.clone())),
         event_queue_capacity: daemon.event_queue_capacity.max(1),
         next_event_seq: daemon.next_event_seq,
         pending_events: daemon.pending_events.iter().cloned().collect(),
@@ -818,7 +813,7 @@ fn spawn_daemon_task(state: Arc<parking_lot::Mutex<DaemonState>>, mut vm: crate:
                 Some(text) => VmValue::String(std::sync::Arc::from(text)),
                 None => VmValue::Nil,
             },
-            VmValue::Dict(std::sync::Arc::new(options)),
+            VmValue::dict(options),
         ];
 
         crate::llm::install_current_host_bridge(bridge);

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -1,5 +1,4 @@
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 
 use super::agents_workers;
 use super::{SubAgentExecutionResult, SubAgentRunSpec};
@@ -213,7 +212,7 @@ fn validate_child_anchor_against_parent(
 
 fn validate_sub_agent_request_envelope(
     args: &[VmValue],
-) -> Result<&BTreeMap<String, VmValue>, VmError> {
+) -> Result<&crate::value::DictMap, VmError> {
     match args.first() {
         Some(VmValue::Dict(map)) => Ok(map.as_ref()),
         _ => Err(invalid_sub_agent_request()),
@@ -227,7 +226,7 @@ fn invalid_sub_agent_request() -> VmError {
 }
 
 fn resolve_sub_agent_policies(
-    request: &BTreeMap<String, VmValue>,
+    request: &crate::value::DictMap,
     parser: &mut OptionsParser<'_>,
 ) -> Result<SubAgentPolicyResolution, VmError> {
     let allowed_tools =
@@ -258,7 +257,7 @@ fn prepare_sub_agent_options(
     parser: &mut OptionsParser<'_>,
     session_id: &str,
     requested_policy: Option<&CapabilityPolicy>,
-) -> Result<BTreeMap<String, VmValue>, VmError> {
+) -> Result<crate::value::DictMap, VmError> {
     let mut options = parser
         .optional_dict("options")?
         .cloned()
@@ -276,7 +275,7 @@ fn prepare_sub_agent_options(
     Ok(options)
 }
 
-fn inject_sub_agent_skill_context(options: &mut BTreeMap<String, VmValue>) {
+fn inject_sub_agent_skill_context(options: &mut crate::value::DictMap) {
     let Some(context) = crate::orchestration::current_workflow_skill_context() else {
         return;
     };
@@ -297,13 +296,13 @@ fn sub_agent_error_dict(
     message: impl Into<String>,
     tool: Option<String>,
 ) -> VmValue {
-    let mut error = BTreeMap::new();
+    let mut error = crate::value::DictMap::new();
     error.put_str("category", category);
     error.put_str("message", message.into());
     if let Some(tool) = tool {
         error.put_str("tool", tool);
     }
-    VmValue::Dict(std::sync::Arc::new(error))
+    VmValue::dict(error)
 }
 
 fn sub_agent_base_envelope(
@@ -313,8 +312,8 @@ fn sub_agent_base_envelope(
     tokens_used: i64,
     budget_exceeded: bool,
     session_id: &str,
-) -> BTreeMap<String, VmValue> {
-    let mut envelope = BTreeMap::new();
+) -> crate::value::DictMap {
+    let mut envelope = crate::value::DictMap::new();
     envelope.insert("ok".to_string(), VmValue::Bool(true));
     envelope.put_str("summary", summary);
     envelope.insert("artifacts".to_string(), artifacts);
@@ -353,7 +352,7 @@ fn wrap_sub_agent_error(
     if let Some(transcript) = transcript {
         envelope.insert("transcript".to_string(), transcript);
     }
-    VmValue::Dict(std::sync::Arc::new(envelope))
+    VmValue::dict(envelope)
 }
 
 fn append_parent_sub_agent_event(parent_session_id: Option<&str>, event: VmValue) {
@@ -632,7 +631,7 @@ fn collect_transcript_fallbacks(transcript: &VmValue) -> TranscriptFallbacks {
     fallbacks
 }
 
-fn option_requests_structured_output(options: &BTreeMap<String, VmValue>) -> bool {
+fn option_requests_structured_output(options: &crate::value::DictMap) -> bool {
     matches!(
         options.get("response_format"),
         Some(VmValue::String(value)) if value.as_ref() == "json"
@@ -742,7 +741,7 @@ pub(super) async fn execute_sub_agent(
             .as_ref()
             .map(|system| VmValue::String(std::sync::Arc::from(system.clone())))
             .unwrap_or(VmValue::Nil),
-        VmValue::Dict(std::sync::Arc::new(loop_options)),
+        VmValue::dict(loop_options),
     ];
     let result = crate::stdlib::harn_entry::call_harn_export_by_name(
         ctx,
@@ -967,7 +966,7 @@ pub(super) async fn execute_sub_agent(
     );
 
     Ok(SubAgentExecutionResult {
-        payload: crate::llm::vm_value_to_json(&VmValue::Dict(std::sync::Arc::new(envelope))),
+        payload: crate::llm::vm_value_to_json(&VmValue::dict(envelope)),
         transcript,
     })
 }
@@ -995,7 +994,7 @@ mod tests {
     }
 
     fn assistant_message(text: &str) -> VmValue {
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "role".to_string(),
                 VmValue::String(std::sync::Arc::from("assistant")),
@@ -1004,11 +1003,11 @@ mod tests {
                 "content".to_string(),
                 VmValue::String(std::sync::Arc::from(text)),
             ),
-        ])))
+        ]))
     }
 
     fn normalized_request(extra: Vec<(&str, VmValue)>) -> VmValue {
-        let mut request = BTreeMap::from([
+        let mut request = crate::value::DictMap::from_iter([
             (
                 "_type".to_string(),
                 VmValue::String(std::sync::Arc::from("sub_agent_request")),
@@ -1021,7 +1020,7 @@ mod tests {
         for (key, value) in extra {
             request.insert(key.to_string(), value);
         }
-        VmValue::Dict(std::sync::Arc::new(request))
+        VmValue::dict(request)
     }
 
     #[test]
@@ -1054,7 +1053,7 @@ mod tests {
     fn anchor_dict(primary: &str, additional: Vec<(&str, &str)>) -> VmValue {
         let mut roots = Vec::new();
         for (path, mount_mode) in additional {
-            roots.push(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            roots.push(VmValue::dict(crate::value::DictMap::from_iter([
                 (
                     "path".to_string(),
                     VmValue::String(std::sync::Arc::from(path)),
@@ -1067,9 +1066,9 @@ mod tests {
                     "mounted_at".to_string(),
                     VmValue::String(std::sync::Arc::from("2026-05-24T00:00:00Z")),
                 ),
-            ]))));
+            ])));
         }
-        let mut anchor = BTreeMap::from([
+        let mut anchor = crate::value::DictMap::from_iter([
             (
                 "primary".to_string(),
                 VmValue::String(std::sync::Arc::from(primary)),
@@ -1085,7 +1084,7 @@ mod tests {
                 VmValue::List(std::sync::Arc::new(roots)),
             );
         }
-        VmValue::Dict(std::sync::Arc::new(anchor))
+        VmValue::dict(anchor)
     }
 
     fn path_string(path: &std::path::Path) -> String {
@@ -1273,7 +1272,7 @@ mod tests {
             name: "research-worker".to_string(),
             task: "inspect the repo".to_string(),
             system: None,
-            options: BTreeMap::from([
+            options: crate::value::DictMap::from_iter([
                 (
                     "provider".to_string(),
                     VmValue::String(std::sync::Arc::from("mock")),
@@ -1337,7 +1336,7 @@ mod tests {
         reset_llm_mock_state();
         let _policy = push_recursion_policy(0);
         let parent = crate::agent_sessions::open_or_create(Some("parent-budget".into()));
-        let mut options = BTreeMap::from([
+        let mut options = crate::value::DictMap::from_iter([
             (
                 "provider".to_string(),
                 VmValue::String(std::sync::Arc::from("mock")),

--- a/crates/harn-vm/src/stdlib/agents_workers/audit.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/audit.rs
@@ -4,12 +4,12 @@ use crate::orchestration::MutationSessionRecord;
 use crate::value::{VmError, VmValue};
 
 pub(super) fn parse_worker_audit(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
 ) -> Result<MutationSessionRecord, VmError> {
     let audit_value = dict
         .get("audit")
         .cloned()
-        .unwrap_or_else(|| VmValue::Dict(std::sync::Arc::new(BTreeMap::new())));
+        .unwrap_or_else(|| VmValue::dict(BTreeMap::new()));
     let parent_session = crate::orchestration::current_mutation_session();
     let mut audit: MutationSessionRecord =
         serde_json::from_value(crate::llm::vm_value_to_json(&audit_value))

--- a/crates/harn-vm/src/stdlib/agents_workers/config.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/config.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -31,7 +30,7 @@ fn worker_config_to_json(config: &WorkerConfig) -> serde_json::Value {
             "mode": "workflow",
             "graph": graph,
             "artifacts": artifacts,
-            "options": options.iter().map(|(key, value)| (key.clone(), crate::llm::vm_value_to_json(value))).collect::<BTreeMap<_, _>>(),
+            "options": options.iter().map(|(key, value)| (key.clone(), crate::llm::vm_value_to_json(value))).collect::<std::collections::BTreeMap<_, _>>(),
         }),
         WorkerConfig::Stage {
             node,
@@ -59,7 +58,7 @@ fn sub_agent_spec_to_json(spec: &SubAgentRunSpec) -> serde_json::Value {
             .options
             .iter()
             .map(|(key, value)| (key.clone(), crate::llm::vm_value_to_json(value)))
-            .collect::<BTreeMap<_, _>>(),
+            .collect::<std::collections::BTreeMap<_, _>>(),
         "returns_schema": spec
             .returns_schema
             .as_ref()
@@ -81,7 +80,7 @@ fn sub_agent_spec_from_json(value: &serde_json::Value) -> Result<SubAgentRunSpec
             options
                 .iter()
                 .map(|(key, value)| (key.clone(), crate::stdlib::json_to_vm_value(value)))
-                .collect::<BTreeMap<_, _>>()
+                .collect::<crate::value::DictMap>()
         })
         .unwrap_or_default();
     Ok(SubAgentRunSpec {
@@ -150,7 +149,7 @@ fn worker_config_from_json(value: &serde_json::Value) -> Result<WorkerConfig, Vm
             object
                 .iter()
                 .map(|(key, value)| (key.clone(), crate::stdlib::json_to_vm_value(value)))
-                .collect::<BTreeMap<_, _>>()
+                .collect::<crate::value::DictMap>()
         })
         .unwrap_or_default();
     let mut parser = OptionsParser::new(WORKER_SNAPSHOT_CONFIG, &parser_dict, ErrorKind::Runtime);
@@ -502,7 +501,7 @@ pub(in super::super) fn parse_worker_config(value: &VmValue) -> Result<WorkerIni
                 .cloned()
                 .unwrap_or_default();
             raw_model_policy.insert("permissions".to_string(), permissions);
-            node.raw_model_policy = Some(VmValue::Dict(std::sync::Arc::new(raw_model_policy)));
+            node.raw_model_policy = Some(VmValue::dict(raw_model_policy));
         }
         let artifacts = parse_artifact_list(artifacts_value)?;
         WorkerConfig::Stage {

--- a/crates/harn-vm/src/stdlib/agents_workers/execution.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/execution.rs
@@ -82,7 +82,7 @@ fn ensure_worker_stage_session_id(
         .cloned()
         .unwrap_or_default();
     raw_model_policy.put_str("session_id", session_id.clone());
-    node.raw_model_policy = Some(VmValue::Dict(std::sync::Arc::new(raw_model_policy)));
+    node.raw_model_policy = Some(VmValue::dict(raw_model_policy));
     session_id
 }
 
@@ -211,7 +211,7 @@ async fn execute_worker_config(
                     crate::stdlib::json_to_vm_value(
                         &serde_json::to_value(&artifacts).unwrap_or_default(),
                     ),
-                    VmValue::Dict(std::sync::Arc::new(options)),
+                    VmValue::dict(options),
                 ],
             )
             .await;
@@ -224,9 +224,7 @@ async fn execute_worker_config(
             let transcript = dict.get("transcript").cloned();
             let artifacts = super::super::parse_artifact_list(dict.get("artifacts"))?;
             Ok(WorkerExecutionResult {
-                payload: crate::llm::vm_value_to_json(&VmValue::Dict(std::sync::Arc::new(
-                    dict.clone(),
-                ))),
+                payload: crate::llm::vm_value_to_json(&VmValue::dict(dict.clone())),
                 transcript,
                 artifacts,
                 execution,

--- a/crates/harn-vm/src/stdlib/agents_workers/mod.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/mod.rs
@@ -35,7 +35,7 @@ pub(super) enum WorkerConfig {
     Workflow {
         graph: Box<WorkflowGraph>,
         artifacts: Vec<ArtifactRecord>,
-        options: BTreeMap<String, VmValue>,
+        options: crate::value::DictMap,
     },
     Stage {
         node: Box<crate::orchestration::WorkflowNode>,
@@ -284,7 +284,7 @@ fn request_items_from_vm_value(value: Option<&VmValue>) -> Vec<serde_json::Value
 }
 
 fn request_items_from_vm_dict(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
     keys: &[&str],
 ) -> Vec<serde_json::Value> {
     keys.iter()
@@ -344,7 +344,7 @@ fn canonical_request_payload(
 fn worker_request_from_vm_dict(
     task: &str,
     system: Option<String>,
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
 ) -> WorkerRequestRecord {
     let research_questions = request_items_from_vm_dict(dict, &["research_questions", "questions"]);
     let action_items = request_items_from_vm_dict(dict, &["action_items", "actions"]);

--- a/crates/harn-vm/src/stdlib/agents_workers/policy.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/policy.rs
@@ -36,7 +36,7 @@ fn display_non_empty(value: Option<&VmValue>) -> Option<String> {
 }
 
 pub(in crate::stdlib::agents) fn parse_worker_carry_policy(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
 ) -> Result<WorkerCarryPolicy, VmError> {
     let mut parent = OptionsParser::new(SPAWN_AGENT_FN, dict, ErrorKind::Runtime);
     let Some(carry) = parent.optional_dict("carry")? else {
@@ -141,7 +141,7 @@ fn parse_worker_tools_policy(value: Option<&VmValue>) -> Result<Option<Capabilit
 }
 
 pub(super) fn resolve_worker_policy(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
 ) -> Result<Option<CapabilityPolicy>, VmError> {
     let carry = dict
         .get("carry")
@@ -224,16 +224,16 @@ fn fork_worker_transcript(transcript: VmValue) -> VmValue {
             Some(VmValue::Dict(metadata)) => {
                 let mut metadata = metadata.as_ref().clone();
                 metadata.put_str("parent_transcript_id", parent_id);
-                VmValue::Dict(std::sync::Arc::new(metadata))
+                VmValue::dict(metadata)
             }
-            _ => VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            _ => VmValue::dict(BTreeMap::from([(
                 "parent_transcript_id".to_string(),
                 VmValue::String(std::sync::Arc::from(parent_id)),
-            )]))),
+            )])),
         };
         next.insert("metadata".to_string(), metadata);
     }
-    VmValue::Dict(std::sync::Arc::new(next))
+    VmValue::dict(next)
 }
 
 pub(in super::super) async fn compact_worker_transcript(
@@ -294,5 +294,5 @@ pub(in super::super) async fn compact_worker_transcript(
         VmValue::List(std::sync::Arc::new(events)),
     );
     next.put_str("summary", outcome.summary);
-    Ok(VmValue::Dict(std::sync::Arc::new(next)))
+    Ok(VmValue::dict(next))
 }

--- a/crates/harn-vm/src/stdlib/agents_workers/tests.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/tests.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -13,12 +12,12 @@ fn vm_string(value: &str) -> VmValue {
 }
 
 fn vm_dict(pairs: Vec<(&str, VmValue)>) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(
+    VmValue::dict(
         pairs
             .into_iter()
             .map(|(key, value)| (key.to_string(), value))
-            .collect(),
-    ))
+            .collect::<crate::value::DictMap>(),
+    )
 }
 
 #[test]
@@ -50,10 +49,10 @@ fn worker_snapshot_round_trip_preserves_resume_fields() {
                 ..Default::default()
             }),
             artifacts: Vec::new(),
-            transcript: Some(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            transcript: Some(VmValue::dict(crate::value::DictMap::from_iter([(
                 "_type".to_string(),
                 VmValue::String(std::sync::Arc::from("transcript")),
-            )])))),
+            )]))),
         },
         handle: None,
         cancel_token: Arc::new(AtomicBool::new(false)),
@@ -78,10 +77,10 @@ fn worker_snapshot_round_trip_preserves_resume_fields() {
         },
         latest_payload: Some(serde_json::json!({"status": "completed"})),
         latest_error: None,
-        transcript: Some(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        transcript: Some(VmValue::dict(crate::value::DictMap::from_iter([(
             "_type".to_string(),
             VmValue::String(std::sync::Arc::from("transcript")),
-        )])))),
+        )]))),
         artifacts: vec![ArtifactRecord {
             type_name: "artifact".to_string(),
             id: "artifact_1".to_string(),
@@ -97,7 +96,7 @@ fn worker_snapshot_round_trip_preserves_resume_fields() {
             relevance: Some(1.0),
             estimated_tokens: Some(1),
             stage: Some("stage".to_string()),
-            metadata: BTreeMap::new(),
+            metadata: std::collections::BTreeMap::new(),
         }],
         parent_worker_id: Some("parent".to_string()),
         parent_stage_id: Some("stage".to_string()),
@@ -226,7 +225,7 @@ fn worker_summary_exposes_request_and_provenance() {
                 name: "worker".to_string(),
                 task: "latest task".to_string(),
                 system: Some("system".to_string()),
-                options: BTreeMap::new(),
+                options: crate::value::DictMap::new(),
                 returns_schema: None,
                 session_id: "session_worker".to_string(),
                 parent_session_id: Some("session_parent".to_string()),
@@ -368,7 +367,7 @@ fn transcript_carry_policy_can_reset_or_fork_transcripts() {
 #[tokio::test(flavor = "current_thread")]
 async fn compact_transcript_mode_reduces_carried_messages() {
     let messages = vec![
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "role".to_string(),
                 VmValue::String(std::sync::Arc::from("user")),
@@ -377,8 +376,8 @@ async fn compact_transcript_mode_reduces_carried_messages() {
                 "content".to_string(),
                 VmValue::String(std::sync::Arc::from("one")),
             ),
-        ]))),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        ])),
+        VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "role".to_string(),
                 VmValue::String(std::sync::Arc::from("assistant")),
@@ -387,8 +386,8 @@ async fn compact_transcript_mode_reduces_carried_messages() {
                 "content".to_string(),
                 VmValue::String(std::sync::Arc::from("two")),
             ),
-        ]))),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        ])),
+        VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "role".to_string(),
                 VmValue::String(std::sync::Arc::from("user")),
@@ -397,8 +396,8 @@ async fn compact_transcript_mode_reduces_carried_messages() {
                 "content".to_string(),
                 VmValue::String(std::sync::Arc::from("three")),
             ),
-        ]))),
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        ])),
+        VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "role".to_string(),
                 VmValue::String(std::sync::Arc::from("assistant")),
@@ -407,7 +406,7 @@ async fn compact_transcript_mode_reduces_carried_messages() {
                 "content".to_string(),
                 VmValue::String(std::sync::Arc::from("four")),
             ),
-        ]))),
+        ])),
     ];
     let transcript = crate::llm::helpers::new_transcript_with_events(
         Some("compact-transcript".to_string()),
@@ -452,7 +451,7 @@ fn worker_policy_inherits_parent_ceiling_when_unspecified() {
         ..Default::default()
     });
 
-    let dict = BTreeMap::from([(
+    let dict = crate::value::DictMap::from_iter([(
         "task".to_string(),
         VmValue::String(std::sync::Arc::from("draft note")),
     )]);
@@ -478,20 +477,20 @@ fn worker_policy_intersects_explicit_policy_and_tools_shorthand() {
         ..Default::default()
     });
 
-    let dict = BTreeMap::from([
+    let dict = crate::value::DictMap::from_iter([
         (
             "task".to_string(),
             VmValue::String(std::sync::Arc::from("draft note")),
         ),
         (
             "policy".to_string(),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            VmValue::dict(crate::value::DictMap::from_iter([(
                 "tools".to_string(),
                 VmValue::List(std::sync::Arc::new(vec![
                     VmValue::String(std::sync::Arc::from("read")),
                     VmValue::String(std::sync::Arc::from("write")),
                 ])),
-            )]))),
+            )])),
         ),
         (
             "tools".to_string(),

--- a/crates/harn-vm/src/stdlib/artifact_emit.rs
+++ b/crates/harn-vm/src/stdlib/artifact_emit.rs
@@ -4,8 +4,6 @@
 //! transcript event when the session is known locally, and publishes the same
 //! payload on the live agent event stream for ACP/A2A surfaces.
 
-use std::collections::BTreeMap;
-
 use serde_json::{json, Value as JsonValue};
 
 use crate::agent_events::AgentEvent;
@@ -151,7 +149,7 @@ fn err(message: impl Into<String>) -> VmError {
 
 fn parse_options(value: Option<&VmValue>) -> Result<ArtifactEmitOptions, VmError> {
     let opts = match value {
-        None | Some(VmValue::Nil) => BTreeMap::new(),
+        None | Some(VmValue::Nil) => crate::value::DictMap::new(),
         Some(VmValue::Dict(map)) => map.as_ref().clone(),
         Some(other) => {
             return Err(err(format!(
@@ -210,7 +208,7 @@ fn parse_options(value: Option<&VmValue>) -> Result<ArtifactEmitOptions, VmError
     })
 }
 
-fn opt_string(opts: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<String>, VmError> {
+fn opt_string(opts: &crate::value::DictMap, key: &str) -> Result<Option<String>, VmError> {
     match opts.get(key) {
         None | Some(VmValue::Nil) => Ok(None),
         Some(VmValue::String(value)) => {
@@ -231,7 +229,7 @@ fn opt_string(opts: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<Stri
     }
 }
 
-fn opt_int(opts: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<i64>, VmError> {
+fn opt_int(opts: &crate::value::DictMap, key: &str) -> Result<Option<i64>, VmError> {
     match opts.get(key) {
         None | Some(VmValue::Nil) => Ok(None),
         Some(value) => value
@@ -241,7 +239,7 @@ fn opt_int(opts: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<i64>, V
     }
 }
 
-fn opt_object(opts: &BTreeMap<String, VmValue>, key: &str) -> Result<Option<JsonValue>, VmError> {
+fn opt_object(opts: &crate::value::DictMap, key: &str) -> Result<Option<JsonValue>, VmError> {
     match opts.get(key) {
         None | Some(VmValue::Nil) => Ok(None),
         Some(VmValue::Dict(_)) => {

--- a/crates/harn-vm/src/stdlib/assemble.rs
+++ b/crates/harn-vm/src/stdlib/assemble.rs
@@ -66,7 +66,7 @@ async fn assemble_context_impl(
     Ok(assembled_to_vm(&assembled))
 }
 
-fn parse_assemble_options(dict: &BTreeMap<String, VmValue>) -> Result<AssembleOptions, VmError> {
+fn parse_assemble_options(dict: &crate::value::DictMap) -> Result<AssembleOptions, VmError> {
     let defaults = AssembleOptions::default();
     let mut options = defaults;
     if let Some(value) = dict.get("budget_tokens").and_then(VmValue::as_int) {
@@ -150,7 +150,7 @@ fn chunk_to_vm(chunk: &AssembledChunk, with_score: bool) -> VmValue {
     if with_score {
         map.insert("score".to_string(), VmValue::Float(chunk.score));
     }
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 /// Compact VM representation of a chunk for the ranker callback (no score yet).
@@ -228,7 +228,7 @@ fn assembled_to_vm(assembled: &AssembledContext) -> VmValue {
                 "tokens_included".to_string(),
                 VmValue::Int(summary.tokens_included as i64),
             );
-            VmValue::Dict(std::sync::Arc::new(map))
+            VmValue::dict(map)
         })
         .collect();
 
@@ -255,7 +255,7 @@ fn assembled_to_vm(assembled: &AssembledContext) -> VmValue {
                     .map(|text| VmValue::String(std::sync::Arc::from(text.as_str())))
                     .unwrap_or(VmValue::Nil),
             );
-            VmValue::Dict(std::sync::Arc::new(map))
+            VmValue::dict(map)
         })
         .collect();
 
@@ -270,7 +270,7 @@ fn assembled_to_vm(assembled: &AssembledContext) -> VmValue {
             map.insert("score".to_string(), VmValue::Float(reason.score));
             map.insert("included".to_string(), VmValue::Bool(reason.included));
             map.put_str("reason", reason.reason);
-            VmValue::Dict(std::sync::Arc::new(map))
+            VmValue::dict(map)
         })
         .collect();
 
@@ -301,7 +301,7 @@ fn assembled_to_vm(assembled: &AssembledContext) -> VmValue {
     );
     map.put_str("strategy", assembled.strategy.as_str());
     map.put_str("dedup", assembled.dedup.as_str());
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 /// Convenience entry point used by the agent_loop integration hook:

--- a/crates/harn-vm/src/stdlib/calendar.rs
+++ b/crates/harn-vm/src/stdlib/calendar.rs
@@ -281,9 +281,7 @@ fn calendar_parts_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue
         "timezone",
     )?;
     let dt = datetime_like_arg(args.first(), timezone, "__calendar_parts")?;
-    Ok(VmValue::Dict(std::sync::Arc::new(parts_dict(
-        dt.with_timezone(&timezone),
-    ))))
+    Ok(VmValue::dict(parts_dict(dt.with_timezone(&timezone))))
 }
 
 #[harn_builtin(
@@ -693,7 +691,7 @@ fn calendar_business_window_builtin(
     } else {
         "after_window"
     };
-    Ok(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    Ok(VmValue::dict(BTreeMap::from([
         ("inside".to_string(), VmValue::Bool(inside)),
         ("business_day".to_string(), VmValue::Bool(business_day)),
         ("reason".to_string(), VmValue::string(reason)),
@@ -714,12 +712,12 @@ fn calendar_business_window_builtin(
             "ends_at".to_string(),
             timestamp_value(ends_at.with_timezone(&Utc)),
         ),
-    ]))))
+    ])))
 }
 
-fn parts_dict(dt: DateTime<Tz>) -> BTreeMap<String, VmValue> {
+fn parts_dict(dt: DateTime<Tz>) -> crate::value::DictMap {
     let iso = dt.iso_week();
-    BTreeMap::from([
+    crate::value::DictMap::from_iter([
         ("year".to_string(), VmValue::Int(dt.year() as i64)),
         ("month".to_string(), VmValue::Int(dt.month() as i64)),
         ("day".to_string(), VmValue::Int(dt.day() as i64)),
@@ -912,7 +910,7 @@ fn parse_datetime_or_date(
 }
 
 fn naive_datetime_from_parts(
-    parts: &BTreeMap<String, VmValue>,
+    parts: &crate::value::DictMap,
     builtin: &str,
 ) -> Result<NaiveDateTime, VmError> {
     let year = i32::try_from(required_i64_field(parts, "year", builtin)?)
@@ -931,7 +929,7 @@ fn naive_datetime_from_parts(
 }
 
 fn required_i64_field(
-    parts: &BTreeMap<String, VmValue>,
+    parts: &crate::value::DictMap,
     field: &str,
     builtin: &str,
 ) -> Result<i64, VmError> {
@@ -940,7 +938,7 @@ fn required_i64_field(
 }
 
 fn optional_i64_field(
-    parts: &BTreeMap<String, VmValue>,
+    parts: &crate::value::DictMap,
     field: &str,
     default: i64,
     builtin: &str,
@@ -1008,7 +1006,7 @@ fn country_value(country: &CountryMeta) -> VmValue {
     } else {
         VmValue::Nil
     };
-    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    VmValue::dict(BTreeMap::from([
         ("code".to_string(), VmValue::string(country.code)),
         ("name".to_string(), VmValue::string(country.name)),
         (
@@ -1032,11 +1030,11 @@ fn country_value(country: &CountryMeta) -> VmValue {
             "holiday_calendars".to_string(),
             string_list_value(country.holiday_calendars.iter().copied()),
         ),
-    ])))
+    ]))
 }
 
 fn holiday_calendar_info(name: &'static str) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    VmValue::dict(BTreeMap::from([
         ("name".to_string(), VmValue::string(name)),
         ("country".to_string(), VmValue::string("US")),
         (
@@ -1047,7 +1045,7 @@ fn holiday_calendar_info(name: &'static str) -> VmValue {
             "description".to_string(),
             VmValue::string("United States federal observed holidays"),
         ),
-    ])))
+    ]))
 }
 
 fn supported_holidays_for_year(calendar: &str, year: i32) -> Result<Vec<Holiday>, VmError> {
@@ -1214,7 +1212,7 @@ fn last_weekday_of_month(year: i32, month: u32, weekday: Weekday) -> NaiveDate {
 }
 
 fn holiday_value(holiday: &Holiday) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    VmValue::dict(BTreeMap::from([
         (
             "date".to_string(),
             VmValue::string(holiday.date.format("%Y-%m-%d").to_string()),
@@ -1225,7 +1223,7 @@ fn holiday_value(holiday: &Holiday) -> VmValue {
         ),
         ("name".to_string(), VmValue::string(holiday.name)),
         ("observed".to_string(), VmValue::Bool(holiday.observed)),
-    ])))
+    ]))
 }
 
 fn business_calendar_arg(
@@ -1267,7 +1265,7 @@ fn supported_business_calendar(raw: &str) -> Result<BusinessCalendar, VmError> {
 }
 
 fn custom_business_calendar(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     builtin: &str,
 ) -> Result<BusinessCalendar, VmError> {
     let name = map
@@ -1368,7 +1366,7 @@ fn is_holiday_date(date: NaiveDate, calendar: &BusinessCalendar) -> Result<bool,
 }
 
 fn business_time_option(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     time_key: &str,
     hour_key: &str,
     default_hour: u32,
@@ -1415,7 +1413,7 @@ fn require_dict<'a>(
     value: Option<&'a VmValue>,
     builtin: &str,
     label: &str,
-) -> Result<&'a BTreeMap<String, VmValue>, VmError> {
+) -> Result<&'a crate::value::DictMap, VmError> {
     match value {
         Some(VmValue::Dict(map)) => Ok(map),
         Some(other) => Err(vm_error(format!(
@@ -1430,7 +1428,7 @@ fn optional_dict<'a>(
     value: Option<&'a VmValue>,
     builtin: &str,
     label: &str,
-) -> Result<Option<&'a BTreeMap<String, VmValue>>, VmError> {
+) -> Result<Option<&'a crate::value::DictMap>, VmError> {
     match value {
         Some(VmValue::Dict(map)) => Ok(Some(map)),
         Some(VmValue::Nil) | None => Ok(None),

--- a/crates/harn-vm/src/stdlib/collections.rs
+++ b/crates/harn-vm/src/stdlib/collections.rs
@@ -2,13 +2,13 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::sync::Arc;
 
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
-use crate::value::{value_structural_hash_key, VmError, VmValue};
+use crate::value::{value_structural_hash_key, DictRetain, VmError, VmValue};
 use crate::vm::{AsyncBuiltinCtx, Vm};
 
-fn dict_arg(value: &VmValue, builtin: &str) -> Result<Arc<BTreeMap<String, VmValue>>, VmError> {
+fn dict_arg(value: &VmValue, builtin: &str) -> Result<Arc<crate::value::DictMap>, VmError> {
     match value {
         VmValue::Dict(d) => Ok(Arc::clone(d)),
-        VmValue::Nil => Ok(Arc::new(BTreeMap::new())),
+        VmValue::Nil => Ok(Arc::new(crate::value::DictMap::new())),
         other => Err(VmError::TypeError(format!(
             "{builtin}: expected dict, got {}",
             other.type_name()
@@ -130,12 +130,12 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
             let bucket = string_discriminator(&key, "group_by")?;
             groups.entry(bucket).or_default().push(item.clone());
         }
-        Ok(VmValue::Dict(std::sync::Arc::new(
+        Ok(VmValue::dict(
             groups
                 .into_iter()
                 .map(|(key, values)| (key, VmValue::List(std::sync::Arc::new(values))))
-                .collect(),
-        )))
+                .collect::<crate::value::DictMap>(),
+        ))
     });
 
     vm.register_async_builtin("partition", |ctx, args| async move {
@@ -160,7 +160,7 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
                 no_match.push(item.clone());
             }
         }
-        Ok(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        Ok(VmValue::dict(BTreeMap::from([
             (
                 "match".to_string(),
                 VmValue::List(std::sync::Arc::new(matched)),
@@ -169,7 +169,7 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
                 "no_match".to_string(),
                 VmValue::List(std::sync::Arc::new(no_match)),
             ),
-        ]))))
+        ])))
     });
 
     vm.register_async_builtin("dedup_by", |ctx, args| async move {
@@ -285,12 +285,12 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
             let bucket = string_discriminator(&key, "count_by")?;
             *counts.entry(bucket).or_insert(0) += 1;
         }
-        Ok(VmValue::Dict(std::sync::Arc::new(
+        Ok(VmValue::dict(
             counts
                 .into_iter()
                 .map(|(key, count)| (key, VmValue::Int(count)))
-                .collect(),
-        )))
+                .collect::<crate::value::DictMap>(),
+        ))
     });
 
     register_dict_builder_builtins(vm);
@@ -427,7 +427,7 @@ const DICT_BUILDER_BUILTINS: &[&VmBuiltinDef] = &[
 /// (Arc-cloned handle) or violate identity invariants.
 fn shallow_clone(value: &VmValue) -> VmValue {
     match value {
-        VmValue::Dict(d) => VmValue::Dict(std::sync::Arc::new((**d).clone())),
+        VmValue::Dict(d) => VmValue::dict((**d).clone()),
         VmValue::List(items) => VmValue::List(std::sync::Arc::new((**items).clone())),
         VmValue::Set(items) => VmValue::Set(std::sync::Arc::new((**items).clone())),
         other => other.clone(),
@@ -445,7 +445,7 @@ fn deep_clone_value(value: &VmValue) -> VmValue {
             for (key, val) in d.iter() {
                 out.insert(key.clone(), deep_clone_value(val));
             }
-            VmValue::Dict(std::sync::Arc::new(out))
+            VmValue::dict(out)
         }
         VmValue::List(items) => VmValue::List(std::sync::Arc::new(
             items.iter().map(deep_clone_value).collect(),
@@ -496,7 +496,7 @@ fn deep_merge_value(a: &VmValue, b: &VmValue) -> Result<VmValue, VmError> {
             }
         }
     }
-    Ok(VmValue::Dict(std::sync::Arc::new(merged)))
+    Ok(VmValue::dict(merged))
 }
 
 /// Returns a list with duplicate entries removed while preserving the
@@ -532,7 +532,7 @@ fn list_unique(value: &VmValue) -> Result<VmValue, VmError> {
 fn dict_from_pairs(value: &VmValue) -> Result<VmValue, VmError> {
     let pairs = match value {
         VmValue::List(items) | VmValue::Set(items) => Arc::clone(items),
-        VmValue::Nil => return Ok(VmValue::Dict(std::sync::Arc::new(BTreeMap::new()))),
+        VmValue::Nil => return Ok(VmValue::dict(BTreeMap::new())),
         other => {
             return Err(VmError::TypeError(format!(
                 "dict_from_pairs: expected a list of [key, value] pairs, got {}",
@@ -560,7 +560,7 @@ fn dict_from_pairs(value: &VmValue) -> Result<VmValue, VmError> {
         };
         out.insert(key_string, val);
     }
-    Ok(VmValue::Dict(std::sync::Arc::new(out)))
+    Ok(VmValue::dict(out))
 }
 
 fn dict_filter_nil(value: &VmValue) -> Result<VmValue, VmError> {
@@ -570,7 +570,7 @@ fn dict_filter_nil(value: &VmValue) -> Result<VmValue, VmError> {
     }
     let mut out = Arc::try_unwrap(dict).unwrap_or_else(|d| (*d).clone());
     out.retain(|_, value| keep_filter_nil(value));
-    Ok(VmValue::Dict(std::sync::Arc::new(out)))
+    Ok(VmValue::dict(out))
 }
 
 fn dict_merge(a: &VmValue, b: &VmValue) -> Result<VmValue, VmError> {
@@ -587,7 +587,7 @@ fn dict_merge(a: &VmValue, b: &VmValue) -> Result<VmValue, VmError> {
         Ok(entries) => merged.extend(entries),
         Err(entries) => merged.extend(entries.iter().map(|(k, v)| (k.clone(), v.clone()))),
     }
-    Ok(VmValue::Dict(std::sync::Arc::new(merged)))
+    Ok(VmValue::dict(merged))
 }
 
 fn dict_pick(data: &VmValue, keys: &VmValue) -> Result<VmValue, VmError> {
@@ -602,7 +602,7 @@ fn dict_pick(data: &VmValue, keys: &VmValue) -> Result<VmValue, VmError> {
             }
         }
     }
-    Ok(VmValue::Dict(std::sync::Arc::new(out)))
+    Ok(VmValue::dict(out))
 }
 
 fn dict_pick_keys(data: &VmValue, keys: &VmValue, drop_nil: bool) -> Result<VmValue, VmError> {
@@ -618,7 +618,7 @@ fn dict_pick_keys(data: &VmValue, keys: &VmValue, drop_nil: bool) -> Result<VmVa
             out.insert(key, value.clone());
         }
     }
-    Ok(VmValue::Dict(std::sync::Arc::new(out)))
+    Ok(VmValue::dict(out))
 }
 
 fn dict_omit(data: &VmValue, keys: &VmValue) -> Result<VmValue, VmError> {
@@ -632,7 +632,7 @@ fn dict_omit(data: &VmValue, keys: &VmValue) -> Result<VmValue, VmError> {
     }
     let mut out = Arc::try_unwrap(dict).unwrap_or_else(|d| (*d).clone());
     out.retain(|key, _| !exclude.contains(key));
-    Ok(VmValue::Dict(std::sync::Arc::new(out)))
+    Ok(VmValue::dict(out))
 }
 
 #[cfg(test)]
@@ -644,7 +644,7 @@ mod tests {
         for (k, v) in entries {
             map.insert((*k).to_string(), v.clone());
         }
-        VmValue::Dict(std::sync::Arc::new(map))
+        VmValue::dict(map)
     }
 
     fn keys(items: &[&str]) -> VmValue {
@@ -736,7 +736,7 @@ mod tests {
 
     #[test]
     fn shallow_clone_decouples_dict_from_source() {
-        let inner = VmValue::Dict(std::sync::Arc::new(BTreeMap::new()));
+        let inner = VmValue::dict(BTreeMap::new());
         let source = dict(&[("inner", inner)]);
         let copy = shallow_clone(&source);
         match (&source, &copy) {

--- a/crates/harn-vm/src/stdlib/compaction.rs
+++ b/crates/harn-vm/src/stdlib/compaction.rs
@@ -42,7 +42,7 @@ fn register_compaction_namespace(vm: &mut Vm) {
     let names = ["policy", "check", "run"];
     vm.set_global(
         "compaction",
-        VmValue::Dict(std::sync::Arc::new(
+        VmValue::dict(
             std::iter::once((
                 "_namespace".to_string(),
                 VmValue::String(std::sync::Arc::from("compaction")),
@@ -54,7 +54,7 @@ fn register_compaction_namespace(vm: &mut Vm) {
                 )
             }))
             .collect::<std::collections::BTreeMap<_, _>>(),
-        )),
+        ),
     );
 }
 
@@ -127,7 +127,7 @@ async fn compaction_run_impl(
     let session_id = resolve_session_id(args.first(), "compaction.run")?;
     let plan = match args.get(1) {
         Some(VmValue::Dict(map)) => (**map).clone(),
-        Some(VmValue::Nil) | None => BTreeMap::new(),
+        Some(VmValue::Nil) | None => crate::value::DictMap::new(),
         Some(other) => {
             return Err(VmError::Runtime(format!(
                 "compaction.run: `plan` must be a dict or nil, got {}",
@@ -156,7 +156,7 @@ async fn compaction_run_impl(
         let raw = if plan.is_empty() {
             VmValue::Nil
         } else {
-            VmValue::Dict(std::sync::Arc::new(plan.clone()))
+            VmValue::dict(plan.clone())
         };
         Some(extract_llm_options(&[
             VmValue::String(std::sync::Arc::from("")),
@@ -244,7 +244,7 @@ fn require_dict(
     value: Option<&VmValue>,
     builtin: &str,
     name: &str,
-) -> Result<BTreeMap<String, VmValue>, VmError> {
+) -> Result<crate::value::DictMap, VmError> {
     match value {
         Some(VmValue::Dict(map)) => Ok((**map).clone()),
         Some(other) => Err(VmError::Runtime(format!(
@@ -256,7 +256,7 @@ fn require_dict(
 }
 
 fn optional_string(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Option<String>, VmError> {
@@ -327,7 +327,7 @@ fn session_compactable_events(id: &str) -> Vec<VmValue> {
 
 fn apply_plan_overrides(
     policy: &mut CompactionPolicyDeclaration,
-    plan: &BTreeMap<String, VmValue>,
+    plan: &crate::value::DictMap,
 ) -> Result<(), VmError> {
     if plan.is_empty() {
         return Ok(());
@@ -373,7 +373,7 @@ fn apply_plan_overrides(
 }
 
 fn plan_int(
-    plan: &BTreeMap<String, VmValue>,
+    plan: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Option<usize>, VmError> {
@@ -425,7 +425,7 @@ fn decision_value(
         map.insert("turn_threshold".to_string(), VmValue::Int(value as i64));
     }
     map.insert("policy_inherited".to_string(), VmValue::Bool(inherited));
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn policy_snapshot_value(
@@ -479,7 +479,7 @@ fn policy_snapshot_value(
         );
     }
     map.insert("policy_inherited".to_string(), VmValue::Bool(inherited));
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn run_result_value(
@@ -521,7 +521,7 @@ fn run_result_value(
         );
     }
     map.insert("transcript".to_string(), transcript);
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[

--- a/crates/harn-vm/src/stdlib/compression.rs
+++ b/crates/harn-vm/src/stdlib/compression.rs
@@ -1,5 +1,4 @@
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 use std::io::{Cursor, Read, Write};
 
 use flate2::read::GzDecoder;
@@ -258,8 +257,8 @@ fn bytes_value(bytes: Vec<u8>) -> VmValue {
     VmValue::Bytes(std::sync::Arc::new(bytes))
 }
 
-fn entry_value(fields: BTreeMap<String, VmValue>) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(fields))
+fn entry_value(fields: crate::value::DictMap) -> VmValue {
+    VmValue::dict(fields)
 }
 
 #[harn_builtin(
@@ -446,7 +445,7 @@ fn tar_extract_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
         let content = read_with_cap(&mut entry, remaining, "tar_extract")?;
         total_extracted = total_extracted.saturating_add(content.len() as u64);
 
-        let mut fields = BTreeMap::new();
+        let mut fields = crate::value::DictMap::new();
         fields.insert("content".to_string(), bytes_value(content));
         fields.insert("mode".to_string(), VmValue::Int(mode));
         fields.put_str("path", path);
@@ -519,7 +518,7 @@ fn zip_extract_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
         let content = read_with_cap(&mut file, remaining, "zip_extract")?;
         total_extracted = total_extracted.saturating_add(content.len() as u64);
 
-        let mut fields = BTreeMap::new();
+        let mut fields = crate::value::DictMap::new();
         fields.insert("content".to_string(), bytes_value(content));
         fields.put_str("path", path);
         output.push(entry_value(fields));
@@ -591,12 +590,12 @@ mod tests {
             ],
         )
         .unwrap();
-        let mut options = BTreeMap::new();
+        let mut options = crate::value::DictMap::new();
         options.insert("max_decompressed_bytes".to_string(), VmValue::Int(1024));
         let result = call(
             &mut vm,
             "gzip_decode",
-            vec![encoded, VmValue::Dict(std::sync::Arc::new(options))],
+            vec![encoded, VmValue::dict(options)],
         );
         let err = result.expect_err("gzip_decode should reject output past cap");
         let message = match err {
@@ -622,19 +621,19 @@ mod tests {
             ],
         )
         .unwrap();
-        let mut options = BTreeMap::new();
+        let mut options = crate::value::DictMap::new();
         options.insert("max_decompressed_bytes".to_string(), VmValue::Int(1024));
         let result = call(
             &mut vm,
             "zstd_decode",
-            vec![encoded, VmValue::Dict(std::sync::Arc::new(options))],
+            vec![encoded, VmValue::dict(options)],
         );
         assert!(result.is_err(), "zstd_decode should reject output past cap");
     }
 
     #[test]
     fn tar_round_trip_preserves_mode() {
-        let mut fields = BTreeMap::new();
+        let mut fields = crate::value::DictMap::new();
         fields.insert("path".to_string(), text("bin/run"));
         fields.insert("content".to_string(), text("echo hi"));
         fields.insert("mode".to_string(), VmValue::Int(0o755));

--- a/crates/harn-vm/src/stdlib/concurrency.rs
+++ b/crates/harn-vm/src/stdlib/concurrency.rs
@@ -91,7 +91,7 @@ fn select_result(index: usize, value: VmValue, channel_name: &str) -> VmValue {
     result.insert("index".to_string(), VmValue::Int(index as i64));
     result.insert("value".to_string(), value);
     result.put_str("channel", channel_name);
-    VmValue::Dict(std::sync::Arc::new(result))
+    VmValue::dict(result)
 }
 
 /// Build a select result dict indicating no channel was ready (index = -1).
@@ -100,7 +100,7 @@ fn select_none() -> VmValue {
     result.insert("index".to_string(), VmValue::Int(-1));
     result.insert("value".to_string(), VmValue::Nil);
     result.insert("channel".to_string(), VmValue::Nil);
-    VmValue::Dict(std::sync::Arc::new(result))
+    VmValue::dict(result)
 }
 
 fn require_channel_list(args: &[VmValue], builtin: &str) -> Result<Vec<VmValue>, VmError> {
@@ -151,7 +151,7 @@ fn cancelled_vm_error() -> VmError {
 }
 
 fn channel_closed_error(operation: &str, channel_name: &str) -> VmError {
-    VmError::Thrown(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    VmError::Thrown(VmValue::dict(BTreeMap::from([
         (
             "type".to_string(),
             VmValue::String(std::sync::Arc::from("ChannelClosed")),
@@ -170,7 +170,7 @@ fn channel_closed_error(operation: &str, channel_name: &str) -> VmError {
                 "{operation}: channel '{channel_name}' is closed"
             ))),
         ),
-    ]))))
+    ])))
 }
 
 fn guard_sync_self_deadlock(
@@ -244,7 +244,7 @@ fn positive_u32_arg(
         .map_err(|_| VmError::Runtime(format!("{name}: value {value} exceeds u32::MAX")))
 }
 
-fn dict_string(dict: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn dict_string(dict: &crate::value::DictMap, key: &str) -> Option<String> {
     dict.get(key).and_then(|value| match value {
         VmValue::String(text) if !text.is_empty() => Some(text.to_string()),
         VmValue::Nil => None,
@@ -262,7 +262,7 @@ fn context_string(context: &VmValue, key: &str) -> Option<String> {
 fn resolve_shared_scope(
     vm: &Vm,
     raw_scope: Option<&str>,
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     builtin: &str,
 ) -> Result<String, VmError> {
     let context = crate::runtime_context::runtime_context_value(vm);
@@ -313,7 +313,7 @@ fn resolve_shared_scope(
     Ok(format!("{scope}:{resolved}"))
 }
 
-fn shared_options(args: &[VmValue]) -> Option<&BTreeMap<String, VmValue>> {
+fn shared_options(args: &[VmValue]) -> Option<&crate::value::DictMap> {
     args.first().and_then(VmValue::as_dict)
 }
 
@@ -322,7 +322,7 @@ fn scoped_from_open_args(
     args: &[VmValue],
     builtin: &str,
     key_field: &str,
-) -> Result<(ScopedKey, Option<BTreeMap<String, VmValue>>), VmError> {
+) -> Result<(ScopedKey, Option<crate::value::DictMap>), VmError> {
     let options = shared_options(args);
     let key = if let Some(options) = options {
         dict_string(options, key_field)
@@ -1623,7 +1623,7 @@ fn timer_start_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
     let mut timer = BTreeMap::new();
     timer.put_str("name", name);
     timer.insert("start_ms".to_string(), VmValue::Int(now_ms));
-    Ok(VmValue::Dict(std::sync::Arc::new(timer)))
+    Ok(VmValue::dict(timer))
 }
 
 #[harn_builtin(

--- a/crates/harn-vm/src/stdlib/connectors.rs
+++ b/crates/harn-vm/src/stdlib/connectors.rs
@@ -47,7 +47,7 @@ async fn connector_call_impl(
                 "connector_call: params must be a dict when provided",
             ))));
         }
-        _ => vm_value_to_json(&VmValue::Dict(std::sync::Arc::new(BTreeMap::new()))),
+        _ => vm_value_to_json(&VmValue::dict(BTreeMap::new())),
     };
 
     let client = active_connector_client(&provider).ok_or_else(|| {

--- a/crates/harn-vm/src/stdlib/cookies.rs
+++ b/crates/harn-vm/src/stdlib/cookies.rs
@@ -12,8 +12,8 @@ fn cookie_error(message: impl Into<String>) -> VmError {
     VmError::Runtime(format!("cookie: {}", message.into()))
 }
 
-fn dict(fields: BTreeMap<String, VmValue>) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(fields))
+fn dict(fields: crate::value::DictMap) -> VmValue {
+    VmValue::dict(fields)
 }
 
 fn list(items: Vec<VmValue>) -> VmValue {
@@ -43,7 +43,7 @@ fn option_map<'a>(
     args: &'a [VmValue],
     index: usize,
     name: &str,
-) -> Result<Option<&'a BTreeMap<String, VmValue>>, VmError> {
+) -> Result<Option<&'a crate::value::DictMap>, VmError> {
     match args.get(index) {
         Some(VmValue::Dict(map)) => Ok(Some(map)),
         Some(VmValue::Nil) | None => Ok(None),
@@ -55,7 +55,7 @@ fn option_map<'a>(
 }
 
 fn option_value<'a>(
-    options: Option<&'a BTreeMap<String, VmValue>>,
+    options: Option<&'a crate::value::DictMap>,
     names: &[&str],
 ) -> Option<&'a VmValue> {
     let options = options?;
@@ -67,11 +67,11 @@ fn option_value<'a>(
     None
 }
 
-fn option_bool(options: Option<&BTreeMap<String, VmValue>>, names: &[&str], default: bool) -> bool {
+fn option_bool(options: Option<&crate::value::DictMap>, names: &[&str], default: bool) -> bool {
     option_value(options, names).map_or(default, VmValue::is_truthy)
 }
 
-fn option_string(options: Option<&BTreeMap<String, VmValue>>, names: &[&str]) -> Option<String> {
+fn option_string(options: Option<&crate::value::DictMap>, names: &[&str]) -> Option<String> {
     option_value(options, names).and_then(|value| match value {
         VmValue::Nil => None,
         other => Some(other.display()),
@@ -79,7 +79,7 @@ fn option_string(options: Option<&BTreeMap<String, VmValue>>, names: &[&str]) ->
 }
 
 fn option_i64(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     names: &[&str],
 ) -> Result<Option<i64>, VmError> {
     match option_value(options, names) {
@@ -201,23 +201,23 @@ fn raw_cookie_headers(value: &VmValue) -> Result<Vec<String>, VmError> {
 }
 
 fn invalid_segment(segment: &str, reason: &str) -> VmValue {
-    dict(BTreeMap::from([
+    dict(crate::value::DictMap::from_iter([
         ("segment".to_string(), string(segment.to_string())),
         ("reason".to_string(), string(reason.to_string())),
     ]))
 }
 
 struct ParsedCookieHeader {
-    cookies: BTreeMap<String, VmValue>,
+    cookies: crate::value::DictMap,
     pairs: Vec<VmValue>,
     values: BTreeMap<String, Vec<String>>,
     invalid: Vec<VmValue>,
 }
 
 fn parse_cookie_header_value(raw: &str) -> ParsedCookieHeader {
-    let mut cookies = BTreeMap::new();
+    let mut cookies = crate::value::DictMap::new();
     let mut pairs = Vec::new();
-    let mut all_values: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut all_values: BTreeMap<String, Vec<String>> = std::collections::BTreeMap::new();
     let mut invalid = Vec::new();
 
     for segment in raw.split(';') {
@@ -252,7 +252,7 @@ fn parse_cookie_header_value(raw: &str) -> ParsedCookieHeader {
             .entry(name.to_string())
             .or_default()
             .push(value.clone());
-        pairs.push(dict(BTreeMap::from([
+        pairs.push(dict(crate::value::DictMap::from_iter([
             ("name".to_string(), string(name.to_string())),
             ("value".to_string(), string(value)),
         ])));
@@ -268,9 +268,9 @@ fn parse_cookie_header_value(raw: &str) -> ParsedCookieHeader {
 
 fn parse_cookie_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
     require_args(args, 1, "cookie_parse")?;
-    let mut cookies = BTreeMap::new();
+    let mut cookies = crate::value::DictMap::new();
     let mut pairs = Vec::new();
-    let mut all_values: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut all_values: BTreeMap<String, Vec<String>> = std::collections::BTreeMap::new();
     let mut invalid = Vec::new();
 
     for header in raw_cookie_headers(&args[0])? {
@@ -299,7 +299,7 @@ fn parse_cookie_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
         })
         .collect();
 
-    Ok(dict(BTreeMap::from([
+    Ok(dict(crate::value::DictMap::from_iter([
         ("cookies".to_string(), dict(cookies)),
         ("pairs".to_string(), list(pairs)),
         ("duplicates".to_string(), dict(duplicates)),
@@ -310,7 +310,7 @@ fn parse_cookie_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
 fn serialize_cookie_with_defaults(
     name: &str,
     value: &str,
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     defaults: CookieDefaults,
 ) -> Result<String, VmError> {
     if !valid_cookie_name(name) {
@@ -465,7 +465,7 @@ fn cookie_sign_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
 }
 
 fn cookie_verify_result(ok: bool, value: Option<String>, error: Option<&str>) -> VmValue {
-    let mut result = BTreeMap::new();
+    let mut result = crate::value::DictMap::new();
     result.insert("ok".to_string(), bool_value(ok));
     result.insert("value".to_string(), value.map(string).unwrap_or_else(nil));
     result.insert("error".to_string(), error.map(string).unwrap_or_else(nil));
@@ -497,7 +497,7 @@ fn session_sign_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
 }
 
 fn session_verify_result(ok: bool, payload: VmValue, error: Option<&str>) -> VmValue {
-    dict(BTreeMap::from([
+    dict(crate::value::DictMap::from_iter([
         ("ok".to_string(), bool_value(ok)),
         ("payload".to_string(), payload),
         ("error".to_string(), error.map(string).unwrap_or_else(nil)),
@@ -649,7 +649,7 @@ fn cookie_round_trip_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
     };
 
     let parsed_request = parse_cookie_builtin(&[request_value])?;
-    let mut cookies = BTreeMap::<String, String>::new();
+    let mut cookies = std::collections::BTreeMap::new();
     if let VmValue::Dict(result) = parsed_request {
         if let Some(VmValue::Dict(parsed)) = result.get("cookies") {
             for (name, value) in parsed.iter() {
@@ -672,8 +672,8 @@ fn cookie_round_trip_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
     let cookie_values = cookies
         .iter()
         .map(|(name, value)| (name.clone(), string(value.clone())))
-        .collect();
-    Ok(dict(BTreeMap::from([
+        .collect::<crate::value::DictMap>();
+    Ok(dict(crate::value::DictMap::from_iter([
         ("cookie_header".to_string(), string(header)),
         ("cookies".to_string(), dict(cookie_values)),
     ])))

--- a/crates/harn-vm/src/stdlib/crypto.rs
+++ b/crates/harn-vm/src/stdlib/crypto.rs
@@ -136,7 +136,7 @@ fn int_arg(args: &[VmValue], index: usize, name: &str) -> Result<i64, VmError> {
 }
 
 fn option_string(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Option<String>, VmError> {
@@ -151,7 +151,7 @@ fn option_string(
 }
 
 fn option_int(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Option<i64>, VmError> {
@@ -328,7 +328,7 @@ fn append_query(prefix: &str, query: &str) -> String {
 fn claims_arg<'a>(
     args: &'a [VmValue],
     options: &SignedUrlOptions,
-) -> Result<&'a BTreeMap<String, VmValue>, VmError> {
+) -> Result<&'a crate::value::DictMap, VmError> {
     let Some(value) = args.get(1) else {
         return Err(signed_url_error("claims is required"));
     };
@@ -398,9 +398,9 @@ fn verification_result(
     expired: bool,
     expires_at: Option<i64>,
     kid: Option<String>,
-    claims: BTreeMap<String, VmValue>,
+    claims: crate::value::DictMap,
 ) -> VmValue {
-    let mut result = BTreeMap::new();
+    let mut result = crate::value::DictMap::new();
     result.insert("valid".to_string(), VmValue::Bool(valid));
     result.put_str("reason", reason);
     result.insert(
@@ -417,11 +417,8 @@ fn verification_result(
         kid.map(|kid| VmValue::String(std::sync::Arc::from(kid)))
             .unwrap_or(VmValue::Nil),
     );
-    result.insert(
-        "claims".to_string(),
-        VmValue::Dict(std::sync::Arc::new(claims)),
-    );
-    VmValue::Dict(std::sync::Arc::new(result))
+    result.insert("claims".to_string(), VmValue::dict(claims));
+    VmValue::dict(result)
 }
 
 fn choose_secret(secret_or_keys: &VmValue, kid: Option<&str>) -> Result<Option<String>, VmError> {
@@ -483,7 +480,7 @@ fn verify_signed_url_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
             false,
             None,
             None,
-            BTreeMap::new(),
+            crate::value::DictMap::new(),
         ));
     }
     let signature = signatures[0].clone();
@@ -502,7 +499,7 @@ fn verify_signed_url_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
             false,
             None,
             None,
-            BTreeMap::new(),
+            crate::value::DictMap::new(),
         ));
     }
     let expires_at = match expires_values[0].parse::<i64>() {
@@ -515,7 +512,7 @@ fn verify_signed_url_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
                 false,
                 None,
                 None,
-                BTreeMap::new(),
+                crate::value::DictMap::new(),
             ));
         }
     };
@@ -534,12 +531,12 @@ fn verify_signed_url_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
             false,
             Some(expires_at),
             None,
-            BTreeMap::new(),
+            crate::value::DictMap::new(),
         ));
     }
     let kid = kid_values.first().cloned();
 
-    let mut claims = BTreeMap::new();
+    let mut claims = crate::value::DictMap::new();
     for (key, value) in &parts.query_pairs {
         if key != &options.signature_param
             && key != &options.expires_param
@@ -599,7 +596,7 @@ fn aws_sigv4_error(message: impl Into<String>) -> VmError {
     VmError::Runtime(format!("aws_sigv4_headers: {}", message.into()))
 }
 
-fn required_spec_string(spec: &BTreeMap<String, VmValue>, key: &str) -> Result<String, VmError> {
+fn required_spec_string(spec: &crate::value::DictMap, key: &str) -> Result<String, VmError> {
     match spec.get(key) {
         Some(VmValue::String(value)) if !value.trim().is_empty() => Ok(value.to_string()),
         Some(value) if !matches!(value, VmValue::Nil) => Err(aws_sigv4_error(format!(
@@ -611,7 +608,7 @@ fn required_spec_string(spec: &BTreeMap<String, VmValue>, key: &str) -> Result<S
 }
 
 fn optional_spec_string(
-    spec: &BTreeMap<String, VmValue>,
+    spec: &crate::value::DictMap,
     key: &str,
 ) -> Result<Option<String>, VmError> {
     match spec.get(key) {
@@ -625,10 +622,10 @@ fn optional_spec_string(
 }
 
 fn aws_sigv4_headers_arg(
-    spec: &BTreeMap<String, VmValue>,
+    spec: &crate::value::DictMap,
 ) -> Result<BTreeMap<String, String>, VmError> {
     match spec.get("headers") {
-        None | Some(VmValue::Nil) => Ok(BTreeMap::new()),
+        None | Some(VmValue::Nil) => Ok(std::collections::BTreeMap::new()),
         Some(VmValue::Dict(headers)) => Ok(headers
             .iter()
             .map(|(key, value)| (key.clone(), value.display()))
@@ -640,7 +637,7 @@ fn aws_sigv4_headers_arg(
     }
 }
 
-fn aws_sigv4_body_bytes(spec: &BTreeMap<String, VmValue>) -> Vec<u8> {
+fn aws_sigv4_body_bytes(spec: &crate::value::DictMap) -> Vec<u8> {
     match spec.get("body") {
         Some(VmValue::Bytes(bytes)) => bytes.as_ref().clone(),
         Some(VmValue::Nil) | None => Vec::new(),
@@ -1161,10 +1158,10 @@ fn ed25519_keypair_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue,
     rand::rng().fill(&mut bytes);
     let signing = SigningKey::from_bytes(&bytes);
     let verifying: VerifyingKey = signing.verifying_key();
-    let mut dict = std::collections::BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.put_str("private", hex::encode(signing.to_bytes()));
     dict.put_str("public", hex::encode(verifying.to_bytes()));
-    Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+    Ok(VmValue::dict(dict))
 }
 
 #[harn_builtin(
@@ -1246,10 +1243,10 @@ fn x25519_keypair_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, 
     rand::rng().fill(&mut bytes);
     let secret = StaticSecret::from(bytes);
     let public = PublicKey::from(&secret);
-    let mut dict = std::collections::BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.put_str("private", hex::encode(secret.to_bytes()));
     dict.put_str("public", hex::encode(public.to_bytes()));
-    Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+    Ok(VmValue::dict(dict))
 }
 
 #[harn_builtin(
@@ -1345,10 +1342,10 @@ fn jwt_verify_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
         ))))
     })?;
     let claims_value = crate::schema::json_to_vm_value(&decoded.claims);
-    let mut dict = std::collections::BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.insert("valid".to_string(), VmValue::Bool(true));
     dict.insert("claims".to_string(), claims_value);
-    Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+    Ok(VmValue::dict(dict))
 }
 
 pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
@@ -1396,7 +1393,6 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
 mod tests {
     use super::*;
     use crate::vm::Vm;
-    use std::collections::BTreeMap;
 
     const ES256_PRIVATE_KEY: &str = "-----BEGIN PRIVATE KEY-----\n\
 MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgWTFfCGljY6aw3Hrt\n\
@@ -1426,20 +1422,20 @@ C/edCMRM78P8eQTBCDUTK1ywSYaszvQZvneiW6gNtWEJndSreEcyyUdVvg==\n\
     }
 
     fn jwt_claims() -> VmValue {
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        VmValue::dict(crate::value::DictMap::from_iter([
             ("exp".to_string(), VmValue::Int(4_102_444_800)),
             ("iat".to_string(), VmValue::Int(1_700_000_000)),
             ("iss".to_string(), s("12345")),
-        ])))
+        ]))
     }
 
     fn dict(items: &[(&str, VmValue)]) -> VmValue {
-        VmValue::Dict(std::sync::Arc::new(
+        VmValue::dict(
             items
                 .iter()
                 .map(|(key, value)| (key.to_string(), value.clone()))
-                .collect(),
-        ))
+                .collect::<crate::value::DictMap>(),
+        )
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/csv.rs
+++ b/crates/harn-vm/src/stdlib/csv.rs
@@ -12,7 +12,7 @@ use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
-fn opt_bool(opts: Option<&BTreeMap<String, VmValue>>, key: &str, default: bool) -> bool {
+fn opt_bool(opts: Option<&crate::value::DictMap>, key: &str, default: bool) -> bool {
     opts.and_then(|d| match d.get(key) {
         Some(VmValue::Bool(b)) => Some(*b),
         _ => None,
@@ -21,7 +21,7 @@ fn opt_bool(opts: Option<&BTreeMap<String, VmValue>>, key: &str, default: bool) 
 }
 
 fn opt_delimiter(
-    opts: Option<&BTreeMap<String, VmValue>>,
+    opts: Option<&crate::value::DictMap>,
     key: &str,
     default: u8,
     builtin: &str,
@@ -92,7 +92,7 @@ fn csv_parse_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
                 let cell = record.get(i).unwrap_or("");
                 row.insert(h.to_string(), VmValue::String(std::sync::Arc::from(cell)));
             }
-            rows.push(VmValue::Dict(std::sync::Arc::new(row)));
+            rows.push(VmValue::dict(row));
         }
         Ok(VmValue::List(std::sync::Arc::new(rows)))
     } else {
@@ -226,12 +226,12 @@ mod tests {
     }
 
     fn dict(items: impl IntoIterator<Item = (&'static str, VmValue)>) -> VmValue {
-        VmValue::Dict(std::sync::Arc::new(
+        VmValue::dict(
             items
                 .into_iter()
                 .map(|(key, value)| (key.to_string(), value))
-                .collect(),
-        ))
+                .collect::<crate::value::DictMap>(),
+        )
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/datetime.rs
+++ b/crates/harn-vm/src/stdlib/datetime.rs
@@ -1,5 +1,4 @@
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 
 use chrono::{
     DateTime, Datelike, LocalResult, NaiveDate, NaiveDateTime, Offset, TimeZone, Timelike, Utc,
@@ -30,7 +29,7 @@ fn date_now_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
         "iso8601",
         now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(result)))
+    Ok(VmValue::dict(result))
 }
 
 #[harn_builtin(sig = "date_now_iso() -> string", category = "datetime")]
@@ -83,7 +82,7 @@ fn date_in_zone_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
     let local = dt.with_timezone(&tz);
     let mut result = zoned_datetime_dict(local);
     result.put_str("zone", tz_name);
-    Ok(VmValue::Dict(std::sync::Arc::new(result)))
+    Ok(VmValue::dict(result))
 }
 
 #[harn_builtin(
@@ -267,7 +266,7 @@ fn require_arg<'a>(
 fn require_dict<'a>(
     value: Option<&'a VmValue>,
     builtin: &str,
-) -> Result<&'a BTreeMap<String, VmValue>, VmError> {
+) -> Result<&'a crate::value::DictMap, VmError> {
     match value {
         Some(VmValue::Dict(map)) => Ok(map),
         Some(other) => Err(vm_error(format!(
@@ -282,8 +281,8 @@ pub(crate) fn vm_error(message: impl Into<String>) -> VmError {
     VmError::Thrown(VmValue::String(std::sync::Arc::from(message.into())))
 }
 
-fn utc_datetime_dict(dt: DateTime<Utc>) -> BTreeMap<String, VmValue> {
-    let mut result = BTreeMap::new();
+fn utc_datetime_dict(dt: DateTime<Utc>) -> crate::value::DictMap {
+    let mut result = crate::value::DictMap::new();
     result.insert("year".to_string(), VmValue::Int(dt.year() as i64));
     result.insert("month".to_string(), VmValue::Int(dt.month() as i64));
     result.insert("day".to_string(), VmValue::Int(dt.day() as i64));
@@ -297,8 +296,8 @@ fn utc_datetime_dict(dt: DateTime<Utc>) -> BTreeMap<String, VmValue> {
     result
 }
 
-fn zoned_datetime_dict(dt: DateTime<Tz>) -> BTreeMap<String, VmValue> {
-    let mut result = BTreeMap::new();
+fn zoned_datetime_dict(dt: DateTime<Tz>) -> crate::value::DictMap {
+    let mut result = crate::value::DictMap::new();
     result.insert("year".to_string(), VmValue::Int(dt.year() as i64));
     result.insert("month".to_string(), VmValue::Int(dt.month() as i64));
     result.insert("day".to_string(), VmValue::Int(dt.day() as i64));
@@ -465,7 +464,7 @@ fn timestamp_millis_value(millis: i128) -> Result<VmValue, VmError> {
 }
 
 fn component_i64(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     key: &str,
     default: Option<i64>,
 ) -> Result<i64, VmError> {
@@ -480,10 +479,7 @@ fn component_i64(
     }
 }
 
-fn datetime_from_components(
-    map: &BTreeMap<String, VmValue>,
-    tz: Tz,
-) -> Result<DateTime<Tz>, VmError> {
+fn datetime_from_components(map: &crate::value::DictMap, tz: Tz) -> Result<DateTime<Tz>, VmError> {
     let year = i32::try_from(component_i64(map, "year", None)?)
         .map_err(|_| vm_error("date_from_components: year out of range"))?;
     let month = u32::try_from(component_i64(map, "month", None)?).unwrap_or(0);

--- a/crates/harn-vm/src/stdlib/durable_step.rs
+++ b/crates/harn-vm/src/stdlib/durable_step.rs
@@ -91,7 +91,7 @@ fn register_step_namespace(vm: &mut Vm) {
     let names = ["run", "inspect"];
     vm.set_global(
         "step",
-        VmValue::Dict(std::sync::Arc::new(
+        VmValue::dict(
             std::iter::once((
                 "_namespace".to_string(),
                 VmValue::String(std::sync::Arc::from("step")),
@@ -103,7 +103,7 @@ fn register_step_namespace(vm: &mut Vm) {
                 )
             }))
             .collect::<BTreeMap<_, _>>(),
-        )),
+        ),
     );
 }
 
@@ -307,7 +307,7 @@ fn parse_step_inspect_namespace(args: Vec<VmValue>, vm: &Vm) -> Result<String, V
 }
 
 fn reject_unknown_options(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
     builtin: &str,
     allowed: &[&str],
 ) -> Result<(), VmError> {
@@ -538,10 +538,7 @@ mod tests {
 
     #[test]
     fn options_reject_unknown_keys() {
-        let options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
-            "namesapce".to_string(),
-            vm_str("oops"),
-        )])));
+        let options = VmValue::dict(BTreeMap::from([("namesapce".to_string(), vm_str("oops"))]));
 
         let err = parse_step_options(&options, "step.run").unwrap_err();
 

--- a/crates/harn-vm/src/stdlib/event_log.rs
+++ b/crates/harn-vm/src/stdlib/event_log.rs
@@ -118,7 +118,7 @@ fn register_event_log_namespace(vm: &mut Vm) {
     let names = ["emit", "latest", "subscribe"];
     vm.set_global(
         "event_log",
-        VmValue::Dict(std::sync::Arc::new(
+        VmValue::dict(
             std::iter::once((
                 "_namespace".to_string(),
                 VmValue::String(std::sync::Arc::from("event_log")),
@@ -130,7 +130,7 @@ fn register_event_log_namespace(vm: &mut Vm) {
                 )
             }))
             .collect::<BTreeMap<_, _>>(),
-        )),
+        ),
     );
 }
 

--- a/crates/harn-vm/src/stdlib/fs.rs
+++ b/crates/harn-vm/src/stdlib/fs.rs
@@ -87,37 +87,37 @@ fn result_err(value: VmValue) -> VmValue {
     VmValue::enum_variant("Result", "Err", vec![value])
 }
 
-fn bool_option(opts: &BTreeMap<String, VmValue>, key: &str) -> Option<bool> {
+fn bool_option(opts: &crate::value::DictMap, key: &str) -> Option<bool> {
     match opts.get(key) {
         Some(VmValue::Bool(value)) => Some(*value),
         _ => None,
     }
 }
 
-fn string_option(opts: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn string_option(opts: &crate::value::DictMap, key: &str) -> Option<String> {
     match opts.get(key) {
         Some(VmValue::String(value)) => Some(value.to_string()),
         _ => None,
     }
 }
 
-fn usize_option(opts: &BTreeMap<String, VmValue>, key: &str) -> Option<usize> {
+fn usize_option(opts: &crate::value::DictMap, key: &str) -> Option<usize> {
     opts.get(key)
         .and_then(VmValue::as_int)
         .and_then(|value| usize::try_from(value).ok())
 }
 
-fn u64_option(opts: &BTreeMap<String, VmValue>, key: &str) -> Option<u64> {
+fn u64_option(opts: &crate::value::DictMap, key: &str) -> Option<u64> {
     opts.get(key)
         .and_then(VmValue::as_int)
         .and_then(|value| u64::try_from(value).ok())
 }
 
-fn int_option(opts: &BTreeMap<String, VmValue>, key: &str) -> Option<i64> {
+fn int_option(opts: &crate::value::DictMap, key: &str) -> Option<i64> {
     opts.get(key).and_then(VmValue::as_int)
 }
 
-fn string_list_option(opts: &BTreeMap<String, VmValue>, key: &str) -> Vec<String> {
+fn string_list_option(opts: &crate::value::DictMap, key: &str) -> Vec<String> {
     match opts.get(key) {
         Some(VmValue::String(value)) => vec![value.to_string()],
         Some(VmValue::List(values)) => values
@@ -182,7 +182,7 @@ fn walk_entry_to_vm(entry: WalkDirEntry) -> VmValue {
     dict.insert("is_dir".to_string(), VmValue::Bool(entry.is_dir));
     dict.insert("is_file".to_string(), VmValue::Bool(entry.is_file));
     dict.insert("depth".to_string(), VmValue::Int(entry.depth));
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn walk_entries_to_json(entries: Vec<WalkDirEntry>) -> serde_json::Value {
@@ -785,7 +785,7 @@ fn stat_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError>
             info.insert("modified".to_string(), VmValue::Float(dur.as_secs_f64()));
         }
     }
-    Ok(VmValue::Dict(std::sync::Arc::new(info)))
+    Ok(VmValue::dict(info))
 }
 
 #[harn_builtin(

--- a/crates/harn-vm/src/stdlib/fs/find_text.rs
+++ b/crates/harn-vm/src/stdlib/fs/find_text.rs
@@ -273,7 +273,7 @@ fn text_match_to_vm(hit: TextMatch) -> VmValue {
     dict.insert("col".to_string(), VmValue::Int(hit.col));
     dict.insert("column".to_string(), VmValue::Int(hit.col));
     dict.put_str("text", hit.text);
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn text_matches_to_json(hits: Vec<TextMatch>) -> serde_json::Value {

--- a/crates/harn-vm/src/stdlib/fs/tests.rs
+++ b/crates/harn-vm/src/stdlib/fs/tests.rs
@@ -24,12 +24,12 @@ fn b(v: bool) -> VmValue {
 }
 
 fn dict(entries: Vec<(&str, VmValue)>) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(
+    VmValue::dict(
         entries
             .into_iter()
             .map(|(key, value)| (key.to_string(), value))
-            .collect(),
-    ))
+            .collect::<crate::value::DictMap>(),
+    )
 }
 
 fn drain_feedback(session_id: &str, handle_id: &str) -> serde_json::Value {

--- a/crates/harn-vm/src/stdlib/git.rs
+++ b/crates/harn-vm/src/stdlib/git.rs
@@ -1,5 +1,4 @@
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use serde_json::{json, Value as JsonValue};
@@ -389,7 +388,7 @@ fn register_git_namespace(vm: &mut Vm) {
         ("create", "git.worktree.create"),
         ("remove", "git.worktree.remove"),
     ]);
-    let mut root = BTreeMap::new();
+    let mut root = crate::value::DictMap::new();
     root.put_str("_namespace", "git");
     root.insert("repo".to_string(), repo);
     root.insert("worktree".to_string(), worktree);
@@ -410,11 +409,11 @@ fn register_git_namespace(vm: &mut Vm) {
             VmValue::BuiltinRef(std::sync::Arc::from(builtin)),
         );
     }
-    vm.set_global("git", VmValue::Dict(std::sync::Arc::new(root)));
+    vm.set_global("git", VmValue::dict(root));
 }
 
 fn namespace(entries: &[(&str, &str)]) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(
+    VmValue::dict(
         entries
             .iter()
             .map(|(name, builtin)| {
@@ -423,8 +422,8 @@ fn namespace(entries: &[(&str, &str)]) -> VmValue {
                     VmValue::BuiltinRef(std::sync::Arc::from(*builtin)),
                 )
             })
-            .collect(),
-    ))
+            .collect::<crate::value::DictMap>(),
+    )
 }
 
 async fn run_git_command(
@@ -579,7 +578,7 @@ const GIT_NONINTERACTIVE_ENV: &[(&str, &str)] = &[
 ];
 
 async fn exec_argv(command: &GitCommand) -> Result<VmValue, VmError> {
-    let mut params = BTreeMap::new();
+    let mut params = crate::value::DictMap::new();
     params.put_str("mode", "argv");
     params.insert(
         "argv".to_string(),
@@ -606,14 +605,14 @@ async fn exec_argv(command: &GitCommand) -> Result<VmValue, VmError> {
     // credential / host-key prompt fails fast instead of hanging a
     // TTY-less runtime. `env_mode: "merge"` keeps inherited PATH/HOME
     // and any credentials already present in the environment.
-    let mut env = BTreeMap::new();
+    let mut env = crate::value::DictMap::new();
     for (key, value) in GIT_NONINTERACTIVE_ENV {
         env.insert(
             (*key).to_string(),
             VmValue::String(std::sync::Arc::from(*value)),
         );
     }
-    params.insert("env".to_string(), VmValue::Dict(std::sync::Arc::new(env)));
+    params.insert("env".to_string(), VmValue::dict(env));
     params.put_str("env_mode", "merge");
     let caller = json!({
         "surface": "stdlib.git",
@@ -843,7 +842,7 @@ async fn persist_receipt_and_trust(
         .unwrap_or_else(|| install_memory_for_current_thread(EVENT_LOG_QUEUE_DEPTH));
     let topic = Topic::new(GIT_RECEIPTS_TOPIC)
         .map_err(|error| VmError::Runtime(format!("git receipt topic: {error}")))?;
-    let mut headers = BTreeMap::new();
+    let mut headers = std::collections::BTreeMap::new();
     if let Some(trace_id) = receipt.get("trace_id").and_then(|value| value.as_str()) {
         headers.insert("trace_id".to_string(), trace_id.to_string());
     }
@@ -1108,7 +1107,7 @@ fn repo_path_arg(args: &[VmValue], index: usize, builtin: &str) -> Result<PathBu
     }
 }
 
-fn repo_path_from_map(map: &BTreeMap<String, VmValue>, builtin: &str) -> Result<PathBuf, VmError> {
+fn repo_path_from_map(map: &crate::value::DictMap, builtin: &str) -> Result<PathBuf, VmError> {
     for key in ["root", "path", "cwd"] {
         if let Some(VmValue::String(path)) = map.get(key) {
             if !path.is_empty() {
@@ -1141,14 +1140,14 @@ fn required_string_arg(
     }
 }
 
-fn optional_dict_arg(args: &[VmValue], index: usize) -> Option<&BTreeMap<String, VmValue>> {
+fn optional_dict_arg(args: &[VmValue], index: usize) -> Option<&crate::value::DictMap> {
     args.get(index).and_then(|value| match value {
         VmValue::Dict(map) => Some(map.as_ref()),
         _ => None,
     })
 }
 
-fn string_option(map: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<String> {
+fn string_option(map: Option<&crate::value::DictMap>, key: &str) -> Option<String> {
     map.and_then(|map| map.get(key))
         .and_then(|value| match value {
             VmValue::String(value) if !value.is_empty() => Some(value.to_string()),
@@ -1156,7 +1155,7 @@ fn string_option(map: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<S
         })
 }
 
-fn bool_option(map: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<bool> {
+fn bool_option(map: Option<&crate::value::DictMap>, key: &str) -> Option<bool> {
     map.and_then(|map| map.get(key))
         .and_then(|value| match value {
             VmValue::Bool(value) => Some(*value),
@@ -1181,7 +1180,7 @@ fn string_list_arg(
 }
 
 fn string_list_option(
-    map: Option<&BTreeMap<String, VmValue>>,
+    map: Option<&crate::value::DictMap>,
     key: &str,
 ) -> Result<Option<Vec<String>>, VmError> {
     let Some(value) = map.and_then(|map| map.get(key)) else {

--- a/crates/harn-vm/src/stdlib/harn_entry.rs
+++ b/crates/harn-vm/src/stdlib/harn_entry.rs
@@ -119,7 +119,7 @@ pub(crate) async fn call_agent_loop(
     ctx: &AsyncBuiltinCtx,
     prompt: String,
     system: Option<String>,
-    options: std::collections::BTreeMap<String, VmValue>,
+    options: crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     call_harn_export_by_name(
         ctx,
@@ -131,7 +131,7 @@ pub(crate) async fn call_agent_loop(
             system
                 .map(|value| VmValue::String(std::sync::Arc::from(value)))
                 .unwrap_or(VmValue::Nil),
-            VmValue::Dict(std::sync::Arc::new(options)),
+            VmValue::dict(options),
         ],
     )
     .await

--- a/crates/harn-vm/src/stdlib/hitl.rs
+++ b/crates/harn-vm/src/stdlib/hitl.rs
@@ -619,7 +619,7 @@ pub(crate) async fn request_approval_for_side_effect(
     reviewers: Vec<String>,
     capabilities_requested: Vec<String>,
 ) -> Result<VmValue, VmError> {
-    let mut options = BTreeMap::new();
+    let mut options = crate::value::DictMap::new();
     options.insert("args".to_string(), crate::stdlib::json_to_vm_value(&detail));
     options.insert(
         "detail".to_string(),
@@ -646,7 +646,7 @@ pub(crate) async fn request_approval_for_side_effect(
     );
     let args = vec![
         VmValue::String(std::sync::Arc::from(action.to_string())),
-        VmValue::Dict(std::sync::Arc::new(options)),
+        VmValue::dict(options),
     ];
     request_approval_impl(None, &args).await
 }
@@ -1397,7 +1397,7 @@ async fn maybe_apply_mock_response(
         .unwrap_or_default()
         .into_iter()
         .map(|(key, value)| (key, crate::stdlib::json_to_vm_value(&value)))
-        .collect::<BTreeMap<_, _>>();
+        .collect::<crate::value::DictMap>();
     params.put_str("request_id", request_id);
     let Some(result) = dispatch_mock_host_call("hitl", kind.as_str(), &params) else {
         return Ok(());
@@ -1424,7 +1424,7 @@ async fn maybe_apply_mock_response(
 
 fn parse_hitl_response_dict(
     request_id: &str,
-    response_dict: &BTreeMap<String, VmValue>,
+    response_dict: &crate::value::DictMap,
 ) -> Result<HitlHostResponse, VmError> {
     Ok(HitlHostResponse {
         request_id: request_id.to_string(),
@@ -1707,7 +1707,7 @@ fn request_headers(request: &HitlRequestEnvelope) -> BTreeMap<String, String> {
 }
 
 fn response_headers(request_id: &str) -> BTreeMap<String, String> {
-    let mut headers = BTreeMap::new();
+    let mut headers = std::collections::BTreeMap::new();
     headers.insert("request_id".to_string(), request_id.to_string());
     headers
 }

--- a/crates/harn-vm/src/stdlib/hitl_read.rs
+++ b/crates/harn-vm/src/stdlib/hitl_read.rs
@@ -213,7 +213,7 @@ fn pending_row_to_value(row: PendingHitlRow) -> VmValue {
         "metadata".to_string(),
         crate::stdlib::json_to_vm_value(&row.metadata),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn parse_filters(value: Option<&VmValue>) -> Result<HitlPendingFilters, VmError> {

--- a/crates/harn-vm/src/stdlib/host.rs
+++ b/crates/harn-vm/src/stdlib/host.rs
@@ -36,7 +36,7 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
 struct HostMock {
     capability: String,
     operation: String,
-    params: Option<BTreeMap<String, VmValue>>,
+    params: Option<crate::value::DictMap>,
     result: Option<VmValue>,
     error: Option<String>,
 }
@@ -45,7 +45,7 @@ struct HostMock {
 struct HostMockCall {
     capability: String,
     operation: String,
-    params: BTreeMap<String, VmValue>,
+    params: crate::value::DictMap,
 }
 
 thread_local! {
@@ -87,8 +87,8 @@ fn pop_host_mock_scope() -> bool {
     }
 }
 
-fn capability_manifest_map() -> BTreeMap<String, VmValue> {
-    let mut root = BTreeMap::new();
+fn capability_manifest_map() -> crate::value::DictMap {
+    let mut root = crate::value::DictMap::new();
     root.insert(
         "process".to_string(),
         capability(
@@ -168,7 +168,7 @@ fn mocked_operation_entry() -> VmValue {
 }
 
 fn ensure_mocked_capability(
-    root: &mut BTreeMap<String, VmValue>,
+    root: &mut crate::value::DictMap,
     capability_name: &str,
     operation_name: &str,
 ) {
@@ -210,14 +210,8 @@ fn ensure_mocked_capability(
         .or_insert_with(mocked_operation_entry);
 
     entry.insert("ops".to_string(), VmValue::List(std::sync::Arc::new(ops)));
-    entry.insert(
-        "operations".to_string(),
-        VmValue::Dict(std::sync::Arc::new(operations)),
-    );
-    root.insert(
-        capability_name.to_string(),
-        VmValue::Dict(std::sync::Arc::new(entry)),
-    );
+    entry.insert("operations".to_string(), VmValue::dict(operations));
+    root.insert(capability_name.to_string(), VmValue::dict(entry));
 }
 
 fn capability_manifest_with_mocks() -> VmValue {
@@ -227,17 +221,17 @@ fn capability_manifest_with_mocks() -> VmValue {
             ensure_mocked_capability(&mut root, &host_mock.capability, &host_mock.operation);
         }
     });
-    VmValue::Dict(std::sync::Arc::new(root))
+    VmValue::dict(root)
 }
 
 fn op(name: &str, description: &str) -> (String, VmValue) {
-    let mut entry = BTreeMap::new();
+    let mut entry = crate::value::DictMap::new();
     entry.put_str("description", description);
-    (name.to_string(), VmValue::Dict(std::sync::Arc::new(entry)))
+    (name.to_string(), VmValue::dict(entry))
 }
 
 fn capability(description: &str, ops: &[(String, VmValue)]) -> VmValue {
-    let mut entry = BTreeMap::new();
+    let mut entry = crate::value::DictMap::new();
     entry.put_str("description", description);
     entry.insert(
         "ops".to_string(),
@@ -247,21 +241,15 @@ fn capability(description: &str, ops: &[(String, VmValue)]) -> VmValue {
                 .collect(),
         )),
     );
-    let mut op_dict = BTreeMap::new();
+    let mut op_dict = crate::value::DictMap::new();
     for (name, op) in ops {
         op_dict.insert(name.clone(), op.clone());
     }
-    entry.insert(
-        "operations".to_string(),
-        VmValue::Dict(std::sync::Arc::new(op_dict)),
-    );
-    VmValue::Dict(std::sync::Arc::new(entry))
+    entry.insert("operations".to_string(), VmValue::dict(op_dict));
+    VmValue::dict(entry)
 }
 
-pub(crate) fn require_param(
-    params: &BTreeMap<String, VmValue>,
-    key: &str,
-) -> Result<String, VmError> {
+pub(crate) fn require_param(params: &crate::value::DictMap, key: &str) -> Result<String, VmError> {
     params
         .get(key)
         .map(|v| v.display())
@@ -275,7 +263,7 @@ pub(crate) fn require_param(
 
 fn render_template(
     path: &str,
-    bindings: Option<&BTreeMap<String, VmValue>>,
+    bindings: Option<&crate::value::DictMap>,
 ) -> Result<String, VmError> {
     let asset = crate::stdlib::template::TemplateAsset::render_target(path).map_err(|msg| {
         VmError::Thrown(VmValue::String(std::sync::Arc::from(format!(
@@ -285,10 +273,7 @@ fn render_template(
     crate::stdlib::template::render_asset_result(&asset, bindings).map_err(VmError::from)
 }
 
-fn params_match(
-    expected: Option<&BTreeMap<String, VmValue>>,
-    actual: &BTreeMap<String, VmValue>,
-) -> bool {
+fn params_match(expected: Option<&crate::value::DictMap>, actual: &crate::value::DictMap) -> bool {
     let Some(expected) = expected else {
         return true;
     };
@@ -349,17 +334,14 @@ fn push_host_mock(host_mock: HostMock) {
 }
 
 fn mock_call_value(call: &HostMockCall) -> VmValue {
-    let mut item = BTreeMap::new();
+    let mut item = crate::value::DictMap::new();
     item.put_str("capability", call.capability.clone());
     item.put_str("operation", call.operation.clone());
-    item.insert(
-        "params".to_string(),
-        VmValue::Dict(std::sync::Arc::new(call.params.clone())),
-    );
-    VmValue::Dict(std::sync::Arc::new(item))
+    item.insert("params".to_string(), VmValue::dict(call.params.clone()));
+    VmValue::dict(item)
 }
 
-fn record_mock_call(capability: &str, operation: &str, params: &BTreeMap<String, VmValue>) {
+fn record_mock_call(capability: &str, operation: &str, params: &crate::value::DictMap) {
     HOST_MOCK_CALLS.with(|calls| {
         calls.borrow_mut().push(HostMockCall {
             capability: capability.to_string(),
@@ -372,7 +354,7 @@ fn record_mock_call(capability: &str, operation: &str, params: &BTreeMap<String,
 pub(crate) fn dispatch_mock_host_call(
     capability: &str,
     operation: &str,
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
 ) -> Option<Result<VmValue, VmError>> {
     let matched = HOST_MOCKS.with(|mocks| {
         mocks
@@ -415,7 +397,7 @@ pub trait HostCallBridge: Send + Sync {
         &self,
         capability: &str,
         operation: &str,
-        params: &BTreeMap<String, VmValue>,
+        params: &crate::value::DictMap,
     ) -> Result<Option<VmValue>, VmError>;
 
     fn list_tools(&self) -> Result<Option<VmValue>, VmError> {
@@ -456,7 +438,7 @@ pub fn clear_host_call_bridge() {
 pub fn dispatch_host_call_bridge(
     capability: &str,
     operation: &str,
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
 ) -> Option<Result<VmValue, VmError>> {
     let bridge = HOST_CALL_BRIDGE.with(|b| b.borrow().clone())?;
     match bridge.dispatch(capability, operation, params) {
@@ -540,7 +522,7 @@ pub(crate) async fn dispatch_host_tool_call_with_ctx(
 pub(crate) async fn dispatch_host_operation(
     capability: &str,
     operation: &str,
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     dispatch_host_operation_with_ctx(None, capability, operation, params).await
 }
@@ -549,7 +531,7 @@ pub(crate) async fn dispatch_host_operation_with_ctx(
     ctx: Option<&AsyncBuiltinCtx>,
     capability: &str,
     operation: &str,
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     if let Some(mocked) = dispatch_mock_host_call(capability, operation, params) {
         return mocked;
@@ -599,7 +581,7 @@ pub(crate) async fn dispatch_host_operation_with_ctx(
 async fn dispatch_builtin_host_operation(
     capability: &str,
     operation: &str,
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     match (capability, operation) {
         ("process", "list_shells") => Ok(crate::shells::list_shells_vm_value()),
@@ -661,7 +643,7 @@ async fn dispatch_builtin_host_operation(
 }
 
 pub(crate) async fn dispatch_process_exec(
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
     caller: serde_json::Value,
 ) -> Result<VmValue, VmError> {
     dispatch_process_exec_with_policy(None, params, caller).await
@@ -669,7 +651,7 @@ pub(crate) async fn dispatch_process_exec(
 
 async fn dispatch_process_exec_with_policy(
     ctx: Option<&AsyncBuiltinCtx>,
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
     caller: serde_json::Value,
 ) -> Result<VmValue, VmError> {
     let (params, command_policy_context, command_policy_decisions) =
@@ -724,7 +706,7 @@ async fn dispatch_process_exec_with_policy(
 /// poll/wait, which are not themselves command executions.
 async fn dispatch_process_spawn_with_policy(
     ctx: Option<&AsyncBuiltinCtx>,
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
     caller: serde_json::Value,
 ) -> Result<VmValue, VmError> {
     let params =
@@ -754,7 +736,7 @@ async fn dispatch_process_spawn_with_policy(
 
 async fn dispatch_process_exec_after_policy(
     ctx: Option<&AsyncBuiltinCtx>,
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
     command_policy_context: JsonValue,
     command_policy_decisions: Vec<crate::orchestration::CommandPolicyDecision>,
 ) -> Result<VmValue, VmError> {
@@ -859,7 +841,7 @@ async fn dispatch_process_exec_after_policy(
 /// behaviour on the returned command. `label` ("process.exec" or
 /// "process.spawn") is woven into error messages.
 pub(crate) fn build_sandboxed_command(
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
     label: &str,
 ) -> Result<tokio::process::Command, VmError> {
     let (program, args) = process_exec_argv(params)?;
@@ -923,7 +905,7 @@ struct ProcessExecResponse<'a> {
 
 fn process_exec_response(response: ProcessExecResponse<'_>) -> VmValue {
     let combined = format!("{}{}", response.stdout, response.stderr);
-    let mut result = BTreeMap::new();
+    let mut result = crate::value::DictMap::new();
     result.put_str(
         "command_id",
         format!(
@@ -975,14 +957,14 @@ fn process_exec_response(response: ProcessExecResponse<'_>) -> VmValue {
         VmValue::Int(response.exit_code as i64),
     );
     result.insert("success".to_string(), VmValue::Bool(response.success));
-    VmValue::Dict(std::sync::Arc::new(result))
+    VmValue::dict(result)
 }
 
 fn resolve_process_exec_cwd(cwd: &str) -> std::path::PathBuf {
     crate::stdlib::process::resolve_source_relative_path(cwd)
 }
 
-fn process_exec_argv(params: &BTreeMap<String, VmValue>) -> Result<(String, Vec<String>), VmError> {
+fn process_exec_argv(params: &crate::value::DictMap) -> Result<(String, Vec<String>), VmError> {
     match optional_string(params, "mode")
         .as_deref()
         .unwrap_or("shell")
@@ -1052,7 +1034,7 @@ impl Drop for SandboxProfileGuard {
     }
 }
 
-pub(crate) fn optional_i64(params: &BTreeMap<String, VmValue>, key: &str) -> Option<i64> {
+pub(crate) fn optional_i64(params: &crate::value::DictMap, key: &str) -> Option<i64> {
     match params.get(key) {
         Some(VmValue::Int(value)) => Some(*value),
         Some(VmValue::Float(value)) if value.fract() == 0.0 => Some(*value as i64),
@@ -1060,11 +1042,11 @@ pub(crate) fn optional_i64(params: &BTreeMap<String, VmValue>, key: &str) -> Opt
     }
 }
 
-pub(crate) fn optional_string(params: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+pub(crate) fn optional_string(params: &crate::value::DictMap, key: &str) -> Option<String> {
     params.get(key).and_then(vm_string).map(ToString::to_string)
 }
 
-fn optional_string_list(params: &BTreeMap<String, VmValue>, key: &str) -> Option<Vec<String>> {
+fn optional_string_list(params: &crate::value::DictMap, key: &str) -> Option<Vec<String>> {
     let VmValue::List(values) = params.get(key)? else {
         return None;
     };
@@ -1075,7 +1057,7 @@ fn optional_string_list(params: &BTreeMap<String, VmValue>, key: &str) -> Option
 }
 
 fn optional_string_dict(
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
     key: &str,
 ) -> Result<Option<BTreeMap<String, String>>, VmError> {
     let Some(value) = params.get(key) else {
@@ -1086,7 +1068,7 @@ fn optional_string_dict(
             "host_call process.exec {key} must be a dict"
         )));
     };
-    let mut out = BTreeMap::new();
+    let mut out = std::collections::BTreeMap::new();
     for (key, value) in dict.iter() {
         let Some(value) = vm_string(value) else {
             return Err(VmError::Runtime(format!(
@@ -1247,7 +1229,7 @@ mod tests {
         reset_host_state, resolve_process_exec_cwd, set_host_call_bridge, HostCallBridge, HostMock,
     };
     use crate::value::VmDictExt;
-    use std::collections::BTreeMap;
+
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -1262,7 +1244,7 @@ mod tests {
             crate::orchestration::RunExecutionRecord {
                 cwd: Some(dir.path().to_string_lossy().into_owned()),
                 source_dir: Some(dir.path().join("src").to_string_lossy().into_owned()),
-                env: BTreeMap::new(),
+                env: std::collections::BTreeMap::new(),
                 adapter: None,
                 repo_path: None,
                 worktree_path: None,
@@ -1303,7 +1285,7 @@ mod tests {
             capability: "project".to_string(),
             operation: "metadata_get".to_string(),
             params: None,
-            result: Some(VmValue::Dict(std::sync::Arc::new(BTreeMap::new()))),
+            result: Some(VmValue::dict(crate::value::DictMap::new())),
             error: None,
         });
         let manifest = capability_manifest_with_mocks();
@@ -1323,7 +1305,7 @@ mod tests {
     #[test]
     fn mock_host_call_matches_partial_params_and_overrides_order() {
         reset_host_state();
-        let mut exact_params = BTreeMap::new();
+        let mut exact_params = crate::value::DictMap::new();
         exact_params.put_str("namespace", "facts");
         push_host_mock(HostMock {
             capability: "project".to_string(),
@@ -1340,7 +1322,7 @@ mod tests {
             error: None,
         });
 
-        let mut call_params = BTreeMap::new();
+        let mut call_params = crate::value::DictMap::new();
         call_params.put_str("dir", "pkg");
         call_params.put_str("namespace", "facts");
         let exact = dispatch_mock_host_call("project", "metadata_get", &call_params)
@@ -1366,7 +1348,7 @@ mod tests {
             result: None,
             error: Some("boom".to_string()),
         });
-        let params = BTreeMap::new();
+        let params = crate::value::DictMap::new();
         let result = dispatch_mock_host_call("project", "metadata_get", &params)
             .expect("expected mock result");
         match result {
@@ -1384,13 +1366,13 @@ mod tests {
             &self,
             _capability: &str,
             _operation: &str,
-            _params: &BTreeMap<String, VmValue>,
+            _params: &crate::value::DictMap,
         ) -> Result<Option<VmValue>, VmError> {
             Ok(None)
         }
 
         fn list_tools(&self) -> Result<Option<VmValue>, VmError> {
-            let tool = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            let tool = VmValue::dict(crate::value::DictMap::from_iter([
                 (
                     "name".to_string(),
                     VmValue::String(std::sync::Arc::from("Read".to_string())),
@@ -1403,13 +1385,13 @@ mod tests {
                 ),
                 (
                     "schema".to_string(),
-                    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+                    VmValue::dict(crate::value::DictMap::from_iter([(
                         "type".to_string(),
                         VmValue::String(std::sync::Arc::from("object".to_string())),
-                    )]))),
+                    )])),
                 ),
                 ("deprecated".to_string(), VmValue::Bool(false)),
-            ])));
+            ]));
             Ok(Some(VmValue::List(std::sync::Arc::new(vec![tool]))))
         }
 
@@ -1437,20 +1419,20 @@ mod tests {
             &self,
             capability: &str,
             operation: &str,
-            _params: &BTreeMap<String, VmValue>,
+            _params: &crate::value::DictMap,
         ) -> Result<Option<VmValue>, VmError> {
             if (capability, operation) != ("process", "exec") {
                 return Ok(None);
             }
             self.calls.fetch_add(1, Ordering::SeqCst);
-            Ok(Some(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            Ok(Some(VmValue::dict(crate::value::DictMap::from_iter([
                 (
                     "status".to_string(),
                     VmValue::String(std::sync::Arc::from("completed".to_string())),
                 ),
                 ("exit_code".to_string(), VmValue::Int(0)),
                 ("success".to_string(), VmValue::Bool(true)),
-            ])))))
+            ]))))
         }
     }
 
@@ -1491,10 +1473,10 @@ mod tests {
     fn host_tool_call_uses_installed_host_call_bridge() {
         run_host_async_test(|| async {
             set_host_call_bridge(Arc::new(TestHostToolBridge));
-            let args = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            let args = VmValue::dict(crate::value::DictMap::from_iter([(
                 "path".to_string(),
                 VmValue::String(std::sync::Arc::from("README.md".to_string())),
-            )])));
+            )]));
             let value = dispatch_host_tool_call("Read", &args)
                 .await
                 .expect("tool call");
@@ -1525,7 +1507,7 @@ mod tests {
             let result = dispatch_host_operation(
                 "process",
                 "exec",
-                &BTreeMap::from([
+                &crate::value::DictMap::from_iter([
                     (
                         "mode".to_string(),
                         VmValue::String(std::sync::Arc::from("shell")),
@@ -1567,7 +1549,7 @@ mod tests {
         // explicitly-provided child var. The parent var is set on this
         // process's environment immediately before the spawn.
         std::env::set_var("PARENT_VAR", "inherited");
-        let mut params = BTreeMap::from([
+        let mut params = crate::value::DictMap::from_iter([
             (
                 "mode".to_string(),
                 VmValue::String(std::sync::Arc::from("argv")),
@@ -1605,10 +1587,10 @@ mod tests {
         run_host_async_test(|| async {
             // No `env_mode`: the provided key must be added WITHOUT clearing
             // the inherited parent environment (the env-clear footgun fix).
-            let child_env = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            let child_env = VmValue::dict(crate::value::DictMap::from_iter([(
                 "CHILD_VAR".to_string(),
                 VmValue::String(std::sync::Arc::from("provided")),
-            )])));
+            )]));
             let (parent, child) = process_exec_env_probe(child_env, None).await;
             assert_eq!(
                 parent, "inherited",
@@ -1628,10 +1610,10 @@ mod tests {
             // Explicit `replace`: the inherited parent var must be gone and
             // only the provided key survives. This preserves the ability to
             // fully replace the environment when intentionally requested.
-            let child_env = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            let child_env = VmValue::dict(crate::value::DictMap::from_iter([(
                 "CHILD_VAR".to_string(),
                 VmValue::String(std::sync::Arc::from("provided")),
-            )])));
+            )]));
             let (parent, child) = process_exec_env_probe(child_env, Some("replace")).await;
             assert_eq!(parent, "", "explicit replace must clear parent env");
             assert_eq!(
@@ -1645,7 +1627,7 @@ mod tests {
     #[test]
     fn process_exec_env_mode_unknown_is_rejected() {
         run_host_async_test(|| async {
-            let params = BTreeMap::from([
+            let params = crate::value::DictMap::from_iter([
                 (
                     "mode".to_string(),
                     VmValue::String(std::sync::Arc::from("argv")),
@@ -1658,10 +1640,10 @@ mod tests {
                 ),
                 (
                     "env".to_string(),
-                    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+                    VmValue::dict(crate::value::DictMap::from_iter([(
                         "CHILD_VAR".to_string(),
                         VmValue::String(std::sync::Arc::from("x")),
-                    )]))),
+                    )])),
                 ),
                 (
                     "env_mode".to_string(),

--- a/crates/harn-vm/src/stdlib/http_response.rs
+++ b/crates/harn-vm/src/stdlib/http_response.rs
@@ -47,7 +47,12 @@ pub(crate) fn register_http_response_builtins(vm: &mut Vm) {
 #[harn_builtin(sig = "http_ok(body: any?) -> dict", category = "http_response")]
 fn http_ok_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let body = args.first().cloned().unwrap_or(VmValue::Nil);
-    Ok(envelope(200, body, BODY_KIND_JSON, BTreeMap::new()))
+    Ok(envelope(
+        200,
+        body,
+        BODY_KIND_JSON,
+        crate::value::DictMap::new(),
+    ))
 }
 
 #[harn_builtin(
@@ -56,7 +61,7 @@ fn http_ok_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError>
 )]
 fn http_created_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let body = args.first().cloned().unwrap_or(VmValue::Nil);
-    let mut headers = BTreeMap::new();
+    let mut headers = crate::value::DictMap::new();
     if let Some(location) = args.get(1).and_then(string_or_nil) {
         headers.put_str("Location", location);
     }
@@ -65,7 +70,12 @@ fn http_created_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
 
 #[harn_builtin(sig = "http_no_content() -> dict", category = "http_response")]
 fn http_no_content_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    Ok(envelope(204, VmValue::Nil, BODY_KIND_NONE, BTreeMap::new()))
+    Ok(envelope(
+        204,
+        VmValue::Nil,
+        BODY_KIND_NONE,
+        crate::value::DictMap::new(),
+    ))
 }
 
 #[harn_builtin(
@@ -83,7 +93,7 @@ fn http_error_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
     let message = require_nonempty_string(args.get(2), "http_error", "message")?;
     let details = args.get(3).cloned().unwrap_or(VmValue::Nil);
 
-    let mut body = BTreeMap::new();
+    let mut body = crate::value::DictMap::new();
     body.put_str("code", code);
     body.put_str("message", message);
     if !matches!(details, VmValue::Nil) {
@@ -91,12 +101,12 @@ fn http_error_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
     }
     let mut env = envelope_map(
         status,
-        VmValue::Dict(std::sync::Arc::new(body)),
+        VmValue::dict(body),
         BODY_KIND_JSON,
-        BTreeMap::new(),
+        crate::value::DictMap::new(),
     );
     env.insert("is_error".to_string(), VmValue::Bool(true));
-    Ok(VmValue::Dict(std::sync::Arc::new(env)))
+    Ok(VmValue::dict(env))
 }
 
 #[harn_builtin(
@@ -141,7 +151,7 @@ async fn http_stream_impl(
         .unwrap_or_else(|| "application/octet-stream".to_string());
 
     let chunks = drain_to_list(source, "http_stream").await?;
-    let mut headers = BTreeMap::new();
+    let mut headers = crate::value::DictMap::new();
     headers.put_str("Content-Type", content_type);
     Ok(envelope(
         200,
@@ -183,7 +193,7 @@ async fn http_sse_impl(
     };
 
     let events = drain_to_list(source, "http_sse").await?;
-    let mut headers = BTreeMap::new();
+    let mut headers = crate::value::DictMap::new();
     headers.put_str("Content-Type", "text/event-stream");
     headers.put_str("Cache-Control", "no-cache");
     let mut env = envelope_map(
@@ -195,37 +205,32 @@ async fn http_sse_impl(
     if let Some(retry_ms) = retry_ms {
         env.insert("retry_ms".to_string(), VmValue::Int(retry_ms));
     }
-    Ok(VmValue::Dict(std::sync::Arc::new(env)))
+    Ok(VmValue::dict(env))
 }
 
 fn envelope(
     status: i64,
     body: VmValue,
     body_kind: &str,
-    headers: BTreeMap<String, VmValue>,
+    headers: crate::value::DictMap,
 ) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(envelope_map(
-        status, body, body_kind, headers,
-    )))
+    VmValue::dict(envelope_map(status, body, body_kind, headers))
 }
 
 fn envelope_map(
     status: i64,
     body: VmValue,
     body_kind: &str,
-    headers: BTreeMap<String, VmValue>,
-) -> BTreeMap<String, VmValue> {
-    let mut map = BTreeMap::new();
+    headers: crate::value::DictMap,
+) -> crate::value::DictMap {
+    let mut map = crate::value::DictMap::new();
     map.insert(
         HTTP_RESPONSE_TAG_KEY.to_string(),
         VmValue::String(std::sync::Arc::from(HTTP_RESPONSE_TAG_VERSION)),
     );
     map.insert("status".to_string(), VmValue::Int(status));
     map.put_str("body_kind", body_kind);
-    map.insert(
-        "headers".to_string(),
-        VmValue::Dict(std::sync::Arc::new(headers)),
-    );
+    map.insert("headers".to_string(), VmValue::dict(headers));
     if !matches!(body, VmValue::Nil) {
         map.insert("body".to_string(), body);
     }
@@ -285,12 +290,9 @@ fn string_or_nil(value: &VmValue) -> Option<String> {
     }
 }
 
-fn parse_headers(
-    value: Option<&VmValue>,
-    fn_name: &str,
-) -> Result<BTreeMap<String, VmValue>, VmError> {
+fn parse_headers(value: Option<&VmValue>, fn_name: &str) -> Result<crate::value::DictMap, VmError> {
     match value {
-        None | Some(VmValue::Nil) => Ok(BTreeMap::new()),
+        None | Some(VmValue::Nil) => Ok(crate::value::DictMap::new()),
         Some(VmValue::Dict(dict)) => Ok((**dict).clone()),
         Some(other) => Err(thrown_err(format!(
             "{fn_name}: headers must be a dict (got {})",
@@ -647,14 +649,11 @@ fn http_push_hints_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
         "Link".to_string(),
         VmValue::List(std::sync::Arc::new(combined)),
     );
-    envelope_map.insert(
-        "headers".to_string(),
-        VmValue::Dict(std::sync::Arc::new(headers)),
-    );
-    Ok(VmValue::Dict(std::sync::Arc::new(envelope_map)))
+    envelope_map.insert("headers".to_string(), VmValue::dict(headers));
+    Ok(VmValue::dict(envelope_map))
 }
 
-fn is_http_response_envelope(map: &BTreeMap<String, VmValue>) -> bool {
+fn is_http_response_envelope(map: &crate::value::DictMap) -> bool {
     matches!(
         map.get(HTTP_RESPONSE_TAG_KEY),
         Some(VmValue::String(tag)) if tag.as_ref() == HTTP_RESPONSE_TAG_VERSION,
@@ -738,7 +737,7 @@ fn http_upgrade_ws_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
         .find(|client| offered_subprotocols.iter().any(|name| name == *client))
         .cloned();
 
-    let mut headers = BTreeMap::new();
+    let mut headers = crate::value::DictMap::new();
     headers.put_str("Upgrade", "websocket");
     headers.put_str("Connection", "Upgrade");
     if let Some(name) = &negotiated {
@@ -761,8 +760,8 @@ fn http_upgrade_ws_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
     let mut env_map = envelope_map(101, VmValue::Nil, BODY_KIND_NONE, headers);
     env_map.insert(
         "ws_upgrade".to_string(),
-        VmValue::Dict(std::sync::Arc::new({
-            let mut map = BTreeMap::new();
+        VmValue::dict({
+            let mut map = crate::value::DictMap::new();
             map.insert(
                 "subprotocol".to_string(),
                 match &negotiated {
@@ -789,12 +788,12 @@ fn http_upgrade_ws_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
                 map.put_str("on_message", handler.clone());
             }
             map
-        })),
+        }),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(env_map)))
+    Ok(VmValue::dict(env_map))
 }
 
-fn header_lookup(headers: &BTreeMap<String, VmValue>, name: &str) -> Option<String> {
+fn header_lookup(headers: &crate::value::DictMap, name: &str) -> Option<String> {
     let needle = name.to_ascii_lowercase();
     headers
         .iter()
@@ -938,7 +937,7 @@ mod tests {
     use super::*;
     use crate::llm::helpers::vm_value_to_json;
 
-    fn dict(value: &VmValue) -> &BTreeMap<String, VmValue> {
+    fn dict(value: &VmValue) -> &crate::value::DictMap {
         value.as_dict().expect("envelope is a dict")
     }
 
@@ -975,10 +974,10 @@ mod tests {
 
     #[test]
     fn http_created_sets_location_header() {
-        let body = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        let body = VmValue::dict(crate::value::DictMap::from_iter([(
             "id".to_string(),
             VmValue::String(std::sync::Arc::from("sess_1")),
-        )])));
+        )]));
         let location = VmValue::String(std::sync::Arc::from("/v1/sessions/sess_1"));
         let response = http_created_impl(&[body, location], &mut String::new()).expect("created");
         let map = dict(&response);
@@ -1071,10 +1070,10 @@ mod tests {
     #[test]
     fn http_reply_bytes_uses_bytes_body_kind() {
         let bytes = VmValue::Bytes(std::sync::Arc::new(vec![0x00, 0xff, 0xfe, 0x80]));
-        let headers = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        let headers = VmValue::dict(crate::value::DictMap::from_iter([(
             "Content-Type".to_string(),
             VmValue::String(std::sync::Arc::from("application/octet-stream")),
-        )])));
+        )]));
         let response =
             http_reply_impl(&[VmValue::Int(200), bytes, headers], &mut String::new()).unwrap();
         let map = dict(&response);
@@ -1131,10 +1130,10 @@ mod tests {
 
     #[test]
     fn http_sse_sets_event_stream_headers_and_optional_retry() {
-        let events = vec![VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        let events = vec![VmValue::dict(crate::value::DictMap::from_iter([(
             "data".to_string(),
             VmValue::String(std::sync::Arc::from("ping")),
-        )])))];
+        )]))];
         let response = run_sync(|| {
             http_sse_impl(
                 crate::vm::AsyncBuiltinCtx::for_test(Vm::new()),
@@ -1168,10 +1167,10 @@ mod tests {
                 VmValue::Int(404),
                 VmValue::String(std::sync::Arc::from("not_found")),
                 VmValue::String(std::sync::Arc::from("missing")),
-                VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+                VmValue::dict(crate::value::DictMap::from_iter([(
                     "id".to_string(),
                     VmValue::String(std::sync::Arc::from("sess_404")),
-                )]))),
+                )])),
             ],
             &mut String::new(),
         )
@@ -1305,7 +1304,7 @@ mod tests {
     #[test]
     fn http_push_hints_appends_link_headers_with_inferred_as() {
         let envelope = http_ok_impl(
-            &[VmValue::Dict(std::sync::Arc::new(BTreeMap::new()))],
+            &[VmValue::dict(crate::value::DictMap::new())],
             &mut String::new(),
         )
         .unwrap();
@@ -1373,10 +1372,10 @@ mod tests {
 
     #[test]
     fn http_push_hints_rejects_untagged_envelope() {
-        let plain = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        let plain = VmValue::dict(crate::value::DictMap::from_iter([(
             "status".to_string(),
             VmValue::Int(200),
-        )])));
+        )]));
         let paths = VmValue::List(std::sync::Arc::new(vec![VmValue::String(
             std::sync::Arc::from("/main.css"),
         )]));
@@ -1392,11 +1391,11 @@ mod tests {
         let envelope = http_reply_impl(
             &[
                 VmValue::Int(200),
-                VmValue::Dict(std::sync::Arc::new(BTreeMap::new())),
-                VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+                VmValue::dict(crate::value::DictMap::new()),
+                VmValue::dict(crate::value::DictMap::from_iter([(
                     "Link".to_string(),
                     VmValue::String(std::sync::Arc::from("</legacy.css>; rel=preload; as=style")),
-                )]))),
+                )])),
             ],
             &mut String::new(),
         )
@@ -1421,20 +1420,20 @@ mod tests {
 
     #[test]
     fn http_upgrade_ws_envelope_negotiates_subprotocol() {
-        let req = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        let req = VmValue::dict(crate::value::DictMap::from_iter([(
             "headers".to_string(),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            VmValue::dict(crate::value::DictMap::from_iter([(
                 "Sec-WebSocket-Protocol".to_string(),
                 VmValue::String(std::sync::Arc::from("v0.harn, v1.harn")),
-            )]))),
-        )])));
-        let options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            )])),
+        )]));
+        let options = VmValue::dict(crate::value::DictMap::from_iter([(
             "subprotocols".to_string(),
             VmValue::List(std::sync::Arc::new(vec![
                 VmValue::String(std::sync::Arc::from("v1.harn")),
                 VmValue::String(std::sync::Arc::from("v2.harn")),
             ])),
-        )])));
+        )]));
         let response = http_upgrade_ws_impl(&[req, options], &mut String::new()).unwrap();
         let map = dict(&response);
         assert!(matches!(map.get("status"), Some(VmValue::Int(101))));
@@ -1473,20 +1472,20 @@ mod tests {
         // disagree (server-order picked v1; client-order picks v2).
         // The envelope MUST match what the upgrade handshake echoes
         // back, so we honour client preference everywhere.
-        let req = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        let req = VmValue::dict(crate::value::DictMap::from_iter([(
             "headers".to_string(),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            VmValue::dict(crate::value::DictMap::from_iter([(
                 "Sec-WebSocket-Protocol".to_string(),
                 VmValue::String(std::sync::Arc::from("v2.harn, v1.harn")),
-            )]))),
-        )])));
-        let options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            )])),
+        )]));
+        let options = VmValue::dict(crate::value::DictMap::from_iter([(
             "subprotocols".to_string(),
             VmValue::List(std::sync::Arc::new(vec![
                 VmValue::String(std::sync::Arc::from("v1.harn")),
                 VmValue::String(std::sync::Arc::from("v2.harn")),
             ])),
-        )])));
+        )]));
         let response = http_upgrade_ws_impl(&[req, options], &mut String::new()).unwrap();
         let upgrade = dict(&response)
             .get("ws_upgrade")
@@ -1500,14 +1499,14 @@ mod tests {
 
     #[test]
     fn parse_envelope_round_trips_ws_upgrade_marker() {
-        let req = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        let req = VmValue::dict(crate::value::DictMap::from_iter([(
             "headers".to_string(),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            VmValue::dict(crate::value::DictMap::from_iter([(
                 "Sec-WebSocket-Protocol".to_string(),
                 VmValue::String(std::sync::Arc::from("v1.harn")),
-            )]))),
-        )])));
-        let options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            )])),
+        )]));
+        let options = VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "subprotocols".to_string(),
                 VmValue::List(std::sync::Arc::new(vec![VmValue::String(
@@ -1515,7 +1514,7 @@ mod tests {
                 )])),
             ),
             ("idle_ping_ms".to_string(), VmValue::Int(15_000)),
-        ])));
+        ]));
         let response = http_upgrade_ws_impl(&[req, options], &mut String::new()).unwrap();
         let json = vm_value_to_json(&response);
         let envelope = parse_envelope(&json).expect("envelope parses");
@@ -1528,7 +1527,7 @@ mod tests {
 
     #[test]
     fn http_upgrade_ws_falls_through_when_no_subprotocols_offered() {
-        let req = VmValue::Dict(std::sync::Arc::new(BTreeMap::new()));
+        let req = VmValue::dict(crate::value::DictMap::new());
         let response = http_upgrade_ws_impl(&[req], &mut String::new()).unwrap();
         let map = dict(&response);
         let upgrade = map

--- a/crates/harn-vm/src/stdlib/io.rs
+++ b/crates/harn-vm/src/stdlib/io.rs
@@ -288,7 +288,7 @@ fn read_line_result(outcome: ReadLineOutcome) -> VmValue {
             out.insert("error".to_string(), VmValue::string(error));
         }
     }
-    VmValue::Dict(std::sync::Arc::new(out))
+    VmValue::dict(out)
 }
 
 const READ_LINE_FN: &str = "std/io.read_line";
@@ -1119,17 +1119,11 @@ fn render_progress_line(args: &[VmValue]) -> String {
     }
 }
 
-fn progress_dict_int(
-    options: &std::collections::BTreeMap<String, VmValue>,
-    key: &str,
-) -> Option<i64> {
+fn progress_dict_int(options: &crate::value::DictMap, key: &str) -> Option<i64> {
     options.get(key).and_then(|value| value.as_int())
 }
 
-fn progress_dict_str<'a>(
-    options: &'a std::collections::BTreeMap<String, VmValue>,
-    key: &str,
-) -> Option<&'a str> {
+fn progress_dict_str<'a>(options: &'a crate::value::DictMap, key: &str) -> Option<&'a str> {
     match options.get(key) {
         Some(VmValue::String(value)) => Some(value.as_ref()),
         _ => None,
@@ -1233,7 +1227,7 @@ mod tests {
         let line = render_progress_line(&[
             VmValue::String(std::sync::Arc::from("build")),
             VmValue::String(std::sync::Arc::from("Compiling")),
-            VmValue::Dict(std::sync::Arc::new(options)),
+            VmValue::dict(options),
         ]);
 
         assert_eq!(line, "[build] [######----] Compiling (3/5)\n");
@@ -1248,7 +1242,7 @@ mod tests {
         let line = render_progress_line(&[
             VmValue::String(std::sync::Arc::from("sync")),
             VmValue::String(std::sync::Arc::from("Waiting")),
-            VmValue::Dict(std::sync::Arc::new(options)),
+            VmValue::dict(options),
         ]);
 
         assert_eq!(line, "[sync] - Waiting\n");
@@ -1266,8 +1260,7 @@ mod tests {
         options.put_str("prompt", "  > ");
         options.insert("trim".to_string(), VmValue::Bool(false));
 
-        let parsed =
-            super::parse_read_line_options(&[VmValue::Dict(std::sync::Arc::new(options))]).unwrap();
+        let parsed = super::parse_read_line_options(&[VmValue::dict(options)]).unwrap();
 
         assert_eq!(parsed.prompt, "  > ");
         assert!(!parsed.trim);
@@ -1278,8 +1271,7 @@ mod tests {
         let mut options = BTreeMap::new();
         options.put_str("promtp", "> ");
 
-        let err = super::parse_read_line_options(&[VmValue::Dict(std::sync::Arc::new(options))])
-            .unwrap_err();
+        let err = super::parse_read_line_options(&[VmValue::dict(options)]).unwrap_err();
 
         match err {
             crate::value::VmError::Runtime(message) => assert!(message.contains("promtp")),

--- a/crates/harn-vm/src/stdlib/iter.rs
+++ b/crates/harn-vm/src/stdlib/iter.rs
@@ -136,7 +136,7 @@ fn register_stream_namespace(vm: &mut Vm) {
     ];
     vm.set_global(
         "stream",
-        VmValue::Dict(std::sync::Arc::new(
+        VmValue::dict(
             std::iter::once((
                 "_namespace".to_string(),
                 VmValue::String(std::sync::Arc::from("stream")),
@@ -148,7 +148,7 @@ fn register_stream_namespace(vm: &mut Vm) {
                 )
             }))
             .collect::<BTreeMap<_, _>>(),
-        )),
+        ),
     );
 }
 

--- a/crates/harn-vm/src/stdlib/json.rs
+++ b/crates/harn-vm/src/stdlib/json.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::BTreeMap, thread_local};
+use std::{cell::RefCell, thread_local};
 
 use crate::runtime_limits::RuntimeLimits;
 use crate::schema;
@@ -14,7 +14,10 @@ use crate::vm::Vm;
 const JSON_PARSE_CACHE_LIMIT: usize = RuntimeLimits::DEFAULT.max_json_parse_cache_entries;
 
 thread_local! {
-    static JSON_PARSE_CACHE: RefCell<BTreeMap<String, VmValue>> = const { RefCell::new(BTreeMap::new()) };
+    // Internal parse cache (source -> parsed value), not a Dict payload, so it
+    // stays a plain `BTreeMap`: it is mutated in place and needs a `const` init.
+    static JSON_PARSE_CACHE: RefCell<std::collections::BTreeMap<String, VmValue>> =
+        const { RefCell::new(std::collections::BTreeMap::new()) };
 }
 
 pub(crate) fn reset_json_state() {
@@ -499,10 +502,10 @@ fn pointer_set_at(value: &VmValue, tokens: &[String], replacement: VmValue) -> V
             let mut next = map.as_ref().clone();
             if tail.is_empty() {
                 next.insert(head.clone(), replacement);
-                VmValue::Dict(std::sync::Arc::new(next))
+                VmValue::dict(next)
             } else if let Some(child) = map.get(head) {
                 next.insert(head.clone(), pointer_set_at(child, tail, replacement));
-                VmValue::Dict(std::sync::Arc::new(next))
+                VmValue::dict(next)
             } else {
                 value.clone()
             }
@@ -553,10 +556,10 @@ fn pointer_delete_at(value: &VmValue, tokens: &[String]) -> VmValue {
             let mut next = map.as_ref().clone();
             if tail.is_empty() {
                 next.remove(head);
-                VmValue::Dict(std::sync::Arc::new(next))
+                VmValue::dict(next)
             } else if let Some(child) = map.get(head) {
                 next.insert(head.clone(), pointer_delete_at(child, tail));
-                VmValue::Dict(std::sync::Arc::new(next))
+                VmValue::dict(next)
             } else {
                 value.clone()
             }

--- a/crates/harn-vm/src/stdlib/json_query.rs
+++ b/crates/harn-vm/src/stdlib/json_query.rs
@@ -116,7 +116,7 @@ impl Expr {
                         expr.eval(input).into_iter().next().unwrap_or(VmValue::Nil),
                     );
                 }
-                vec![VmValue::Dict(std::sync::Arc::new(out))]
+                vec![VmValue::dict(out)]
             }
             Expr::Literal(value) => vec![value.clone()],
             Expr::Compare { .. } | Expr::Bool { .. } | Expr::Not(_) => {

--- a/crates/harn-vm/src/stdlib/json_stream.rs
+++ b/crates/harn-vm/src/stdlib/json_stream.rs
@@ -749,11 +749,7 @@ fn status_value(status: &JsonStreamStatus) -> VmValue {
                     VmValue::String(std::sync::Arc::from(path.as_str())),
                 ),
             ]);
-            VmValue::enum_variant(
-                "JsonStreamStatus",
-                "Invalid",
-                vec![VmValue::Dict(std::sync::Arc::new(payload))],
-            )
+            VmValue::enum_variant("JsonStreamStatus", "Invalid", vec![VmValue::dict(payload)])
         }
     }
 }
@@ -778,7 +774,7 @@ fn verdict_value(status: &JsonStreamStatus) -> VmValue {
             dict.put_str("path", path.as_str());
         }
     }
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn early_invalid(buffer: &str, schema: &VmValue) -> Option<EarlyInvalid> {
@@ -795,7 +791,7 @@ fn early_invalid(buffer: &str, schema: &VmValue) -> Option<EarlyInvalid> {
 
 fn early_invalid_object(
     buffer: &str,
-    schema: &BTreeMap<String, VmValue>,
+    schema: &crate::value::DictMap,
     path: &str,
 ) -> Option<EarlyInvalid> {
     if !schema_is_object_like(schema) {
@@ -846,7 +842,7 @@ fn early_invalid_object(
                     let value = schema::json_to_vm_value(&json);
                     if let Some(invalid) = schema_validation_error(
                         &value,
-                        &VmValue::Dict(std::sync::Arc::new(child_schema.clone())),
+                        &VmValue::dict(child_schema.clone()),
                         &child_path,
                     ) {
                         return Some(invalid);
@@ -866,7 +862,7 @@ fn early_invalid_object(
 
 fn invalid_type_start(
     first: char,
-    schema: &BTreeMap<String, VmValue>,
+    schema: &crate::value::DictMap,
     path: &str,
 ) -> Option<EarlyInvalid> {
     let expected = expected_type(schema)?;
@@ -915,7 +911,7 @@ fn schema_validation_error(value: &VmValue, schema: &VmValue, path: &str) -> Opt
     }
 }
 
-fn expected_type(schema: &BTreeMap<String, VmValue>) -> Option<&str> {
+fn expected_type(schema: &crate::value::DictMap) -> Option<&str> {
     if schema_is_object_like(schema) {
         return Some("dict");
     }
@@ -925,7 +921,7 @@ fn expected_type(schema: &BTreeMap<String, VmValue>) -> Option<&str> {
     }
 }
 
-fn schema_is_object_like(schema: &BTreeMap<String, VmValue>) -> bool {
+fn schema_is_object_like(schema: &crate::value::DictMap) -> bool {
     matches!(schema.get("type"), Some(VmValue::String(value)) if value.as_ref() == "dict")
         || schema.contains_key("properties")
         || schema.contains_key("required")
@@ -1091,12 +1087,12 @@ mod tests {
     }
 
     fn dict(entries: impl IntoIterator<Item = (&'static str, VmValue)>) -> VmValue {
-        VmValue::Dict(std::sync::Arc::new(
+        VmValue::dict(
             entries
                 .into_iter()
                 .map(|(key, value)| (key.to_string(), value))
-                .collect(),
-        ))
+                .collect::<crate::value::DictMap>(),
+        )
     }
 
     fn list(items: Vec<VmValue>) -> VmValue {

--- a/crates/harn-vm/src/stdlib/jsonrpc.rs
+++ b/crates/harn-vm/src/stdlib/jsonrpc.rs
@@ -21,9 +21,8 @@
 //! mock plumbing, and the egress allowlist apply identically to RPC
 //! traffic.
 
-use crate::value::VmDictExt;
+use crate::value::{DictRetain, VmDictExt};
 use std::cell::Cell;
-use std::collections::BTreeMap;
 
 use crate::http::execute_http_request;
 use crate::stdlib::json::vm_value_to_data_value;
@@ -157,9 +156,9 @@ struct BatchSlot {
 
 fn build_request_options(
     body: String,
-    options: Option<&BTreeMap<String, VmValue>>,
-) -> BTreeMap<String, VmValue> {
-    let mut headers = BTreeMap::new();
+    options: Option<&crate::value::DictMap>,
+) -> crate::value::DictMap {
+    let mut headers = crate::value::DictMap::new();
     headers.put_str("Content-Type", "application/json");
     headers.put_str("Accept", "application/json");
     if let Some(extra) = options
@@ -174,12 +173,9 @@ fn build_request_options(
             headers.insert(k.clone(), v.clone());
         }
     }
-    let mut request_options = BTreeMap::new();
+    let mut request_options = crate::value::DictMap::new();
     request_options.put_str("body", body);
-    request_options.insert(
-        "headers".to_string(),
-        VmValue::Dict(std::sync::Arc::new(headers)),
-    );
+    request_options.insert("headers".to_string(), VmValue::dict(headers));
     if let Some(d) = options {
         if let Some(timeout) = d.get("timeout_ms") {
             request_options.insert("timeout_ms".to_string(), timeout.clone());
@@ -213,7 +209,7 @@ fn next_id_value() -> VmValue {
 }
 
 fn build_envelope(method: &str, params: &VmValue, id: &VmValue, notify: bool) -> VmValue {
-    let mut m = BTreeMap::new();
+    let mut m = crate::value::DictMap::new();
     m.put_str("jsonrpc", "2.0");
     m.put_str("method", method);
     if !matches!(params, VmValue::Nil) {
@@ -222,7 +218,7 @@ fn build_envelope(method: &str, params: &VmValue, id: &VmValue, notify: bool) ->
     if !notify {
         m.insert("id".to_string(), id.clone());
     }
-    VmValue::Dict(std::sync::Arc::new(m))
+    VmValue::dict(m)
 }
 
 /// Extracts `result` from a JSON-RPC response envelope or raises a
@@ -232,9 +228,7 @@ fn build_envelope(method: &str, params: &VmValue, id: &VmValue, notify: bool) ->
 fn unwrap_jsonrpc_response(response: VmValue) -> Result<VmValue, VmError> {
     let envelope = decode_response_envelope(&response, "jsonrpc_call")?;
     if let Some(err) = envelope.get("error") {
-        return Err(VmError::Thrown(VmValue::Dict(std::sync::Arc::new(
-            error_to_dict(err),
-        ))));
+        return Err(VmError::Thrown(VmValue::dict(error_to_dict(err))));
     }
     let result = envelope
         .get("result")
@@ -289,15 +283,15 @@ fn unwrap_batch_response(response: VmValue, slots: &[BatchSlot]) -> Result<VmVal
             // Server dropped a response for a non-notify call. Emit
             // a synthetic error so the slot is still populated and
             // callers can detect the mismatch.
-            let mut err_dict = BTreeMap::new();
+            let mut err_dict = crate::value::DictMap::new();
             err_dict.insert("jsonrpc_error".to_string(), VmValue::Bool(true));
             err_dict.insert("code".to_string(), VmValue::Int(0));
             err_dict.put_str("message", "missing response for call");
-            out.push(VmValue::Dict(std::sync::Arc::new(err_dict)));
+            out.push(VmValue::dict(err_dict));
             continue;
         };
         if let Some(err) = entry.get("error") {
-            out.push(VmValue::Dict(std::sync::Arc::new(error_to_dict(err))));
+            out.push(VmValue::dict(error_to_dict(err)));
             continue;
         }
         let result = entry
@@ -339,13 +333,13 @@ fn decode_response_envelope(
         .map_err(|e| jsonrpc_err(&format!("{builtin}: response is not JSON: {e}")))
 }
 
-fn error_to_dict(err: &serde_json::Value) -> BTreeMap<String, VmValue> {
+fn error_to_dict(err: &serde_json::Value) -> crate::value::DictMap {
     let code = err.get("code").and_then(|c| c.as_i64()).unwrap_or(0);
     let message = err
         .get("message")
         .and_then(|m| m.as_str())
         .unwrap_or("jsonrpc error");
-    let mut error_dict = BTreeMap::new();
+    let mut error_dict = crate::value::DictMap::new();
     error_dict.insert("jsonrpc_error".to_string(), VmValue::Bool(true));
     error_dict.insert("code".to_string(), VmValue::Int(code));
     error_dict.put_str("message", message);
@@ -403,14 +397,9 @@ mod tests {
 
     #[test]
     fn envelope_includes_params_when_present() {
-        let mut params = BTreeMap::new();
+        let mut params = crate::value::DictMap::new();
         params.insert("x".to_string(), VmValue::Int(42));
-        let env = build_envelope(
-            "echo",
-            &VmValue::Dict(std::sync::Arc::new(params)),
-            &VmValue::Int(1),
-            false,
-        );
+        let env = build_envelope("echo", &VmValue::dict(params), &VmValue::Int(1), false);
         let dict = env.as_dict().unwrap();
         let params = dict.get("params").and_then(VmValue::as_dict).unwrap();
         assert_eq!(params.get("x").and_then(VmValue::as_int), Some(42));
@@ -419,10 +408,10 @@ mod tests {
     #[test]
     fn unwrap_returns_result_field() {
         let body = serde_json::json!({"jsonrpc":"2.0","result":{"ok":true},"id":1});
-        let mut response = BTreeMap::new();
+        let mut response = crate::value::DictMap::new();
         response.insert("status".to_string(), VmValue::Int(200));
         response.put_str("body", body.to_string());
-        let result = unwrap_jsonrpc_response(VmValue::Dict(std::sync::Arc::new(response))).unwrap();
+        let result = unwrap_jsonrpc_response(VmValue::dict(response)).unwrap();
         let dict = result.as_dict().unwrap();
         match dict.get("ok") {
             Some(VmValue::Bool(true)) => {}
@@ -437,11 +426,10 @@ mod tests {
             "error":{"code":-32601,"message":"Method not found"},
             "id":1,
         });
-        let mut response = BTreeMap::new();
+        let mut response = crate::value::DictMap::new();
         response.insert("status".to_string(), VmValue::Int(200));
         response.put_str("body", body.to_string());
-        let err =
-            unwrap_jsonrpc_response(VmValue::Dict(std::sync::Arc::new(response))).unwrap_err();
+        let err = unwrap_jsonrpc_response(VmValue::dict(response)).unwrap_err();
         match err {
             VmError::Thrown(VmValue::Dict(d)) => {
                 assert_eq!(d.get("code").and_then(VmValue::as_int), Some(-32601));
@@ -456,13 +444,10 @@ mod tests {
 
     #[test]
     fn build_request_options_case_insensitive_override() {
-        let mut user_headers = BTreeMap::new();
+        let mut user_headers = crate::value::DictMap::new();
         user_headers.put_str("content-type", "application/x-test");
-        let mut opts = BTreeMap::new();
-        opts.insert(
-            "headers".to_string(),
-            VmValue::Dict(std::sync::Arc::new(user_headers)),
-        );
+        let mut opts = crate::value::DictMap::new();
+        opts.insert("headers".to_string(), VmValue::dict(user_headers));
         let request_options = build_request_options("{}".to_string(), Some(&opts));
         let headers = request_options
             .get("headers")
@@ -474,7 +459,12 @@ mod tests {
             .keys()
             .filter(|k| k.eq_ignore_ascii_case("content-type"))
             .count();
-        assert_eq!(content_type_count, 1, "headers: {:?}", headers.keys());
+        assert_eq!(
+            content_type_count,
+            1,
+            "headers: {:?}",
+            headers.keys().collect::<Vec<_>>()
+        );
         assert_eq!(
             headers.get("content-type").map(VmValue::display),
             Some("application/x-test".to_string())
@@ -488,7 +478,7 @@ mod tests {
             {"jsonrpc":"2.0","result":"second","id":2},
             {"jsonrpc":"2.0","result":"first","id":1},
         ]);
-        let mut response = BTreeMap::new();
+        let mut response = crate::value::DictMap::new();
         response.insert("status".to_string(), VmValue::Int(200));
         response.put_str("body", body.to_string());
         let slots = vec![
@@ -501,8 +491,7 @@ mod tests {
                 notify: false,
             },
         ];
-        let result = unwrap_batch_response(VmValue::Dict(std::sync::Arc::new(response)), &slots)
-            .expect("batch unwrap");
+        let result = unwrap_batch_response(VmValue::dict(response), &slots).expect("batch unwrap");
         let items = match result {
             VmValue::List(items) => items,
             other => panic!("expected list, got {other:?}"),
@@ -517,7 +506,7 @@ mod tests {
             {"jsonrpc":"2.0","result":"ok","id":1},
             {"jsonrpc":"2.0","error":{"code":-32602,"message":"bad params"},"id":2},
         ]);
-        let mut response = BTreeMap::new();
+        let mut response = crate::value::DictMap::new();
         response.insert("status".to_string(), VmValue::Int(200));
         response.put_str("body", body.to_string());
         let slots = vec![
@@ -530,8 +519,7 @@ mod tests {
                 notify: false,
             },
         ];
-        let result = unwrap_batch_response(VmValue::Dict(std::sync::Arc::new(response)), &slots)
-            .expect("batch unwrap");
+        let result = unwrap_batch_response(VmValue::dict(response), &slots).expect("batch unwrap");
         let items = match result {
             VmValue::List(items) => items,
             other => panic!("expected list, got {other:?}"),

--- a/crates/harn-vm/src/stdlib/junit.rs
+++ b/crates/harn-vm/src/stdlib/junit.rs
@@ -14,7 +14,6 @@
 //! dating later is straightforward if drift becomes a real problem.
 
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 use std::time::Duration;
 
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
@@ -97,7 +96,7 @@ fn parse_junit_xml_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
 }
 
 fn record_to_value(record: TestRecord) -> VmValue {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: crate::value::DictMap = crate::value::DictMap::new();
     map.put_str("name", record.name.as_str());
     map.put_str("status", record.status.as_str());
     map.insert(
@@ -125,7 +124,7 @@ fn record_to_value(record: TestRecord) -> VmValue {
             .map(|s| VmValue::String(std::sync::Arc::from(s)))
             .unwrap_or(VmValue::Nil),
     );
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn parse_junit_xml(bytes: &[u8]) -> Vec<TestRecord> {

--- a/crates/harn-vm/src/stdlib/lifecycle_receipts.rs
+++ b/crates/harn-vm/src/stdlib/lifecycle_receipts.rs
@@ -159,7 +159,7 @@ fn lifecycle_replay_resume_input_impl(
         Some(crate::llm::vm_value_to_json(&candidate))
     };
     match replay_resume_input(&receipt, candidate_json.as_ref()) {
-        Ok(cached) => Ok(VmValue::Dict(std::sync::Arc::new({
+        Ok(cached) => Ok(VmValue::dict({
             let mut map = BTreeMap::new();
             map.insert("ok".to_string(), VmValue::Bool(true));
             map.insert(
@@ -170,7 +170,7 @@ fn lifecycle_replay_resume_input_impl(
                     .unwrap_or(VmValue::Nil),
             );
             map
-        }))),
+        })),
         Err(error) => Ok(error_value(error)),
     }
 }
@@ -195,12 +195,12 @@ fn lifecycle_replay_drain_decision_impl(
         ))
     })?;
     match replay_drain_decision(&receipt, candidate_prompt.as_deref()) {
-        Ok(action) => Ok(VmValue::Dict(std::sync::Arc::new({
+        Ok(action) => Ok(VmValue::dict({
             let mut map = BTreeMap::new();
             map.insert("ok".to_string(), VmValue::Bool(true));
             map.put_str("action", drain_action_str(action));
             map
-        }))),
+        })),
         Err(error) => Ok(error_value(error)),
     }
 }
@@ -392,7 +392,7 @@ fn drain_action_str(action: DrainAction) -> String {
     .to_string()
 }
 
-fn parse_trigger_match(dict: &BTreeMap<String, VmValue>) -> TriggerMatchInfo {
+fn parse_trigger_match(dict: &crate::value::DictMap) -> TriggerMatchInfo {
     TriggerMatchInfo {
         source: optional_string(dict, "source").unwrap_or_default(),
         event_id: optional_string(dict, "event_id").unwrap_or_default(),
@@ -424,12 +424,12 @@ fn parse_redaction_policy(value: Option<&VmValue>) -> Option<RedactionPolicy> {
     }
 }
 
-fn require_string(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<String, VmError> {
+fn require_string(dict: &crate::value::DictMap, key: &str) -> Result<String, VmError> {
     optional_string(dict, key)
         .ok_or_else(|| VmError::Runtime(format!("lifecycle receipt: missing {key}")))
 }
 
-fn optional_string(dict: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn optional_string(dict: &crate::value::DictMap, key: &str) -> Option<String> {
     dict.get(key).and_then(|value| match value {
         VmValue::String(text) if !text.is_empty() => Some(text.to_string()),
         VmValue::Nil => None,
@@ -480,7 +480,7 @@ fn verification_value(result: Result<(), LifecycleReceiptError>) -> VmValue {
             map.put_str("error", error.to_string());
         }
     }
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn error_value(error: LifecycleReceiptError) -> VmValue {
@@ -496,7 +496,7 @@ fn error_value(error: LifecycleReceiptError) -> VmValue {
         LifecycleReceiptError::Persistence(_) => "HARN-SUS-013",
     };
     map.put_str("code", code);
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn json_to_vm(value: &JsonValue) -> VmValue {

--- a/crates/harn-vm/src/stdlib/logging.rs
+++ b/crates/harn-vm/src/stdlib/logging.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::sync::atomic::AtomicU8;
 
 use crate::value::VmValue;
@@ -81,7 +80,7 @@ pub(crate) fn vm_value_to_json_fragment(val: &VmValue) -> String {
 pub(crate) fn vm_build_log_line(
     level: &str,
     msg: &str,
-    fields: Option<&BTreeMap<String, VmValue>>,
+    fields: Option<&crate::value::DictMap>,
 ) -> String {
     let ts = vm_format_timestamp_utc();
     let mut parts: Vec<String> = Vec::new();

--- a/crates/harn-vm/src/stdlib/long_running.rs
+++ b/crates/harn-vm/src/stdlib/long_running.rs
@@ -32,7 +32,7 @@ impl OperationHandleInfo {
         dict.put_str("status", "running");
         dict.put_str("operation", self.operation);
         dict.put_str("command_or_op_descriptor", self.descriptor);
-        VmValue::Dict(std::sync::Arc::new(dict))
+        VmValue::dict(dict)
     }
 }
 

--- a/crates/harn-vm/src/stdlib/memory.rs
+++ b/crates/harn-vm/src/stdlib/memory.rs
@@ -430,14 +430,14 @@ fn coerce_finite_f64(value: &VmValue) -> Option<f64> {
     }
 }
 
-fn option_string(options: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<String> {
+fn option_string(options: Option<&crate::value::DictMap>, key: &str) -> Option<String> {
     options
         .and_then(|opts| opts.get(key))
         .map(VmValue::display)
         .filter(|value| !value.trim().is_empty())
 }
 
-fn option_bool(options: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<bool> {
+fn option_bool(options: Option<&crate::value::DictMap>, key: &str) -> Option<bool> {
     match options.and_then(|opts| opts.get(key))? {
         VmValue::Bool(value) => Some(*value),
         VmValue::Nil => None,
@@ -445,7 +445,7 @@ fn option_bool(options: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option
     }
 }
 
-fn memory_root(options: Option<&BTreeMap<String, VmValue>>) -> PathBuf {
+fn memory_root(options: Option<&crate::value::DictMap>) -> PathBuf {
     resolve_memory_root(option_string(options, "root").as_deref())
 }
 
@@ -920,7 +920,7 @@ async fn ensure_embedding(
     if let Some(cached) = read_cached_embedding(&path)? {
         return Ok(cached.vector);
     }
-    let mut params = BTreeMap::new();
+    let mut params = crate::value::DictMap::new();
     params.put_str("text", text);
     params.put_str("model_hint", hint);
     let result = dispatch_host_operation("memory", "embed", &params).await?;
@@ -1271,7 +1271,7 @@ fn values_as_strings(value: &VmValue) -> Vec<String> {
 }
 
 fn memory_record_to_vm(record: &MemoryRecord, score: Option<f64>) -> VmValue {
-    let mut map = BTreeMap::new();
+    let mut map = crate::value::DictMap::new();
     map.put_str("_type", MEMORY_TYPE);
     map.put_str("id", record.id.as_str());
     map.put_str("namespace", record.namespace.as_str());
@@ -1303,7 +1303,7 @@ fn memory_record_to_vm(record: &MemoryRecord, score: Option<f64>) -> VmValue {
     if let Some(score) = score {
         map.insert("score".to_string(), VmValue::Float(score));
     }
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn summary_to_vm(namespace: &str, records: Vec<MemoryRecord>) -> VmValue {
@@ -1320,7 +1320,7 @@ fn summary_to_vm(namespace: &str, records: Vec<MemoryRecord>) -> VmValue {
         }
         text.push_str(&line);
     }
-    let mut map = BTreeMap::new();
+    let mut map = crate::value::DictMap::new();
     map.put_str("_type", "memory_summary");
     map.put_str("namespace", namespace);
     map.insert("count".to_string(), VmValue::Int(records.len() as i64));
@@ -1334,11 +1334,11 @@ fn summary_to_vm(namespace: &str, records: Vec<MemoryRecord>) -> VmValue {
                 .collect(),
         )),
     );
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn forget_result_to_vm(event: &ForgetEvent) -> VmValue {
-    let mut map = BTreeMap::new();
+    let mut map = crate::value::DictMap::new();
     map.put_str("_type", "memory_forget");
     map.put_str("id", event.id.as_str());
     map.put_str("namespace", event.namespace.as_str());
@@ -1357,11 +1357,11 @@ fn forget_result_to_vm(event: &ForgetEvent) -> VmValue {
         )),
     );
     map.put_str("forgotten_at", event.forgotten_at.as_str());
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn memory_open_to_vm(event: &OpenEvent) -> VmValue {
-    let mut map = BTreeMap::new();
+    let mut map = crate::value::DictMap::new();
     map.put_str("_type", "memory_open");
     map.put_str("id", event.id.as_str());
     map.put_str("namespace", event.namespace.as_str());
@@ -1401,7 +1401,7 @@ fn memory_open_to_vm(event: &OpenEvent) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     map.put_str("opened_at", event.opened_at.as_str());
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 fn first_line(text: &str) -> String {
@@ -1556,7 +1556,7 @@ mod tests {
 
     #[test]
     fn parse_embedding_response_validates_dim_and_vector_types() {
-        let mut dict = BTreeMap::new();
+        let mut dict = crate::value::DictMap::new();
         dict.insert(
             "vector".to_string(),
             VmValue::List(std::sync::Arc::new(vec![
@@ -1567,19 +1567,19 @@ mod tests {
         );
         dict.insert("dim".to_string(), VmValue::Int(3));
         dict.put_str("model", "test-model");
-        let value = VmValue::Dict(std::sync::Arc::new(dict));
+        let value = VmValue::dict(dict);
         let parsed = parse_embedding_response(value, "fallback").unwrap();
         assert_eq!(parsed.dim, 3);
         assert_eq!(parsed.model, "test-model");
         assert_eq!(parsed.vector, vec![0.1, 0.2, 1.0]);
 
-        let mut bad = BTreeMap::new();
+        let mut bad = crate::value::DictMap::new();
         bad.insert(
             "vector".to_string(),
             VmValue::List(std::sync::Arc::new(vec![VmValue::Float(0.1)])),
         );
         bad.insert("dim".to_string(), VmValue::Int(2));
-        let err = parse_embedding_response(VmValue::Dict(std::sync::Arc::new(bad)), "fallback")
+        let err = parse_embedding_response(VmValue::dict(bad), "fallback")
             .expect_err("dim mismatch must error");
         assert!(err.to_string().contains("dim=2"));
     }

--- a/crates/harn-vm/src/stdlib/monitors.rs
+++ b/crates/harn-vm/src/stdlib/monitors.rs
@@ -408,7 +408,7 @@ fn parse_source(value: Option<&VmValue>) -> Result<MonitorSource, VmError> {
 fn required_dict<'a>(
     value: Option<&'a VmValue>,
     builtin: &str,
-) -> Result<&'a BTreeMap<String, VmValue>, VmError> {
+) -> Result<&'a crate::value::DictMap, VmError> {
     match value {
         Some(VmValue::Dict(map)) => Ok(map),
         Some(other) => Err(VmError::Runtime(format!(
@@ -420,7 +420,7 @@ fn required_dict<'a>(
 }
 
 fn required_closure(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     field: &str,
     builtin: &str,
 ) -> Result<Arc<VmClosure>, VmError> {
@@ -429,7 +429,7 @@ fn required_closure(
 }
 
 fn optional_closure(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     field: &str,
     builtin: &str,
 ) -> Result<Option<Arc<VmClosure>>, VmError> {
@@ -464,7 +464,7 @@ fn parse_duration_value(value: &VmValue) -> Result<StdDuration, VmError> {
     )
 }
 
-fn string_field(map: &BTreeMap<String, VmValue>, field: &str) -> Result<Option<String>, VmError> {
+fn string_field(map: &crate::value::DictMap, field: &str) -> Result<Option<String>, VmError> {
     let Some(value) = map.get(field) else {
         return Ok(None);
     };
@@ -479,7 +479,7 @@ fn string_field(map: &BTreeMap<String, VmValue>, field: &str) -> Result<Option<S
     }
 }
 
-fn bool_field(map: &BTreeMap<String, VmValue>, field: &str) -> Result<Option<bool>, VmError> {
+fn bool_field(map: &crate::value::DictMap, field: &str) -> Result<Option<bool>, VmError> {
     let Some(value) = map.get(field) else {
         return Ok(None);
     };

--- a/crates/harn-vm/src/stdlib/multipart.rs
+++ b/crates/harn-vm/src/stdlib/multipart.rs
@@ -36,8 +36,8 @@ fn bytes_value(bytes: Vec<u8>) -> VmValue {
     VmValue::Bytes(std::sync::Arc::new(bytes))
 }
 
-fn dict_value(fields: BTreeMap<String, VmValue>) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(fields))
+fn dict_value(fields: crate::value::DictMap) -> VmValue {
+    VmValue::dict(fields)
 }
 
 fn list_value(items: Vec<VmValue>) -> VmValue {
@@ -93,7 +93,7 @@ fn expect_dict<'a>(
     value: &'a VmValue,
     builtin: &str,
     label: &str,
-) -> Result<&'a BTreeMap<String, VmValue>, VmError> {
+) -> Result<&'a crate::value::DictMap, VmError> {
     match value {
         VmValue::Dict(map) => Ok(map.as_ref()),
         other => Err(builtin_error(
@@ -107,7 +107,7 @@ fn optional_options<'a>(
     args: &'a [VmValue],
     index: usize,
     builtin: &str,
-) -> Result<Option<&'a BTreeMap<String, VmValue>>, VmError> {
+) -> Result<Option<&'a crate::value::DictMap>, VmError> {
     match args.get(index) {
         Some(VmValue::Dict(map)) => Ok(Some(map.as_ref())),
         Some(VmValue::Nil) | None => Ok(None),
@@ -123,7 +123,7 @@ fn optional_options<'a>(
 }
 
 fn opt_usize(
-    opts: Option<&BTreeMap<String, VmValue>>,
+    opts: Option<&crate::value::DictMap>,
     key: &str,
     default: usize,
     builtin: &str,
@@ -142,10 +142,7 @@ fn opt_usize(
     }
 }
 
-fn parse_limits(
-    opts: Option<&BTreeMap<String, VmValue>>,
-    builtin: &str,
-) -> Result<Limits, VmError> {
+fn parse_limits(opts: Option<&crate::value::DictMap>, builtin: &str) -> Result<Limits, VmError> {
     Ok(Limits {
         max_total_bytes: opt_usize(opts, "max_total_bytes", DEFAULT_MAX_TOTAL_BYTES, builtin)?,
         max_field_bytes: opt_usize(opts, "max_field_bytes", DEFAULT_MAX_FIELD_BYTES, builtin)?,
@@ -214,7 +211,7 @@ fn unquote_param(value: &str) -> String {
 fn parse_header_value_params(value: &str) -> (String, BTreeMap<String, String>) {
     let mut parts = split_params(value).into_iter();
     let base = parts.next().unwrap_or_default().to_ascii_lowercase();
-    let mut params = BTreeMap::new();
+    let mut params = std::collections::BTreeMap::new();
     for part in parts {
         let Some((name, value)) = part.split_once('=') else {
             continue;
@@ -290,7 +287,7 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 fn parse_part_headers(raw: &[u8], builtin: &str) -> Result<BTreeMap<String, String>, VmError> {
     let text = std::str::from_utf8(raw)
         .map_err(|error| builtin_error(builtin, format!("part headers are not UTF-8: {error}")))?;
-    let mut headers = BTreeMap::new();
+    let mut headers = std::collections::BTreeMap::new();
     if text.is_empty() {
         return Ok(headers);
     }
@@ -438,7 +435,7 @@ fn parsed_field_value(field: ParsedField) -> VmValue {
         Ok(text) => VmValue::string(text),
         Err(_) => VmValue::Nil,
     };
-    let mut map = BTreeMap::new();
+    let mut map = crate::value::DictMap::new();
     map.insert("name".to_string(), VmValue::string(field.name));
     map.insert("filename".to_string(), nil_or_string(field.filename));
     map.insert(
@@ -465,7 +462,7 @@ fn multipart_parse_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValu
     let fields = parse_multipart_body(&body, &boundary, &limits, "multipart_parse")?;
     let field_count = fields.len() as i64;
 
-    let mut result = BTreeMap::new();
+    let mut result = crate::value::DictMap::new();
     result.insert("boundary".to_string(), VmValue::string(boundary));
     result.insert(
         "fields".to_string(),
@@ -479,7 +476,7 @@ fn multipart_parse_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValu
 fn field_dict<'a>(
     args: &'a [VmValue],
     builtin: &str,
-) -> Result<&'a BTreeMap<String, VmValue>, VmError> {
+) -> Result<&'a crate::value::DictMap, VmError> {
     match args.first() {
         Some(value) => expect_dict(value, builtin, "field"),
         None => Err(builtin_error(builtin, "missing argument 1")),
@@ -532,7 +529,7 @@ fn multipart_field_text_builtin(args: &[VmValue], _out: &mut String) -> Result<V
 }
 
 fn field_input_string(
-    field: &BTreeMap<String, VmValue>,
+    field: &crate::value::DictMap,
     key: &str,
     builtin: &str,
     required: bool,
@@ -551,10 +548,7 @@ fn field_input_string(
     }
 }
 
-fn field_input_content(
-    field: &BTreeMap<String, VmValue>,
-    builtin: &str,
-) -> Result<Vec<u8>, VmError> {
+fn field_input_content(field: &crate::value::DictMap, builtin: &str) -> Result<Vec<u8>, VmError> {
     match field.get("content").or_else(|| field.get("value")) {
         Some(VmValue::Bytes(bytes)) => Ok(bytes.as_ref().clone()),
         Some(VmValue::String(text)) => Ok(text.as_bytes().to_vec()),
@@ -567,14 +561,14 @@ fn field_input_content(
 }
 
 fn input_headers(
-    field: &BTreeMap<String, VmValue>,
+    field: &crate::value::DictMap,
     builtin: &str,
 ) -> Result<BTreeMap<String, String>, VmError> {
     let Some(value) = field.get("headers") else {
-        return Ok(BTreeMap::new());
+        return Ok(std::collections::BTreeMap::new());
     };
     let headers = expect_dict(value, builtin, "headers")?;
-    let mut out = BTreeMap::new();
+    let mut out = std::collections::BTreeMap::new();
     for (name, value) in headers {
         if name.contains('\r') || name.contains('\n') || name.trim().is_empty() {
             return Err(builtin_error(builtin, "header names must be single-line"));
@@ -608,7 +602,7 @@ fn quote_header_param(value: &str) -> String {
 fn write_field_part(
     out: &mut Vec<u8>,
     boundary: &str,
-    field: &BTreeMap<String, VmValue>,
+    field: &crate::value::DictMap,
 ) -> Result<(), VmError> {
     let name = field_input_string(field, "name", "multipart_form_data", true)?.unwrap();
     if name.contains('\r') || name.contains('\n') {
@@ -755,7 +749,7 @@ fn multipart_form_data_builtin(args: &[VmValue], _out: &mut String) -> Result<Vm
 
 fn form_data_result(boundary: String, body: Vec<u8>) -> Result<VmValue, VmError> {
     let content_type = format!("multipart/form-data; boundary={boundary}");
-    let mut result = BTreeMap::new();
+    let mut result = crate::value::DictMap::new();
     result.insert("boundary".to_string(), VmValue::string(boundary));
     result.insert("content_type".to_string(), VmValue::string(content_type));
     result.insert("body".to_string(), bytes_value(body));
@@ -840,7 +834,7 @@ mod tests {
             vec![
                 body,
                 s("multipart/form-data; boundary=x"),
-                dict_value(BTreeMap::from([(
+                dict_value(crate::value::DictMap::from_iter([(
                     "max_fields".to_string(),
                     VmValue::Int(0),
                 )])),

--- a/crates/harn-vm/src/stdlib/net.rs
+++ b/crates/harn-vm/src/stdlib/net.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -23,7 +22,7 @@ struct UnixSocketOptions {
     max_response_bytes: usize,
 }
 
-fn option_int(options: Option<&BTreeMap<String, VmValue>>, key: &str, default: i64) -> i64 {
+fn option_int(options: Option<&crate::value::DictMap>, key: &str, default: i64) -> i64 {
     options
         .and_then(|opts| opts.get(key))
         .and_then(VmValue::as_int)
@@ -45,11 +44,11 @@ fn unix_socket_options(value: Option<&VmValue>) -> UnixSocketOptions {
     }
 }
 
-fn insert_string(dict: &mut BTreeMap<String, VmValue>, key: &str, value: impl Into<String>) {
+fn insert_string(dict: &mut crate::value::DictMap, key: &str, value: impl Into<String>) {
     dict.insert(key.to_string(), VmValue::String(Arc::from(value.into())));
 }
 
-fn insert_int(dict: &mut BTreeMap<String, VmValue>, key: &str, value: i64) {
+fn insert_int(dict: &mut crate::value::DictMap, key: &str, value: i64) {
     dict.insert(key.to_string(), VmValue::Int(value));
 }
 
@@ -66,7 +65,7 @@ fn socket_result(
     raw_response: Option<String>,
     response: Option<VmValue>,
 ) -> VmValue {
-    let mut out = BTreeMap::new();
+    let mut out = crate::value::DictMap::new();
     out.insert("ok".to_string(), VmValue::Bool(ok));
     insert_string(&mut out, "status", status);
     insert_string(&mut out, "path", path);
@@ -81,7 +80,7 @@ fn socket_result(
     if let Some(response) = response {
         out.insert("response".to_string(), response);
     }
-    VmValue::Dict(Arc::new(out))
+    VmValue::dict(out)
 }
 
 #[cfg(unix)]

--- a/crates/harn-vm/src/stdlib/net_policy.rs
+++ b/crates/harn-vm/src/stdlib/net_policy.rs
@@ -149,7 +149,7 @@ fn net_policy_create_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue
         .cloned()
         .unwrap_or_else(|| VmValue::String(std::sync::Arc::from("error")));
     policy.insert("on_violation".to_string(), on_violation);
-    Ok(VmValue::Dict(std::sync::Arc::new(policy)))
+    Ok(VmValue::dict(policy))
 }
 
 pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
@@ -169,7 +169,7 @@ fn rule_dict(kind: &'static str, fields: &[(&str, VmValue)]) -> VmValue {
     for (key, value) in fields {
         dict.insert((*key).to_string(), value.clone());
     }
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn require_string(args: &[VmValue], index: usize, callee: &str) -> Result<String, VmError> {

--- a/crates/harn-vm/src/stdlib/oauth_dynreg.rs
+++ b/crates/harn-vm/src/stdlib/oauth_dynreg.rs
@@ -115,7 +115,7 @@ struct DynregStore {
 
 thread_local! {
     static DYNREG_STORES: RefCell<BTreeMap<String, DynregStore>> =
-        const { RefCell::new(BTreeMap::new()) };
+        const { RefCell::new(std::collections::BTreeMap::new()) };
 }
 
 static STORE_ID_COUNTER: Mutex<u64> = Mutex::new(0);
@@ -238,16 +238,16 @@ fn next_store_id() -> String {
 }
 
 fn store_handle(id: &str) -> VmValue {
-    let mut fields = BTreeMap::new();
+    let mut fields = crate::value::DictMap::new();
     fields.insert(
         HANDLE_KEY_KIND.to_string(),
         VmValue::string(KIND_DYNREG_STORE),
     );
     fields.insert(HANDLE_KEY_ID.to_string(), VmValue::string(id));
-    VmValue::Dict(std::sync::Arc::new(fields))
+    VmValue::dict(fields)
 }
 
-fn handle_id(handle: &BTreeMap<String, VmValue>) -> Result<String, VmError> {
+fn handle_id(handle: &crate::value::DictMap) -> Result<String, VmError> {
     let kind = handle.get(HANDLE_KEY_KIND).and_then(|value| match value {
         VmValue::String(s) => Some(s.to_string()),
         _ => None,
@@ -278,10 +278,10 @@ fn handle_id(handle: &BTreeMap<String, VmValue>) -> Result<String, VmError> {
 
 // ----- Validation -----------------------------------------------------------
 
-fn validate_metadata_value(metadata: &BTreeMap<String, VmValue>) -> VmValue {
+fn validate_metadata_value(metadata: &crate::value::DictMap) -> VmValue {
     let mut errors: Vec<String> = Vec::new();
     validate_metadata(metadata, &mut errors);
-    let mut out = BTreeMap::new();
+    let mut out = crate::value::DictMap::new();
     out.insert("ok".to_string(), VmValue::Bool(errors.is_empty()));
     out.insert(
         "errors".to_string(),
@@ -289,12 +289,12 @@ fn validate_metadata_value(metadata: &BTreeMap<String, VmValue>) -> VmValue {
             errors.iter().map(VmValue::string).collect::<Vec<_>>(),
         )),
     );
-    VmValue::Dict(std::sync::Arc::new(out))
+    VmValue::dict(out)
 }
 
 /// Run RFC 7591 §2 validation, pushing human-readable errors. Each error
 /// is prefixed `HARN-OAU-005: ` so callers can pattern-match consistently.
-fn validate_metadata(metadata: &BTreeMap<String, VmValue>, errors: &mut Vec<String>) {
+fn validate_metadata(metadata: &crate::value::DictMap, errors: &mut Vec<String>) {
     // redirect_uris: required, non-empty list, https or loopback http, no
     // fragments. RFC 7591 §2 + §5 — server may reject otherwise.
     let redirect_uris = metadata.get("redirect_uris");
@@ -462,7 +462,7 @@ fn is_loopback_redirect_host(host: &str) -> bool {
 }
 
 fn validate_enum_list(
-    metadata: &BTreeMap<String, VmValue>,
+    metadata: &crate::value::DictMap,
     field: &str,
     allowed: &[&str],
     optional: bool,
@@ -500,7 +500,7 @@ fn validate_enum_list(
 }
 
 fn validate_optional_bounded_string(
-    metadata: &BTreeMap<String, VmValue>,
+    metadata: &crate::value::DictMap,
     field: &str,
     max_len: usize,
     errors: &mut Vec<String>,
@@ -521,11 +521,7 @@ fn validate_optional_bounded_string(
     }
 }
 
-fn validate_optional_url(
-    metadata: &BTreeMap<String, VmValue>,
-    field: &str,
-    errors: &mut Vec<String>,
-) {
+fn validate_optional_url(metadata: &crate::value::DictMap, field: &str, errors: &mut Vec<String>) {
     if let Some(value) = metadata.get(field) {
         match value {
             VmValue::Nil => {}
@@ -546,7 +542,7 @@ fn validate_optional_url(
 
 // ----- Metadata builders ----------------------------------------------------
 
-fn build_client_metadata_value(metadata: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
+fn build_client_metadata_value(metadata: &crate::value::DictMap) -> Result<VmValue, VmError> {
     let mut errors: Vec<String> = Vec::new();
     validate_metadata(metadata, &mut errors);
     if !errors.is_empty() {
@@ -559,7 +555,7 @@ fn build_client_metadata_value(metadata: &BTreeMap<String, VmValue>) -> Result<V
     // Apply RFC 7591 §2 defaults when fields are omitted: response_types
     // defaults to `["code"]`; grant_types defaults to `["authorization_code"]`;
     // token_endpoint_auth_method defaults to `client_secret_basic`.
-    let mut out: BTreeMap<String, VmValue> = metadata.clone();
+    let mut out: crate::value::DictMap = metadata.clone();
     out.entry("response_types".to_string())
         .or_insert_with(|| VmValue::List(std::sync::Arc::new(vec![VmValue::string("code")])));
     out.entry("grant_types".to_string()).or_insert_with(|| {
@@ -569,18 +565,18 @@ fn build_client_metadata_value(metadata: &BTreeMap<String, VmValue>) -> Result<V
     });
     out.entry("token_endpoint_auth_method".to_string())
         .or_insert_with(|| VmValue::string("client_secret_basic"));
-    Ok(VmValue::Dict(std::sync::Arc::new(out)))
+    Ok(VmValue::dict(out))
 }
 
 fn build_authorization_server_metadata_value(
-    provider: &BTreeMap<String, VmValue>,
-    overrides: Option<&BTreeMap<String, VmValue>>,
+    provider: &crate::value::DictMap,
+    overrides: Option<&crate::value::DictMap>,
 ) -> Result<VmValue, VmError> {
     let auth_url = require_string_field(provider, "auth_url", "provider")?;
     let token_url = require_string_field(provider, "token_url", "provider")?;
     let issuer = derive_issuer(&auth_url)?;
 
-    let mut out: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut out: crate::value::DictMap = crate::value::DictMap::new();
     out.insert("issuer".to_string(), VmValue::string(&issuer));
     out.insert(
         "authorization_endpoint".to_string(),
@@ -646,7 +642,7 @@ fn build_authorization_server_metadata_value(
             out.insert(k.clone(), v.clone());
         }
     }
-    Ok(VmValue::Dict(std::sync::Arc::new(out)))
+    Ok(VmValue::dict(out))
 }
 
 fn derive_issuer(auth_url: &str) -> Result<String, VmError> {
@@ -670,8 +666,8 @@ fn derive_issuer(auth_url: &str) -> Result<String, VmError> {
 // ----- Registration ---------------------------------------------------------
 
 fn register_client_value(
-    handle: &BTreeMap<String, VmValue>,
-    metadata: &BTreeMap<String, VmValue>,
+    handle: &crate::value::DictMap,
+    metadata: &crate::value::DictMap,
 ) -> Result<VmValue, VmError> {
     let mut errors: Vec<String> = Vec::new();
     validate_metadata(metadata, &mut errors);
@@ -701,7 +697,7 @@ fn register_client_value(
         .entry("token_endpoint_auth_method".to_string())
         .or_insert_with(|| VmValue::string("client_secret_basic"));
 
-    let canonical_dict = VmValue::Dict(std::sync::Arc::new(canonical.clone()));
+    let canonical_dict = VmValue::dict(canonical.clone());
     let canonical_json = vm_value_to_json(&canonical_dict);
 
     let stored = StoredClient {
@@ -721,16 +717,16 @@ fn register_client_value(
     })?;
 
     // Build the response dict — full RFC 7591 §3.2.1 success body.
-    let mut response: BTreeMap<String, VmValue> = canonical;
+    let mut response: crate::value::DictMap = canonical;
     response.insert("client_id".to_string(), VmValue::string(&client_id));
     response.insert("client_secret".to_string(), VmValue::string(&client_secret));
     response.insert("client_id_issued_at".to_string(), VmValue::Int(issued_at));
     // Per RFC 7591 §3.2.1, `client_secret_expires_at: 0` means non-expiring.
     response.insert("client_secret_expires_at".to_string(), VmValue::Int(0));
-    Ok(VmValue::Dict(std::sync::Arc::new(response)))
+    Ok(VmValue::dict(response))
 }
 
-fn get_client_value(handle: &BTreeMap<String, VmValue>, client_id: &str) -> VmValue {
+fn get_client_value(handle: &crate::value::DictMap, client_id: &str) -> VmValue {
     let store_id = match handle_id(handle) {
         Ok(v) => v,
         Err(_) => return VmValue::Nil,
@@ -748,9 +744,9 @@ fn get_client_value(handle: &BTreeMap<String, VmValue>, client_id: &str) -> VmVa
         // metadata + id + issued_at so logs/audits cannot accidentally
         // leak credentials.
         let metadata_value = json_to_vm_value(&client.metadata);
-        let mut response: BTreeMap<String, VmValue> = match metadata_value {
+        let mut response: crate::value::DictMap = match metadata_value {
             VmValue::Dict(dict) => dict.as_ref().clone(),
-            _ => BTreeMap::new(),
+            _ => crate::value::DictMap::new(),
         };
         response.insert("client_id".to_string(), VmValue::string(&client.client_id));
         response.insert(
@@ -758,11 +754,11 @@ fn get_client_value(handle: &BTreeMap<String, VmValue>, client_id: &str) -> VmVa
             VmValue::Int(client.client_id_issued_at),
         );
         response.insert("client_secret_expires_at".to_string(), VmValue::Int(0));
-        VmValue::Dict(std::sync::Arc::new(response))
+        VmValue::dict(response)
     })
 }
 
-fn list_clients_value(handle: &BTreeMap<String, VmValue>) -> VmValue {
+fn list_clients_value(handle: &crate::value::DictMap) -> VmValue {
     let store_id = match handle_id(handle) {
         Ok(v) => v,
         Err(_) => return VmValue::List(std::sync::Arc::new(Vec::new())),
@@ -801,7 +797,7 @@ fn require_handle(
     args: &[VmValue],
     index: usize,
     fn_name: &str,
-) -> Result<BTreeMap<String, VmValue>, VmError> {
+) -> Result<crate::value::DictMap, VmError> {
     match args.get(index) {
         Some(VmValue::Dict(dict)) => Ok(dict.as_ref().clone()),
         Some(other) => Err(VmError::Runtime(format!(
@@ -819,7 +815,7 @@ fn require_dict_arg(
     index: usize,
     fn_name: &str,
     arg_name: &str,
-) -> Result<BTreeMap<String, VmValue>, VmError> {
+) -> Result<crate::value::DictMap, VmError> {
     match args.get(index) {
         Some(VmValue::Dict(dict)) => Ok(dict.as_ref().clone()),
         Some(other) => Err(VmError::Runtime(format!(
@@ -837,7 +833,7 @@ fn optional_dict_arg(
     index: usize,
     fn_name: &str,
     arg_name: &str,
-) -> Result<Option<BTreeMap<String, VmValue>>, VmError> {
+) -> Result<Option<crate::value::DictMap>, VmError> {
     match args.get(index) {
         None | Some(VmValue::Nil) => Ok(None),
         Some(VmValue::Dict(dict)) => Ok(Some(dict.as_ref().clone())),
@@ -867,7 +863,7 @@ fn required_string_arg(
 }
 
 fn require_string_field(
-    metadata: &BTreeMap<String, VmValue>,
+    metadata: &crate::value::DictMap,
     field: &str,
     owner: &str,
 ) -> Result<String, VmError> {
@@ -886,8 +882,8 @@ fn require_string_field(
 mod tests {
     use super::*;
 
-    fn metadata_with_redirect(uri: &str) -> BTreeMap<String, VmValue> {
-        let mut m = BTreeMap::new();
+    fn metadata_with_redirect(uri: &str) -> crate::value::DictMap {
+        let mut m = crate::value::DictMap::new();
         m.insert(
             "redirect_uris".to_string(),
             VmValue::List(std::sync::Arc::new(vec![VmValue::string(uri)])),
@@ -948,7 +944,7 @@ mod tests {
 
     #[test]
     fn empty_redirect_uris_fails() {
-        let mut m = BTreeMap::new();
+        let mut m = crate::value::DictMap::new();
         m.insert(
             "redirect_uris".to_string(),
             VmValue::List(std::sync::Arc::new(Vec::new())),
@@ -960,7 +956,7 @@ mod tests {
 
     #[test]
     fn missing_redirect_uris_fails() {
-        let m: BTreeMap<String, VmValue> = BTreeMap::new();
+        let m: crate::value::DictMap = crate::value::DictMap::new();
         let mut errors = Vec::new();
         validate_metadata(&m, &mut errors);
         assert!(errors[0].contains("redirect_uris is required"));
@@ -992,7 +988,7 @@ mod tests {
 
     #[test]
     fn build_authorization_server_metadata_minimal() {
-        let mut provider = BTreeMap::new();
+        let mut provider = crate::value::DictMap::new();
         provider.insert(
             "auth_url".to_string(),
             VmValue::string("https://idp.example/authorize"),
@@ -1031,7 +1027,7 @@ mod tests {
                 .borrow_mut()
                 .insert(id.clone(), DynregStore::default());
         });
-        let mut handle = BTreeMap::new();
+        let mut handle = crate::value::DictMap::new();
         handle.insert("kind".to_string(), VmValue::string(KIND_DYNREG_STORE));
         handle.insert("id".to_string(), VmValue::string(&id));
         let m = metadata_with_redirect("https://app.example/cb");
@@ -1064,7 +1060,7 @@ mod tests {
                 .borrow_mut()
                 .insert(id.clone(), DynregStore::default());
         });
-        let mut handle = BTreeMap::new();
+        let mut handle = crate::value::DictMap::new();
         handle.insert("kind".to_string(), VmValue::string(KIND_DYNREG_STORE));
         handle.insert("id".to_string(), VmValue::string(&id));
         let m = metadata_with_redirect("http://attacker.example/cb");

--- a/crates/harn-vm/src/stdlib/oauth_storage.rs
+++ b/crates/harn-vm/src/stdlib/oauth_storage.rs
@@ -68,12 +68,12 @@ const FILE_ENVELOPE_VERSION: u32 = 1;
 
 thread_local! {
     static MEMORY_STORE: RefCell<BTreeMap<String, BTreeMap<String, StoredEntry>>> =
-        const { RefCell::new(BTreeMap::new()) };
+        const { RefCell::new(std::collections::BTreeMap::new()) };
 
     /// File-handle encryption keys, kept off the user-visible handle
     /// dict so a stray `to_string(handle)` cannot exfiltrate the secret.
     static FILE_SECRETS: RefCell<BTreeMap<String, Vec<u8>>> =
-        const { RefCell::new(BTreeMap::new()) };
+        const { RefCell::new(std::collections::BTreeMap::new()) };
 }
 
 static MEMORY_ID_COUNTER: Mutex<u64> = Mutex::new(0);
@@ -209,10 +209,10 @@ fn memory_handle() -> VmValue {
         *guard = guard.wrapping_add(1);
         format!("memory-{}", *guard)
     };
-    let mut fields = BTreeMap::new();
+    let mut fields = crate::value::DictMap::new();
     fields.insert(HANDLE_KEY_KIND.to_string(), VmValue::string(KIND_MEMORY));
     fields.insert(HANDLE_KEY_ID.to_string(), VmValue::string(&id));
-    VmValue::Dict(std::sync::Arc::new(fields))
+    VmValue::dict(fields)
 }
 
 fn file_handle(path: &str, secret: &[u8]) -> VmValue {
@@ -225,11 +225,11 @@ fn file_handle(path: &str, secret: &[u8]) -> VmValue {
     FILE_SECRETS.with(|secrets| {
         secrets.borrow_mut().insert(id.clone(), secret.to_vec());
     });
-    let mut fields = BTreeMap::new();
+    let mut fields = crate::value::DictMap::new();
     fields.insert(HANDLE_KEY_KIND.to_string(), VmValue::string(KIND_FILE));
     fields.insert(HANDLE_KEY_ID.to_string(), VmValue::string(&id));
     fields.insert(HANDLE_KEY_PATH.to_string(), VmValue::string(path));
-    VmValue::Dict(std::sync::Arc::new(fields))
+    VmValue::dict(fields)
 }
 
 fn cloud_handle(kind: &'static str) -> VmValue {
@@ -238,14 +238,14 @@ fn cloud_handle(kind: &'static str) -> VmValue {
     } else {
         "session"
     };
-    let mut fields = BTreeMap::new();
+    let mut fields = crate::value::DictMap::new();
     fields.insert(HANDLE_KEY_KIND.to_string(), VmValue::string(kind));
     fields.insert(HANDLE_KEY_ID.to_string(), VmValue::string(kind));
     fields.insert(HANDLE_KEY_SCOPE.to_string(), VmValue::string(scope));
-    VmValue::Dict(std::sync::Arc::new(fields))
+    VmValue::dict(fields)
 }
 
-fn handle_kind(handle: &BTreeMap<String, VmValue>) -> Result<String, VmError> {
+fn handle_kind(handle: &crate::value::DictMap) -> Result<String, VmError> {
     handle
         .get(HANDLE_KEY_KIND)
         .and_then(|value| match value {
@@ -260,7 +260,7 @@ fn handle_kind(handle: &BTreeMap<String, VmValue>) -> Result<String, VmError> {
         })
 }
 
-fn handle_id(handle: &BTreeMap<String, VmValue>) -> Result<String, VmError> {
+fn handle_id(handle: &crate::value::DictMap) -> Result<String, VmError> {
     handle
         .get(HANDLE_KEY_ID)
         .and_then(|value| match value {
@@ -270,7 +270,7 @@ fn handle_id(handle: &BTreeMap<String, VmValue>) -> Result<String, VmError> {
         .ok_or_else(|| VmError::Runtime("oauth storage handle is missing `id`".to_string()))
 }
 
-async fn backend_get(handle: &BTreeMap<String, VmValue>, key: &str) -> Result<VmValue, VmError> {
+async fn backend_get(handle: &crate::value::DictMap, key: &str) -> Result<VmValue, VmError> {
     match handle_kind(handle)?.as_str() {
         KIND_MEMORY => Ok(memory_get(&handle_id(handle)?, key)),
         KIND_FILE => file_get(handle, key),
@@ -280,12 +280,12 @@ async fn backend_get(handle: &BTreeMap<String, VmValue>, key: &str) -> Result<Vm
 }
 
 async fn backend_set(
-    handle: &BTreeMap<String, VmValue>,
+    handle: &crate::value::DictMap,
     key: &str,
-    token: &BTreeMap<String, VmValue>,
+    token: &crate::value::DictMap,
     ttl_seconds: Option<i64>,
 ) -> Result<(), VmError> {
-    let json_token = vm_value_to_json(&VmValue::Dict(std::sync::Arc::new(token.clone())));
+    let json_token = vm_value_to_json(&VmValue::dict(token.clone()));
     match handle_kind(handle)?.as_str() {
         KIND_MEMORY => {
             memory_set(&handle_id(handle)?, key, json_token, ttl_seconds);
@@ -302,7 +302,7 @@ async fn backend_set(
     }
 }
 
-async fn backend_delete(handle: &BTreeMap<String, VmValue>, key: &str) -> Result<(), VmError> {
+async fn backend_delete(handle: &crate::value::DictMap, key: &str) -> Result<(), VmError> {
     match handle_kind(handle)?.as_str() {
         KIND_MEMORY => {
             memory_delete(&handle_id(handle)?, key);
@@ -353,7 +353,7 @@ fn memory_delete(handle_id: &str, key: &str) {
     });
 }
 
-fn file_path(handle: &BTreeMap<String, VmValue>) -> Result<PathBuf, VmError> {
+fn file_path(handle: &crate::value::DictMap) -> Result<PathBuf, VmError> {
     handle
         .get(HANDLE_KEY_PATH)
         .and_then(|value| match value {
@@ -363,7 +363,7 @@ fn file_path(handle: &BTreeMap<String, VmValue>) -> Result<PathBuf, VmError> {
         .ok_or_else(|| VmError::Runtime("oauth storage file handle is missing `path`".to_string()))
 }
 
-fn file_secret(handle: &BTreeMap<String, VmValue>) -> Result<Vec<u8>, VmError> {
+fn file_secret(handle: &crate::value::DictMap) -> Result<Vec<u8>, VmError> {
     let id = handle_id(handle)?;
     FILE_SECRETS
         .with(|secrets| secrets.borrow().get(&id).cloned())
@@ -386,7 +386,7 @@ fn read_file_entries(path: &Path, secret: &[u8]) -> Result<BTreeMap<String, Stor
     let raw = match fs::read(path) {
         Ok(bytes) => bytes,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(BTreeMap::new());
+            return Ok(std::collections::BTreeMap::new());
         }
         Err(error) => {
             return Err(VmError::Runtime(format!(
@@ -396,7 +396,7 @@ fn read_file_entries(path: &Path, secret: &[u8]) -> Result<BTreeMap<String, Stor
         }
     };
     if raw.is_empty() {
-        return Ok(BTreeMap::new());
+        return Ok(std::collections::BTreeMap::new());
     }
     let envelope: FileEnvelope = serde_json::from_slice(&raw).map_err(|error| {
         VmError::Runtime(format!(
@@ -545,7 +545,7 @@ fn write_file_entries(
 /// meaningfully constraining an attacker who can already move files.
 const FILE_AAD: &[u8] = HKDF_INFO;
 
-fn file_get(handle: &BTreeMap<String, VmValue>, key: &str) -> Result<VmValue, VmError> {
+fn file_get(handle: &crate::value::DictMap, key: &str) -> Result<VmValue, VmError> {
     let path = file_path(handle)?;
     let secret = file_secret(handle)?;
     let entries = read_file_entries(&path, &secret)?;
@@ -556,7 +556,7 @@ fn file_get(handle: &BTreeMap<String, VmValue>, key: &str) -> Result<VmValue, Vm
 }
 
 fn file_set(
-    handle: &BTreeMap<String, VmValue>,
+    handle: &crate::value::DictMap,
     key: &str,
     token: JsonValue,
     ttl_seconds: Option<i64>,
@@ -568,7 +568,7 @@ fn file_set(
     write_file_entries(&path, &secret, &entries)
 }
 
-fn file_delete(handle: &BTreeMap<String, VmValue>, key: &str) -> Result<(), VmError> {
+fn file_delete(handle: &crate::value::DictMap, key: &str) -> Result<(), VmError> {
     let path = file_path(handle)?;
     let secret = file_secret(handle)?;
     let mut entries = read_file_entries(&path, &secret)?;
@@ -589,7 +589,7 @@ fn file_delete(handle: &BTreeMap<String, VmValue>, key: &str) -> Result<(), VmEr
     }
 }
 
-fn cloud_scope(handle: &BTreeMap<String, VmValue>) -> Result<String, VmError> {
+fn cloud_scope(handle: &crate::value::DictMap) -> Result<String, VmError> {
     handle
         .get(HANDLE_KEY_SCOPE)
         .and_then(|value| match value {
@@ -601,22 +601,22 @@ fn cloud_scope(handle: &BTreeMap<String, VmValue>) -> Result<String, VmError> {
         })
 }
 
-async fn cloud_get(handle: &BTreeMap<String, VmValue>, key: &str) -> Result<VmValue, VmError> {
+async fn cloud_get(handle: &crate::value::DictMap, key: &str) -> Result<VmValue, VmError> {
     let scope = cloud_scope(handle)?;
-    let mut params = BTreeMap::new();
+    let mut params = crate::value::DictMap::new();
     params.insert("scope".to_string(), VmValue::string(&scope));
     params.insert("key".to_string(), VmValue::string(key));
     dispatch_host_operation("oauth_storage", "cloud_get", &params).await
 }
 
 async fn cloud_set(
-    handle: &BTreeMap<String, VmValue>,
+    handle: &crate::value::DictMap,
     key: &str,
     token: JsonValue,
     ttl_seconds: Option<i64>,
 ) -> Result<(), VmError> {
     let scope = cloud_scope(handle)?;
-    let mut params = BTreeMap::new();
+    let mut params = crate::value::DictMap::new();
     params.insert("scope".to_string(), VmValue::string(&scope));
     params.insert("key".to_string(), VmValue::string(key));
     params.insert("token".to_string(), json_to_vm_dict(&token));
@@ -627,9 +627,9 @@ async fn cloud_set(
     Ok(())
 }
 
-async fn cloud_delete(handle: &BTreeMap<String, VmValue>, key: &str) -> Result<(), VmError> {
+async fn cloud_delete(handle: &crate::value::DictMap, key: &str) -> Result<(), VmError> {
     let scope = cloud_scope(handle)?;
-    let mut params = BTreeMap::new();
+    let mut params = crate::value::DictMap::new();
     params.insert("scope".to_string(), VmValue::string(&scope));
     params.insert("key".to_string(), VmValue::string(key));
     dispatch_host_operation("oauth_storage", "cloud_delete", &params).await?;
@@ -644,7 +644,7 @@ fn require_handle(
     args: &[VmValue],
     index: usize,
     fn_name: &str,
-) -> Result<BTreeMap<String, VmValue>, VmError> {
+) -> Result<crate::value::DictMap, VmError> {
     match args.get(index) {
         Some(VmValue::Dict(dict)) => Ok(dict.as_ref().clone()),
         Some(other) => Err(VmError::Runtime(format!(
@@ -714,7 +714,7 @@ fn require_dict_arg(
     index: usize,
     fn_name: &str,
     arg_name: &str,
-) -> Result<BTreeMap<String, VmValue>, VmError> {
+) -> Result<crate::value::DictMap, VmError> {
     match args.get(index) {
         Some(VmValue::Dict(dict)) => Ok(dict.as_ref().clone()),
         Some(other) => Err(VmError::Runtime(format!(
@@ -749,13 +749,13 @@ mod tests {
     use super::*;
     use crate::value::values_equal;
 
-    fn token_dict(access: &str) -> BTreeMap<String, VmValue> {
-        let mut dict = BTreeMap::new();
+    fn token_dict(access: &str) -> crate::value::DictMap {
+        let mut dict = crate::value::DictMap::new();
         dict.insert("access_token".to_string(), VmValue::string(access));
         dict
     }
 
-    fn dict_from_vm(value: &VmValue) -> BTreeMap<String, VmValue> {
+    fn dict_from_vm(value: &VmValue) -> crate::value::DictMap {
         match value {
             VmValue::Dict(dict) => dict.as_ref().clone(),
             other => panic!("expected dict, got {}", other.type_name()),

--- a/crates/harn-vm/src/stdlib/observability.rs
+++ b/crates/harn-vm/src/stdlib/observability.rs
@@ -34,7 +34,7 @@ impl Default for ObsConfig {
     fn default() -> Self {
         Self {
             backend: serde_json::json!({"kind": "auto", "id": "auto"}),
-            backends: BTreeMap::new(),
+            backends: std::collections::BTreeMap::new(),
             routes: Vec::new(),
             processors: Vec::new(),
             audit_to_pretty_stderr: true,
@@ -501,7 +501,7 @@ fn field_string(value: Option<&VmValue>, key: &str) -> Option<String> {
 }
 
 fn span_to_vm_value(span: &ObsSpan) -> VmValue {
-    let mut out = BTreeMap::new();
+    let mut out = crate::value::DictMap::new();
     out.put_str("trace_id", span.trace_id.as_str());
     out.put_str("span_id", span.id.as_str());
     out.put_str("name", span.name.as_str());
@@ -509,7 +509,7 @@ fn span_to_vm_value(span: &ObsSpan) -> VmValue {
         "attrs".to_string(),
         json_to_vm_value(&serde_json::Value::Object(span.attrs.clone())),
     );
-    VmValue::Dict(std::sync::Arc::new(out))
+    VmValue::dict(out)
 }
 
 fn base_event(
@@ -854,7 +854,7 @@ fn pretty_payload(event: &serde_json::Value) -> serde_json::Value {
         .or_else(|| event.get("name"))
         .and_then(serde_json::Value::as_str)
         .unwrap_or("");
-    let mut fields = BTreeMap::new();
+    let mut fields = crate::value::DictMap::new();
     if let Some(serde_json::Value::Object(map)) = event.get("fields") {
         for (key, value) in map {
             fields.insert(key.clone(), json_to_vm_value(value));

--- a/crates/harn-vm/src/stdlib/options.rs
+++ b/crates/harn-vm/src/stdlib/options.rs
@@ -19,7 +19,7 @@
 //! without per-item attributes.
 #![allow(dead_code)]
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::fmt::Display;
 use std::time::Duration as StdDuration;
 
@@ -59,7 +59,7 @@ pub(crate) fn dict_arg<'a>(
     fn_name: &'static str,
     arg_name: &str,
     kind: ErrorKind,
-) -> Result<&'a BTreeMap<String, VmValue>, VmError> {
+) -> Result<&'a crate::value::DictMap, VmError> {
     match args.get(idx) {
         Some(VmValue::Dict(dict)) => Ok(dict.as_ref()),
         Some(value) => Err(fn_err(
@@ -82,7 +82,7 @@ pub(crate) fn optional_dict_arg<'a>(
     fn_name: &'static str,
     arg_name: &str,
     kind: ErrorKind,
-) -> Result<Option<&'a BTreeMap<String, VmValue>>, VmError> {
+) -> Result<Option<&'a crate::value::DictMap>, VmError> {
     match args.get(idx) {
         None | Some(VmValue::Nil) => Ok(None),
         Some(VmValue::Dict(dict)) => Ok(Some(dict.as_ref())),
@@ -215,7 +215,7 @@ pub(crate) fn duration_from_value(
 /// [`OptionsParser::allow`] first.
 pub(crate) struct OptionsParser<'a> {
     fn_name: &'static str,
-    dict: &'a BTreeMap<String, VmValue>,
+    dict: &'a crate::value::DictMap,
     seen: BTreeSet<&'static str>,
     kind: ErrorKind,
 }
@@ -223,7 +223,7 @@ pub(crate) struct OptionsParser<'a> {
 impl<'a> OptionsParser<'a> {
     pub(crate) fn new(
         fn_name: &'static str,
-        dict: &'a BTreeMap<String, VmValue>,
+        dict: &'a crate::value::DictMap,
         kind: ErrorKind,
     ) -> Self {
         Self {
@@ -364,7 +364,7 @@ impl<'a> OptionsParser<'a> {
     pub(crate) fn optional_dict(
         &mut self,
         key: &'static str,
-    ) -> Result<Option<&'a BTreeMap<String, VmValue>>, VmError> {
+    ) -> Result<Option<&'a crate::value::DictMap>, VmError> {
         self.mark(key);
         match self.dict.get(key) {
             None | Some(VmValue::Nil) => Ok(None),
@@ -403,7 +403,7 @@ impl<'a> OptionsParser<'a> {
 mod tests {
     use super::*;
 
-    fn dict(pairs: &[(&str, VmValue)]) -> BTreeMap<String, VmValue> {
+    fn dict(pairs: &[(&str, VmValue)]) -> crate::value::DictMap {
         pairs
             .iter()
             .map(|(k, v)| ((*k).to_string(), v.clone()))
@@ -537,7 +537,7 @@ mod tests {
 
     #[test]
     fn dict_arg_extracts() {
-        let v = VmValue::Dict(std::sync::Arc::new(dict(&[("a", VmValue::Bool(true))])));
+        let v = VmValue::dict(dict(&[("a", VmValue::Bool(true))]));
         let args = vec![v];
         let got = dict_arg(&args, 0, "fn", "config", ErrorKind::Runtime).unwrap();
         assert_eq!(got.len(), 1);

--- a/crates/harn-vm/src/stdlib/path.rs
+++ b/crates/harn-vm/src/stdlib/path.rs
@@ -6,8 +6,6 @@
 //! called from Harn code without surprises when a Windows-style path
 //! crosses the wire.
 
-use std::collections::BTreeMap;
-
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
@@ -207,7 +205,7 @@ fn relative_to(p: &str, base: &str) -> Option<String> {
 }
 
 fn workspace_path_info_to_vm(info: WorkspacePathInfo) -> VmValue {
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: crate::value::DictMap = crate::value::DictMap::new();
     map.insert(
         "input".into(),
         VmValue::String(std::sync::Arc::from(info.input)),
@@ -246,7 +244,7 @@ fn workspace_path_info_to_vm(info: WorkspacePathInfo) -> VmValue {
             .map(|value| VmValue::String(std::sync::Arc::from(value)))
             .unwrap_or(VmValue::Nil),
     );
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 pub(crate) fn register_path_helper_builtins(vm: &mut Vm) {
@@ -258,7 +256,7 @@ pub(crate) fn register_path_helper_builtins(vm: &mut Vm) {
 #[harn_builtin(sig = "path_parts(path: string?) -> dict", category = "path")]
 fn path_parts_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let p = args.first().map(|a| a.display()).unwrap_or_default();
-    let mut map: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut map: crate::value::DictMap = crate::value::DictMap::new();
     map.insert(
         "dir".into(),
         VmValue::String(std::sync::Arc::from(parent(&p))),
@@ -285,7 +283,7 @@ fn path_parts_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
                 .collect(),
         )),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(map)))
+    Ok(VmValue::dict(map))
 }
 
 #[harn_builtin(sig = "path_parent(path: string?) -> string", category = "path")]

--- a/crates/harn-vm/src/stdlib/path_scope_guard.rs
+++ b/crates/harn-vm/src/stdlib/path_scope_guard.rs
@@ -8,7 +8,6 @@
 //! a typed alert body listing the three handoff options (add_root,
 //! reanchor, fork to sub-agent) before rejecting the call.
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::llm::helpers::{ReminderPropagate, ReminderRoleHint, ReminderSource, SystemReminder};
@@ -59,7 +58,7 @@ pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] =
 )]
 fn register_path_scope_guard(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let opts = match args.first() {
-        None | Some(VmValue::Nil) => BTreeMap::new(),
+        None | Some(VmValue::Nil) => crate::value::DictMap::new(),
         Some(VmValue::Dict(map)) => map.as_ref().clone(),
         Some(other) => {
             return Err(VmError::Runtime(format!(
@@ -183,7 +182,7 @@ enum Violation {
     Reminder,
 }
 
-fn parse_arg_keys(opts: &BTreeMap<String, VmValue>) -> Result<Vec<String>, VmError> {
+fn parse_arg_keys(opts: &crate::value::DictMap) -> Result<Vec<String>, VmError> {
     match opts.get("arg_keys") {
         None | Some(VmValue::Nil) => {
             Ok(DEFAULT_ARG_KEYS.iter().map(|key| key.to_string()).collect())
@@ -208,7 +207,7 @@ fn parse_arg_keys(opts: &BTreeMap<String, VmValue>) -> Result<Vec<String>, VmErr
     }
 }
 
-fn parse_on_violation(opts: &BTreeMap<String, VmValue>) -> Result<Violation, VmError> {
+fn parse_on_violation(opts: &crate::value::DictMap) -> Result<Violation, VmError> {
     match opts.get("on_violation") {
         None | Some(VmValue::Nil) => Ok(Violation::Deny),
         Some(VmValue::String(value)) => match value.as_ref() {
@@ -225,7 +224,7 @@ fn parse_on_violation(opts: &BTreeMap<String, VmValue>) -> Result<Violation, VmE
     }
 }
 
-fn parse_mount_modes(opts: &BTreeMap<String, VmValue>) -> Result<Vec<MountMode>, VmError> {
+fn parse_mount_modes(opts: &crate::value::DictMap) -> Result<Vec<MountMode>, VmError> {
     let raw = match opts.get("mount_modes") {
         None | Some(VmValue::Nil) => {
             return Ok(vec![MountMode::Extend, MountMode::Sandboxed]);
@@ -313,13 +312,13 @@ mod tests {
 
     #[test]
     fn parse_mount_modes_defaults_to_writable_mounts() {
-        let modes = parse_mount_modes(&BTreeMap::new()).expect("default modes");
+        let modes = parse_mount_modes(&crate::value::DictMap::new()).expect("default modes");
         assert_eq!(modes, vec![MountMode::Extend, MountMode::Sandboxed]);
     }
 
     #[test]
     fn parse_on_violation_rejects_unknown_value() {
-        let opts = BTreeMap::from([(
+        let opts = crate::value::DictMap::from_iter([(
             "on_violation".to_string(),
             VmValue::String(std::sync::Arc::from("warn")),
         )]);

--- a/crates/harn-vm/src/stdlib/pool/mod.rs
+++ b/crates/harn-vm/src/stdlib/pool/mod.rs
@@ -168,7 +168,7 @@ struct PoolEntry {
     /// Optional per-create user-supplied config (queue strategy, priority
     /// fn, backpressure). Queue strategy is evaluated by this module;
     /// later pool tickets wire the other config knobs.
-    config: BTreeMap<String, VmValue>,
+    config: crate::value::DictMap,
     /// Durability scope. `Session` is in-memory only.
     /// `Pipeline` writes a JSONL append-log under `.harn/pools/` so the
     /// pool's pending queue + in-flight task metadata survives process
@@ -587,12 +587,9 @@ fn task_handle_from_value(value: &VmValue, builtin: &str) -> Result<(String, Str
     Ok((pool_id, task_id))
 }
 
-fn parse_options(
-    value: Option<&VmValue>,
-    builtin: &str,
-) -> Result<BTreeMap<String, VmValue>, VmError> {
+fn parse_options(value: Option<&VmValue>, builtin: &str) -> Result<crate::value::DictMap, VmError> {
     match value {
-        None | Some(VmValue::Nil) => Ok(BTreeMap::new()),
+        None | Some(VmValue::Nil) => Ok(crate::value::DictMap::new()),
         Some(VmValue::Dict(map)) => Ok((**map).clone()),
         Some(other) => Err(VmError::Runtime(format!(
             "{builtin}: options must be a dict (got {})",
@@ -601,7 +598,7 @@ fn parse_options(
     }
 }
 
-fn parse_max_concurrent(opts: &BTreeMap<String, VmValue>) -> Result<usize, VmError> {
+fn parse_max_concurrent(opts: &crate::value::DictMap) -> Result<usize, VmError> {
     match opts.get("max_concurrent") {
         None | Some(VmValue::Nil) => Ok(DEFAULT_MAX_CONCURRENT),
         Some(VmValue::Int(n)) => {
@@ -619,14 +616,14 @@ fn parse_max_concurrent(opts: &BTreeMap<String, VmValue>) -> Result<usize, VmErr
     }
 }
 
-fn parse_name(opts: &BTreeMap<String, VmValue>) -> Option<String> {
+fn parse_name(opts: &crate::value::DictMap) -> Option<String> {
     opts.get("name").and_then(|value| match value {
         VmValue::String(text) if !text.trim().is_empty() => Some(text.to_string()),
         _ => None,
     })
 }
 
-fn parse_scope(opts: &BTreeMap<String, VmValue>) -> Result<PoolScope, VmError> {
+fn parse_scope(opts: &crate::value::DictMap) -> Result<PoolScope, VmError> {
     match opts.get("scope") {
         None | Some(VmValue::Nil) => Ok(PoolScope::Session),
         Some(VmValue::String(text)) => PoolScope::parse(text),
@@ -637,7 +634,7 @@ fn parse_scope(opts: &BTreeMap<String, VmValue>) -> Result<PoolScope, VmError> {
     }
 }
 
-fn parse_scope_id_override(opts: &BTreeMap<String, VmValue>) -> Option<String> {
+fn parse_scope_id_override(opts: &crate::value::DictMap) -> Option<String> {
     for key in ["scope_id", "pipeline_id", "run_id"] {
         if let Some(VmValue::String(text)) = opts.get(key) {
             if !text.trim().is_empty() {
@@ -648,7 +645,7 @@ fn parse_scope_id_override(opts: &BTreeMap<String, VmValue>) -> Option<String> {
     None
 }
 
-fn parse_stale_after_ms(opts: &BTreeMap<String, VmValue>) -> Result<i64, VmError> {
+fn parse_stale_after_ms(opts: &crate::value::DictMap) -> Result<i64, VmError> {
     match opts.get("stale_after_ms") {
         None | Some(VmValue::Nil) => Ok(DEFAULT_STALE_AFTER_MS),
         Some(VmValue::Int(n)) if *n >= 0 => Ok(*n),
@@ -660,7 +657,7 @@ fn parse_stale_after_ms(opts: &BTreeMap<String, VmValue>) -> Result<i64, VmError
     }
 }
 
-fn parse_idempotency_key(opts: &BTreeMap<String, VmValue>) -> Result<Option<String>, VmError> {
+fn parse_idempotency_key(opts: &crate::value::DictMap) -> Result<Option<String>, VmError> {
     match opts.get("idempotency_key").or_else(|| opts.get("id")) {
         None | Some(VmValue::Nil) => Ok(None),
         Some(VmValue::String(text)) if !text.trim().is_empty() => Ok(Some(text.to_string())),
@@ -680,7 +677,7 @@ fn parse_idempotency_key(opts: &BTreeMap<String, VmValue>) -> Result<Option<Stri
 /// channel scope contract when no pipeline id is in scope.
 fn resolve_pipeline_scope_id(
     ctx: Option<&AsyncBuiltinCtx>,
-    opts: &BTreeMap<String, VmValue>,
+    opts: &crate::value::DictMap,
 ) -> Result<String, VmError> {
     if let Some(explicit) = parse_scope_id_override(opts) {
         return Ok(explicit);
@@ -703,7 +700,7 @@ fn resolve_pipeline_scope_id(
     ))
 }
 
-fn parse_priority(opts: &BTreeMap<String, VmValue>) -> Result<i64, VmError> {
+fn parse_priority(opts: &crate::value::DictMap) -> Result<i64, VmError> {
     match opts.get("priority") {
         None | Some(VmValue::Nil) => Ok(0),
         Some(VmValue::Int(n)) => Ok(*n),
@@ -714,7 +711,7 @@ fn parse_priority(opts: &BTreeMap<String, VmValue>) -> Result<i64, VmError> {
     }
 }
 
-fn parse_key(opts: &BTreeMap<String, VmValue>) -> Result<Option<String>, VmError> {
+fn parse_key(opts: &crate::value::DictMap) -> Result<Option<String>, VmError> {
     match opts.get("key") {
         None | Some(VmValue::Nil) => Ok(None),
         Some(VmValue::String(text)) => Ok(Some(text.to_string())),
@@ -726,7 +723,7 @@ fn parse_key(opts: &BTreeMap<String, VmValue>) -> Result<Option<String>, VmError
 }
 
 fn parse_submit_key(
-    opts: &BTreeMap<String, VmValue>,
+    opts: &crate::value::DictMap,
     queue_strategy: &QueueStrategy,
 ) -> Result<Option<String>, VmError> {
     if let Some(field) = queue_strategy.key_field() {
@@ -744,7 +741,7 @@ fn parse_submit_key(
     parse_key(opts)
 }
 
-fn parse_queue_strategy(opts: &BTreeMap<String, VmValue>) -> Result<QueueStrategy, VmError> {
+fn parse_queue_strategy(opts: &crate::value::DictMap) -> Result<QueueStrategy, VmError> {
     let Some(value) = opts.get("queue") else {
         return Ok(QueueStrategy::Priority);
     };
@@ -794,7 +791,7 @@ fn parse_queue_strategy_name(name: &str) -> Result<QueueStrategy, VmError> {
     }
 }
 
-fn parse_backpressure(opts: &BTreeMap<String, VmValue>) -> Result<BackpressureStrategy, VmError> {
+fn parse_backpressure(opts: &crate::value::DictMap) -> Result<BackpressureStrategy, VmError> {
     let Some(value) = opts.get("backpressure") else {
         return Ok(BackpressureStrategy::Unbounded);
     };
@@ -901,7 +898,7 @@ fn pool_snapshot_value(pool: &PoolEntry) -> VmValue {
             _ => {}
         }
     }
-    let mut snapshot = BTreeMap::new();
+    let mut snapshot = crate::value::DictMap::new();
     snapshot.put_str("_type", POOL_TYPE);
     snapshot.put_str("id", pool.id.as_str());
     snapshot.put_str("name", pool.name.as_str());
@@ -939,16 +936,13 @@ fn pool_snapshot_value(pool: &PoolEntry) -> VmValue {
         VmValue::Int(pool.stale_after_ms),
     );
     if !pool.config.is_empty() {
-        snapshot.insert(
-            "config".to_string(),
-            VmValue::Dict(std::sync::Arc::new(pool.config.clone())),
-        );
+        snapshot.insert("config".to_string(), VmValue::dict(pool.config.clone()));
     }
-    VmValue::Dict(std::sync::Arc::new(snapshot))
+    VmValue::dict(snapshot)
 }
 
 fn backpressure_snapshot_value(backpressure: &BackpressureStrategy) -> VmValue {
-    let mut value = BTreeMap::new();
+    let mut value = crate::value::DictMap::new();
     value.put_str("_type", "backpressure");
     value.put_str("kind", backpressure.name());
     if let Some(max_depth) = backpressure.max_depth() {
@@ -957,7 +951,7 @@ fn backpressure_snapshot_value(backpressure: &BackpressureStrategy) -> VmValue {
     if let BackpressureStrategy::Queue { on_full, .. } = backpressure {
         value.put_str("on_full", on_full.as_str());
     }
-    VmValue::Dict(std::sync::Arc::new(value))
+    VmValue::dict(value)
 }
 
 fn task_sort_key(task: &VmValue) -> String {
@@ -971,7 +965,7 @@ fn task_sort_key(task: &VmValue) -> String {
 }
 
 fn task_snapshot_value(task: &TaskState) -> VmValue {
-    let mut entry = BTreeMap::new();
+    let mut entry = crate::value::DictMap::new();
     entry.put_str("_type", POOL_TASK_TYPE);
     entry.put_str("id", task.id.as_str());
     entry.put_str("pool_id", task.pool_id.as_str());
@@ -988,11 +982,11 @@ fn task_snapshot_value(task: &TaskState) -> VmValue {
     entry.put_opt_str("error", task.error.as_deref());
     entry.put_opt_str("rejection_reason", task.rejection_reason.as_deref());
     entry.put_opt_str("rejection_policy", task.rejection_policy.as_deref());
-    VmValue::Dict(std::sync::Arc::new(entry))
+    VmValue::dict(entry)
 }
 
 fn task_handle_value(task: &TaskState) -> VmValue {
-    let mut handle = BTreeMap::new();
+    let mut handle = crate::value::DictMap::new();
     handle.put_str("_type", POOL_TASK_TYPE);
     handle.put_str("id", task.id.as_str());
     handle.put_str("pool_id", task.pool_id.as_str());
@@ -1003,11 +997,11 @@ fn task_handle_value(task: &TaskState) -> VmValue {
     handle.put_opt_str("error", task.error.as_deref());
     handle.put_opt_str("rejection_reason", task.rejection_reason.as_deref());
     handle.put_opt_str("rejection_policy", task.rejection_policy.as_deref());
-    VmValue::Dict(std::sync::Arc::new(handle))
+    VmValue::dict(handle)
 }
 
-fn ordered_pool_config(opts: &BTreeMap<String, VmValue>) -> BTreeMap<String, VmValue> {
-    let mut config = BTreeMap::new();
+fn ordered_pool_config(opts: &crate::value::DictMap) -> crate::value::DictMap {
+    let mut config = crate::value::DictMap::new();
     for key in ["queue", "backpressure", "priority"] {
         if let Some(value) = opts.get(key) {
             config.insert(key.to_string(), value.clone());
@@ -1092,7 +1086,7 @@ async fn pool_create_sync(
         round_robin_after: None,
         active: HashMap::new(),
         reserved_slots: 0,
-        tasks: BTreeMap::new(),
+        tasks: std::collections::BTreeMap::new(),
         space_waiters: Vec::new(),
         config: ordered_pool_config(&opts),
         scope,
@@ -1145,7 +1139,7 @@ fn pipeline_pool_file_path(dir_override: Option<&str>, pipeline_id: &str, name: 
     ))
 }
 
-fn parse_durable_dir(opts: &BTreeMap<String, VmValue>) -> Result<Option<String>, VmError> {
+fn parse_durable_dir(opts: &crate::value::DictMap) -> Result<Option<String>, VmError> {
     match opts.get("dir") {
         None | Some(VmValue::Nil) => Ok(None),
         Some(VmValue::String(text)) if !text.trim().is_empty() => Ok(Some(text.to_string())),
@@ -1829,7 +1823,8 @@ fn rehydrate_persisted_state(
 ) -> Result<(), VmError> {
     let now = now_ms_for_pool();
     let mut idempotency_index: HashMap<String, String> = HashMap::new();
-    let mut tasks: BTreeMap<String, Arc<parking_lot::Mutex<TaskState>>> = BTreeMap::new();
+    let mut tasks: BTreeMap<String, Arc<parking_lot::Mutex<TaskState>>> =
+        std::collections::BTreeMap::new();
     let mut rehydrated_persisted: Vec<PersistedTask> = Vec::new();
 
     {
@@ -2050,7 +2045,7 @@ fn pool_drop_audit(
 
 async fn emit_pool_drop(audit: PoolDropAudit) {
     let topic = Topic::new(POOL_AUDIT_TOPIC).expect("static pool audit topic is valid");
-    let mut headers = BTreeMap::new();
+    let mut headers = std::collections::BTreeMap::new();
     headers.insert("schema".to_string(), "harn.pool_drop.v1".to_string());
     headers.insert("policy".to_string(), audit.policy.clone());
     let payload = json!({
@@ -2087,7 +2082,7 @@ fn pool_submit_receipt(pool: &PoolEntry, task: &TaskState) -> PoolSubmitReceipt 
 
 async fn emit_pool_submit_receipt(receipt: PoolSubmitReceipt) {
     let topic = Topic::new(POOL_AUDIT_TOPIC).expect("static pool audit topic is valid");
-    let mut headers = BTreeMap::new();
+    let mut headers = std::collections::BTreeMap::new();
     headers.insert("schema".to_string(), "harn.pool_submit.v1".to_string());
     let payload = json!({
         "pool_id": receipt.pool_id,
@@ -2132,7 +2127,7 @@ async fn emit_pool_dequeue_receipt(
     receipt: PoolDequeueReceipt,
 ) {
     let topic = Topic::new(POOL_AUDIT_TOPIC).expect("static pool audit topic is valid");
-    let mut headers = BTreeMap::new();
+    let mut headers = std::collections::BTreeMap::new();
     headers.insert("schema".to_string(), "harn.pool_dequeue.v1".to_string());
     let payload = json!({
         "pool_id": receipt.pool_id,
@@ -2238,7 +2233,7 @@ fn spawn_task(pool: Arc<parking_lot::Mutex<PoolEntry>>, pending: PendingTask) {
     let span_links: Vec<crate::tracing::SpanLink> = submit_link
         .into_iter()
         .map(|link| {
-            link.with_attributes(BTreeMap::from([(
+            link.with_attributes(std::collections::BTreeMap::from([(
                 "harn.link.kind".to_string(),
                 "pool_submit".to_string(),
             )]))

--- a/crates/harn-vm/src/stdlib/postgres/advisory.rs
+++ b/crates/harn-vm/src/stdlib/postgres/advisory.rs
@@ -30,8 +30,6 @@
 //! identifiers ("migrations", "release-cut") work without callers picking
 //! a magic number.
 
-use std::collections::BTreeMap;
-
 use sqlx_core::query::query;
 
 use crate::stdlib::macros::{harn_builtin, BuiltinSignature, Param, TY_ANY, TY_BOOL};
@@ -197,7 +195,7 @@ enum LockKey {
 
 fn resolve_key(
     value: &VmValue,
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     builtin: &'static str,
 ) -> Result<LockKey, VmError> {
     let mut key = match value {

--- a/crates/harn-vm/src/stdlib/postgres/introspect.rs
+++ b/crates/harn-vm/src/stdlib/postgres/introspect.rs
@@ -39,7 +39,7 @@
 //! partitions so inserts never hit the DEFAULT partition.
 
 use crate::value::VmDictExt;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 
@@ -209,7 +209,7 @@ async fn pg_pool_stats_impl(
     let max = record.max_connections;
     let in_use = (size as usize).saturating_sub(idle);
 
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.insert("size".to_string(), VmValue::Int(i64::from(size)));
     dict.insert("idle".to_string(), VmValue::Int(idle as i64));
     dict.insert("in_use".to_string(), VmValue::Int(in_use as i64));
@@ -228,10 +228,10 @@ async fn pg_pool_stats_impl(
             .replicas
             .iter()
             .map(|pool| {
-                let mut entry = BTreeMap::new();
+                let mut entry = crate::value::DictMap::new();
                 entry.insert("size".to_string(), VmValue::Int(i64::from(pool.size())));
                 entry.insert("idle".to_string(), VmValue::Int(pool.num_idle() as i64));
-                VmValue::Dict(std::sync::Arc::new(entry))
+                VmValue::dict(entry)
             })
             .collect();
         dict.insert(
@@ -252,7 +252,7 @@ async fn pg_pool_stats_impl(
             .map(VmValue::Int)
             .unwrap_or(VmValue::Nil),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+    Ok(VmValue::dict(dict))
 }
 
 #[harn_builtin(
@@ -638,7 +638,7 @@ async fn existing_partition_names(
 /// the matching granularity so it compares correctly against partition
 /// upper bounds under bytewise ordering.
 fn retention_cutoff(
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Result<String, VmError> {
     if let Some(days) = options.get("keep_days") {
@@ -794,7 +794,7 @@ fn qualified_identifier(input: &str, builtin: &'static str) -> Result<QualifiedI
     })
 }
 
-fn render_bounds_clause(bounds: &BTreeMap<String, VmValue>) -> Result<String, VmError> {
+fn render_bounds_clause(bounds: &crate::value::DictMap) -> Result<String, VmError> {
     if let (Some(from), Some(to)) = (bounds.get("from"), bounds.get("to")) {
         let from_lit = sql_literal(from, "pg_partition_attach.bounds.from")?;
         let to_lit = sql_literal(to, "pg_partition_attach.bounds.to")?;
@@ -918,7 +918,7 @@ mod tests {
 
     #[test]
     fn render_bounds_clause_handles_three_shapes() {
-        let from_to = BTreeMap::from([
+        let from_to = crate::value::DictMap::from_iter([
             (
                 "from".to_string(),
                 VmValue::String(std::sync::Arc::from("2026-01-01")),
@@ -932,7 +932,7 @@ mod tests {
             render_bounds_clause(&from_to).unwrap(),
             "FOR VALUES FROM ('2026-01-01') TO ('2026-02-01')"
         );
-        let in_clause = BTreeMap::from([(
+        let in_clause = crate::value::DictMap::from_iter([(
             "in".to_string(),
             VmValue::List(std::sync::Arc::new(vec![VmValue::Int(1), VmValue::Int(2)])),
         )]);
@@ -940,9 +940,10 @@ mod tests {
             render_bounds_clause(&in_clause).unwrap(),
             "FOR VALUES IN (1, 2)"
         );
-        let default = BTreeMap::from([("default".to_string(), VmValue::Bool(true))]);
+        let default =
+            crate::value::DictMap::from_iter([("default".to_string(), VmValue::Bool(true))]);
         assert_eq!(render_bounds_clause(&default).unwrap(), "DEFAULT");
-        let bad = BTreeMap::new();
+        let bad = crate::value::DictMap::new();
         assert!(render_bounds_clause(&bad).is_err());
     }
 
@@ -956,7 +957,7 @@ mod tests {
 
     #[test]
     fn render_bounds_clause_handles_hash() {
-        let hash = BTreeMap::from([
+        let hash = crate::value::DictMap::from_iter([
             ("modulus".to_string(), VmValue::Int(4)),
             ("remainder".to_string(), VmValue::Int(0)),
         ]);
@@ -965,13 +966,13 @@ mod tests {
             "FOR VALUES WITH (MODULUS 4, REMAINDER 0)"
         );
         // remainder must be strictly less than modulus.
-        let bad_remainder = BTreeMap::from([
+        let bad_remainder = crate::value::DictMap::from_iter([
             ("modulus".to_string(), VmValue::Int(4)),
             ("remainder".to_string(), VmValue::Int(4)),
         ]);
         assert!(render_bounds_clause(&bad_remainder).is_err());
         // modulus must be >= 1.
-        let zero_modulus = BTreeMap::from([
+        let zero_modulus = crate::value::DictMap::from_iter([
             ("modulus".to_string(), VmValue::Int(0)),
             ("remainder".to_string(), VmValue::Int(0)),
         ]);
@@ -1019,14 +1020,14 @@ mod tests {
         let now = chrono::DateTime::parse_from_rfc3339("2026-05-28T12:34:56Z")
             .unwrap()
             .with_timezone(&chrono::Utc);
-        let days = BTreeMap::from([("keep_days".to_string(), VmValue::Int(90))]);
+        let days = crate::value::DictMap::from_iter([("keep_days".to_string(), VmValue::Int(90))]);
         assert_eq!(retention_cutoff(&days, now).unwrap(), "2026-02-27");
-        let hours = BTreeMap::from([("keep_hours".to_string(), VmValue::Int(6))]);
+        let hours = crate::value::DictMap::from_iter([("keep_hours".to_string(), VmValue::Int(6))]);
         assert_eq!(
             retention_cutoff(&hours, now).unwrap(),
             "2026-05-28 06:00:00"
         );
-        let empty = BTreeMap::new();
+        let empty = crate::value::DictMap::new();
         assert!(retention_cutoff(&empty, now).is_err());
     }
 

--- a/crates/harn-vm/src/stdlib/postgres/listen.rs
+++ b/crates/harn-vm/src/stdlib/postgres/listen.rs
@@ -70,7 +70,7 @@ impl ListenerRecord {
 
 thread_local! {
     static LISTENERS: RefCell<BTreeMap<String, Arc<ListenerRecord>>> =
-        const { RefCell::new(BTreeMap::new()) };
+        const { RefCell::new(std::collections::BTreeMap::new()) };
 }
 
 pub(super) fn reset_state() {
@@ -120,7 +120,7 @@ async fn pg_listen_impl(
             .insert(id.clone(), Arc::clone(&record));
     });
 
-    let mut meta = BTreeMap::new();
+    let mut meta = crate::value::DictMap::new();
     meta.insert(
         "channels".to_string(),
         VmValue::List(std::sync::Arc::new(
@@ -176,14 +176,14 @@ async fn pg_listener_recv_impl(
 
     let channel = notification.channel().to_string();
     let payload = notification.payload().to_string();
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.put_str("channel", channel.clone());
     dict.put_str("payload", payload.clone());
     dict.insert(
         "process_id".to_string(),
         VmValue::Int(i64::from(notification.process_id())),
     );
-    let value = VmValue::Dict(std::sync::Arc::new(dict));
+    let value = VmValue::dict(dict);
 
     if record.bridge {
         let parsed_payload: serde_json::Value = serde_json::from_str(&payload)

--- a/crates/harn-vm/src/stdlib/postgres/migrate.rs
+++ b/crates/harn-vm/src/stdlib/postgres/migrate.rs
@@ -54,7 +54,7 @@ enum Ledger {
 }
 
 impl Ledger {
-    fn parse(opts: &BTreeMap<String, VmValue>) -> Result<Self, VmError> {
+    fn parse(opts: &crate::value::DictMap) -> Result<Self, VmError> {
         match opts.get("ledger") {
             None => Ok(Ledger::Harn),
             Some(VmValue::String(s)) => match s.as_ref() {
@@ -198,7 +198,7 @@ async fn run_harn(
     ))
 }
 
-fn dir_arg(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<PathBuf, VmError> {
+fn dir_arg(dict: &crate::value::DictMap, key: &str) -> Result<PathBuf, VmError> {
     let value = dict.get(key).ok_or_else(|| {
         runtime_error(format!(
             "pg_migrate: option `{key}` is required and must be a path"
@@ -433,7 +433,7 @@ fn build_response(
     response.insert("dry_run".to_string(), VmValue::Bool(dry_run));
     response.insert("duration_ms".to_string(), VmValue::Int(duration_ms));
     response.put_str("table", table_name);
-    VmValue::Dict(Arc::new(response))
+    VmValue::dict(response)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/harn-vm/src/stdlib/postgres/mod.rs
+++ b/crates/harn-vm/src/stdlib/postgres/mod.rs
@@ -69,10 +69,10 @@ type PgTxCell = Arc<Mutex<Option<Transaction<'static, Postgres>>>>;
 type PgTxRegistry = BTreeMap<String, PgTxCell>;
 
 thread_local! {
-    static POOLS: RefCell<BTreeMap<String, Arc<PoolRecord>>> = const { RefCell::new(BTreeMap::new()) };
+    static POOLS: RefCell<BTreeMap<String, Arc<PoolRecord>>> = const { RefCell::new(std::collections::BTreeMap::new()) };
     static TXS: RefCell<PgTxRegistry> =
-        const { RefCell::new(BTreeMap::new()) };
-    static MOCKS: RefCell<BTreeMap<String, MockPool>> = const { RefCell::new(BTreeMap::new()) };
+        const { RefCell::new(std::collections::BTreeMap::new()) };
+    static MOCKS: RefCell<BTreeMap<String, MockPool>> = const { RefCell::new(std::collections::BTreeMap::new()) };
     /// Server-described per-slot parameter OIDs, keyed by the SQL string.
     ///
     /// Postgres infers every `$n` slot's type from the query *structure* (casts,
@@ -84,7 +84,7 @@ thread_local! {
     /// to match the `POOLS`/`TXS`/`MOCKS` registries above (the harn VM runs on a
     /// current-thread runtime).
     static DESCRIBED_OIDS: RefCell<BTreeMap<String, Arc<Vec<PgTypeInfo>>>> =
-        const { RefCell::new(BTreeMap::new()) };
+        const { RefCell::new(std::collections::BTreeMap::new()) };
 }
 
 // Counts how many times an *uncached* server describe round-trip is performed.
@@ -144,15 +144,15 @@ fn register_postgres_namespace(vm: &mut Vm) {
     );
     vm.set_global(
         "pg",
-        VmValue::Dict(Arc::new(BTreeMap::from([
+        VmValue::dict(crate::value::DictMap::from_iter([
             ("_namespace".to_string(), VmValue::String(Arc::from("pg"))),
             ("jsonb".to_string(), jsonb),
-        ]))),
+        ])),
     );
 }
 
 fn namespace(name: &str, entries: &[(&str, &str)]) -> VmValue {
-    VmValue::Dict(Arc::new(
+    VmValue::dict(
         std::iter::once((
             "_namespace".to_string(),
             VmValue::String(Arc::from(name.to_string())),
@@ -164,7 +164,7 @@ fn namespace(name: &str, entries: &[(&str, &str)]) -> VmValue {
             )
         }))
         .collect::<BTreeMap<_, _>>(),
-    ))
+    )
 }
 
 pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[
@@ -311,7 +311,7 @@ fn stmt_cache_clear_result(
     connections_cleared: i64,
     connections_skipped: i64,
 ) -> VmValue {
-    let mut result = BTreeMap::new();
+    let mut result = crate::value::DictMap::new();
     result.insert("pools".to_string(), VmValue::Int(pools));
     result.insert(
         "connections_cleared".to_string(),
@@ -321,7 +321,7 @@ fn stmt_cache_clear_result(
         "connections_skipped".to_string(),
         VmValue::Int(connections_skipped),
     );
-    VmValue::Dict(std::sync::Arc::new(result))
+    VmValue::dict(result)
 }
 
 async fn clear_idle_statement_caches(
@@ -507,7 +507,7 @@ pub(super) async fn run_managed_transaction(
     let tx_id = next_id("pgtx");
     let tx_cell = Arc::new(Mutex::new(Some(tx)));
     register_tx(&tx_id, Arc::clone(&tx_cell));
-    let tx_handle = handle_value(HANDLE_TX, &tx_id, BTreeMap::new());
+    let tx_handle = handle_value(HANDLE_TX, &tx_id, crate::value::DictMap::new());
 
     if let Err(error) = prepare(&tx_id).await {
         unregister_tx(&tx_id);
@@ -614,7 +614,7 @@ fn pg_mock_pool_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
             },
         );
     });
-    Ok(handle_value(HANDLE_MOCK, &id, BTreeMap::new()))
+    Ok(handle_value(HANDLE_MOCK, &id, crate::value::DictMap::new()))
 }
 
 #[harn_builtin(
@@ -636,7 +636,7 @@ fn pg_mock_calls_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
 async fn open_pool(
     ctx: &crate::vm::AsyncBuiltinCtx,
     source: &VmValue,
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     single_connection: bool,
 ) -> Result<VmValue, VmError> {
     let primary_url = resolve_connection_url(ctx, source).await?;
@@ -744,7 +744,7 @@ fn register_local_pool_handle(
     } else {
         "pgpool"
     });
-    let mut meta = BTreeMap::new();
+    let mut meta = crate::value::DictMap::new();
     meta.insert(
         "max_connections".to_string(),
         VmValue::Int(i64::from(record.max_connections)),
@@ -773,7 +773,7 @@ fn register_local_pool_handle(
 
 async fn build_pool(
     url: &str,
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     max_connections: u32,
     stmt_cache_capacity: usize,
     label: &'static str,
@@ -816,7 +816,7 @@ async fn build_pool(
 
 async fn collect_replica_urls(
     ctx: &crate::vm::AsyncBuiltinCtx,
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<Vec<String>, VmError> {
     let Some(replicas_value) = options.and_then(|opts| opts.get("replicas")) else {
         return Ok(Vec::new());
@@ -837,7 +837,7 @@ async fn collect_replica_urls(
     Ok(urls)
 }
 
-fn build_circuit_breaker(options: Option<&BTreeMap<String, VmValue>>) -> CircuitBreakerState {
+fn build_circuit_breaker(options: Option<&crate::value::DictMap>) -> CircuitBreakerState {
     let Some(cb) = options
         .and_then(|opts| opts.get("circuit_breaker"))
         .and_then(VmValue::as_dict)
@@ -1145,7 +1145,7 @@ fn is_allowed_transaction_setting(key: &str) -> bool {
 
 async fn apply_transaction_settings(
     tx_id: &str,
-    settings: &BTreeMap<String, VmValue>,
+    settings: &crate::value::DictMap,
 ) -> Result<(), VmError> {
     for (key, value) in settings {
         if !is_allowed_transaction_setting(key) {
@@ -1540,13 +1540,13 @@ async fn run_described_query<T>(
 }
 
 pub(super) fn row_to_value(row: PgRow) -> Result<VmValue, VmError> {
-    let mut map = BTreeMap::new();
+    let mut map = crate::value::DictMap::new();
     for (index, column) in row.columns().iter().enumerate() {
         let name = column.name().to_string();
         let value = column_value(&row, index, column.type_info().name())?;
         map.insert(name, value);
     }
-    Ok(VmValue::Dict(std::sync::Arc::new(map)))
+    Ok(VmValue::dict(map))
 }
 
 fn column_value(row: &PgRow, index: usize, type_name: &str) -> Result<VmValue, VmError> {
@@ -1669,7 +1669,7 @@ fn column_value(row: &PgRow, index: usize, type_name: &str) -> Result<VmValue, V
         // it as `BTreeMap<String, Option<String>>` already.
         "HSTORE" => {
             let map: sqlx_postgres::types::PgHstore = row.try_get(index).map_err(decode_error)?;
-            let mut dict = BTreeMap::new();
+            let mut dict = crate::value::DictMap::new();
             for (key, value) in map.0 {
                 dict.insert(
                     key,
@@ -1678,7 +1678,7 @@ fn column_value(row: &PgRow, index: usize, type_name: &str) -> Result<VmValue, V
                         .unwrap_or(VmValue::Nil),
                 );
             }
-            VmValue::Dict(std::sync::Arc::new(dict))
+            VmValue::dict(dict)
         }
         // Postgres geometric types decode into dictionaries that preserve
         // the native shape while staying idiomatic to Harn callers.
@@ -1797,12 +1797,12 @@ fn point_value(x: f64, y: f64) -> VmValue {
 }
 
 fn dict_value<const N: usize>(pairs: [(&'static str, VmValue); N]) -> VmValue {
-    VmValue::Dict(Arc::new(
+    VmValue::dict(
         pairs
             .into_iter()
             .map(|(key, value)| (key.to_string(), value))
-            .collect(),
-    ))
+            .collect::<crate::value::DictMap>(),
+    )
 }
 
 fn decode_error(error: sqlx_core::error::Error) -> VmError {
@@ -1888,7 +1888,7 @@ fn query_result_value(result: PgQueryResult, duration: std::time::Duration) -> V
 }
 
 fn execute_result_value(rows_affected: u64, duration: std::time::Duration) -> VmValue {
-    let mut map = BTreeMap::new();
+    let mut map = crate::value::DictMap::new();
     map.insert(
         "rows_affected".to_string(),
         VmValue::Int(rows_affected as i64),
@@ -1897,7 +1897,7 @@ fn execute_result_value(rows_affected: u64, duration: std::time::Duration) -> Vm
         "duration_ms".to_string(),
         VmValue::Int(duration.as_millis() as i64),
     );
-    VmValue::Dict(std::sync::Arc::new(map))
+    VmValue::dict(map)
 }
 
 async fn resolve_connection_url(
@@ -2037,10 +2037,10 @@ pub(super) fn unregister_tx(id: &str) {
     });
 }
 
-pub(super) fn handle_value(kind: &str, id: &str, mut extra: BTreeMap<String, VmValue>) -> VmValue {
+pub(super) fn handle_value(kind: &str, id: &str, mut extra: crate::value::DictMap) -> VmValue {
     extra.put_str("_type", kind);
     extra.put_str("id", id);
-    VmValue::Dict(std::sync::Arc::new(extra))
+    VmValue::dict(extra)
 }
 
 pub(super) fn handle_kind(value: &VmValue) -> Option<String> {
@@ -2178,7 +2178,7 @@ impl ReadRoutingPolicy {
 }
 
 fn read_routing_policy_from_options(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<ReadRoutingPolicy, VmError> {
     Ok(parse_read_routing_policy(
         options
@@ -2190,7 +2190,7 @@ fn read_routing_policy_from_options(
 }
 
 fn query_routing_policy_from_options(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<Option<ReadRoutingPolicy>, VmError> {
     parse_read_routing_policy(
         options
@@ -2225,7 +2225,7 @@ fn parse_read_routing_policy(
 }
 
 pub(super) fn routing_from_options(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<QueryRouting, VmError> {
     if let Some(policy) = query_routing_policy_from_options(options)? {
         Ok(QueryRouting::Policy(policy))
@@ -2261,7 +2261,7 @@ pub(super) fn params_arg(value: Option<&VmValue>, builtin: &str) -> Result<Vec<V
     }
 }
 
-fn option_string(options: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<String> {
+fn option_string(options: Option<&crate::value::DictMap>, key: &str) -> Option<String> {
     options
         .and_then(|opts| opts.get(key))
         .map(VmValue::display)
@@ -2275,7 +2275,7 @@ pub(super) fn option_bool(value: Option<&VmValue>) -> Option<bool> {
     }
 }
 
-fn option_int(options: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<i64> {
+fn option_int(options: Option<&crate::value::DictMap>, key: &str) -> Option<i64> {
     options
         .and_then(|opts| opts.get(key))
         .and_then(|value| match value {
@@ -2291,7 +2291,7 @@ fn option_int(options: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<
         })
 }
 
-fn option_duration_ms(options: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<u64> {
+fn option_duration_ms(options: Option<&crate::value::DictMap>, key: &str) -> Option<u64> {
     options.and_then(|opts| opts.get(key)).and_then(|value| {
         non_negative_millis_from_value(value, "postgres", key, ErrorKind::Runtime).ok()
     })

--- a/crates/harn-vm/src/stdlib/postgres/shared.rs
+++ b/crates/harn-vm/src/stdlib/postgres/shared.rs
@@ -92,7 +92,7 @@ impl PoolKey {
     pub(super) fn new(
         primary_url: &str,
         replica_urls: &[String],
-        options: Option<&BTreeMap<String, VmValue>>,
+        options: Option<&crate::value::DictMap>,
         single_connection: bool,
     ) -> Self {
         let mut hasher = Sha256::new();
@@ -253,7 +253,7 @@ mod tests {
         VmValue::String(std::sync::Arc::from(value))
     }
 
-    fn opts(pairs: &[(&str, VmValue)]) -> BTreeMap<String, VmValue> {
+    fn opts(pairs: &[(&str, VmValue)]) -> crate::value::DictMap {
         pairs
             .iter()
             .map(|(k, v)| ((*k).to_string(), v.clone()))
@@ -357,14 +357,8 @@ mod tests {
     /// Nested option dicts (e.g. `circuit_breaker`) participate structurally.
     #[test]
     fn nested_option_dicts_affect_key() {
-        let cb1 = VmValue::Dict(std::sync::Arc::new(opts(&[(
-            "failure_threshold",
-            VmValue::Int(3),
-        )])));
-        let cb2 = VmValue::Dict(std::sync::Arc::new(opts(&[(
-            "failure_threshold",
-            VmValue::Int(9),
-        )])));
+        let cb1 = VmValue::dict(opts(&[("failure_threshold", VmValue::Int(3))]));
+        let cb2 = VmValue::dict(opts(&[("failure_threshold", VmValue::Int(9))]));
         let o1 = opts(&[("circuit_breaker", cb1)]);
         let o2 = opts(&[("circuit_breaker", cb2)]);
         assert_ne!(

--- a/crates/harn-vm/src/stdlib/postgres/tests.rs
+++ b/crates/harn-vm/src/stdlib/postgres/tests.rs
@@ -7,12 +7,12 @@ fn s(value: &str) -> VmValue {
 }
 
 fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(
+    VmValue::dict(
         pairs
             .iter()
             .map(|(key, value)| ((*key).to_string(), value.clone()))
-            .collect(),
-    ))
+            .collect::<crate::value::DictMap>(),
+    )
 }
 
 fn lazy_pool_for_test() -> Arc<PgPool> {
@@ -83,26 +83,30 @@ fn routing_record(replicas: usize, policy: ReadRoutingPolicy) -> Arc<PoolRecord>
 
 #[test]
 fn read_routing_policy_options_parse_named_modes() {
-    let pool_options =
-        BTreeMap::from([("read_routing_policy".to_string(), s("round_robin_replica"))]);
+    let pool_options = crate::value::DictMap::from_iter([(
+        "read_routing_policy".to_string(),
+        s("round_robin_replica"),
+    )]);
     assert_eq!(
         read_routing_policy_from_options(Some(&pool_options)).unwrap(),
         ReadRoutingPolicy::RoundRobinReplica
     );
 
-    let query_options = BTreeMap::from([("route".to_string(), s("replica"))]);
+    let query_options = crate::value::DictMap::from_iter([("route".to_string(), s("replica"))]);
     assert_eq!(
         routing_from_options(Some(&query_options)).unwrap(),
         QueryRouting::Policy(ReadRoutingPolicy::Replica)
     );
 
-    let read_only_options = BTreeMap::from([("read_only".to_string(), VmValue::Bool(true))]);
+    let read_only_options =
+        crate::value::DictMap::from_iter([("read_only".to_string(), VmValue::Bool(true))]);
     assert_eq!(
         routing_from_options(Some(&read_only_options)).unwrap(),
         QueryRouting::ReadOnly
     );
 
-    let bad_options = BTreeMap::from([("routing_policy".to_string(), s("nearby"))]);
+    let bad_options =
+        crate::value::DictMap::from_iter([("routing_policy".to_string(), s("nearby"))]);
     assert!(routing_from_options(Some(&bad_options)).is_err());
 }
 
@@ -188,7 +192,7 @@ fn mock_pool_matches_parameterized_query_and_records_calls() {
             },
         );
     });
-    let handle = handle_value(HANDLE_MOCK, &id, BTreeMap::new());
+    let handle = handle_value(HANDLE_MOCK, &id, crate::value::DictMap::new());
     let rows = mock_query(
         &handle,
         "select * from claims where tenant_id = $1",
@@ -222,7 +226,7 @@ fn mock_execute_returns_rows_affected() {
             },
         );
     });
-    let handle = handle_value(HANDLE_MOCK, &id, BTreeMap::new());
+    let handle = handle_value(HANDLE_MOCK, &id, crate::value::DictMap::new());
     let rows = mock_query(
         &handle,
         "update receipts set status = $1",
@@ -277,7 +281,7 @@ async fn postgres_round_trip_when_env_url_is_set() {
         return;
     };
     reset_postgres_state();
-    let mut options = BTreeMap::new();
+    let mut options = crate::value::DictMap::new();
     options.insert("max_connections".to_string(), VmValue::Int(1));
     options.insert(
         "application_name".to_string(),
@@ -319,7 +323,7 @@ async fn postgres_round_trip_when_env_url_is_set() {
 /// Opens a single-connection pool against the test database so every query
 /// reuses the same physical connection (and prepared-statement cache).
 async fn open_single_conn_pool(url: &str) -> VmValue {
-    let mut options = BTreeMap::new();
+    let mut options = crate::value::DictMap::new();
     options.insert("max_connections".to_string(), VmValue::Int(1));
     options.insert("application_name".to_string(), s("harn-postgres-bind-test"));
     let ctx = crate::vm::AsyncBuiltinCtx::for_test(crate::Vm::new());

--- a/crates/harn-vm/src/stdlib/process.rs
+++ b/crates/harn-vm/src/stdlib/process.rs
@@ -375,7 +375,7 @@ fn runtime_paths_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, V
         "worktree_root",
         crate::runtime_paths::worktree_root(&runtime_base).to_string_lossy(),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(paths)))
+    Ok(VmValue::dict(paths))
 }
 
 #[harn_builtin(sig = "spawn_captured(opts: dict) -> dict", category = "process")]
@@ -525,7 +525,7 @@ pub(crate) fn spawn_captured_value(args: &[VmValue]) -> Result<VmValue, VmError>
     result.insert("duration_ms".to_string(), VmValue::Int(duration_ms));
     result.insert("success".to_string(), VmValue::Bool(success));
     result.insert("timed_out".to_string(), VmValue::Bool(timed_out));
-    Ok(VmValue::Dict(std::sync::Arc::new(result)))
+    Ok(VmValue::dict(result))
 }
 
 /// Parameters for [`run_captured_spawn`]: a single synchronous subprocess
@@ -765,7 +765,7 @@ fn captured_run_to_value(run: &CapturedRun) -> VmValue {
     result.insert("success".to_string(), VmValue::Bool(success));
     result.insert("timed_out".to_string(), VmValue::Bool(run.timed_out));
     result.insert("duration_ms".to_string(), VmValue::Int(run.duration_ms));
-    VmValue::Dict(std::sync::Arc::new(result))
+    VmValue::dict(result)
 }
 
 #[harn_builtin(
@@ -904,7 +904,7 @@ fn vm_output_to_value(output: std::process::Output) -> VmValue {
         "success".to_string(),
         VmValue::Bool(output.status.success()),
     );
-    VmValue::Dict(std::sync::Arc::new(result))
+    VmValue::dict(result)
 }
 
 fn exec_command(
@@ -1250,12 +1250,12 @@ mod tests {
 
     #[cfg(unix)]
     fn exec_opts_dict(pairs: &[(&str, VmValue)]) -> VmValue {
-        VmValue::Dict(std::sync::Arc::new(
+        VmValue::dict(
             pairs
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.clone()))
-                .collect(),
-        ))
+                .collect::<crate::value::DictMap>(),
+        )
     }
 
     #[cfg(unix)]

--- a/crates/harn-vm/src/stdlib/process_spawn.rs
+++ b/crates/harn-vm/src/stdlib/process_spawn.rs
@@ -201,7 +201,7 @@ fn evict_if_needed(registry: &mut BTreeMap<String, Arc<SpawnEntry>>) {
 /// can fall through.
 pub(crate) async fn dispatch(
     operation: &str,
-    params: &BTreeMap<String, VmValue>,
+    params: &crate::value::DictMap,
 ) -> Option<Result<VmValue, VmError>> {
     match operation {
         "spawn" => Some(spawn(params).await),
@@ -213,7 +213,7 @@ pub(crate) async fn dispatch(
     }
 }
 
-async fn spawn(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
+async fn spawn(params: &crate::value::DictMap) -> Result<VmValue, VmError> {
     let timeout_ms = optional_i64(params, "timeout")
         .or_else(|| optional_i64(params, "timeout_ms"))
         .filter(|value| *value > 0)
@@ -276,7 +276,7 @@ async fn spawn(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
     result.put_str("started_at", started_at);
     result.put_str("command", command_display);
     result.put_str("status", "running");
-    Ok(VmValue::Dict(std::sync::Arc::new(result)))
+    Ok(VmValue::dict(result))
 }
 
 /// Detached task: drain stdout/stderr, await exit vs kill vs timeout, then
@@ -380,7 +380,7 @@ async fn drain_into<R: AsyncReadExt + Unpin>(mut reader: R, buf: Arc<Mutex<Vec<u
     }
 }
 
-fn command_display(params: &BTreeMap<String, VmValue>) -> String {
+fn command_display(params: &crate::value::DictMap) -> String {
     if let Some(command) = optional_string(params, "command") {
         return command;
     }
@@ -394,7 +394,7 @@ fn command_display(params: &BTreeMap<String, VmValue>) -> String {
     String::new()
 }
 
-fn poll(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
+fn poll(params: &crate::value::DictMap) -> Result<VmValue, VmError> {
     let handle_id = require_param(params, "handle_id")?;
     let entry = lookup(&handle_id)?;
     let state = entry.state.lock().expect("spawn state poisoned");
@@ -423,10 +423,10 @@ fn poll(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
     );
     result.put_str("stdout", String::from_utf8_lossy(&state.stdout));
     result.put_str("stderr", String::from_utf8_lossy(&state.stderr));
-    Ok(VmValue::Dict(std::sync::Arc::new(result)))
+    Ok(VmValue::dict(result))
 }
 
-async fn wait(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
+async fn wait(params: &crate::value::DictMap) -> Result<VmValue, VmError> {
     let handle_id = require_param(params, "handle_id")?;
     let entry = lookup(&handle_id)?;
     let timeout_ms = optional_i64(params, "timeout")
@@ -453,7 +453,7 @@ async fn wait(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
                     result.insert("timed_out".to_string(), VmValue::Bool(true));
                     result.insert("running".to_string(), VmValue::Bool(true));
                     result.put_str("status", "running");
-                    return Ok(VmValue::Dict(std::sync::Arc::new(result)));
+                    return Ok(VmValue::dict(result));
                 }
             }
             None => {
@@ -480,10 +480,10 @@ async fn wait(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
         VmValue::Bool(status == SpawnStatus::TimedOut),
     );
     result.insert("running".to_string(), VmValue::Bool(false));
-    Ok(VmValue::Dict(std::sync::Arc::new(result)))
+    Ok(VmValue::dict(result))
 }
 
-async fn kill(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
+async fn kill(params: &crate::value::DictMap) -> Result<VmValue, VmError> {
     let handle_id = require_param(params, "handle_id")?;
     let entry = lookup(&handle_id)?;
 
@@ -519,10 +519,10 @@ fn kill_result(success: bool, status: SpawnStatus) -> VmValue {
     let mut result = BTreeMap::new();
     result.insert("success".to_string(), VmValue::Bool(success));
     result.put_str("status", status.as_str());
-    VmValue::Dict(std::sync::Arc::new(result))
+    VmValue::dict(result)
 }
 
-fn release(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
+fn release(params: &crate::value::DictMap) -> Result<VmValue, VmError> {
     let handle_id = require_param(params, "handle_id")?;
     let removed = {
         let mut registry = SPAWN_REGISTRY.lock().expect("spawn registry poisoned");
@@ -537,7 +537,7 @@ fn release(params: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
     }
     let mut result = BTreeMap::new();
     result.insert("released".to_string(), VmValue::Bool(removed.is_some()));
-    Ok(VmValue::Dict(std::sync::Arc::new(result)))
+    Ok(VmValue::dict(result))
 }
 
 #[cfg(all(test, unix))]
@@ -553,7 +553,7 @@ mod tests {
     use super::*;
     use std::sync::Arc as StdArc;
 
-    fn params(pairs: &[(&str, VmValue)]) -> BTreeMap<String, VmValue> {
+    fn params(pairs: &[(&str, VmValue)]) -> crate::value::DictMap {
         pairs
             .iter()
             .map(|(k, v)| (k.to_string(), v.clone()))

--- a/crates/harn-vm/src/stdlib/project.rs
+++ b/crates/harn-vm/src/stdlib/project.rs
@@ -277,7 +277,7 @@ impl ProjectFingerprint {
                     .collect(),
             )),
         );
-        VmValue::Dict(std::sync::Arc::new(value))
+        VmValue::dict(value)
     }
 }
 
@@ -348,7 +348,7 @@ impl ProjectTreeEntry {
         value.put_str("dir", self.metadata_path);
         value.put_str("structure_hash", self.structure_hash);
         value.put_str("content_hash", self.content_hash);
-        VmValue::Dict(std::sync::Arc::new(value))
+        VmValue::dict(value)
     }
 }
 
@@ -443,12 +443,12 @@ impl ProjectEvidence {
         );
         result.insert(
             "declared_scripts".to_string(),
-            VmValue::Dict(std::sync::Arc::new(
+            VmValue::dict(
                 self.declared_scripts
                     .into_iter()
                     .map(|(k, v)| (k, VmValue::String(std::sync::Arc::from(v))))
-                    .collect(),
-            )),
+                    .collect::<crate::value::DictMap>(),
+            ),
         );
         result.insert(
             "readme_code_fences".to_string(),
@@ -477,7 +477,7 @@ impl ProjectEvidence {
                     .collect(),
             )),
         );
-        VmValue::Dict(std::sync::Arc::new(result))
+        VmValue::dict(result)
     }
 }
 
@@ -645,11 +645,8 @@ impl ContextProfileResolution {
             "prompt_fragments".to_string(),
             VmValue::List(std::sync::Arc::new(prompt_fragments)),
         );
-        out.insert(
-            "token_delta".to_string(),
-            VmValue::Dict(std::sync::Arc::new(token_delta)),
-        );
-        VmValue::Dict(std::sync::Arc::new(out))
+        out.insert("token_delta".to_string(), VmValue::dict(token_delta));
+        VmValue::dict(out)
     }
 }
 
@@ -668,7 +665,7 @@ impl ContextSignals {
             "credentials".to_string(),
             string_list_value(self.credentials.into_iter().collect()),
         );
-        VmValue::Dict(std::sync::Arc::new(out))
+        VmValue::dict(out)
     }
 }
 
@@ -682,7 +679,7 @@ impl GitRemoteSignal {
             self.slug.map(VmValue::string).unwrap_or(VmValue::Nil),
         );
         out.insert("url".to_string(), VmValue::string(self.redacted_url));
-        VmValue::Dict(std::sync::Arc::new(out))
+        VmValue::dict(out)
     }
 }
 
@@ -696,7 +693,7 @@ impl ContextProfileFragment {
             "requires_caps".to_string(),
             string_list_value(self.requires_caps),
         );
-        VmValue::Dict(std::sync::Arc::new(out))
+        VmValue::dict(out)
     }
 }
 
@@ -709,7 +706,7 @@ impl McpPresetCandidate {
             "missing_credentials".to_string(),
             string_list_value(self.missing_credentials),
         );
-        VmValue::Dict(std::sync::Arc::new(out))
+        VmValue::dict(out)
     }
 }
 
@@ -741,7 +738,7 @@ impl ContextProfileActivation {
             "prompt_fragment".to_string(),
             self.prompt_fragment.into_vm_value(),
         );
-        VmValue::Dict(std::sync::Arc::new(out))
+        VmValue::dict(out)
     }
 }
 
@@ -833,11 +830,11 @@ fn project_scan_tree_native_impl(args: &[VmValue], _out: &mut String) -> Result<
     let options = parse_project_options(args.get(1));
     let base = resolve_existing_directory(&path)?;
     let tree = scan_project_tree(&base, &options)?;
-    Ok(VmValue::Dict(std::sync::Arc::new(
+    Ok(VmValue::dict(
         tree.into_iter()
             .map(|(rel, evidence)| (rel, evidence.into_vm_value()))
-            .collect(),
-    )))
+            .collect::<crate::value::DictMap>(),
+    ))
 }
 
 #[crate::stdlib::macros::harn_builtin(
@@ -1225,7 +1222,7 @@ fn project_fingerprint_from_value(value: &VmValue) -> Option<ProjectFingerprint>
     project_fingerprint_from_dict(value.as_dict()?)
 }
 
-fn project_fingerprint_from_dict(dict: &BTreeMap<String, VmValue>) -> Option<ProjectFingerprint> {
+fn project_fingerprint_from_dict(dict: &crate::value::DictMap) -> Option<ProjectFingerprint> {
     if !dict_has_project_fingerprint_shape(dict) {
         return None;
     }
@@ -1262,7 +1259,7 @@ fn project_fingerprint_from_dict(dict: &BTreeMap<String, VmValue>) -> Option<Pro
     })
 }
 
-fn dict_has_project_fingerprint_shape(dict: &BTreeMap<String, VmValue>) -> bool {
+fn dict_has_project_fingerprint_shape(dict: &crate::value::DictMap) -> bool {
     [
         "primary_language",
         "languages",
@@ -1497,7 +1494,7 @@ fn strip_url_suffix(value: &str) -> &str {
     sanitized
 }
 
-fn string_list_field(dict: &BTreeMap<String, VmValue>, key: &str) -> Vec<String> {
+fn string_list_field(dict: &crate::value::DictMap, key: &str) -> Vec<String> {
     match dict.get(key) {
         Some(VmValue::List(items)) => items
             .iter()
@@ -1516,7 +1513,7 @@ fn string_list_field(dict: &BTreeMap<String, VmValue>, key: &str) -> Vec<String>
     }
 }
 
-fn optional_string_field(dict: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn optional_string_field(dict: &crate::value::DictMap, key: &str) -> Option<String> {
     dict.get(key)
         .and_then(value_as_string)
         .filter(|value| !value.is_empty())
@@ -2857,7 +2854,7 @@ fn confidence_value(evidence: &ProjectEvidence) -> VmValue {
     {
         confidence.insert(label.clone(), VmValue::Float(*score));
     }
-    VmValue::Dict(std::sync::Arc::new(confidence))
+    VmValue::dict(confidence)
 }
 
 fn sorted_confident_labels(scores: &BTreeMap<String, f64>) -> Vec<String> {
@@ -2965,7 +2962,7 @@ fn catalog_entry_value(entry: &ProjectCatalogEntry) -> VmValue {
             .map(|value| VmValue::String(std::sync::Arc::from(value.to_string())))
             .unwrap_or(VmValue::Nil),
     );
-    VmValue::Dict(std::sync::Arc::new(value))
+    VmValue::dict(value)
 }
 
 #[cfg(test)]

--- a/crates/harn-vm/src/stdlib/project_enrich.rs
+++ b/crates/harn-vm/src/stdlib/project_enrich.rs
@@ -127,7 +127,7 @@ async fn project_enrich_impl(
             "_provenance".to_string(),
             provenance_value(None, estimated_input_tokens, 0, false),
         );
-        return Ok(VmValue::Dict(std::sync::Arc::new(budget_result)));
+        return Ok(VmValue::dict(budget_result));
     }
 
     let llm_options_value = llm_options_value(&options, &rendered_prompt);
@@ -459,7 +459,7 @@ fn augment_project_evidence(
             ci_evidence_value(collect_ci_evidence(root)),
         );
     }
-    VmValue::Dict(std::sync::Arc::new(merged))
+    VmValue::dict(merged)
 }
 
 fn collect_ci_evidence(root: &Path) -> CiEvidence {
@@ -691,7 +691,7 @@ fn classify_workflow_job(
 fn collect_hook_evidence(root: &Path) -> HookEvidence {
     let mut providers = Vec::new();
     let mut files = Vec::new();
-    let mut stages = BTreeMap::new();
+    let mut stages = std::collections::BTreeMap::new();
     let mut warnings = Vec::new();
 
     let githooks_dir = root.join(".githooks");
@@ -1483,19 +1483,19 @@ fn enrichment_bindings(
     root: &Path,
     base_evidence: &VmValue,
     files: &[RelevantFile],
-) -> BTreeMap<String, VmValue> {
-    let mut bindings = BTreeMap::new();
+) -> crate::value::DictMap {
+    let mut bindings = crate::value::DictMap::new();
     bindings.put_str("path", root.to_string_lossy());
     bindings.insert("base_evidence".to_string(), base_evidence.clone());
     bindings.insert("evidence".to_string(), base_evidence.clone());
     let file_values = files
         .iter()
         .map(|file| {
-            let mut value = BTreeMap::new();
+            let mut value = crate::value::DictMap::new();
             value.put_str("path", file.rel_path.clone());
             value.put_str("content", file.content.clone());
             value.insert("truncated".to_string(), VmValue::Bool(file.truncated));
-            VmValue::Dict(std::sync::Arc::new(value))
+            VmValue::dict(value)
         })
         .collect::<Vec<_>>();
     bindings.insert(
@@ -1511,7 +1511,7 @@ fn enrichment_bindings(
 }
 
 fn llm_options_value(options: &ProjectEnrichOptions, rendered_prompt: &str) -> VmValue {
-    let mut llm_options = BTreeMap::new();
+    let mut llm_options = crate::value::DictMap::new();
     llm_options.put_str("provider", options.provider.clone());
     llm_options.put_str("model", options.model.clone());
     if let Some(temperature) = options.temperature {
@@ -1533,7 +1533,7 @@ fn llm_options_value(options: &ProjectEnrichOptions, rendered_prompt: &str) -> V
             }),
         )])),
     );
-    VmValue::Dict(std::sync::Arc::new(llm_options))
+    VmValue::dict(llm_options)
 }
 
 fn validation_envelope(
@@ -1543,14 +1543,14 @@ fn validation_envelope(
     input_tokens: i64,
     output_tokens: i64,
 ) -> VmValue {
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.insert("base_evidence".to_string(), base_evidence.clone());
     dict.put_str("validation_error", message);
     dict.insert(
         "_provenance".to_string(),
         provenance_value(model, input_tokens, output_tokens, false),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn attach_provenance(
@@ -1567,16 +1567,16 @@ fn attach_provenance(
                 "_provenance".to_string(),
                 provenance_value(model, input_tokens, output_tokens, cached),
             );
-            VmValue::Dict(std::sync::Arc::new(merged))
+            VmValue::dict(merged)
         }
         other => {
-            let mut wrapped = BTreeMap::new();
+            let mut wrapped = crate::value::DictMap::new();
             wrapped.insert("data".to_string(), other);
             wrapped.insert(
                 "_provenance".to_string(),
                 provenance_value(model, input_tokens, output_tokens, cached),
             );
-            VmValue::Dict(std::sync::Arc::new(wrapped))
+            VmValue::dict(wrapped)
         }
     }
 }
@@ -1590,14 +1590,14 @@ fn attach_ci_metadata(value: VmValue, base_evidence: &VmValue) -> VmValue {
         return value;
     };
     let Some(dict) = value.as_dict() else {
-        let mut wrapped = BTreeMap::new();
+        let mut wrapped = crate::value::DictMap::new();
         wrapped.insert("data".to_string(), value);
         wrapped.insert("ci".to_string(), ci_value);
-        return VmValue::Dict(std::sync::Arc::new(wrapped));
+        return VmValue::dict(wrapped);
     };
     let mut merged = (*dict).clone();
     merged.insert("ci".to_string(), ci_value);
-    VmValue::Dict(std::sync::Arc::new(merged))
+    VmValue::dict(merged)
 }
 
 fn provenance_value(
@@ -1606,23 +1606,20 @@ fn provenance_value(
     output_tokens: i64,
     cached: bool,
 ) -> VmValue {
-    let mut tokens = BTreeMap::new();
+    let mut tokens = crate::value::DictMap::new();
     tokens.insert("in".to_string(), VmValue::Int(input_tokens));
     tokens.insert("out".to_string(), VmValue::Int(output_tokens));
 
-    let mut provenance = BTreeMap::new();
+    let mut provenance = crate::value::DictMap::new();
     provenance.insert(
         "model".to_string(),
         model
             .map(|value| VmValue::String(std::sync::Arc::from(value)))
             .unwrap_or(VmValue::Nil),
     );
-    provenance.insert(
-        "tokens".to_string(),
-        VmValue::Dict(std::sync::Arc::new(tokens)),
-    );
+    provenance.insert("tokens".to_string(), VmValue::dict(tokens));
     provenance.insert("cached".to_string(), VmValue::Bool(cached));
-    VmValue::Dict(std::sync::Arc::new(provenance))
+    VmValue::dict(provenance)
 }
 
 fn result_with_cached_flag(value: VmValue, cached: bool) -> VmValue {
@@ -1636,11 +1633,8 @@ fn result_with_cached_flag(value: VmValue, cached: bool) -> VmValue {
         .map(|value| (*value).clone())
         .unwrap_or_default();
     provenance.insert("cached".to_string(), VmValue::Bool(cached));
-    merged.insert(
-        "_provenance".to_string(),
-        VmValue::Dict(std::sync::Arc::new(provenance)),
-    );
-    VmValue::Dict(std::sync::Arc::new(merged))
+    merged.insert("_provenance".to_string(), VmValue::dict(provenance));
+    VmValue::dict(merged)
 }
 
 fn hash_relevant_files(files: &[RelevantFile]) -> String {
@@ -1921,7 +1915,7 @@ commands:
         let options = ProjectEnrichOptions {
             base_evidence: None,
             prompt: "Return JSON.".to_string(),
-            schema: VmValue::Dict(std::sync::Arc::new(BTreeMap::new())),
+            schema: VmValue::dict(crate::value::DictMap::new()),
             budget_tokens: 4000,
             model: "mock-model".to_string(),
             provider: "mock".to_string(),
@@ -2120,7 +2114,7 @@ jobs:
             "pub fn greet() -> &'static str { \"hi\" }\n",
         );
 
-        let base = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        let base = VmValue::dict(crate::value::DictMap::from_iter([
             (
                 "languages".to_string(),
                 VmValue::List(std::sync::Arc::new(vec![VmValue::String(
@@ -2139,7 +2133,7 @@ jobs:
                     std::sync::Arc::from("Cargo.lock"),
                 )])),
             ),
-        ])));
+        ]));
         let files = collect_relevant_files(dir.path(), &base);
         let paths = files
             .iter()
@@ -2152,21 +2146,21 @@ jobs:
 
     #[test]
     fn attach_ci_metadata_merges_ci_block_into_result() {
-        let base = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        let base = VmValue::dict(crate::value::DictMap::from_iter([(
             "ci".to_string(),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            VmValue::dict(crate::value::DictMap::from_iter([(
                 "merge_policy".to_string(),
-                VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+                VmValue::dict(crate::value::DictMap::from_iter([(
                     "squash_only".to_string(),
                     VmValue::Bool(true),
-                )]))),
-            )]))),
-        )])));
+                )])),
+            )])),
+        )]));
         let result = attach_ci_metadata(
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            VmValue::dict(crate::value::DictMap::from_iter([(
                 "summary".to_string(),
                 VmValue::String(std::sync::Arc::from("ok")),
-            )]))),
+            )])),
             &base,
         );
         let dict = result.as_dict().expect("dict");

--- a/crates/harn-vm/src/stdlib/project_tests.rs
+++ b/crates/harn-vm/src/stdlib/project_tests.rs
@@ -268,12 +268,8 @@ fn context_profile_scans_fingerprint_when_supplied_signals_only_include_remote()
     );
     let mut raw_options = BTreeMap::new();
     raw_options.insert("include_env_credentials".to_string(), VmValue::Bool(false));
-    raw_options.insert(
-        "signals".to_string(),
-        VmValue::Dict(std::sync::Arc::new(signals)),
-    );
-    let options =
-        parse_context_profile_options(Some(&VmValue::Dict(std::sync::Arc::new(raw_options))));
+    raw_options.insert("signals".to_string(), VmValue::dict(signals));
+    let options = parse_context_profile_options(Some(&VmValue::dict(raw_options)));
 
     assert!(options.fingerprint.is_none());
     let resolution = resolve_context_profile(dir.path(), options);

--- a/crates/harn-vm/src/stdlib/records.rs
+++ b/crates/harn-vm/src/stdlib/records.rs
@@ -1383,7 +1383,7 @@ fn eval_metrics_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
                     crate::stdlib::json_to_vm_value(meta),
                 );
             }
-            VmValue::Dict(std::sync::Arc::new(dict))
+            VmValue::dict(dict)
         })
         .collect();
     Ok(VmValue::List(std::sync::Arc::from(list)))

--- a/crates/harn-vm/src/stdlib/regex.rs
+++ b/crates/harn-vm/src/stdlib/regex.rs
@@ -232,7 +232,7 @@ fn regex_captures_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
             }
         }
 
-        results.push(VmValue::Dict(std::sync::Arc::new(dict)));
+        results.push(VmValue::dict(dict));
     }
     Ok(VmValue::List(std::sync::Arc::new(results)))
 }

--- a/crates/harn-vm/src/stdlib/shapes.rs
+++ b/crates/harn-vm/src/stdlib/shapes.rs
@@ -38,13 +38,13 @@ fn entries_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError>
         VmValue::Dict(map) => Ok(VmValue::List(std::sync::Arc::new(
             map.iter()
                 .map(|(k, v)| {
-                    VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+                    VmValue::dict(BTreeMap::from([
                         (
                             "key".to_string(),
                             VmValue::String(std::sync::Arc::from(k.as_str())),
                         ),
                         ("value".to_string(), v.clone()),
-                    ])))
+                    ]))
                 })
                 .collect(),
         ))),
@@ -140,12 +140,12 @@ fn __dict_rest(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> 
                 .collect(),
             _ => std::collections::HashSet::new(),
         };
-        let rest: BTreeMap<String, VmValue> = map
+        let rest: crate::value::DictMap = map
             .iter()
             .filter(|(k, _)| !exclude.contains(k.as_str()))
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
-        Ok(VmValue::Dict(std::sync::Arc::new(rest)))
+        Ok(VmValue::dict(rest))
     } else {
         Ok(VmValue::Nil)
     }
@@ -169,11 +169,11 @@ fn __make_struct(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError
             Some(field_names) => Ok(VmValue::struct_instance_with_layout(
                 struct_name,
                 field_names,
-                BTreeMap::new(),
+                crate::value::DictMap::new(),
             )),
             None => Ok(VmValue::struct_instance_from_map(
                 struct_name,
-                BTreeMap::new(),
+                crate::value::DictMap::new(),
             )),
         },
     }

--- a/crates/harn-vm/src/stdlib/skills.rs
+++ b/crates/harn-vm/src/stdlib/skills.rs
@@ -28,7 +28,7 @@ use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
-fn vm_validate_registry(name: &str, dict: &BTreeMap<String, VmValue>) -> Result<(), VmError> {
+fn vm_validate_registry(name: &str, dict: &crate::value::DictMap) -> Result<(), VmError> {
     match dict.get("_type") {
         Some(VmValue::String(t)) if &**t == "skill_registry" => Ok(()),
         _ => Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
@@ -37,14 +37,14 @@ fn vm_validate_registry(name: &str, dict: &BTreeMap<String, VmValue>) -> Result<
     }
 }
 
-fn vm_get_skills(dict: &BTreeMap<String, VmValue>) -> &[VmValue] {
+fn vm_get_skills(dict: &crate::value::DictMap) -> &[VmValue] {
     match dict.get("skills") {
         Some(VmValue::List(list)) => list,
         _ => &[],
     }
 }
 
-fn vm_skill_entry_id(entry: &BTreeMap<String, VmValue>) -> String {
+fn vm_skill_entry_id(entry: &crate::value::DictMap) -> String {
     let name = entry.get("name").map(|v| v.display()).unwrap_or_default();
     let namespace = entry
         .get("namespace")
@@ -85,14 +85,14 @@ fn vm_skill_catalog_entries(skills: &[VmValue]) -> Vec<VmValue> {
         rendered.put_str("name", id.as_str());
         rendered.put_str("description", description.as_str());
         rendered.put_str("when_to_use", when_to_use.as_str());
-        catalog.push((id, VmValue::Dict(std::sync::Arc::new(rendered))));
+        catalog.push((id, VmValue::dict(rendered)));
     }
     catalog.sort_by(|a, b| a.0.cmp(&b.0));
     catalog.into_iter().map(|(_, value)| value).collect()
 }
 
 fn vm_skill_who_signed(skills: &[VmValue], target: &str) -> Result<VmValue, VmError> {
-    let mut bare_matches: Vec<&BTreeMap<String, VmValue>> = Vec::new();
+    let mut bare_matches: Vec<&crate::value::DictMap> = Vec::new();
     for skill in skills {
         let Some(entry) = skill.as_dict() else {
             continue;
@@ -119,10 +119,10 @@ fn vm_skill_who_signed(skills: &[VmValue], target: &str) -> Result<VmValue, VmEr
     }
 }
 
-fn who_signed_entry(entry: &BTreeMap<String, VmValue>) -> VmValue {
+fn who_signed_entry(entry: &crate::value::DictMap) -> VmValue {
     let mut out = match entry.get("provenance").and_then(VmValue::as_dict) {
         Some(provenance) => provenance.clone(),
-        None => BTreeMap::new(),
+        None => crate::value::DictMap::new(),
     };
     out.put_str("skill_id", vm_skill_entry_id(entry).as_str());
     out.entry("signed".to_string())
@@ -131,10 +131,10 @@ fn who_signed_entry(entry: &BTreeMap<String, VmValue>) -> VmValue {
         .or_insert(VmValue::Bool(false));
     out.entry("endorsements".to_string())
         .or_insert_with(|| VmValue::List(std::sync::Arc::new(Vec::new())));
-    VmValue::Dict(std::sync::Arc::new(out))
+    VmValue::dict(out)
 }
 
-fn render_catalog_entry(entry: &BTreeMap<String, VmValue>) -> Option<String> {
+fn render_catalog_entry(entry: &crate::value::DictMap) -> Option<String> {
     let name = entry.get("name").map(|v| v.display()).unwrap_or_default();
     if name.is_empty() {
         return None;
@@ -251,7 +251,7 @@ fn skill_registry_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, 
         "skills".to_string(),
         VmValue::List(std::sync::Arc::new(Vec::new())),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(registry)))
+    Ok(VmValue::dict(registry))
 }
 
 #[harn_builtin(
@@ -286,7 +286,7 @@ fn skill_define_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
 
     let config = match &args[2] {
         VmValue::Dict(map) => (**map).clone(),
-        VmValue::Nil => BTreeMap::new(),
+        VmValue::Nil => crate::value::DictMap::new(),
         _ => {
             return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
                 "skill_define: third argument must be a config dict",
@@ -362,7 +362,7 @@ fn skill_define_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
     for (k, v) in config.iter() {
         entry.insert(k.clone(), v.clone());
     }
-    let entry_value = VmValue::Dict(std::sync::Arc::new(entry));
+    let entry_value = VmValue::dict(entry);
 
     let skills = vm_get_skills(&registry);
     let mut new_skills: Vec<VmValue> = Vec::with_capacity(skills.len() + 1);
@@ -388,7 +388,7 @@ fn skill_define_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
         "skills".to_string(),
         VmValue::List(std::sync::Arc::new(new_skills)),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(new_registry)))
+    Ok(VmValue::dict(new_registry))
 }
 
 #[harn_builtin(sig = "skill_list(registry: dict) -> list", category = "skills")]
@@ -416,7 +416,7 @@ fn skill_list_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
                 }
                 desc.insert(key.clone(), value.clone());
             }
-            result.push(VmValue::Dict(std::sync::Arc::new(desc)));
+            result.push(VmValue::dict(desc));
         }
     }
     Ok(VmValue::List(std::sync::Arc::new(result)))
@@ -574,7 +574,7 @@ fn skill_select_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
         "skills".to_string(),
         VmValue::List(std::sync::Arc::new(selected)),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(new_registry)))
+    Ok(VmValue::dict(new_registry))
 }
 
 #[harn_builtin(sig = "skill_describe(registry: dict) -> string", category = "skills")]
@@ -667,7 +667,7 @@ fn skill_remove_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
         "skills".to_string(),
         VmValue::List(std::sync::Arc::new(filtered)),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(new_registry)))
+    Ok(VmValue::dict(new_registry))
 }
 
 // `skill_render(skill, args_list)` — substitute `$ARGUMENTS`, `$N`,
@@ -865,7 +865,7 @@ mod tests {
     #[test]
     fn catalog_entries_use_fully_qualified_ids_and_sort() {
         let skills = vec![
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            VmValue::dict(BTreeMap::from([
                 (
                     "name".to_string(),
                     VmValue::String(std::sync::Arc::from("beta")),
@@ -874,8 +874,8 @@ mod tests {
                     "description".to_string(),
                     VmValue::String(std::sync::Arc::from("Second skill")),
                 ),
-            ]))),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            ])),
+            VmValue::dict(BTreeMap::from([
                 (
                     "name".to_string(),
                     VmValue::String(std::sync::Arc::from("deploy")),
@@ -892,7 +892,7 @@ mod tests {
                     "when_to_use".to_string(),
                     VmValue::String(std::sync::Arc::from("Ship a release")),
                 ),
-            ]))),
+            ])),
         ];
 
         let catalog = vm_skill_catalog_entries(&skills);
@@ -906,7 +906,7 @@ mod tests {
     #[test]
     fn render_catalog_is_deterministic_and_budgeted() {
         let entries = vec![
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            VmValue::dict(BTreeMap::from([
                 (
                     "name".to_string(),
                     VmValue::String(std::sync::Arc::from("alpha")),
@@ -919,8 +919,8 @@ mod tests {
                     "when_to_use".to_string(),
                     VmValue::String(std::sync::Arc::from("Use alpha first")),
                 ),
-            ]))),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+            ])),
+            VmValue::dict(BTreeMap::from([
                 (
                     "name".to_string(),
                     VmValue::String(std::sync::Arc::from("beta")),
@@ -933,7 +933,7 @@ mod tests {
                     "when_to_use".to_string(),
                     VmValue::String(std::sync::Arc::from("Use beta second")),
                 ),
-            ]))),
+            ])),
         ];
 
         let once = render_catalog(&entries, 10_000);

--- a/crates/harn-vm/src/stdlib/sqlite/mod.rs
+++ b/crates/harn-vm/src/stdlib/sqlite/mod.rs
@@ -48,9 +48,9 @@ struct MockDb {
 }
 
 thread_local! {
-    static DBS: RefCell<BTreeMap<String, Arc<DbRecord>>> = const { RefCell::new(BTreeMap::new()) };
-    static TXS: RefCell<BTreeMap<String, Arc<DbRecord>>> = const { RefCell::new(BTreeMap::new()) };
-    static MOCKS: RefCell<BTreeMap<String, MockDb>> = const { RefCell::new(BTreeMap::new()) };
+    static DBS: RefCell<BTreeMap<String, Arc<DbRecord>>> = const { RefCell::new(std::collections::BTreeMap::new()) };
+    static TXS: RefCell<BTreeMap<String, Arc<DbRecord>>> = const { RefCell::new(std::collections::BTreeMap::new()) };
+    static MOCKS: RefCell<BTreeMap<String, MockDb>> = const { RefCell::new(std::collections::BTreeMap::new()) };
 }
 
 pub(crate) fn reset_sqlite_state() {
@@ -223,7 +223,7 @@ async fn sqlite_transaction_impl(
     }
 
     register_tx(&tx_id, Arc::clone(&record));
-    let tx_handle = handle_value(HANDLE_TX, &tx_id, BTreeMap::new());
+    let tx_handle = handle_value(HANDLE_TX, &tx_id, crate::value::DictMap::new());
     let mut child_vm = ctx.child_vm();
     let result = child_vm.call_closure_pub(&closure, &[tx_handle]).await;
     ctx.forward_output(&child_vm.take_output());
@@ -322,7 +322,7 @@ fn sqlite_mock_db_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
             },
         );
     });
-    Ok(handle_value(HANDLE_MOCK, &id, BTreeMap::new()))
+    Ok(handle_value(HANDLE_MOCK, &id, crate::value::DictMap::new()))
 }
 
 #[harn_builtin(
@@ -341,7 +341,7 @@ fn sqlite_mock_calls_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue
     Ok(VmValue::List(Arc::new(calls)))
 }
 
-fn open_db(path: &str, options: Option<&BTreeMap<String, VmValue>>) -> Result<VmValue, VmError> {
+fn open_db(path: &str, options: Option<&crate::value::DictMap>) -> Result<VmValue, VmError> {
     let create = option_bool(options.and_then(|opts| opts.get("create"))).unwrap_or(false);
     let read_only = option_bool(options.and_then(|opts| opts.get("read_only"))).unwrap_or(false);
     let is_memory = path == ":memory:" || path.trim().eq_ignore_ascii_case("memory");
@@ -398,7 +398,7 @@ fn open_db(path: &str, options: Option<&BTreeMap<String, VmValue>>) -> Result<Vm
 
     configure_connection(&conn, options, read_only)?;
     let id = next_id("sqlitedb");
-    let mut meta = BTreeMap::new();
+    let mut meta = crate::value::DictMap::new();
     meta.insert("read_only".to_string(), VmValue::Bool(read_only));
     meta.insert("memory".to_string(), VmValue::Bool(is_memory));
     if let Some(path) = &stored_path {
@@ -417,7 +417,7 @@ fn open_db(path: &str, options: Option<&BTreeMap<String, VmValue>>) -> Result<Vm
 
 fn configure_connection(
     conn: &Connection,
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
     read_only: bool,
 ) -> Result<(), VmError> {
     let busy_timeout_ms = option_int(options, "busy_timeout_ms")
@@ -644,7 +644,7 @@ async fn migrate(args: Vec<VmValue>) -> Result<VmValue, VmError> {
         }
     }
 
-    let mut response = BTreeMap::new();
+    let mut response = crate::value::DictMap::new();
     response.insert("applied".to_string(), string_list(applied_now));
     response.insert("skipped".to_string(), string_list(skipped));
     response.insert(
@@ -653,7 +653,7 @@ async fn migrate(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     );
     response.insert("dry_run".to_string(), VmValue::Bool(dry_run));
     response.put_str("table", table);
-    Ok(VmValue::Dict(Arc::new(response)))
+    Ok(VmValue::dict(response))
 }
 
 #[derive(Clone)]
@@ -788,7 +788,7 @@ fn row_to_value(
     names: &[String],
     builtin: &'static str,
 ) -> Result<VmValue, VmError> {
-    let mut map = BTreeMap::new();
+    let mut map = crate::value::DictMap::new();
     for (index, name) in names.iter().enumerate() {
         let value = match row
             .get_ref(index)
@@ -807,7 +807,7 @@ fn row_to_value(
         };
         map.insert(name.clone(), value);
     }
-    Ok(VmValue::Dict(Arc::new(map)))
+    Ok(VmValue::dict(map))
 }
 
 fn bind_params(params: &[VmValue]) -> Vec<Value> {
@@ -908,10 +908,10 @@ fn mock_query(
 }
 
 fn execute_result_value(rows_affected: u64) -> VmValue {
-    VmValue::Dict(Arc::new(BTreeMap::from([(
+    VmValue::dict(crate::value::DictMap::from_iter([(
         "rows_affected".to_string(),
         VmValue::Int(rows_affected as i64),
-    )])))
+    )]))
 }
 
 async fn execute_batch_on_record(
@@ -958,10 +958,10 @@ fn unregister_tx(id: &str) {
     });
 }
 
-fn handle_value(kind: &str, id: &str, mut extra: BTreeMap<String, VmValue>) -> VmValue {
+fn handle_value(kind: &str, id: &str, mut extra: crate::value::DictMap) -> VmValue {
     extra.put_str("_type", kind);
     extra.put_str("id", id);
-    VmValue::Dict(Arc::new(extra))
+    VmValue::dict(extra)
 }
 
 fn handle_kind(value: Option<&VmValue>) -> Option<String> {
@@ -1023,7 +1023,7 @@ fn params_arg(value: Option<&VmValue>, builtin: &'static str) -> Result<Vec<VmVa
     }
 }
 
-fn dir_arg(dict: &BTreeMap<String, VmValue>, key: &str) -> Result<PathBuf, VmError> {
+fn dir_arg(dict: &crate::value::DictMap, key: &str) -> Result<PathBuf, VmError> {
     let value = dict.get(key).ok_or_else(|| {
         runtime_error(format!(
             "sqlite_migrate: option `{key}` is required and must be a path"
@@ -1044,7 +1044,7 @@ fn option_bool(value: Option<&VmValue>) -> Option<bool> {
     }
 }
 
-fn option_int(options: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<i64> {
+fn option_int(options: Option<&crate::value::DictMap>, key: &str) -> Option<i64> {
     options
         .and_then(|opts| opts.get(key))
         .and_then(|value| match value {
@@ -1058,7 +1058,7 @@ fn option_int(options: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<
         })
 }
 
-fn option_string(options: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<String> {
+fn option_string(options: Option<&crate::value::DictMap>, key: &str) -> Option<String> {
     options
         .and_then(|opts| opts.get(key))
         .map(VmValue::display)
@@ -1138,12 +1138,12 @@ mod tests {
     }
 
     fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
-        VmValue::Dict(Arc::new(
+        VmValue::dict(
             pairs
                 .iter()
                 .map(|(key, value)| ((*key).to_string(), value.clone()))
-                .collect(),
-        ))
+                .collect::<crate::value::DictMap>(),
+        )
     }
 
     #[test]
@@ -1193,7 +1193,7 @@ mod tests {
                 },
             );
         });
-        let handle = handle_value(HANDLE_MOCK, &id, BTreeMap::new());
+        let handle = handle_value(HANDLE_MOCK, &id, crate::value::DictMap::new());
         let rows = mock_query(
             &handle,
             "select id from events where topic = ?",

--- a/crates/harn-vm/src/stdlib/strings.rs
+++ b/crates/harn-vm/src/stdlib/strings.rs
@@ -173,7 +173,7 @@ fn provenance_result_dict(
         "spans".to_string(),
         VmValue::List(std::sync::Arc::new(spans_list)),
     );
-    VmValue::Dict(std::sync::Arc::new(out))
+    VmValue::dict(out)
 }
 
 fn span_to_vm_dict(span: &PromptSourceSpan) -> VmValue {
@@ -208,7 +208,7 @@ fn span_to_vm_dict(span: &PromptSourceSpan) -> VmValue {
     if let Some(parent) = span.parent_span.as_deref() {
         d.insert("parent_span".into(), span_to_vm_dict(parent));
     }
-    VmValue::Dict(std::sync::Arc::new(d))
+    VmValue::dict(d)
 }
 
 fn span_kind_label(kind: PromptSpanKind) -> &'static str {

--- a/crates/harn-vm/src/stdlib/supervisor.rs
+++ b/crates/harn-vm/src/stdlib/supervisor.rs
@@ -916,7 +916,7 @@ fn parse_strategy(value: Option<&VmValue>) -> Result<Strategy, VmError> {
 fn require_dict<'a>(
     value: &'a VmValue,
     builtin: &str,
-) -> Result<&'a BTreeMap<String, VmValue>, VmError> {
+) -> Result<&'a crate::value::DictMap, VmError> {
     value
         .as_dict()
         .ok_or_else(|| VmError::Runtime(format!("{builtin}: expected a dict")))
@@ -974,7 +974,7 @@ fn supervisor_handle_value(state: &SupervisorState) -> VmValue {
     dict.insert("_type".to_string(), VmValue::string("supervisor"));
     dict.insert("id".to_string(), VmValue::string(&state.id));
     dict.insert("name".to_string(), VmValue::string(&state.name));
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn supervisor_state_value(state: &SupervisorState) -> VmValue {
@@ -994,7 +994,7 @@ fn supervisor_state_value(state: &SupervisorState) -> VmValue {
             state.children.iter().map(child_state_value).collect(),
         )),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn child_state_value(child: &ChildSlot) -> VmValue {
@@ -1038,7 +1038,7 @@ fn child_state_value(child: &ChildSlot) -> VmValue {
             .map(VmValue::Int)
             .unwrap_or(VmValue::Nil),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn metrics_value(state: &SupervisorState) -> VmValue {
@@ -1052,7 +1052,7 @@ fn metrics_value(state: &SupervisorState) -> VmValue {
         VmValue::Int(state.suppressed_count),
     );
     dict.insert("escalated".to_string(), VmValue::Int(state.escalated_count));
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn events_value(state: &SupervisorState) -> VmValue {
@@ -1122,7 +1122,7 @@ fn event_value(event: &SupervisorEvent) -> VmValue {
             .map(VmValue::string)
             .unwrap_or(VmValue::Nil),
     );
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn child_context_value(supervisor_id: &str, spec: &ChildSpec, generation: u64) -> VmValue {
@@ -1132,7 +1132,7 @@ fn child_context_value(supervisor_id: &str, spec: &ChildSpec, generation: u64) -
     dict.insert("child_kind".to_string(), VmValue::string(&spec.kind));
     dict.insert("attempt".to_string(), VmValue::Int(generation as i64 + 1));
     dict.insert("restart_count".to_string(), VmValue::Int(generation as i64));
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 fn push_event(
@@ -1246,17 +1246,16 @@ mod tests {
 
     #[test]
     fn parses_restart_policy_aliases() {
-        let policy =
-            parse_restart_policy(Some(&VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
-                ("mode".to_string(), VmValue::string("on-failure")),
-                ("max".to_string(), VmValue::Int(2)),
-                ("window".to_string(), VmValue::Duration(500)),
-                ("backoff".to_string(), VmValue::string("10ms")),
-                ("factor".to_string(), VmValue::Float(3.0)),
-                ("jitter".to_string(), VmValue::Int(4)),
-                ("circuit_open".to_string(), VmValue::string("1s")),
-            ])))))
-            .unwrap();
+        let policy = parse_restart_policy(Some(&VmValue::dict(BTreeMap::from([
+            ("mode".to_string(), VmValue::string("on-failure")),
+            ("max".to_string(), VmValue::Int(2)),
+            ("window".to_string(), VmValue::Duration(500)),
+            ("backoff".to_string(), VmValue::string("10ms")),
+            ("factor".to_string(), VmValue::Float(3.0)),
+            ("jitter".to_string(), VmValue::Int(4)),
+            ("circuit_open".to_string(), VmValue::string("1s")),
+        ]))))
+        .unwrap();
 
         assert_eq!(policy.mode, RestartMode::OnFailure);
         assert_eq!(policy.max_restarts, Some(2));

--- a/crates/harn-vm/src/stdlib/template/llm_context.rs
+++ b/crates/harn-vm/src/stdlib/template/llm_context.rs
@@ -64,7 +64,7 @@ impl LlmRenderContext {
         dict.put_str("model", self.model.as_str());
         dict.put_str("family", self.family.as_str());
         dict.insert("capabilities".to_string(), self.capabilities.clone());
-        VmValue::Dict(std::sync::Arc::new(dict))
+        VmValue::dict(dict)
     }
 }
 

--- a/crates/harn-vm/src/stdlib/template/mod.rs
+++ b/crates/harn-vm/src/stdlib/template/mod.rs
@@ -27,7 +27,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
 
-use crate::value::{VmError, VmValue};
+use crate::value::VmError;
 
 mod assets;
 mod ast;
@@ -247,8 +247,8 @@ static LLM_SHADOW_WARN_CACHE: OnceLock<Mutex<HashSet<String>>> = OnceLock::new()
 /// value win for back-compat).
 fn augment_bindings_with_llm(
     asset: &TemplateAsset,
-    bindings: Option<&BTreeMap<String, VmValue>>,
-) -> Option<BTreeMap<String, VmValue>> {
+    bindings: Option<&crate::value::DictMap>,
+) -> Option<crate::value::DictMap> {
     let ctx = current_llm_render_context()?;
     if bindings.is_some_and(|m| m.contains_key("llm")) {
         warn_user_llm_shadowed(asset);
@@ -298,7 +298,7 @@ pub fn validate_template_syntax(src: &str) -> Result<(), String> {
 /// included in error messages.
 pub(crate) fn render_template_result(
     template: &str,
-    bindings: Option<&BTreeMap<String, VmValue>>,
+    bindings: Option<&crate::value::DictMap>,
     base: Option<&Path>,
     source_path: Option<&Path>,
 ) -> Result<String, TemplateError> {
@@ -311,7 +311,7 @@ pub(crate) fn render_template_result(
 /// prompt-template semantics as `render(...)` / `render_prompt(...)`.
 pub fn render_template_to_string(
     template: &str,
-    bindings: Option<&BTreeMap<String, VmValue>>,
+    bindings: Option<&crate::value::DictMap>,
     base: Option<&Path>,
     source_path: Option<&Path>,
 ) -> Result<String, String> {
@@ -420,7 +420,7 @@ pub enum PromptSpanKind {
 /// non-tracked rendering path that the legacy callers use.
 pub(crate) fn render_template_with_provenance(
     template: &str,
-    bindings: Option<&BTreeMap<String, VmValue>>,
+    bindings: Option<&crate::value::DictMap>,
     base: Option<&Path>,
     source_path: Option<&Path>,
     collect_provenance: bool,
@@ -431,7 +431,7 @@ pub(crate) fn render_template_with_provenance(
 
 pub(crate) fn render_asset_result(
     asset: &TemplateAsset,
-    bindings: Option<&BTreeMap<String, VmValue>>,
+    bindings: Option<&crate::value::DictMap>,
 ) -> Result<String, TemplateError> {
     let (rendered, _spans) = render_asset_with_provenance_result(asset, bindings, false)?;
     Ok(rendered)
@@ -439,7 +439,7 @@ pub(crate) fn render_asset_result(
 
 pub(crate) fn render_stdlib_prompt_asset(
     path: &str,
-    bindings: Option<&BTreeMap<String, VmValue>>,
+    bindings: Option<&crate::value::DictMap>,
 ) -> Result<String, VmError> {
     let target = if path.starts_with("std/") {
         path.to_string()
@@ -467,7 +467,7 @@ pub(crate) fn render_template_collect_branch_trace(
 
 pub(crate) fn render_asset_with_provenance_result(
     asset: &TemplateAsset,
-    bindings: Option<&BTreeMap<String, VmValue>>,
+    bindings: Option<&crate::value::DictMap>,
     collect_provenance: bool,
 ) -> Result<(String, Vec<PromptSourceSpan>), TemplateError> {
     let (rendered, spans, _trace) =
@@ -477,7 +477,7 @@ pub(crate) fn render_asset_with_provenance_result(
 
 fn render_asset_with_provenance_and_trace_result(
     asset: &TemplateAsset,
-    bindings: Option<&BTreeMap<String, VmValue>>,
+    bindings: Option<&crate::value::DictMap>,
     collect_provenance: bool,
     force_branch_trace: bool,
 ) -> Result<(String, Vec<PromptSourceSpan>, Vec<BranchDecision>), TemplateError> {
@@ -529,7 +529,7 @@ fn render_asset_with_provenance_and_trace_result(
 /// that need to score section shape without scraping JSONL artifacts.
 pub fn render_template_to_string_with_branch_trace(
     template: &str,
-    bindings: Option<&BTreeMap<String, VmValue>>,
+    bindings: Option<&crate::value::DictMap>,
     base: Option<&Path>,
     source_path: Option<&Path>,
 ) -> Result<(String, Vec<BranchDecision>), String> {

--- a/crates/harn-vm/src/stdlib/template/render.rs
+++ b/crates/harn-vm/src/stdlib/template/render.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use crate::runtime_limits::RuntimeLimits;
 use crate::value::{values_equal, VmValue};
 
@@ -11,13 +9,13 @@ use super::{BranchDecision, BranchKind, PromptSourceSpan, PromptSpanKind, Templa
 #[derive(Default, Debug, Clone)]
 pub(super) struct Scope<'a> {
     /// Root bindings passed by the caller.
-    root: Option<&'a BTreeMap<String, VmValue>>,
+    root: Option<&'a crate::value::DictMap>,
     /// Override stack — pushed for `for`-loop variables and `include with`.
-    overrides: Vec<BTreeMap<String, VmValue>>,
+    overrides: Vec<crate::value::DictMap>,
 }
 
 impl<'a> Scope<'a> {
-    pub(super) fn new(root: Option<&'a BTreeMap<String, VmValue>>) -> Self {
+    pub(super) fn new(root: Option<&'a crate::value::DictMap>) -> Self {
         Self {
             root,
             overrides: Vec::new(),
@@ -33,7 +31,7 @@ impl<'a> Scope<'a> {
         self.root.and_then(|m| m.get(name)).cloned()
     }
 
-    fn push(&mut self, layer: BTreeMap<String, VmValue>) {
+    fn push(&mut self, layer: crate::value::DictMap) {
         self.overrides.push(layer);
     }
 
@@ -43,8 +41,8 @@ impl<'a> Scope<'a> {
 
     /// Materialize a flat BTreeMap merging root + all overrides. Used when
     /// passing a fresh snapshot into an included partial.
-    fn flatten(&self) -> BTreeMap<String, VmValue> {
-        let mut out = BTreeMap::new();
+    fn flatten(&self) -> crate::value::DictMap {
+        let mut out = crate::value::DictMap::new();
         if let Some(r) = self.root {
             for (k, v) in r.iter() {
                 out.insert(k.clone(), v.clone());
@@ -211,18 +209,18 @@ fn render_node(
             } else {
                 let length = items.len() as i64;
                 for (idx, (k, val)) in items.iter().enumerate() {
-                    let mut layer: BTreeMap<String, VmValue> = BTreeMap::new();
+                    let mut layer: crate::value::DictMap = crate::value::DictMap::new();
                     layer.insert(value_var.clone(), val.clone());
                     if let Some(kv) = key_var {
                         layer.insert(kv.clone(), k.clone());
                     }
-                    let mut loop_map: BTreeMap<String, VmValue> = BTreeMap::new();
+                    let mut loop_map: crate::value::DictMap = crate::value::DictMap::new();
                     loop_map.insert("index".into(), VmValue::Int(idx as i64 + 1));
                     loop_map.insert("index0".into(), VmValue::Int(idx as i64));
                     loop_map.insert("first".into(), VmValue::Bool(idx == 0));
                     loop_map.insert("last".into(), VmValue::Bool(idx as i64 == length - 1));
                     loop_map.insert("length".into(), VmValue::Int(length));
-                    layer.insert("loop".into(), VmValue::Dict(std::sync::Arc::new(loop_map)));
+                    layer.insert("loop".into(), VmValue::dict(loop_map));
                     scope.push(layer);
                     let iter_start = out.len();
                     let res = render_nodes(body, scope, rc, out, spans.as_deref_mut());
@@ -337,7 +335,7 @@ fn render_node(
             line,
             col,
         } => {
-            let mut evaluated_args = BTreeMap::new();
+            let mut evaluated_args = crate::value::DictMap::new();
             for (key, expr) in args {
                 evaluated_args.insert(key.clone(), eval_expr(expr, scope, *line, *col)?);
             }

--- a/crates/harn-vm/src/stdlib/template/sections.rs
+++ b/crates/harn-vm/src/stdlib/template/sections.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use crate::value::VmValue;
 
 use super::error::TemplateError;
@@ -45,7 +43,7 @@ pub(super) fn is_builtin_section(name: &str) -> bool {
 pub(super) fn render_section(
     name: &str,
     body: &str,
-    args: &BTreeMap<String, VmValue>,
+    args: &crate::value::DictMap,
     llm: Option<&VmValue>,
     line: usize,
     col: usize,
@@ -187,7 +185,7 @@ fn render_system_framing(body: &str, profile: &SectionProfile) -> SectionRender 
 
 fn render_output_format(
     body: &str,
-    args: &BTreeMap<String, VmValue>,
+    args: &crate::value::DictMap,
     profile: &SectionProfile,
     line: usize,
     col: usize,
@@ -244,7 +242,7 @@ fn render_output_format(
 
 fn render_tools(
     body: &str,
-    args: &BTreeMap<String, VmValue>,
+    args: &crate::value::DictMap,
     profile: &SectionProfile,
     line: usize,
     col: usize,
@@ -461,14 +459,14 @@ fn normalized_body(body: &str) -> (&str, usize, usize) {
     (&body[start..end], start, end)
 }
 
-fn cap_bool(caps: Option<&BTreeMap<String, VmValue>>, key: &str) -> bool {
+fn cap_bool(caps: Option<&crate::value::DictMap>, key: &str) -> bool {
     matches!(
         caps.and_then(|caps| caps.get(key)),
         Some(VmValue::Bool(true))
     )
 }
 
-fn cap_string(caps: Option<&BTreeMap<String, VmValue>>, key: &str) -> Option<String> {
+fn cap_string(caps: Option<&crate::value::DictMap>, key: &str) -> Option<String> {
     match caps.and_then(|caps| caps.get(key)) {
         Some(VmValue::String(value)) => Some(value.to_string()),
         _ => None,

--- a/crates/harn-vm/src/stdlib/template/tests.rs
+++ b/crates/harn-vm/src/stdlib/template/tests.rs
@@ -1,8 +1,7 @@
-use std::collections::BTreeMap;
-
 use super::*;
+use crate::value::VmValue;
 
-fn dict(pairs: &[(&str, VmValue)]) -> BTreeMap<String, VmValue> {
+fn dict(pairs: &[(&str, VmValue)]) -> crate::value::DictMap {
     pairs
         .iter()
         .map(|(k, v)| (k.to_string(), v.clone()))
@@ -13,11 +12,11 @@ fn s(v: &str) -> VmValue {
     VmValue::String(std::sync::Arc::from(v))
 }
 
-fn render(tpl: &str, b: &BTreeMap<String, VmValue>) -> String {
+fn render(tpl: &str, b: &crate::value::DictMap) -> String {
     render_template_result(tpl, Some(b), None, None).unwrap()
 }
 
-fn render_with_spans(tpl: &str, b: &BTreeMap<String, VmValue>) -> (String, Vec<PromptSourceSpan>) {
+fn render_with_spans(tpl: &str, b: &crate::value::DictMap) -> (String, Vec<PromptSourceSpan>) {
     render_template_with_provenance(tpl, Some(b), None, None, true).unwrap()
 }
 
@@ -33,12 +32,9 @@ fn bare_interp() {
 
 #[test]
 fn provenance_expr_span_matches_output_range() {
-    let mut user = BTreeMap::new();
+    let mut user = crate::value::DictMap::new();
     user.insert("name".to_string(), s("alice"));
-    let b = dict(&[
-        ("user", VmValue::Dict(std::sync::Arc::new(user))),
-        ("count", VmValue::Int(42)),
-    ]);
+    let b = dict(&[("user", VmValue::dict(user)), ("count", VmValue::Int(42))]);
     let (out, spans) = render_with_spans("hello {{ user.name }} ({{ count | default: 0 }})", &b);
     assert_eq!(out, "hello alice (42)");
 
@@ -99,9 +95,9 @@ fn provenance_includes_loop_iterations() {
 
 #[test]
 fn provenance_preview_is_truncated() {
-    let mut wrap = BTreeMap::new();
+    let mut wrap = crate::value::DictMap::new();
     wrap.insert("val".to_string(), s(&"x".repeat(500)));
-    let b = dict(&[("blob", VmValue::Dict(std::sync::Arc::new(wrap)))]);
+    let b = dict(&[("blob", VmValue::dict(wrap))]);
     let (_, spans) = render_with_spans("{{blob.val}}", &b);
     let expr = spans
         .iter()
@@ -173,10 +169,10 @@ fn for_empty_else() {
 
 #[test]
 fn for_dict_kv() {
-    let mut d: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut d: crate::value::DictMap = crate::value::DictMap::new();
     d.insert("a".into(), VmValue::Int(1));
     d.insert("b".into(), VmValue::Int(2));
-    let b = dict(&[("m", VmValue::Dict(std::sync::Arc::new(d)))]);
+    let b = dict(&[("m", VmValue::dict(d))]);
     assert_eq!(
         render("{{for k, v in m}}{{k}}={{v}};{{end}}", &b),
         "a=1;b=2;"
@@ -185,9 +181,9 @@ fn for_dict_kv() {
 
 #[test]
 fn nested_path() {
-    let mut inner: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut inner: crate::value::DictMap = crate::value::DictMap::new();
     inner.insert("name".into(), s("Alice"));
-    let b = dict(&[("user", VmValue::Dict(std::sync::Arc::new(inner)))]);
+    let b = dict(&[("user", VmValue::dict(inner))]);
     assert_eq!(render("{{user.name}}", &b), "Alice");
 }
 
@@ -278,20 +274,20 @@ fn logical_section_scaffolding_follows_llm_capabilities() {
 
 #[test]
 fn logical_section_tools_and_output_format_use_section_args() {
-    let tool = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    let tool = VmValue::dict(crate::value::DictMap::from_iter([
         ("name".to_string(), s("read_file")),
         ("description".to_string(), s("Read a file")),
-    ])));
-    let schema = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+    ]));
+    let schema = VmValue::dict(crate::value::DictMap::from_iter([
         ("type".to_string(), s("object")),
         (
             "properties".to_string(),
-            VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+            VmValue::dict(crate::value::DictMap::from_iter([(
                 "answer".to_string(),
                 s("string"),
-            )]))),
+            )])),
         ),
-    ])));
+    ]));
     let b = dict(&[("tools", list(vec![tool])), ("schema", schema)]);
 
     {
@@ -415,11 +411,11 @@ fn logical_section_provenance_adjusts_child_spans() {
 fn filter_json() {
     let b = dict(&[(
         "x",
-        VmValue::Dict(std::sync::Arc::new({
-            let mut m = BTreeMap::new();
+        VmValue::dict({
+            let mut m = crate::value::DictMap::new();
             m.insert("a".into(), VmValue::Int(1));
             m
-        })),
+        }),
     )]);
     assert_eq!(render("{{x | json}}", &b), r#"{"a":1}"#);
 }

--- a/crates/harn-vm/src/stdlib/testbench.rs
+++ b/crates/harn-vm/src/stdlib/testbench.rs
@@ -59,7 +59,7 @@ fn testbench_fs_diff_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValu
             };
             d.put_str("kind", kind_str);
             d.insert("content".to_string(), content_val);
-            VmValue::Dict(std::sync::Arc::new(d))
+            VmValue::dict(d)
         })
         .collect();
     Ok(VmValue::List(std::sync::Arc::new(entries)))
@@ -80,7 +80,7 @@ fn testbench_clock_leaks_impl(_args: &[VmValue], _out: &mut String) -> Result<Vm
             let mut d = BTreeMap::new();
             d.put_str("capability", leak.capability_id);
             d.insert("count".to_string(), VmValue::Int(leak.count as i64));
-            VmValue::Dict(std::sync::Arc::new(d))
+            VmValue::dict(d)
         })
         .collect();
     Ok(VmValue::List(std::sync::Arc::new(entries)))

--- a/crates/harn-vm/src/stdlib/testing.rs
+++ b/crates/harn-vm/src/stdlib/testing.rs
@@ -164,9 +164,7 @@ fn throw_error_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
     let mut err_dict = BTreeMap::new();
     err_dict.put_str("message", message.as_str());
     err_dict.put_str("category", category.as_str());
-    Err(VmError::Thrown(VmValue::Dict(std::sync::Arc::new(
-        err_dict,
-    ))))
+    Err(VmError::Thrown(VmValue::dict(err_dict)))
 }
 
 #[harn_builtin(sig = "is_timeout(error: any) -> bool", category = "testing")]
@@ -245,10 +243,10 @@ mod tests {
     use super::*;
 
     fn dict_err(category: &str) -> VmValue {
-        VmValue::Dict(std::sync::Arc::new(std::collections::BTreeMap::from([(
+        VmValue::dict(std::collections::BTreeMap::from([(
             "category".to_string(),
             VmValue::String(std::sync::Arc::from(category)),
-        )])))
+        )]))
     }
 
     fn as_bool(result: Result<VmValue, VmError>) -> bool {

--- a/crates/harn-vm/src/stdlib/timing.rs
+++ b/crates/harn-vm/src/stdlib/timing.rs
@@ -111,7 +111,7 @@ fn timing_start_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
     );
     handle.put_str("kind", crate::tracing::SpanKind::UserTiming.as_str());
 
-    Ok(VmValue::Dict(std::sync::Arc::new(handle)))
+    Ok(VmValue::dict(handle))
 }
 
 #[harn_builtin(sig = "__timing_now_monotonic_ms() -> int", category = "timing")]

--- a/crates/harn-vm/src/stdlib/token_redaction.rs
+++ b/crates/harn-vm/src/stdlib/token_redaction.rs
@@ -242,7 +242,7 @@ fn token_redaction_drain_audit_impl(
     let list: Vec<VmValue> = events
         .into_iter()
         .map(|event| {
-            let mut entry: BTreeMap<String, VmValue> = BTreeMap::new();
+            let mut entry: crate::value::DictMap = crate::value::DictMap::new();
             entry.put_str("code", TOKEN_REDACTION_DIAGNOSTIC);
             entry.put_str("pattern", event.pattern_name.as_str());
             entry.insert(
@@ -253,7 +253,7 @@ fn token_redaction_drain_audit_impl(
                 "bytes_redacted".to_string(),
                 VmValue::Int(event.bytes_redacted as i64),
             );
-            VmValue::Dict(std::sync::Arc::new(entry))
+            VmValue::dict(entry)
         })
         .collect();
     Ok(VmValue::List(std::sync::Arc::new(list)))

--- a/crates/harn-vm/src/stdlib/tool_hooks.rs
+++ b/crates/harn-vm/src/stdlib/tool_hooks.rs
@@ -60,7 +60,7 @@ fn require_dict<'a>(
     value: &'a VmValue,
     builtin: &str,
     role: &str,
-) -> Result<&'a BTreeMap<String, VmValue>, VmError> {
+) -> Result<&'a crate::value::DictMap, VmError> {
     match value {
         VmValue::Dict(d) => Ok(d.as_ref()),
         other => Err(err(format!(
@@ -75,7 +75,7 @@ fn require_tagged<'a>(
     expected: &str,
     builtin: &str,
     role: &str,
-) -> Result<&'a BTreeMap<String, VmValue>, VmError> {
+) -> Result<&'a crate::value::DictMap, VmError> {
     let dict = require_dict(value, builtin, role)?;
     match dict.get("_type") {
         Some(VmValue::String(t)) if t.as_ref() == expected => Ok(dict),
@@ -89,7 +89,7 @@ fn require_tagged<'a>(
 }
 
 fn required_string_field(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<String, VmError> {
@@ -107,7 +107,7 @@ fn required_string_field(
 }
 
 fn optional_string_field(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Option<String>, VmError> {
@@ -122,7 +122,7 @@ fn optional_string_field(
 }
 
 fn optional_int_field(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Option<i64>, VmError> {
@@ -137,7 +137,7 @@ fn optional_int_field(
 }
 
 fn optional_string_list(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Vec<String>, VmError> {
@@ -200,9 +200,9 @@ fn validate_severity(value: Option<&VmValue>, builtin: &str) -> Result<String, V
 }
 
 fn validate_rule_dict(
-    config: &BTreeMap<String, VmValue>,
+    config: &crate::value::DictMap,
     builtin: &str,
-) -> Result<BTreeMap<String, VmValue>, VmError> {
+) -> Result<crate::value::DictMap, VmError> {
     let id = required_string_field(config, "id", builtin)?;
     let pattern = config
         .get("pattern")
@@ -229,7 +229,7 @@ fn validate_rule_dict(
     let _ = optional_string_list(config, "references", builtin)?;
     let _ = optional_int_field(config, "priority", builtin)?;
 
-    let mut rule = BTreeMap::new();
+    let mut rule = crate::value::DictMap::new();
     rule.put_str("_type", TOOL_RULE_TYPE);
     rule.put_str("id", id.as_str());
     rule.insert("pattern".to_string(), pattern.clone());
@@ -274,7 +274,7 @@ fn extract_rules(raw_rules: Option<&VmValue>, builtin: &str) -> Result<Vec<VmVal
     };
     match value {
         VmValue::List(items) => {
-            let mut seen_ids = BTreeMap::new();
+            let mut seen_ids = std::collections::BTreeMap::new();
             let mut rules = Vec::with_capacity(items.len());
             for (idx, entry) in items.iter().enumerate() {
                 // Allow either a tagged tool_rule (already validated) or a
@@ -308,7 +308,7 @@ fn extract_rules(raw_rules: Option<&VmValue>, builtin: &str) -> Result<Vec<VmVal
                         "{builtin}: duplicate rule id `{id}` at indices {prev} and {idx}"
                     )));
                 }
-                rules.push(VmValue::Dict(std::sync::Arc::new(rule_dict)));
+                rules.push(VmValue::dict(rule_dict));
             }
             Ok(rules)
         }
@@ -320,7 +320,7 @@ fn extract_rules(raw_rules: Option<&VmValue>, builtin: &str) -> Result<Vec<VmVal
     }
 }
 
-fn build_catalogue(config: &BTreeMap<String, VmValue>) -> Result<VmValue, VmError> {
+fn build_catalogue(config: &crate::value::DictMap) -> Result<VmValue, VmError> {
     let builtin = "catalogue";
     let id = required_string_field(config, "id", builtin)?;
     let stack = optional_string_field(config, "stack", builtin)?.unwrap_or_default();
@@ -329,7 +329,7 @@ fn build_catalogue(config: &BTreeMap<String, VmValue>) -> Result<VmValue, VmErro
     let priority = optional_int_field(config, "priority", builtin)?.unwrap_or(0);
     let rules = extract_rules(config.get("rules"), builtin)?;
 
-    let mut catalogue = BTreeMap::new();
+    let mut catalogue = crate::value::DictMap::new();
     catalogue.put_str("_type", CATALOGUE_TYPE);
     catalogue.put_str("id", id.as_str());
     catalogue.put_str("stack", stack.as_str());
@@ -340,17 +340,17 @@ fn build_catalogue(config: &BTreeMap<String, VmValue>) -> Result<VmValue, VmErro
         "rules".to_string(),
         VmValue::List(std::sync::Arc::new(rules)),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(catalogue)))
+    Ok(VmValue::dict(catalogue))
 }
 
-fn registry_catalogues(registry: &BTreeMap<String, VmValue>) -> &[VmValue] {
+fn registry_catalogues(registry: &crate::value::DictMap) -> &[VmValue] {
     match registry.get("catalogues") {
         Some(VmValue::List(list)) => list,
         _ => &[],
     }
 }
 
-fn rule_id(rule: &BTreeMap<String, VmValue>) -> String {
+fn rule_id(rule: &crate::value::DictMap) -> String {
     rule.get("id")
         .and_then(|v| match v {
             VmValue::String(s) => Some(s.to_string()),
@@ -359,14 +359,14 @@ fn rule_id(rule: &BTreeMap<String, VmValue>) -> String {
         .unwrap_or_default()
 }
 
-fn rule_priority(rule: &BTreeMap<String, VmValue>) -> i64 {
+fn rule_priority(rule: &crate::value::DictMap) -> i64 {
     match rule.get("priority") {
         Some(VmValue::Int(n)) => *n,
         _ => 0,
     }
 }
 
-fn rule_applies_to(rule: &BTreeMap<String, VmValue>) -> Vec<String> {
+fn rule_applies_to(rule: &crate::value::DictMap) -> Vec<String> {
     match rule.get("applies_to") {
         Some(VmValue::List(items)) => items
             .iter()
@@ -379,7 +379,7 @@ fn rule_applies_to(rule: &BTreeMap<String, VmValue>) -> Vec<String> {
     }
 }
 
-fn rule_severity(rule: &BTreeMap<String, VmValue>) -> String {
+fn rule_severity(rule: &crate::value::DictMap) -> String {
     match rule.get("severity") {
         Some(VmValue::String(s)) => s.to_string(),
         _ => "warning".to_string(),
@@ -459,10 +459,7 @@ async fn invoke_rule_pattern(
     }
 }
 
-fn make_match_record(
-    catalogue: &BTreeMap<String, VmValue>,
-    rule: &BTreeMap<String, VmValue>,
-) -> VmValue {
+fn make_match_record(catalogue: &crate::value::DictMap, rule: &crate::value::DictMap) -> VmValue {
     let catalogue_id = catalogue
         .get("id")
         .cloned()
@@ -471,7 +468,7 @@ fn make_match_record(
         .get("stack")
         .cloned()
         .unwrap_or_else(|| VmValue::String(std::sync::Arc::from("")));
-    let mut out = BTreeMap::new();
+    let mut out = crate::value::DictMap::new();
     out.insert("catalogue_id".to_string(), catalogue_id);
     out.insert("stack".to_string(), stack);
     out.put_str("rule_id", rule_id(rule).as_str());
@@ -493,11 +490,8 @@ fn make_match_record(
         "rewrite".to_string(),
         rule.get("rewrite").cloned().unwrap_or(VmValue::Nil),
     );
-    out.insert(
-        "rule".to_string(),
-        VmValue::Dict(std::sync::Arc::new(rule.clone())),
-    );
-    VmValue::Dict(std::sync::Arc::new(out))
+    out.insert("rule".to_string(), VmValue::dict(rule.clone()));
+    VmValue::dict(out)
 }
 
 pub(crate) fn register_tool_hooks_builtins(vm: &mut Vm) {
@@ -515,7 +509,7 @@ fn tool_rule_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
         "config",
     )?;
     let rule = validate_rule_dict(config, "tool_rule")?;
-    Ok(VmValue::Dict(std::sync::Arc::new(rule)))
+    Ok(VmValue::dict(rule))
 }
 
 #[harn_builtin(sig = "catalogue(config: dict) -> dict", category = "tool_hooks")]
@@ -531,13 +525,13 @@ fn catalogue_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
 
 #[harn_builtin(sig = "tool_hooks_registry() -> dict", category = "tool_hooks")]
 fn tool_hooks_registry_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    let mut registry = BTreeMap::new();
+    let mut registry = crate::value::DictMap::new();
     registry.put_str("_type", REGISTRY_TYPE);
     registry.insert(
         "catalogues".to_string(),
         VmValue::List(std::sync::Arc::new(Vec::new())),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(registry)))
+    Ok(VmValue::dict(registry))
 }
 
 #[harn_builtin(
@@ -601,7 +595,7 @@ fn tool_hooks_register_impl(args: &[VmValue], _out: &mut String) -> Result<VmVal
         "catalogues".to_string(),
         VmValue::List(std::sync::Arc::new(new_catalogues)),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(next)))
+    Ok(VmValue::dict(next))
 }
 
 #[harn_builtin(
@@ -649,7 +643,7 @@ fn tool_hooks_unregister_impl(args: &[VmValue], _out: &mut String) -> Result<VmV
         "catalogues".to_string(),
         VmValue::List(std::sync::Arc::new(new_catalogues)),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(next)))
+    Ok(VmValue::dict(next))
 }
 
 #[harn_builtin(
@@ -716,7 +710,7 @@ fn tool_hooks_filter_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue
         "catalogues".to_string(),
         VmValue::List(std::sync::Arc::new(filtered)),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(next)))
+    Ok(VmValue::dict(next))
 }
 
 #[harn_builtin(
@@ -740,7 +734,7 @@ fn tool_hooks_list_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
             Some(VmValue::List(rules)) => rules.len(),
             _ => 0,
         };
-        let mut summary = BTreeMap::new();
+        let mut summary = crate::value::DictMap::new();
         summary.insert(
             "id".to_string(),
             dict.get("id").cloned().unwrap_or(VmValue::Nil),
@@ -762,7 +756,7 @@ fn tool_hooks_list_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
             dict.get("priority").cloned().unwrap_or(VmValue::Int(0)),
         );
         summary.insert("rule_count".to_string(), VmValue::Int(rule_count as i64));
-        entries.push(VmValue::Dict(std::sync::Arc::new(summary)));
+        entries.push(VmValue::dict(summary));
     }
     Ok(VmValue::List(std::sync::Arc::new(entries)))
 }
@@ -956,14 +950,14 @@ fn tool_hooks_inject_reminder_impl(
     });
     crate::orchestration::record_lifecycle_audit("tool_hooks.reminder_injected", audit_payload);
 
-    let mut out = BTreeMap::new();
+    let mut out = crate::value::DictMap::new();
     out.put_str("reminder_id", reminder_id.as_str());
     out.insert("deduped_count".to_string(), VmValue::Int(deduped_count));
     out.insert(
         "session_attached".to_string(),
         VmValue::Bool(session_attached),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(out)))
+    Ok(VmValue::dict(out))
 }
 
 // TH-05 (#1898) classifier cache: thread-local map keyed by
@@ -1080,7 +1074,7 @@ struct ClassifierCacheEntry {
 
 thread_local! {
     static CLASSIFIER_CACHE: RefCell<BTreeMap<String, ClassifierCacheEntry>> =
-        const { RefCell::new(BTreeMap::new()) };
+        const { RefCell::new(std::collections::BTreeMap::new()) };
 }
 
 fn classifier_cache_get(key: &str, now_ms: i64) -> VmValue {
@@ -1137,7 +1131,7 @@ mod tests {
     }
 
     fn sample_rule_config() -> VmValue {
-        let mut config: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut config: crate::value::DictMap = crate::value::DictMap::new();
         config.put_str("id", "rust.cargo.target_dir_conflict");
         config.put_str("pattern", r"^cargo (build|test)\b");
         config.insert(
@@ -1151,11 +1145,11 @@ mod tests {
             "explanation",
             "Concurrent cargo runs without --target-dir thrash the lockfile",
         );
-        VmValue::Dict(std::sync::Arc::new(config))
+        VmValue::dict(config)
     }
 
     fn sample_catalogue_config(rule: VmValue) -> VmValue {
-        let mut config: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut config: crate::value::DictMap = crate::value::DictMap::new();
         config.put_str("id", "harn-canon/rust");
         config.put_str("stack", "rust");
         config.put_str("version", "0.1.0");
@@ -1164,10 +1158,10 @@ mod tests {
             "rules".to_string(),
             VmValue::List(std::sync::Arc::new(vec![rule])),
         );
-        VmValue::Dict(std::sync::Arc::new(config))
+        VmValue::dict(config)
     }
 
-    fn dict_string(dict: &BTreeMap<String, VmValue>, key: &str) -> String {
+    fn dict_string(dict: &crate::value::DictMap, key: &str) -> String {
         dict.get(key).map(|v| v.display()).unwrap_or_default()
     }
 
@@ -1184,29 +1178,21 @@ mod tests {
     #[test]
     fn tool_rule_rejects_bad_severity() {
         let vm = vm_with_stdlib();
-        let mut config: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut config: crate::value::DictMap = crate::value::DictMap::new();
         config.put_str("id", "r");
         config.put_str("pattern", ".");
         config.put_str("severity", "catastrophic");
-        let result = call_sync(
-            &vm,
-            "tool_rule",
-            &[VmValue::Dict(std::sync::Arc::new(config))],
-        );
+        let result = call_sync(&vm, "tool_rule", &[VmValue::dict(config)]);
         assert!(matches!(result, Err(VmError::Thrown(_))));
     }
 
     #[test]
     fn tool_rule_rejects_invalid_regex() {
         let vm = vm_with_stdlib();
-        let mut config: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut config: crate::value::DictMap = crate::value::DictMap::new();
         config.put_str("id", "r");
         config.put_str("pattern", "[invalid");
-        let result = call_sync(
-            &vm,
-            "tool_rule",
-            &[VmValue::Dict(std::sync::Arc::new(config))],
-        );
+        let result = call_sync(&vm, "tool_rule", &[VmValue::dict(config)]);
         let Err(VmError::Thrown(VmValue::String(message))) = result else {
             panic!("expected thrown string error, got {result:?}");
         };
@@ -1279,18 +1265,18 @@ mod tests {
 
     #[test]
     fn context_stacks_normalizes_shapes() {
-        let dict_form = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        let dict_form = VmValue::dict(crate::value::DictMap::from_iter([(
             "stacks".to_string(),
             VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                 std::sync::Arc::from("rust"),
             )])),
-        )])));
+        )]));
         assert_eq!(context_stacks(Some(&dict_form)), vec!["rust".to_string()]);
 
-        let dict_string = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        let dict_string = VmValue::dict(crate::value::DictMap::from_iter([(
             "stacks".to_string(),
             VmValue::String(std::sync::Arc::from("python")),
-        )])));
+        )]));
         assert_eq!(
             context_stacks(Some(&dict_string)),
             vec!["python".to_string()]
@@ -1318,32 +1304,22 @@ mod tests {
         let rule = call_sync(&vm, "tool_rule", &[sample_rule_config()]).expect("rule");
         let rust_cat =
             call_sync(&vm, "catalogue", &[sample_catalogue_config(rule.clone())]).expect("cat");
-        let mut shell_cfg: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut shell_cfg: crate::value::DictMap = crate::value::DictMap::new();
         shell_cfg.put_str("id", "harn-canon/shell");
         // Stackless catalogue: matches every requested stack — universal rules.
         shell_cfg.insert(
             "rules".to_string(),
             VmValue::List(std::sync::Arc::new(vec![rule.clone()])),
         );
-        let shell_cat = call_sync(
-            &vm,
-            "catalogue",
-            &[VmValue::Dict(std::sync::Arc::new(shell_cfg))],
-        )
-        .expect("cat");
-        let mut python_cfg: BTreeMap<String, VmValue> = BTreeMap::new();
+        let shell_cat = call_sync(&vm, "catalogue", &[VmValue::dict(shell_cfg)]).expect("cat");
+        let mut python_cfg: crate::value::DictMap = crate::value::DictMap::new();
         python_cfg.put_str("id", "harn-canon/python");
         python_cfg.put_str("stack", "python");
         python_cfg.insert(
             "rules".to_string(),
             VmValue::List(std::sync::Arc::new(vec![rule])),
         );
-        let py_cat = call_sync(
-            &vm,
-            "catalogue",
-            &[VmValue::Dict(std::sync::Arc::new(python_cfg))],
-        )
-        .expect("cat");
+        let py_cat = call_sync(&vm, "catalogue", &[VmValue::dict(python_cfg)]).expect("cat");
 
         let registry = call_sync(&vm, "tool_hooks_registry", &[]).expect("registry");
         let r1 = call_sync(&vm, "tool_hooks_register", &[registry, rust_cat]).expect("r1");
@@ -1415,14 +1391,14 @@ mod tests {
     // TH-03: emit_audit + inject_reminder side-effect helpers.
 
     fn audit_payload(rule_id: &str, command: &str) -> VmValue {
-        let mut payload: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut payload: crate::value::DictMap = crate::value::DictMap::new();
         payload.put_str("rule_id", rule_id);
         payload.put_str("command", command);
-        VmValue::Dict(std::sync::Arc::new(payload))
+        VmValue::dict(payload)
     }
 
     fn reminder_options(body: &str, tag: &str, ttl: i64) -> VmValue {
-        let mut options: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut options: crate::value::DictMap = crate::value::DictMap::new();
         options.put_str("body", body);
         options.insert(
             "tags".to_string(),
@@ -1431,7 +1407,7 @@ mod tests {
             )])),
         );
         options.insert("ttl_turns".to_string(), VmValue::Int(ttl));
-        VmValue::Dict(std::sync::Arc::new(options))
+        VmValue::dict(options)
     }
 
     #[test]
@@ -1510,18 +1486,14 @@ mod tests {
     #[test]
     fn tool_hooks_inject_reminder_requires_body() {
         let vm = vm_with_stdlib();
-        let mut options: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut options: crate::value::DictMap = crate::value::DictMap::new();
         options.insert(
             "tags".to_string(),
             VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                 std::sync::Arc::from("x"),
             )])),
         );
-        let result = call_sync(
-            &vm,
-            "tool_hooks_inject_reminder",
-            &[VmValue::Dict(std::sync::Arc::new(options))],
-        );
+        let result = call_sync(&vm, "tool_hooks_inject_reminder", &[VmValue::dict(options)]);
         let Err(VmError::Thrown(VmValue::String(message))) = result else {
             panic!("expected thrown error, got {result:?}");
         };
@@ -1531,10 +1503,10 @@ mod tests {
     // TH-05: classifier cache helpers.
 
     fn verdict_value(kind: &str) -> VmValue {
-        let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut dict: crate::value::DictMap = crate::value::DictMap::new();
         dict.put_str("kind", kind);
         dict.insert("confidence".to_string(), VmValue::Float(0.9));
-        VmValue::Dict(std::sync::Arc::new(dict))
+        VmValue::dict(dict)
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/tools.rs
+++ b/crates/harn-vm/src/stdlib/tools.rs
@@ -16,7 +16,7 @@ thread_local! {
     /// by `tool_ref` / `tool_def` to resolve tool-name references without
     /// threading the registry through every call site.
     static CURRENT_TOOL_REGISTRY: RefCell<Option<VmValue>> = const { RefCell::new(None) };
-    static TOOL_SYNTHESIS_CACHE: RefCell<BTreeMap<String, SynthesizedToolSpec>> = const { RefCell::new(BTreeMap::new()) };
+    static TOOL_SYNTHESIS_CACHE: RefCell<BTreeMap<String, SynthesizedToolSpec>> = const { RefCell::new(std::collections::BTreeMap::new()) };
 }
 
 #[derive(Clone)]
@@ -66,9 +66,9 @@ pub fn clear_tool_synthesis_cache() {
 }
 
 fn vm_find_tool_entry<'a>(
-    registry: &'a BTreeMap<String, VmValue>,
+    registry: &'a crate::value::DictMap,
     name: &str,
-) -> Option<&'a BTreeMap<String, VmValue>> {
+) -> Option<&'a crate::value::DictMap> {
     let tools = vm_get_tools(registry);
     for tool in tools {
         if let VmValue::Dict(entry) = tool {
@@ -82,7 +82,7 @@ fn vm_find_tool_entry<'a>(
     None
 }
 
-fn vm_registered_names(registry: &BTreeMap<String, VmValue>) -> Vec<String> {
+fn vm_registered_names(registry: &crate::value::DictMap) -> Vec<String> {
     let mut names: Vec<String> = vm_get_tools(registry)
         .iter()
         .filter_map(|tool| match tool {
@@ -203,13 +203,13 @@ fn plan_entries_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
     category = "tools"
 )]
 fn tool_registry_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    let mut registry = BTreeMap::new();
+    let mut registry = crate::value::DictMap::new();
     registry.put_str("_type", "tool_registry");
     registry.insert(
         "tools".to_string(),
         VmValue::List(std::sync::Arc::new(Vec::new())),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(registry)))
+    Ok(VmValue::dict(registry))
 }
 
 #[harn_builtin(
@@ -231,14 +231,14 @@ fn tool_list_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
     let mut result = Vec::new();
     for tool in tools {
         if let VmValue::Dict(entry) = tool {
-            let mut desc = BTreeMap::new();
+            let mut desc = crate::value::DictMap::new();
             for (key, value) in entry.iter() {
                 if key == "handler" {
                     continue;
                 }
                 desc.insert(key.clone(), value.clone());
             }
-            result.push(VmValue::Dict(std::sync::Arc::new(desc)));
+            result.push(VmValue::dict(desc));
         }
     }
     Ok(VmValue::List(std::sync::Arc::new(result)))
@@ -326,7 +326,7 @@ fn tool_select_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
         "tools".to_string(),
         VmValue::List(std::sync::Arc::new(selected)),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(new_registry)))
+    Ok(VmValue::dict(new_registry))
 }
 
 #[harn_builtin(
@@ -424,7 +424,7 @@ fn tool_remove_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
         "tools".to_string(),
         VmValue::List(std::sync::Arc::new(filtered)),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(new_registry)))
+    Ok(VmValue::dict(new_registry))
 }
 
 #[harn_builtin(
@@ -466,7 +466,7 @@ fn tool_schema_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
 
     let tools = match registry.get("tools") {
         Some(VmValue::List(list)) => list,
-        _ => return Ok(VmValue::Dict(std::sync::Arc::new(vm_build_empty_schema()))),
+        _ => return Ok(VmValue::dict(vm_build_empty_schema())),
     };
 
     let mut tool_schemas = Vec::new();
@@ -482,37 +482,31 @@ fn tool_schema_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
             let output_schema =
                 vm_build_output_schema(entry.get("outputSchema"), components.as_ref());
 
-            let mut tool_def = BTreeMap::new();
+            let mut tool_def = crate::value::DictMap::new();
             tool_def.put_str("name", name);
             tool_def.put_str("description", description);
             tool_def.insert("inputSchema".to_string(), input_schema);
             if let Some(output_schema) = output_schema {
                 tool_def.insert("outputSchema".to_string(), output_schema);
             }
-            tool_schemas.push(VmValue::Dict(std::sync::Arc::new(tool_def)));
+            tool_schemas.push(VmValue::dict(tool_def));
         }
     }
 
-    let mut schema = BTreeMap::new();
+    let mut schema = crate::value::DictMap::new();
     schema.put_str("schema_version", "harn-tools/1.0");
 
     if let Some(comps) = &components {
-        let mut comp_wrapper = BTreeMap::new();
-        comp_wrapper.insert(
-            "schemas".to_string(),
-            VmValue::Dict(std::sync::Arc::new(comps.clone())),
-        );
-        schema.insert(
-            "components".to_string(),
-            VmValue::Dict(std::sync::Arc::new(comp_wrapper)),
-        );
+        let mut comp_wrapper = crate::value::DictMap::new();
+        comp_wrapper.insert("schemas".to_string(), VmValue::dict(comps.clone()));
+        schema.insert("components".to_string(), VmValue::dict(comp_wrapper));
     }
 
     schema.insert(
         "tools".to_string(),
         VmValue::List(std::sync::Arc::new(tool_schemas)),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(schema)))
+    Ok(VmValue::dict(schema))
 }
 
 // Unknown config keys (beyond parameters/handler/returns/annotations) are
@@ -750,10 +744,10 @@ fn tool_define_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
     let parameters = config
         .get("parameters")
         .cloned()
-        .unwrap_or(VmValue::Dict(std::sync::Arc::new(BTreeMap::new())));
+        .unwrap_or(VmValue::dict(crate::value::DictMap::new()));
     let output_schema = config.get("returns").cloned().unwrap_or(VmValue::Nil);
 
-    let mut tool_entry = BTreeMap::new();
+    let mut tool_entry = crate::value::DictMap::new();
     tool_entry.put_str("name", name.as_str());
     tool_entry.put_str("description", description);
     tool_entry.insert("handler".to_string(), handler);
@@ -793,14 +787,14 @@ fn tool_define_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
             .collect(),
         _ => Vec::new(),
     };
-    tools.push(VmValue::Dict(std::sync::Arc::new(tool_entry)));
+    tools.push(VmValue::dict(tool_entry));
 
     let mut new_registry = registry;
     new_registry.insert(
         "tools".to_string(),
         VmValue::List(std::sync::Arc::new(tools)),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(new_registry)))
+    Ok(VmValue::dict(new_registry))
 }
 
 #[harn_builtin(sig = "tool_parse_call(text: string?) -> list", category = "tools")]
@@ -889,7 +883,7 @@ fn tool_prompt_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
     prompt.push_str("You may make multiple tool calls in a single response. Wait for tool results before proceeding.\n\n");
     prompt.push_str("## Tools\n\n");
 
-    let mut tool_infos: Vec<(&BTreeMap<String, VmValue>, String)> = Vec::new();
+    let mut tool_infos: Vec<(&crate::value::DictMap, String)> = Vec::new();
     for tool in tools.iter() {
         if let VmValue::Dict(entry) = tool {
             let name = entry.get("name").map(|v| v.display()).unwrap_or_default();
@@ -1008,14 +1002,14 @@ fn tool_def_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError
     };
 
     if let Some(entry) = vm_find_tool_entry(registry, &name) {
-        let mut desc = BTreeMap::new();
+        let mut desc = crate::value::DictMap::new();
         for (key, value) in entry.iter() {
             if key == "handler" {
                 continue;
             }
             desc.insert(key.clone(), value.clone());
         }
-        return Ok(VmValue::Dict(std::sync::Arc::new(desc)));
+        return Ok(VmValue::dict(desc));
     }
 
     let registered = vm_registered_names(registry);
@@ -1081,7 +1075,7 @@ fn synthesize_tool_spec(input: Option<&VmValue>) -> Result<SynthesizedToolSpec, 
         .get("parameters")
         .or_else(|| config.get("params"))
         .cloned()
-        .unwrap_or_else(|| VmValue::Dict(std::sync::Arc::new(BTreeMap::new())));
+        .unwrap_or_else(|| VmValue::dict(crate::value::DictMap::new()));
     let return_type = config
         .get("return_type")
         .or_else(|| config.get("returns"))
@@ -1289,7 +1283,7 @@ fn is_optional_param(schema: &VmValue) -> bool {
 }
 
 fn synthesized_tool_dry_run_result(spec: &SynthesizedToolSpec, call_args: VmValue) -> VmValue {
-    let mut result = BTreeMap::new();
+    let mut result = crate::value::DictMap::new();
     result.put_str("_type", "synthesized_tool_result");
     result.put_str("status", "dry_run");
     result.put_str("tool_id", spec.id.as_str());
@@ -1311,11 +1305,11 @@ fn synthesized_tool_dry_run_result(spec: &SynthesizedToolSpec, call_args: VmValu
         "synthesized tool is pinned and validated, but executor is dry_run; \
              set executor: \"host_bridge\" or \"mcp_server\" to dispatch",
     );
-    VmValue::Dict(std::sync::Arc::new(result))
+    VmValue::dict(result)
 }
 
 fn synthesized_tool_spec_value(spec: &SynthesizedToolSpec) -> VmValue {
-    let mut value = BTreeMap::new();
+    let mut value = crate::value::DictMap::new();
     value.put_str("id", spec.id.as_str());
     value.put_str("name", spec.name.as_str());
     value.put_str("description", spec.description.as_str());
@@ -1351,7 +1345,7 @@ fn synthesized_tool_spec_value(spec: &SynthesizedToolSpec) -> VmValue {
             }
         }
     }
-    VmValue::Dict(std::sync::Arc::new(value))
+    VmValue::dict(value)
 }
 
 fn synthesized_tool_hash(spec: &SynthesizedToolSpec) -> String {
@@ -1389,7 +1383,7 @@ fn synthesized_executor_hash_value(executor: &SynthesizedToolExecutor) -> serde_
 }
 
 fn required_string(
-    config: &BTreeMap<String, VmValue>,
+    config: &crate::value::DictMap,
     builtin: &str,
     key: &str,
 ) -> Result<String, VmError> {
@@ -1401,17 +1395,14 @@ fn required_string(
     }
 }
 
-fn optional_string(config: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn optional_string(config: &crate::value::DictMap, key: &str) -> Option<String> {
     match config.get(key) {
         Some(VmValue::String(value)) => Some(value.to_string()),
         _ => None,
     }
 }
 
-fn optional_string_list(
-    config: &BTreeMap<String, VmValue>,
-    key: &str,
-) -> Result<Vec<String>, VmError> {
+fn optional_string_list(config: &crate::value::DictMap, key: &str) -> Result<Vec<String>, VmError> {
     let Some(value) = config.get(key) else {
         return Ok(Vec::new());
     };
@@ -1506,7 +1497,7 @@ fn infer_side_effect_level(capabilities: &[String]) -> String {
     }
 }
 
-fn vm_validate_registry(name: &str, dict: &BTreeMap<String, VmValue>) -> Result<(), VmError> {
+fn vm_validate_registry(name: &str, dict: &crate::value::DictMap) -> Result<(), VmError> {
     match dict.get("_type") {
         Some(VmValue::String(t)) if &**t == "tool_registry" => Ok(()),
         _ => Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
@@ -1515,7 +1506,7 @@ fn vm_validate_registry(name: &str, dict: &BTreeMap<String, VmValue>) -> Result<
     }
 }
 
-fn vm_get_tools(dict: &BTreeMap<String, VmValue>) -> &[VmValue] {
+fn vm_get_tools(dict: &crate::value::DictMap) -> &[VmValue] {
     match dict.get("tools") {
         Some(VmValue::List(list)) => list,
         _ => &[],
@@ -1558,8 +1549,8 @@ fn vm_format_schema(schema: Option<&VmValue>) -> String {
     }
 }
 
-fn vm_build_empty_schema() -> BTreeMap<String, VmValue> {
-    let mut schema = BTreeMap::new();
+fn vm_build_empty_schema() -> crate::value::DictMap {
+    let mut schema = crate::value::DictMap::new();
     schema.put_str("schema_version", "harn-tools/1.0");
     schema.insert(
         "tools".to_string(),
@@ -1570,9 +1561,9 @@ fn vm_build_empty_schema() -> BTreeMap<String, VmValue> {
 
 fn vm_build_input_schema(
     params: Option<&VmValue>,
-    components: Option<&BTreeMap<String, VmValue>>,
+    components: Option<&crate::value::DictMap>,
 ) -> VmValue {
-    let mut schema = BTreeMap::new();
+    let mut schema = crate::value::DictMap::new();
     schema.put_str("type", "object");
 
     let params_map = match params {
@@ -1580,13 +1571,13 @@ fn vm_build_input_schema(
         _ => {
             schema.insert(
                 "properties".to_string(),
-                VmValue::Dict(std::sync::Arc::new(BTreeMap::new())),
+                VmValue::dict(crate::value::DictMap::new()),
             );
-            return VmValue::Dict(std::sync::Arc::new(schema));
+            return VmValue::dict(schema);
         }
     };
 
-    let mut properties = BTreeMap::new();
+    let mut properties = crate::value::DictMap::new();
     let mut required = Vec::new();
 
     for (key, val) in params_map.iter() {
@@ -1595,10 +1586,7 @@ fn vm_build_input_schema(
         required.push(VmValue::String(std::sync::Arc::from(key.as_str())));
     }
 
-    schema.insert(
-        "properties".to_string(),
-        VmValue::Dict(std::sync::Arc::new(properties)),
-    );
+    schema.insert("properties".to_string(), VmValue::dict(properties));
     if !required.is_empty() {
         required.sort_by_key(|a| a.display());
         schema.insert(
@@ -1607,23 +1595,23 @@ fn vm_build_input_schema(
         );
     }
 
-    VmValue::Dict(std::sync::Arc::new(schema))
+    VmValue::dict(schema)
 }
 
 fn vm_build_output_schema(
     schema: Option<&VmValue>,
-    components: Option<&BTreeMap<String, VmValue>>,
+    components: Option<&crate::value::DictMap>,
 ) -> Option<VmValue> {
     schema.map(|value| vm_resolve_param_type(value, components))
 }
 
-fn vm_resolve_param_type(val: &VmValue, components: Option<&BTreeMap<String, VmValue>>) -> VmValue {
+fn vm_resolve_param_type(val: &VmValue, components: Option<&crate::value::DictMap>) -> VmValue {
     match val {
         VmValue::String(type_name) => {
             let json_type = vm_harn_type_to_json_schema(type_name);
-            let mut prop = BTreeMap::new();
+            let mut prop = crate::value::DictMap::new();
             prop.put_str("type", json_type);
-            VmValue::Dict(std::sync::Arc::new(prop))
+            VmValue::dict(prop)
         }
         VmValue::Dict(map) => {
             if let Some(VmValue::String(ref_name)) = map.get("$ref") {
@@ -1632,17 +1620,17 @@ fn vm_resolve_param_type(val: &VmValue, components: Option<&BTreeMap<String, VmV
                         return resolved.clone();
                     }
                 }
-                let mut prop = BTreeMap::new();
+                let mut prop = crate::value::DictMap::new();
                 prop.put_str("$ref", format!("#/components/schemas/{ref_name}").as_str());
-                VmValue::Dict(std::sync::Arc::new(prop))
+                VmValue::dict(prop)
             } else {
-                VmValue::Dict(std::sync::Arc::new((**map).clone()))
+                VmValue::dict((**map).clone())
             }
         }
         _ => {
-            let mut prop = BTreeMap::new();
+            let mut prop = crate::value::DictMap::new();
             prop.put_str("type", "string");
-            VmValue::Dict(std::sync::Arc::new(prop))
+            VmValue::dict(prop)
         }
     }
 }

--- a/crates/harn-vm/src/stdlib/tracing.rs
+++ b/crates/harn-vm/src/stdlib/tracing.rs
@@ -1,5 +1,4 @@
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 use std::sync::atomic::Ordering;
 
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
@@ -95,12 +94,12 @@ fn trace_start_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
         });
     });
 
-    let mut span = BTreeMap::new();
+    let mut span = crate::value::DictMap::new();
     span.put_str("trace_id", trace_id);
     span.put_str("span_id", span_id);
     span.put_str("name", name);
     span.insert("start_ms".to_string(), VmValue::Int(start_ms));
-    Ok(VmValue::Dict(std::sync::Arc::new(span)))
+    Ok(VmValue::dict(span))
 }
 
 #[harn_builtin(sig = "trace_end(...args: any) -> nil", category = "tracing")]
@@ -108,7 +107,7 @@ fn trace_end_impl(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError
     let (name, trace_id, span_id, duration_ms) = finish_span_from_args(args)?;
     let level_num = 1_u8;
     if level_num >= VM_MIN_LOG_LEVEL.load(Ordering::Relaxed) {
-        let mut fields = BTreeMap::new();
+        let mut fields = crate::value::DictMap::new();
         fields.put_str("trace_id", trace_id);
         fields.put_str("span_id", span_id);
         fields.put_str("name", name);
@@ -138,11 +137,11 @@ fn llm_info_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
         resolved.id
     };
     let api_key_set = crate::llm_config::provider_key_available(&provider);
-    let mut info = BTreeMap::new();
+    let mut info = crate::value::DictMap::new();
     info.put_str("provider", provider);
     info.put_str("model", model);
     info.insert("api_key_set".to_string(), VmValue::Bool(api_key_set));
-    Ok(VmValue::Dict(std::sync::Arc::new(info)))
+    Ok(VmValue::dict(info))
 }
 
 #[harn_builtin(sig = "enable_tracing(enabled?: bool) -> nil", category = "tracing")]
@@ -198,7 +197,7 @@ fn lifecycle_span_end_impl(args: &[VmValue], _out: &mut String) -> Result<VmValu
 #[harn_builtin(sig = "llm_usage() -> dict", category = "tracing")]
 fn llm_usage_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let (total_input, total_output, total_duration, call_count) = crate::llm::peek_trace_summary();
-    let mut usage = BTreeMap::new();
+    let mut usage = crate::value::DictMap::new();
     usage.insert("input_tokens".to_string(), VmValue::Int(total_input));
     usage.insert("output_tokens".to_string(), VmValue::Int(total_output));
     usage.insert(
@@ -207,7 +206,7 @@ fn llm_usage_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
     );
     usage.insert("call_count".to_string(), VmValue::Int(call_count));
     usage.insert("total_calls".to_string(), VmValue::Int(call_count));
-    Ok(VmValue::Dict(std::sync::Arc::new(usage)))
+    Ok(VmValue::dict(usage))
 }
 
 pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[

--- a/crates/harn-vm/src/stdlib/transcript_compact.rs
+++ b/crates/harn-vm/src/stdlib/transcript_compact.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use crate::llm::helpers::{
     extract_llm_options, is_transcript_value, new_transcript_with_events, transcript_asset_list,
     transcript_event, transcript_id, transcript_message_list, transcript_summary_text,
@@ -41,8 +39,8 @@ struct TranscriptCompactOptions {
 
 async fn compact_transcript_impl(
     ctx: &crate::vm::AsyncBuiltinCtx,
-    transcript: &BTreeMap<String, VmValue>,
-    options: Option<&BTreeMap<String, VmValue>>,
+    transcript: &crate::value::DictMap,
+    options: Option<&crate::value::DictMap>,
     raw_options: Option<VmValue>,
 ) -> Result<VmValue, VmError> {
     let provider_options = options
@@ -67,7 +65,7 @@ async fn compact_transcript_impl(
         config.token_threshold = 0;
     }
 
-    let original_transcript = VmValue::Dict(std::sync::Arc::new(transcript.clone()));
+    let original_transcript = VmValue::dict(transcript.clone());
     let mut messages: Vec<serde_json::Value> = transcript_message_list(transcript)?
         .iter()
         .map(vm_value_to_json)
@@ -143,7 +141,7 @@ async fn compact_transcript_impl(
 }
 
 fn parse_options(
-    options: Option<&BTreeMap<String, VmValue>>,
+    options: Option<&crate::value::DictMap>,
 ) -> Result<TranscriptCompactOptions, VmError> {
     let mut parsed = TranscriptCompactOptions {
         strategy: CompactStrategy::ObservationMask,
@@ -240,7 +238,7 @@ fn merge_summary(existing: Option<String>, next: &str) -> Option<String> {
     }
 }
 
-fn transcript_state(transcript: &BTreeMap<String, VmValue>) -> Option<&str> {
+fn transcript_state(transcript: &crate::value::DictMap) -> Option<&str> {
     transcript.get("state").and_then(|value| match value {
         VmValue::String(text) if !text.is_empty() => Some(text.as_ref()),
         _ => None,

--- a/crates/harn-vm/src/stdlib/transcript_project.rs
+++ b/crates/harn-vm/src/stdlib/transcript_project.rs
@@ -265,7 +265,7 @@ pub(crate) fn parse_projection_options(options: &VmValue) -> Result<ProjectionPo
 }
 
 fn optional_usize_alias(
-    dict: Option<&BTreeMap<String, VmValue>>,
+    dict: Option<&crate::value::DictMap>,
     keys: &[&str],
     default: usize,
     builtin: &str,
@@ -296,7 +296,7 @@ fn optional_usize_alias(
 }
 
 fn optional_bool_alias(
-    dict: Option<&BTreeMap<String, VmValue>>,
+    dict: Option<&crate::value::DictMap>,
     keys: &[&str],
     default: bool,
     builtin: &str,
@@ -320,7 +320,7 @@ fn optional_bool_alias(
 }
 
 fn parse_reachability_gc_roots(
-    dict: Option<&BTreeMap<String, VmValue>>,
+    dict: Option<&crate::value::DictMap>,
 ) -> (Vec<String>, Vec<String>, bool) {
     let Some(dict) = dict else {
         return (Vec::new(), Vec::new(), false);
@@ -414,7 +414,7 @@ pub(crate) struct ProjectionResult {
 
 pub(crate) async fn project_transcript(
     ctx: Option<&AsyncBuiltinCtx>,
-    transcript: &BTreeMap<String, VmValue>,
+    transcript: &crate::value::DictMap,
     policy: &ProjectionPolicy,
 ) -> Result<ProjectionResult, VmError> {
     let raw_messages = transcript_message_list(transcript)?;
@@ -425,7 +425,7 @@ pub(crate) async fn project_transcript(
 pub(crate) async fn project_messages(
     ctx: Option<&AsyncBuiltinCtx>,
     raw: &[JsonValue],
-    transcript: &BTreeMap<String, VmValue>,
+    transcript: &crate::value::DictMap,
     policy: &ProjectionPolicy,
 ) -> Result<ProjectionResult, VmError> {
     let mut decision = match policy.kind {
@@ -526,7 +526,8 @@ fn project_clean_tool_repair(raw: &[JsonValue]) -> ProjectionDecision {
     let mut dropped: Vec<usize> = Vec::new();
     // Map tool_name -> indices of failed assistant turns calling it, and
     // their corresponding tool_result indices.
-    let mut failed_for_tool: BTreeMap<String, Vec<FailedCallRecord>> = BTreeMap::new();
+    let mut failed_for_tool: BTreeMap<String, Vec<FailedCallRecord>> =
+        std::collections::BTreeMap::new();
 
     for (idx, msg) in raw.iter().enumerate() {
         if msg.get("role").and_then(JsonValue::as_str) != Some("assistant") {
@@ -649,7 +650,7 @@ fn project_squash_failed_calls(raw: &[JsonValue]) -> ProjectionDecision {
 /// the next provider call a compact roll-up.
 fn project_summary_prefix(
     raw: &[JsonValue],
-    transcript: &BTreeMap<String, VmValue>,
+    transcript: &crate::value::DictMap,
     keep_last: usize,
     summary_text: &Option<String>,
 ) -> ProjectionDecision {
@@ -1474,7 +1475,7 @@ fn canonical_json(value: &JsonValue) -> String {
 }
 
 pub(crate) fn result_to_vm(result: &ProjectionResult, policy: &ProjectionPolicy) -> VmValue {
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.put_str("policy", policy.kind.as_str());
     dict.put_str("reason", result.reason.clone());
     dict.put_str("prefix_hash", result.prefix_hash.clone());
@@ -1559,7 +1560,7 @@ pub(crate) fn result_to_vm(result: &ProjectionResult, policy: &ProjectionPolicy)
         VmValue::Bool(result.provider_safety_blocked),
     );
     dict.insert("event".to_string(), projection_event_value(result, policy));
-    VmValue::Dict(std::sync::Arc::new(dict))
+    VmValue::dict(dict)
 }
 
 pub(crate) fn projection_event_value(
@@ -1604,17 +1605,14 @@ fn projection_event_metadata(result: &ProjectionResult, policy: &ProjectionPolic
 mod tests {
     use super::*;
 
-    fn json_dict_to_btree(value: &JsonValue) -> BTreeMap<String, VmValue> {
+    fn json_dict_to_btree(value: &JsonValue) -> crate::value::DictMap {
         match json_to_vm_value(value) {
             VmValue::Dict(d) => (*d).clone(),
-            _ => BTreeMap::new(),
+            _ => crate::value::DictMap::new(),
         }
     }
 
-    fn transcript_with(
-        messages: Vec<JsonValue>,
-        summary: Option<&str>,
-    ) -> BTreeMap<String, VmValue> {
+    fn transcript_with(messages: Vec<JsonValue>, summary: Option<&str>) -> crate::value::DictMap {
         let mut transcript = serde_json::json!({
             "_type": "transcript",
             "version": 2,

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -728,7 +728,7 @@ fn register_trust_namespace(vm: &mut Vm) {
     let names = ["query", "record", "score", "policy_for", "verify_chain"];
     vm.set_global(
         "trust",
-        VmValue::Dict(std::sync::Arc::new(
+        VmValue::dict(
             std::iter::once((
                 "_namespace".to_string(),
                 VmValue::String(std::sync::Arc::from("trust")),
@@ -740,7 +740,7 @@ fn register_trust_namespace(vm: &mut Vm) {
                 )
             }))
             .collect::<BTreeMap<_, _>>(),
-        )),
+        ),
     );
 }
 
@@ -748,7 +748,7 @@ fn register_corrections_namespace(vm: &mut Vm) {
     let names = ["query", "record"];
     vm.set_global(
         "corrections",
-        VmValue::Dict(std::sync::Arc::new(
+        VmValue::dict(
             std::iter::once((
                 "_namespace".to_string(),
                 VmValue::String(std::sync::Arc::from("corrections")),
@@ -760,7 +760,7 @@ fn register_corrections_namespace(vm: &mut Vm) {
                 )
             }))
             .collect::<BTreeMap<_, _>>(),
-        )),
+        ),
     );
 }
 
@@ -1240,7 +1240,7 @@ fn trigger_handle_from_args(
     }
 }
 
-fn parse_trigger_config(config: &BTreeMap<String, VmValue>) -> Result<TriggerBindingSpec, VmError> {
+fn parse_trigger_config(config: &crate::value::DictMap) -> Result<TriggerBindingSpec, VmError> {
     let id = optional_string(config, "id").unwrap_or_default();
     let kind = required_string(config, "kind", "trigger_register")?;
     let provider =
@@ -1488,9 +1488,7 @@ fn parse_trigger_config(config: &BTreeMap<String, VmValue>) -> Result<TriggerBin
     })
 }
 
-pub(crate) fn validate_resume_trigger_spec(
-    config: &BTreeMap<String, VmValue>,
-) -> Result<(), VmError> {
+pub(crate) fn validate_resume_trigger_spec(config: &crate::value::DictMap) -> Result<(), VmError> {
     let mut normalized = config.clone();
     normalized.entry("handler".to_string()).or_insert_with(|| {
         VmValue::String(std::sync::Arc::from("worker://__resume_auto_resume__"))
@@ -1617,7 +1615,7 @@ fn sanitize_auto_resume_id(worker_id: &str) -> String {
 }
 
 fn auto_resume_timeout_spec(
-    conditions: &BTreeMap<String, VmValue>,
+    conditions: &crate::value::DictMap,
 ) -> Result<Option<AutoResumeTimeoutSpec>, VmError> {
     let Some(timeout) = conditions.get("timeout") else {
         return Ok(None);
@@ -2032,7 +2030,7 @@ fn parse_query_timestamp(builtin: &str, field: &str, raw: &str) -> Result<Offset
 }
 
 fn parse_retry_config(
-    retry: Option<&BTreeMap<String, VmValue>>,
+    retry: Option<&crate::value::DictMap>,
     builtin: &str,
 ) -> Result<TriggerRetryConfig, VmError> {
     let Some(retry) = retry else {
@@ -2116,7 +2114,7 @@ fn parse_handler_value(
 /// (#1876) both ship as dict-shaped handlers so the trigger DSL keeps a
 /// single uniform `handler:` syntax; future variants plug in here too.
 fn parse_handler_dict(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     builtin: &str,
     field_name: &str,
 ) -> Result<(TriggerHandlerSpec, serde_json::Value), VmError> {
@@ -2190,7 +2188,7 @@ fn parse_handler_dict(
 /// workers tagged with a given org / tenant). `reason` is propagated to every
 /// suspended worker's `WorkerSuspension::reason` and audit entry.
 fn parse_interrupt_and_suspend_handler(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     builtin: &str,
 ) -> Result<(TriggerHandlerSpec, serde_json::Value), VmError> {
     let target_value = map.get("target_agents").or_else(|| map.get("target"));
@@ -2272,7 +2270,7 @@ fn parse_interrupt_and_suspend_handler(
 /// `transcript.inject_reminder` (#1815 R-02) shape so authors can reuse
 /// the same mental model.
 fn parse_reminder_inject_handler(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     builtin: &str,
 ) -> Result<(TriggerHandlerSpec, serde_json::Value), VmError> {
     let target_value = map.get("target").or_else(|| map.get("target_session_id"));
@@ -2359,10 +2357,7 @@ fn parse_reminder_inject_handler(
     ))
 }
 
-fn parse_reminder_tags(
-    map: &BTreeMap<String, VmValue>,
-    builtin: &str,
-) -> Result<Vec<String>, VmError> {
+fn parse_reminder_tags(map: &crate::value::DictMap, builtin: &str) -> Result<Vec<String>, VmError> {
     match map.get("tags") {
         None | Some(VmValue::Nil) => Ok(Vec::new()),
         Some(VmValue::List(list)) => {
@@ -2395,7 +2390,7 @@ fn parse_reminder_tags(
 }
 
 fn parse_reminder_ttl_turns(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     builtin: &str,
 ) -> Result<Option<i64>, VmError> {
     match map.get("ttl_turns") {
@@ -2417,7 +2412,7 @@ fn parse_reminder_ttl_turns(
 }
 
 fn parse_reminder_propagate(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     builtin: &str,
 ) -> Result<crate::llm::helpers::ReminderPropagate, VmError> {
     match map.get("propagate") {
@@ -2438,7 +2433,7 @@ fn parse_reminder_propagate(
 }
 
 fn parse_reminder_role_hint(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     builtin: &str,
 ) -> Result<crate::llm::helpers::ReminderRoleHint, VmError> {
     match map.get("role_hint") {
@@ -2460,7 +2455,7 @@ fn parse_reminder_role_hint(
 }
 
 fn optional_path_string(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     field: &str,
     variant: &str,
 ) -> Result<Option<String>, VmError> {
@@ -2552,7 +2547,7 @@ fn require_dict_arg<'a>(
     args: &'a [VmValue],
     index: usize,
     builtin: &str,
-) -> Result<&'a BTreeMap<String, VmValue>, VmError> {
+) -> Result<&'a crate::value::DictMap, VmError> {
     match args.get(index) {
         Some(VmValue::Dict(dict)) => Ok(dict),
         Some(other) => Err(VmError::Runtime(format!(
@@ -2594,7 +2589,7 @@ fn optional_string_arg(
 }
 
 fn required_string(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<String, VmError> {
@@ -2602,7 +2597,7 @@ fn required_string(
         .ok_or_else(|| VmError::Runtime(format!("{builtin}: missing string field `{key}`")))
 }
 
-fn optional_string(map: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn optional_string(map: &crate::value::DictMap, key: &str) -> Option<String> {
     map.get(key).and_then(|value| match value {
         VmValue::String(text) => Some(text.to_string()),
         _ => None,
@@ -2610,7 +2605,7 @@ fn optional_string(map: &BTreeMap<String, VmValue>, key: &str) -> Option<String>
 }
 
 fn optional_bool(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Option<bool>, VmError> {
@@ -2658,7 +2653,7 @@ fn webhook_intake_error(error: WebhookIntakeError) -> VmError {
 }
 
 fn parse_webhook_intake_config(
-    config: &BTreeMap<String, VmValue>,
+    config: &crate::value::DictMap,
 ) -> Result<WebhookIntakeConfig, VmError> {
     let signature_header = required_string(config, "signature_header", "webhook_intake_register")?;
     let delivery_id_header =
@@ -2731,7 +2726,7 @@ fn parse_webhook_intake_config(
     })
 }
 
-fn parse_intake_secret(config: &BTreeMap<String, VmValue>) -> Result<Vec<u8>, VmError> {
+fn parse_intake_secret(config: &crate::value::DictMap) -> Result<Vec<u8>, VmError> {
     match config.get("secret") {
         Some(VmValue::String(text)) => Ok(text.as_bytes().to_vec()),
         Some(VmValue::Bytes(bytes)) => Ok((**bytes).clone()),
@@ -2746,7 +2741,7 @@ fn parse_intake_secret(config: &BTreeMap<String, VmValue>) -> Result<Vec<u8>, Vm
 }
 
 fn parse_webhook_intake_request(
-    request: &BTreeMap<String, VmValue>,
+    request: &crate::value::DictMap,
 ) -> Result<WebhookIntakeRequest, VmError> {
     let headers = match request.get("headers") {
         Some(VmValue::Dict(dict)) => dict

--- a/crates/harn-vm/src/stdlib/tui.rs
+++ b/crates/harn-vm/src/stdlib/tui.rs
@@ -109,7 +109,7 @@ fn parse_page_options(args: &[VmValue]) -> Result<PageOptions, VmError> {
 }
 
 fn required_string(
-    opts: &BTreeMap<String, VmValue>,
+    opts: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<String, VmError> {
@@ -126,7 +126,7 @@ fn required_string(
 }
 
 fn optional_string(
-    opts: &BTreeMap<String, VmValue>,
+    opts: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Option<String>, VmError> {
@@ -141,7 +141,7 @@ fn optional_string(
 }
 
 fn optional_bool(
-    opts: &BTreeMap<String, VmValue>,
+    opts: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<Option<bool>, VmError> {
@@ -304,7 +304,7 @@ fn page_result(ok: bool, paged: bool, error: Option<String>) -> VmValue {
     if let Some(error) = error {
         result.put_str("error", error);
     }
-    VmValue::Dict(std::sync::Arc::new(result))
+    VmValue::dict(result)
 }
 
 fn terminal_width(default_width: usize) -> usize {
@@ -350,7 +350,7 @@ mod tests {
             .iter()
             .map(|(key, value)| ((*key).to_string(), value.clone()))
             .collect::<BTreeMap<_, _>>();
-        vec![VmValue::Dict(std::sync::Arc::new(map))]
+        vec![VmValue::dict(map)]
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/url_parse.rs
+++ b/crates/harn-vm/src/stdlib/url_parse.rs
@@ -10,7 +10,7 @@ use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
 use crate::value::{VmError, VmValue};
 use crate::vm::Vm;
 
-fn dict_str<'a>(d: &'a BTreeMap<String, VmValue>, key: &str) -> Option<&'a str> {
+fn dict_str<'a>(d: &'a crate::value::DictMap, key: &str) -> Option<&'a str> {
     match d.get(key) {
         Some(VmValue::String(s)) => Some(s.as_ref()),
         _ => None,
@@ -85,7 +85,7 @@ fn url_parse_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
             .map(|p| VmValue::String(std::sync::Arc::from(p)))
             .unwrap_or(VmValue::Nil),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+    Ok(VmValue::dict(dict))
 }
 
 #[harn_builtin(sig = "url_build(parts: dict) -> string", category = "url")]
@@ -168,7 +168,7 @@ fn query_parse_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
             let mut row = BTreeMap::new();
             row.put_str("key", &k);
             row.put_str("value", &v);
-            VmValue::Dict(std::sync::Arc::new(row))
+            VmValue::dict(row)
         })
         .collect();
     Ok(VmValue::List(std::sync::Arc::new(pairs)))

--- a/crates/harn-vm/src/stdlib/waitpoint.rs
+++ b/crates/harn-vm/src/stdlib/waitpoint.rs
@@ -1126,7 +1126,7 @@ fn next_sequence(
 }
 
 fn required_string(
-    dict: &BTreeMap<String, VmValue>,
+    dict: &crate::value::DictMap,
     key: &str,
     builtin: &str,
 ) -> Result<String, VmError> {
@@ -1138,7 +1138,7 @@ fn required_string(
         .ok_or_else(|| VmError::Runtime(format!("{builtin}: missing string field `{key}`")))
 }
 
-fn optional_string(dict: &BTreeMap<String, VmValue>, key: &str) -> Option<String> {
+fn optional_string(dict: &crate::value::DictMap, key: &str) -> Option<String> {
     dict.get(key).and_then(|value| match value {
         VmValue::String(text) if !text.is_empty() => Some(text.to_string()),
         _ => None,

--- a/crates/harn-vm/src/stdlib/waitpoints.rs
+++ b/crates/harn-vm/src/stdlib/waitpoints.rs
@@ -456,7 +456,7 @@ fn parse_wait_options(value: Option<&VmValue>, builtin: &str) -> Result<WaitOpti
 }
 
 fn json_dict_field(
-    map: &BTreeMap<String, VmValue>,
+    map: &crate::value::DictMap,
     field: &str,
     builtin: &str,
 ) -> Result<BTreeMap<String, serde_json::Value>, VmError> {
@@ -474,7 +474,7 @@ fn json_dict_field(
         .collect())
 }
 
-fn string_field(map: &BTreeMap<String, VmValue>, field: &str) -> Result<Option<String>, VmError> {
+fn string_field(map: &crate::value::DictMap, field: &str) -> Result<Option<String>, VmError> {
     let Some(value) = map.get(field) else {
         return Ok(None);
     };

--- a/crates/harn-vm/src/stdlib/web.rs
+++ b/crates/harn-vm/src/stdlib/web.rs
@@ -1,7 +1,5 @@
 //! Pure web-source helpers backing `std/web`.
 
-use std::collections::BTreeMap;
-
 use regex::Regex;
 use scraper::{ElementRef, Html, Selector};
 use url::Url;
@@ -19,8 +17,8 @@ fn vm_list(values: Vec<VmValue>) -> VmValue {
     VmValue::List(std::sync::Arc::new(values))
 }
 
-fn vm_dict(values: BTreeMap<String, VmValue>) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(values))
+fn vm_dict(values: crate::value::DictMap) -> VmValue {
+    VmValue::dict(values)
 }
 
 fn selector(pattern: &str) -> Selector {
@@ -83,7 +81,7 @@ fn html_text_without_scripts(html: &str) -> String {
 
 fn extract_meta(document: &Html) -> VmValue {
     let meta_selector = selector("meta");
-    let mut meta = BTreeMap::new();
+    let mut meta = crate::value::DictMap::new();
     for element in document.select(&meta_selector) {
         let value = element
             .value()
@@ -132,7 +130,7 @@ fn extract_links(document: &Html, base: Option<&Url>) -> VmValue {
         else {
             continue;
         };
-        let mut row = BTreeMap::new();
+        let mut row = crate::value::DictMap::new();
         row.insert("href".to_string(), vm_str(href));
         row.insert("url".to_string(), vm_str(resolve_url(base, href)));
         row.insert("text".to_string(), vm_str(element_text(element)));
@@ -192,7 +190,7 @@ fn extract_tables(document: &Html) -> VmValue {
     let mut tables = Vec::new();
 
     for table in document.select(&table_selector) {
-        let mut rendered = BTreeMap::new();
+        let mut rendered = crate::value::DictMap::new();
         let caption = table
             .select(&caption_selector)
             .next()
@@ -245,7 +243,7 @@ fn extract_html(html: &str, source_url: Option<&str>) -> VmValue {
         .map(vm_str)
         .unwrap_or(VmValue::Nil);
 
-    let mut out = BTreeMap::new();
+    let mut out = crate::value::DictMap::new();
     out.insert("title".to_string(), title);
     out.insert("meta".to_string(), extract_meta(&document));
     out.insert(

--- a/crates/harn-vm/src/stdlib/workflow/artifact.rs
+++ b/crates/harn-vm/src/stdlib/workflow/artifact.rs
@@ -88,10 +88,7 @@ pub(super) fn parse_execution_record(
     }
 }
 
-pub(super) fn optional_string_option(
-    options: &BTreeMap<String, VmValue>,
-    key: &str,
-) -> Option<String> {
+pub(super) fn optional_string_option(options: &crate::value::DictMap, key: &str) -> Option<String> {
     options.get(key).and_then(|value| match value {
         VmValue::Nil => None,
         _ => {

--- a/crates/harn-vm/src/stdlib/workflow/convert.rs
+++ b/crates/harn-vm/src/stdlib/workflow/convert.rs
@@ -39,16 +39,10 @@ pub(in crate::stdlib) fn workflow_graph_to_vm(graph: &WorkflowGraph) -> Result<V
         };
         let mut node_map = (*node_dict).clone();
         node_map.insert("tools".to_string(), raw_tools);
-        nodes.insert(
-            node_id.clone(),
-            VmValue::Dict(std::sync::Arc::new(node_map)),
-        );
+        nodes.insert(node_id.clone(), VmValue::dict(node_map));
     }
-    graph_dict.insert(
-        "nodes".to_string(),
-        VmValue::Dict(std::sync::Arc::new(nodes)),
-    );
-    Ok(VmValue::Dict(std::sync::Arc::new(graph_dict)))
+    graph_dict.insert("nodes".to_string(), VmValue::dict(nodes));
+    Ok(VmValue::dict(graph_dict))
 }
 
 pub(super) fn filter_workflow_tools(
@@ -124,7 +118,7 @@ pub(super) fn filter_workflow_tools_vm(tools: &VmValue, allowed: &[String]) -> V
                 .map(|value| filter_workflow_tools_vm(value, allowed))
                 .unwrap_or_else(|| VmValue::List(std::sync::Arc::new(Vec::new())));
             filtered.insert("tools".to_string(), tool_items);
-            VmValue::Dict(std::sync::Arc::new(filtered))
+            VmValue::dict(filtered)
         }
         VmValue::Dict(map) => {
             let keep = map

--- a/crates/harn-vm/src/stdlib/workflow/hooks.rs
+++ b/crates/harn-vm/src/stdlib/workflow/hooks.rs
@@ -1,7 +1,6 @@
 //! Tool, persona, and step hook registration builtins for workflow execution.
 
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::stdlib::macros::harn_builtin;
@@ -615,7 +614,7 @@ pub(super) async fn fire_session_hook_builtin(
         },
         payload: payload.clone(),
     });
-    let mut out: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut out: crate::value::DictMap = crate::value::DictMap::new();
     match control {
         crate::orchestration::HookControl::Allow => {
             out.put_str("control", "allow");
@@ -639,7 +638,7 @@ pub(super) async fn fire_session_hook_builtin(
             );
         }
     }
-    Ok(VmValue::Dict(std::sync::Arc::new(out)))
+    Ok(VmValue::dict(out))
 }
 
 /// Synchronous emit-only entry point: explicitly notify the session
@@ -708,12 +707,12 @@ mod tests {
     use super::*;
 
     fn dict(entries: &[(&str, VmValue)]) -> VmValue {
-        VmValue::Dict(std::sync::Arc::new(
+        VmValue::dict(
             entries
                 .iter()
                 .map(|(key, value)| ((*key).to_string(), value.clone()))
-                .collect(),
-        ))
+                .collect::<crate::value::DictMap>(),
+        )
     }
 
     #[test]

--- a/crates/harn-vm/src/stdlib/workflow/host.rs
+++ b/crates/harn-vm/src/stdlib/workflow/host.rs
@@ -117,7 +117,7 @@ pub(super) async fn host_workflow_stage_complete_builtin(
             .map(|branch| VmValue::String(std::sync::Arc::from(branch)))
             .unwrap_or(VmValue::Nil),
     );
-    Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+    Ok(VmValue::dict(dict))
 }
 
 /// Record workflow stage transitions and checkpoint low-level run state.

--- a/crates/harn-vm/src/stdlib/workflow/inspect.rs
+++ b/crates/harn-vm/src/stdlib/workflow/inspect.rs
@@ -23,7 +23,7 @@ pub(super) fn workflow_graph_builtin(
     let input = args
         .first()
         .cloned()
-        .unwrap_or(VmValue::Dict(std::sync::Arc::new(BTreeMap::new())));
+        .unwrap_or(VmValue::dict(BTreeMap::new()));
     let graph = normalize_workflow_value(&input)?;
     workflow_graph_to_vm(&graph)
 }
@@ -40,7 +40,7 @@ pub(super) fn workflow_validate_builtin(
     let input = args
         .first()
         .cloned()
-        .unwrap_or(VmValue::Dict(std::sync::Arc::new(BTreeMap::new())));
+        .unwrap_or(VmValue::dict(BTreeMap::new()));
     let graph = normalize_workflow_value(&input)?;
     let ceiling = args.get(1).map(normalize_policy).transpose()?;
     to_vm(&validate_workflow(
@@ -61,7 +61,7 @@ pub(super) fn workflow_inspect_builtin(
     let input = args
         .first()
         .cloned()
-        .unwrap_or(VmValue::Dict(std::sync::Arc::new(BTreeMap::new())));
+        .unwrap_or(VmValue::dict(BTreeMap::new()));
     let graph = normalize_workflow_value(&input)?;
     let ceiling = args.get(1).map(normalize_policy).transpose()?;
     let builtin = builtin_ceiling();
@@ -86,7 +86,7 @@ pub(super) fn workflow_policy_report_builtin(
     let input = args
         .first()
         .cloned()
-        .unwrap_or(VmValue::Dict(std::sync::Arc::new(BTreeMap::new())));
+        .unwrap_or(VmValue::dict(BTreeMap::new()));
     let graph = normalize_workflow_value(&input)?;
     let ceiling = args.get(1).map(normalize_policy).transpose()?;
     let builtin = builtin_ceiling();
@@ -116,7 +116,7 @@ pub(super) fn workflow_clone_builtin(
     let input = args
         .first()
         .cloned()
-        .unwrap_or(VmValue::Dict(std::sync::Arc::new(BTreeMap::new())));
+        .unwrap_or(VmValue::dict(BTreeMap::new()));
     let mut graph = normalize_workflow_value(&input)?;
     graph.id = format!("{}_clone", graph.id);
     graph.version += 1;

--- a/crates/harn-vm/src/stdlib/workflow/policy.rs
+++ b/crates/harn-vm/src/stdlib/workflow/policy.rs
@@ -47,7 +47,7 @@ pub(super) fn set_node_policy(
 
 pub(super) fn apply_runtime_node_overrides(
     mut node: crate::orchestration::WorkflowNode,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> crate::orchestration::WorkflowNode {
     if node.model_policy.provider.is_none() {
         node.model_policy.provider = options

--- a/crates/harn-vm/src/stdlib/workflow/state.rs
+++ b/crates/harn-vm/src/stdlib/workflow/state.rs
@@ -32,7 +32,7 @@ use super::usage::{llm_usage_delta, llm_usage_snapshot, UsageSnapshot};
 
 thread_local! {
     pub(super) static WORKFLOW_RUN_STATES: RefCell<BTreeMap<String, WorkflowRunState>> =
-        const { RefCell::new(BTreeMap::new()) };
+        const { RefCell::new(std::collections::BTreeMap::new()) };
 }
 
 pub(super) struct WorkflowRunState {
@@ -79,7 +79,7 @@ pub(super) enum StageExecution {
     },
     HarnMapCall {
         artifacts: Vec<ArtifactRecord>,
-        map_options: BTreeMap<String, VmValue>,
+        map_options: crate::value::DictMap,
         usage_before: UsageSnapshot,
         attempt_started_at: String,
         input_transcript: Option<VmValue>,
@@ -97,7 +97,7 @@ pub(super) struct WorkflowExecutedStageRecord {
     pub(super) produced_artifact_ids: Vec<String>,
 }
 
-pub(super) fn parse_options_arg(args: &[VmValue], index: usize) -> BTreeMap<String, VmValue> {
+pub(super) fn parse_options_arg(args: &[VmValue], index: usize) -> crate::value::DictMap {
     args.get(index)
         .and_then(|v| v.as_dict())
         .cloned()
@@ -164,7 +164,7 @@ pub(super) fn workflow_control_to_vm(
     state: &WorkflowRunState,
     include_graph: bool,
 ) -> Result<VmValue, VmError> {
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.put_str("state_id", state.state_id.as_str());
     dict.put_str("run_id", state.run.id.as_str());
     dict.insert(
@@ -182,7 +182,7 @@ pub(super) fn workflow_control_to_vm(
     if include_graph {
         dict.insert("graph".to_string(), workflow_graph_to_vm(&state.graph)?);
     }
-    Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+    Ok(VmValue::dict(dict))
 }
 
 pub(super) fn insert_workflow_state(state: WorkflowRunState) {
@@ -260,10 +260,10 @@ fn validate_workflow_skill_registry(value: VmValue) -> Option<VmValue> {
             Some(value)
         }
         VmValue::List(list) => {
-            let mut dict = BTreeMap::new();
+            let mut dict = crate::value::DictMap::new();
             dict.put_str("_type", "skill_registry");
             dict.insert("skills".to_string(), VmValue::List(list.clone()));
-            Some(VmValue::Dict(std::sync::Arc::new(dict)))
+            Some(VmValue::dict(dict))
         }
         _ => None,
     }
@@ -294,7 +294,7 @@ pub(super) fn prepare_workflow_state(
     task: String,
     graph: WorkflowGraph,
     mut artifacts: Vec<ArtifactRecord>,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<WorkflowRunState, VmError> {
     crate::llm::enable_tracing();
     crate::tracing::set_tracing_enabled(true);
@@ -383,7 +383,7 @@ pub(super) fn prepare_workflow_state(
         tool_recordings: Vec::new(),
         hitl_questions: Vec::new(),
         persona_runtime: Vec::new(),
-        metadata: BTreeMap::new(),
+        metadata: std::collections::BTreeMap::new(),
         persisted_path: None,
     });
     let requested_mutation_scope = optional_string_option(options, "mutation_scope")
@@ -409,7 +409,7 @@ pub(super) fn prepare_workflow_state(
     let audit_input = options
         .get("audit")
         .cloned()
-        .unwrap_or_else(|| VmValue::Dict(std::sync::Arc::new(BTreeMap::new())));
+        .unwrap_or_else(|| VmValue::dict(crate::value::DictMap::new()));
     let mut mutation_session: MutationSessionRecord =
         serde_json::from_value(crate::llm::vm_value_to_json(&audit_input))
             .map_err(|e| VmError::Runtime(format!("workflow_execute: audit parse error: {e}")))?;
@@ -657,7 +657,7 @@ fn stage_metadata(
 }
 
 fn workflow_stage_plan_to_vm(scope: &StageExecutionScope) -> Result<VmValue, VmError> {
-    let mut dict = BTreeMap::new();
+    let mut dict = crate::value::DictMap::new();
     dict.put_str("kind", scope.node.kind.as_str());
     match &scope.execution {
         StageExecution::Precomputed(executed) => {
@@ -688,11 +688,11 @@ fn workflow_stage_plan_to_vm(scope: &StageExecutionScope) -> Result<VmValue, VmE
                 );
                 dict.insert(
                     "llm_options".to_string(),
-                    VmValue::Dict(std::sync::Arc::new(prepared.llm_options.clone())),
+                    VmValue::dict(prepared.llm_options.clone()),
                 );
                 dict.insert(
                     "agent_loop_options".to_string(),
-                    VmValue::Dict(std::sync::Arc::new(prepared.agent_loop_options.clone())),
+                    VmValue::dict(prepared.agent_loop_options.clone()),
                 );
             }
         }
@@ -706,11 +706,11 @@ fn workflow_stage_plan_to_vm(scope: &StageExecutionScope) -> Result<VmValue, VmE
             dict.insert("artifacts".to_string(), to_vm(artifacts)?);
             dict.insert(
                 "map_options".to_string(),
-                VmValue::Dict(std::sync::Arc::new(map_options.clone())),
+                VmValue::dict(map_options.clone()),
             );
         }
     }
-    Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+    Ok(VmValue::dict(dict))
 }
 
 fn workflow_stage_error_result(error: &VmError) -> serde_json::Value {
@@ -945,7 +945,7 @@ pub(super) async fn prepare_workflow_stage_state(
     ctx: &AsyncBuiltinCtx,
     mut state: WorkflowRunState,
     node_id: String,
-    options: &BTreeMap<String, VmValue>,
+    options: &crate::value::DictMap,
 ) -> Result<(WorkflowRunState, VmValue), VmError> {
     if state.stage_scope.is_some() {
         return Err(VmError::Runtime(format!(
@@ -1045,7 +1045,7 @@ pub(super) async fn prepare_workflow_stage_state(
             .iter()
             .map(|artifact| artifact.id.clone())
             .collect::<Vec<_>>();
-        let mut map_options = BTreeMap::new();
+        let mut map_options = crate::value::DictMap::new();
         map_options.put_str("task", state.run.task.clone());
         if let Some(transcript) = transcript.clone() {
             map_options.insert("transcript".to_string(), transcript);

--- a/crates/harn-vm/src/stdlib/workflow/tests.rs
+++ b/crates/harn-vm/src/stdlib/workflow/tests.rs
@@ -7,7 +7,6 @@ use crate::orchestration::{
     VerificationContract, WorkflowGraph, WorkflowNode,
 };
 use crate::tracing::{set_tracing_enabled, span_end, span_start, SpanKind};
-use std::collections::BTreeMap;
 
 #[test]
 fn load_run_tree_recurses_into_child_runs() {
@@ -71,7 +70,7 @@ fn load_run_tree_recovers_child_runs_from_stage_worker_metadata() {
         stages: vec![RunStageRecord {
             id: "stage_1".to_string(),
             node_id: "delegate".to_string(),
-            metadata: BTreeMap::from([(
+            metadata: std::collections::BTreeMap::from_iter([(
                 "worker".to_string(),
                 serde_json::json!({
                     "id": "worker_1",
@@ -108,7 +107,7 @@ fn deterministic_replay_preserves_worker_child_run_metadata() {
         status: "completed".to_string(),
         outcome: "subagent_completed".to_string(),
         branch: Some("success".to_string()),
-        metadata: BTreeMap::from([(
+        metadata: std::collections::BTreeMap::from_iter([(
             "worker".to_string(),
             serde_json::json!({
                 "id": "worker_1",
@@ -180,9 +179,7 @@ async fn verify_stage_reads_transcript_from_session_store() {
             output_kinds: vec!["verification_result".to_string()],
             ..Default::default()
         },
-        raw_model_policy: Some(crate::value::VmValue::Dict(std::sync::Arc::new(
-            raw_model_policy,
-        ))),
+        raw_model_policy: Some(crate::value::VmValue::dict(raw_model_policy)),
         ..Default::default()
     };
 
@@ -209,7 +206,7 @@ async fn verify_stage_reads_transcript_from_session_store() {
 fn workflow_verification_contracts_collect_exact_requirements() {
     let graph = WorkflowGraph {
         entry: "act".to_string(),
-        nodes: BTreeMap::from([(
+        nodes: std::collections::BTreeMap::from_iter([(
             "verify".to_string(),
             WorkflowNode {
                 id: Some("verify".to_string()),
@@ -299,7 +296,7 @@ fn stage_verification_contracts_can_scope_to_local_contract_only() {
             "required_paths": ["src/current.ts"],
             "notes": ["Only the current batch path is in scope."],
         })),
-        metadata: BTreeMap::from([
+        metadata: std::collections::BTreeMap::from_iter([
             (
                 crate::orchestration::WORKFLOW_VERIFICATION_SCOPE_METADATA_KEY.to_string(),
                 serde_json::json!("local_only"),
@@ -334,7 +331,7 @@ fn reset_drains_interned_workflow_run_state() {
     crate::reset_thread_local_state();
     let graph = WorkflowGraph {
         entry: "act".to_string(),
-        nodes: BTreeMap::from([(
+        nodes: std::collections::BTreeMap::from_iter([(
             "act".to_string(),
             WorkflowNode {
                 id: Some("act".to_string()),
@@ -348,7 +345,7 @@ fn reset_drains_interned_workflow_run_state() {
         "leak-probe".to_string(),
         graph,
         Vec::new(),
-        &BTreeMap::new(),
+        &crate::value::DictMap::new(),
     )
     .expect("prepare workflow state");
     super::state::insert_workflow_state(state);

--- a/crates/harn-vm/src/stdlib/workflow_messages.rs
+++ b/crates/harn-vm/src/stdlib/workflow_messages.rs
@@ -488,7 +488,7 @@ fn record_update_response(
 pub(crate) fn register_workflow_message_builtins(vm: &mut Vm) {
     vm.set_global(
         "workflow",
-        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        VmValue::dict(BTreeMap::from([
             (
                 "signal".to_string(),
                 VmValue::BuiltinRef(std::sync::Arc::from("workflow.signal")),
@@ -529,7 +529,7 @@ pub(crate) fn register_workflow_message_builtins(vm: &mut Vm) {
                 "continue_as_new".to_string(),
                 VmValue::BuiltinRef(std::sync::Arc::from("workflow.continue_as_new")),
             ),
-        ]))),
+        ])),
     );
 
     for def in MODULE_BUILTINS {

--- a/crates/harn-vm/src/stdlib/xml.rs
+++ b/crates/harn-vm/src/stdlib/xml.rs
@@ -81,7 +81,7 @@ struct XmlOptions {
 }
 
 impl XmlOptions {
-    fn from_dict(options: Option<&BTreeMap<String, VmValue>>) -> Self {
+    fn from_dict(options: Option<&crate::value::DictMap>) -> Self {
         let mut out = XmlOptions {
             root: "root".to_string(),
             item_tag: "item".to_string(),
@@ -313,7 +313,7 @@ struct ParseOptions {
 }
 
 impl ParseOptions {
-    fn from_dict(options: Option<&BTreeMap<String, VmValue>>) -> Self {
+    fn from_dict(options: Option<&crate::value::DictMap>) -> Self {
         let mut out = ParseOptions::default();
         let Some(dict) = options else {
             return out;
@@ -335,13 +335,13 @@ fn parse_xml(text: &str, parse_opts: &ParseOptions) -> Result<VmValue, VmError> 
     };
     p.skip_ws_and_prologue()?;
     if p.pos >= p.src.len() {
-        return Ok(VmValue::Dict(std::sync::Arc::new(BTreeMap::new())));
+        return Ok(VmValue::dict(BTreeMap::new()));
     }
     let (tag, value) = p.parse_element()?;
     p.skip_ws_and_prologue().ok();
     let mut out = BTreeMap::new();
     out.insert(tag, value);
-    Ok(VmValue::Dict(std::sync::Arc::new(out)))
+    Ok(VmValue::dict(out))
 }
 
 struct Parser<'a> {
@@ -613,13 +613,13 @@ fn finalize_element(
             if opts.preserve_repeated_tag {
                 let mut out = BTreeMap::new();
                 out.insert(tag, VmValue::List(std::sync::Arc::new(values)));
-                return VmValue::Dict(std::sync::Arc::new(out));
+                return VmValue::dict(out);
             }
             return VmValue::List(std::sync::Arc::new(values));
         }
         let mut out = BTreeMap::new();
         out.insert(tag, values.into_iter().next().unwrap());
-        return VmValue::Dict(std::sync::Arc::new(out));
+        return VmValue::dict(out);
     }
     let mut out = BTreeMap::new();
     for (tag, mut values) in children {
@@ -634,15 +634,12 @@ fn finalize_element(
         for (k, v) in attrs {
             attr_dict.insert(k, VmValue::String(std::sync::Arc::from(v)));
         }
-        out.insert(
-            "@attr".to_string(),
-            VmValue::Dict(std::sync::Arc::new(attr_dict)),
-        );
+        out.insert("@attr".to_string(), VmValue::dict(attr_dict));
     }
     if !trimmed.is_empty() {
         out.put_str("@text", trimmed);
     }
-    VmValue::Dict(std::sync::Arc::new(out))
+    VmValue::dict(out)
 }
 
 fn scalar_from_text(text: &str) -> VmValue {
@@ -667,11 +664,8 @@ fn attrs_to_value(attrs: Vec<(String, String)>) -> VmValue {
     for (k, v) in attrs {
         attr_dict.insert(k, VmValue::String(std::sync::Arc::from(v)));
     }
-    out.insert(
-        "@attr".to_string(),
-        VmValue::Dict(std::sync::Arc::new(attr_dict)),
-    );
-    VmValue::Dict(std::sync::Arc::new(out))
+    out.insert("@attr".to_string(), VmValue::dict(attr_dict));
+    VmValue::dict(out)
 }
 
 #[cfg(test)]
@@ -683,7 +677,7 @@ mod tests {
         for (k, v) in entries {
             map.insert((*k).to_string(), v.clone());
         }
-        VmValue::Dict(std::sync::Arc::new(map))
+        VmValue::dict(map)
     }
 
     fn opts() -> XmlOptions {

--- a/crates/harn-vm/src/step_runtime.rs
+++ b/crates/harn-vm/src/step_runtime.rs
@@ -160,9 +160,9 @@ pub struct CompletedStep {
 
 thread_local! {
     static STEP_REGISTRY: RefCell<BTreeMap<String, Arc<StepDefinition>>> =
-        const { RefCell::new(BTreeMap::new()) };
+        const { RefCell::new(std::collections::BTreeMap::new()) };
     static PERSONA_REGISTRY: RefCell<BTreeMap<String, Arc<PersonaDefinition>>> =
-        const { RefCell::new(BTreeMap::new()) };
+        const { RefCell::new(std::collections::BTreeMap::new()) };
     static STEP_REGISTRY_LEN: Cell<usize> = const { Cell::new(0) };
     static PERSONA_REGISTRY_LEN: Cell<usize> = const { Cell::new(0) };
     static PERSONA_STACK: RefCell<Vec<ActivePersona>> = const { RefCell::new(Vec::new()) };
@@ -856,7 +856,7 @@ fn budget_exhausted_error(
     consumed_tokens: f64,
     consumed_cost_usd: f64,
 ) -> VmError {
-    let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+    let mut dict: crate::value::DictMap = crate::value::DictMap::new();
     dict.put_str("category", "budget_exceeded");
     dict.put_str("kind", "budget_exhausted");
     dict.put_str("reason", "step_budget_exhausted");
@@ -886,7 +886,7 @@ fn budget_exhausted_error(
             definition.name, limit, consumed_tokens as i64, limit_value as i64
         ),
     );
-    VmError::Thrown(VmValue::Dict(std::sync::Arc::new(dict)))
+    VmError::Thrown(VmValue::dict(dict))
 }
 
 /// Returns true if the thrown value looks like a budget-exhausted
@@ -930,7 +930,7 @@ pub fn mark_escalated(err: VmError, step_name: Option<&str>, function: Option<&s
         next.entry("function".to_string())
             .or_insert_with(|| VmValue::String(std::sync::Arc::from(function.to_string())));
     }
-    VmError::Thrown(VmValue::Dict(std::sync::Arc::new(next)))
+    VmError::Thrown(VmValue::dict(next))
 }
 
 /// Drain the completed-step log. Used by receipt builders that want a
@@ -986,21 +986,18 @@ mod tests {
     #[test]
     fn registers_and_pops_step_from_dict() {
         fresh_state();
-        let mut budget: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut budget: crate::value::DictMap = crate::value::DictMap::new();
         budget.insert("max_tokens".to_string(), VmValue::Int(100));
         budget.insert("max_usd".to_string(), VmValue::Float(0.05));
-        let mut meta: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut meta: crate::value::DictMap = crate::value::DictMap::new();
         meta.put_str("name", "plan");
         meta.put_str("model", "claude-haiku-4-5");
         meta.put_str("error_boundary", "continue");
-        meta.insert(
-            "budget".to_string(),
-            VmValue::Dict(std::sync::Arc::new(budget)),
-        );
+        meta.insert("budget".to_string(), VmValue::dict(budget));
 
         register_step_from_dict(vec![
             VmValue::String(std::sync::Arc::from("plan_step")),
-            VmValue::Dict(std::sync::Arc::new(meta)),
+            VmValue::dict(meta),
         ])
         .expect("registration succeeds");
 
@@ -1071,15 +1068,15 @@ mod tests {
     #[test]
     fn stage_policy_narrows_but_does_not_widen_parent_policy() {
         fresh_state();
-        let mut meta: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut meta: crate::value::DictMap = crate::value::DictMap::new();
         meta.put_str("name", "research");
         register_step_from_dict(vec![
             VmValue::String(std::sync::Arc::from("research_step")),
-            VmValue::Dict(std::sync::Arc::new(meta)),
+            VmValue::dict(meta),
         ])
         .expect("step registration");
 
-        let mut stage_dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut stage_dict: crate::value::DictMap = crate::value::DictMap::new();
         stage_dict.put_str("name", "research");
         // Stage tries to add `edit` on top of a parent that only allowed `read`.
         stage_dict.insert(
@@ -1089,7 +1086,7 @@ mod tests {
                 VmValue::String(std::sync::Arc::from("edit")),
             ])),
         );
-        let mut persona_meta: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut persona_meta: crate::value::DictMap = crate::value::DictMap::new();
         persona_meta.put_str("name", "scoped");
         persona_meta.insert(
             "stages".to_string(),
@@ -1099,7 +1096,7 @@ mod tests {
         );
         register_persona_from_dict(vec![
             VmValue::String(std::sync::Arc::from("scoped_persona")),
-            VmValue::Dict(std::sync::Arc::new(persona_meta)),
+            VmValue::dict(persona_meta),
         ])
         .expect("persona registration");
 
@@ -1121,15 +1118,15 @@ mod tests {
     #[test]
     fn stage_policy_is_pushed_and_popped_around_step() {
         fresh_state();
-        let mut meta: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut meta: crate::value::DictMap = crate::value::DictMap::new();
         meta.put_str("name", "research");
         register_step_from_dict(vec![
             VmValue::String(std::sync::Arc::from("research_step")),
-            VmValue::Dict(std::sync::Arc::new(meta)),
+            VmValue::dict(meta),
         ])
         .expect("step registration succeeds");
 
-        let mut stage_dict: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut stage_dict: crate::value::DictMap = crate::value::DictMap::new();
         stage_dict.put_str("name", "research");
         stage_dict.insert(
             "allowed_tools".to_string(),
@@ -1137,7 +1134,7 @@ mod tests {
                 std::sync::Arc::from("read"),
             )])),
         );
-        let mut persona_meta: BTreeMap<String, VmValue> = BTreeMap::new();
+        let mut persona_meta: crate::value::DictMap = crate::value::DictMap::new();
         persona_meta.put_str("name", "scoped");
         persona_meta.insert(
             "stages".to_string(),
@@ -1147,7 +1144,7 @@ mod tests {
         );
         register_persona_from_dict(vec![
             VmValue::String(std::sync::Arc::from("scoped_persona")),
-            VmValue::Dict(std::sync::Arc::new(persona_meta)),
+            VmValue::dict(persona_meta),
         ])
         .expect("persona registration succeeds");
 

--- a/crates/harn-vm/src/store.rs
+++ b/crates/harn-vm/src/store.rs
@@ -128,7 +128,7 @@ fn json_to_vm(jv: &serde_json::Value) -> VmValue {
             for (k, v) in map {
                 m.insert(k.clone(), json_to_vm(v));
             }
-            VmValue::Dict(std::sync::Arc::new(m))
+            VmValue::dict(m)
         }
     }
 }

--- a/crates/harn-vm/src/synchronization.rs
+++ b/crates/harn-vm/src/synchronization.rs
@@ -337,7 +337,7 @@ impl VmSyncPrimitive {
             "total_held_ms".to_string(),
             VmValue::Int(metrics.total_held_ms as i64),
         );
-        VmValue::Dict(std::sync::Arc::new(dict))
+        VmValue::dict(dict)
     }
 }
 

--- a/crates/harn-vm/src/tool_surface.rs
+++ b/crates/harn-vm/src/tool_surface.rs
@@ -254,7 +254,7 @@ fn parse_tool_annotations(map: &serde_json::Map<String, serde_json::Value>) -> T
 
 pub fn tool_annotations_from_spec(value: &serde_json::Value) -> BTreeMap<String, ToolAnnotations> {
     match value {
-        serde_json::Value::Null => BTreeMap::new(),
+        serde_json::Value::Null => std::collections::BTreeMap::new(),
         serde_json::Value::Array(items) => items
             .iter()
             .filter_map(|item| match item {
@@ -277,20 +277,20 @@ pub fn tool_annotations_from_spec(value: &serde_json::Value) -> BTreeMap<String,
                 .and_then(|value| value.as_str())
                 .filter(|name| !name.is_empty())
                 .map(|name| {
-                    let mut annotations = BTreeMap::new();
+                    let mut annotations = std::collections::BTreeMap::new();
                     annotations.insert(name.to_string(), parse_tool_annotations(map));
                     annotations
                 })
                 .unwrap_or_default()
         }
-        _ => BTreeMap::new(),
+        _ => std::collections::BTreeMap::new(),
     }
 }
 
 pub fn tool_capability_policy_from_spec(value: &serde_json::Value) -> CapabilityPolicy {
     let tools = tool_names_from_spec(value);
     let tool_annotations = tool_annotations_from_spec(value);
-    let mut capabilities: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut capabilities: BTreeMap<String, Vec<String>> = std::collections::BTreeMap::new();
     for annotations in tool_annotations.values() {
         for (capability, ops) in &annotations.capabilities {
             let entry = capabilities.entry(capability.clone()).or_default();
@@ -1311,7 +1311,7 @@ mod tests {
         policy
             .tool_annotations
             .insert("run".into(), execute_annotations());
-        let tools = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        let tools = VmValue::dict(std::collections::BTreeMap::from_iter([
             (
                 "_type".into(),
                 VmValue::String(std::sync::Arc::from("tool_registry")),
@@ -1319,20 +1319,23 @@ mod tests {
             (
                 "tools".into(),
                 VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
-                    std::sync::Arc::new(BTreeMap::from([
-                        ("name".into(), VmValue::String(std::sync::Arc::from("run"))),
+                    std::sync::Arc::new(crate::value::DictMap::from_iter([
                         (
-                            "parameters".into(),
-                            VmValue::Dict(std::sync::Arc::new(BTreeMap::new())),
+                            "name".to_string(),
+                            VmValue::String(std::sync::Arc::from("run")),
                         ),
                         (
-                            "executor".into(),
+                            "parameters".to_string(),
+                            VmValue::dict(crate::value::DictMap::new()),
+                        ),
+                        (
+                            "executor".to_string(),
                             VmValue::String(std::sync::Arc::from("host_bridge")),
                         ),
                     ])),
                 )])),
             ),
-        ])));
+        ]));
         let report = validate_tool_surface(&ToolSurfaceInput {
             tools: Some(tools),
             policy: Some(policy),

--- a/crates/harn-vm/src/tracing.rs
+++ b/crates/harn-vm/src/tracing.rs
@@ -594,12 +594,12 @@ pub fn span_to_vm_value(span: &Span) -> VmValue {
     d.insert("duration_ms".into(), VmValue::Int(span.duration_ms as i64));
 
     if !span.metadata.is_empty() {
-        let meta: BTreeMap<String, VmValue> = span
+        let meta: crate::value::DictMap = span
             .metadata
             .iter()
             .map(|(k, v)| (k.clone(), crate::stdlib::json_to_vm_value(v)))
             .collect();
-        d.insert("metadata".into(), VmValue::Dict(std::sync::Arc::new(meta)));
+        d.insert("metadata".into(), VmValue::dict(meta));
     }
     if !span.links.is_empty() {
         d.insert(
@@ -614,7 +614,7 @@ pub fn span_to_vm_value(span: &Span) -> VmValue {
         );
     }
 
-    VmValue::Dict(std::sync::Arc::new(d))
+    VmValue::dict(d)
 }
 
 /// Generate a formatted summary of all spans.

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -2668,7 +2668,7 @@ impl Dispatcher {
         // body strings without `{{ ... }}` round-trip unchanged.
         let event_json =
             serde_json::to_value(event).map_err(|error| DispatchError::Serde(error.to_string()))?;
-        let mut bindings = BTreeMap::new();
+        let mut bindings = crate::value::DictMap::new();
         bindings.insert(
             "event".to_string(),
             crate::schema::json_to_vm_value(&event_json),

--- a/crates/harn-vm/src/triggers/dispatcher/util.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/util.rs
@@ -121,7 +121,7 @@ pub(super) fn event_to_handler_value(event: &TriggerEvent) -> Result<VmValue, Di
                 "raw_body".to_string(),
                 VmValue::Bytes(std::sync::Arc::new(raw_body.clone())),
             );
-            Ok(VmValue::Dict(std::sync::Arc::new(map)))
+            Ok(VmValue::dict(map))
         }
         (_, other) => Ok(other),
     }

--- a/crates/harn-vm/src/typecheck.rs
+++ b/crates/harn-vm/src/typecheck.rs
@@ -568,12 +568,9 @@ mod tests {
         }]);
         let mut good = std::collections::BTreeMap::new();
         good.insert("x".to_string(), vm_int(7));
-        assert!(matches_type(
-            &VmValue::Dict(std::sync::Arc::new(good)),
-            &shape
-        ));
+        assert!(matches_type(&VmValue::dict(good), &shape));
         assert!(!matches_type(
-            &VmValue::Dict(std::sync::Arc::new(std::collections::BTreeMap::new())),
+            &VmValue::dict(std::collections::BTreeMap::new()),
             &shape
         ));
     }
@@ -639,11 +636,10 @@ mod tests {
 
     #[test]
     fn validate_user_call_uses_cached_runtime_guard_metadata() {
-        let string_schema =
-            VmValue::Dict(std::sync::Arc::new(std::collections::BTreeMap::from([(
-                "type".to_string(),
-                VmValue::String(std::sync::Arc::from("string")),
-            )])));
+        let string_schema = VmValue::dict(std::collections::BTreeMap::from([(
+            "type".to_string(),
+            VmValue::String(std::sync::Arc::from("string")),
+        )]));
         let guard = RuntimeParamGuard::CanonicalSchema(
             crate::schema::canonical_param_schema(&string_schema).unwrap(),
         );

--- a/crates/harn-vm/src/value/build.rs
+++ b/crates/harn-vm/src/value/build.rs
@@ -1,4 +1,4 @@
-//! Ergonomic builders for the `BTreeMap<String, VmValue>` that backs
+//! Ergonomic builders for the string-keyed `VmValue` maps that back
 //! `VmValue::Dict`.
 //!
 //! Harn builtins assemble result dicts by hand, and the raw
@@ -7,16 +7,37 @@
 //! field. [`VmDictExt`] collapses each field to a single call while keeping
 //! the receiver, so the common shapes read as `dict.put_str("key", v)` /
 //! `dict.put_opt_str("key", maybe.as_deref())`. There is no behavioural
-//! change: every method is a thin wrapper over `BTreeMap::insert`.
+//! change: every method is a thin wrapper over the map's `insert`.
 
 use std::collections::BTreeMap;
 
-use super::VmValue;
+use super::{DictMap, VmValue};
+
+/// Minimal string-keyed insert, implemented for both the transient `BTreeMap`
+/// builders still used at call sites and the persistent [`DictMap`] that backs
+/// a live `VmValue::Dict`. Keeps [`VmDictExt`] a single generic impl rather
+/// than two near-identical copies.
+pub trait DictInsert {
+    fn dict_insert(&mut self, key: String, value: VmValue);
+}
+
+impl DictInsert for BTreeMap<String, VmValue> {
+    fn dict_insert(&mut self, key: String, value: VmValue) {
+        self.insert(key, value);
+    }
+}
+
+impl DictInsert for DictMap {
+    fn dict_insert(&mut self, key: String, value: VmValue) {
+        self.insert(key, value);
+    }
+}
 
 /// Field-insertion helpers for a `VmValue::Dict` backing map.
 ///
-/// Implemented for the concrete `BTreeMap<String, VmValue>` only, so the
-/// methods are unavailable on unrelated maps and cannot be applied by mistake.
+/// Implemented for any [`DictInsert`] map (the transient `BTreeMap` builders
+/// and the persistent [`DictMap`]), so the methods are unavailable on unrelated
+/// maps and cannot be applied by mistake.
 pub trait VmDictExt {
     /// Inserts `value` under `key` (owning the key as a `String`).
     fn put(&mut self, key: &str, value: VmValue);
@@ -32,33 +53,57 @@ pub trait VmDictExt {
     fn put_int(&mut self, key: &str, value: i64);
 }
 
-impl VmDictExt for BTreeMap<String, VmValue> {
+/// `retain` for the persistent [`DictMap`].
+///
+/// `imbl::OrdMap` has no in-place `retain` (it is structurally shared), so this
+/// rebuilds the map keeping only the entries for which `keep` returns true. The
+/// closure signature mirrors `BTreeMap::retain` (`&K, &mut V`) so call sites
+/// read identically. Cold-path helper (filter/dedup), so the rebuild cost is
+/// not on any hot loop.
+pub trait DictRetain {
+    fn retain(&mut self, keep: impl FnMut(&String, &mut VmValue) -> bool);
+}
+
+impl DictRetain for DictMap {
+    fn retain(&mut self, mut keep: impl FnMut(&String, &mut VmValue) -> bool) {
+        let mut result = DictMap::new();
+        for (k, v) in self.iter() {
+            let mut v = v.clone();
+            if keep(k, &mut v) {
+                result.insert(k.clone(), v);
+            }
+        }
+        *self = result;
+    }
+}
+
+impl<M: DictInsert> VmDictExt for M {
     fn put(&mut self, key: &str, value: VmValue) {
-        self.insert(key.to_string(), value);
+        self.dict_insert(key.to_string(), value);
     }
 
     fn put_str(&mut self, key: &str, value: impl AsRef<str>) {
-        self.insert(key.to_string(), VmValue::string(value));
+        self.dict_insert(key.to_string(), VmValue::string(value));
     }
 
     fn put_opt_str(&mut self, key: &str, value: Option<impl AsRef<str>>) {
         if let Some(value) = value {
-            self.insert(key.to_string(), VmValue::string(value));
+            self.dict_insert(key.to_string(), VmValue::string(value));
         }
     }
 
     fn put_opt(&mut self, key: &str, value: Option<VmValue>) {
         if let Some(value) = value {
-            self.insert(key.to_string(), value);
+            self.dict_insert(key.to_string(), value);
         }
     }
 
     fn put_bool(&mut self, key: &str, value: bool) {
-        self.insert(key.to_string(), VmValue::Bool(value));
+        self.dict_insert(key.to_string(), VmValue::Bool(value));
     }
 
     fn put_int(&mut self, key: &str, value: i64) {
-        self.insert(key.to_string(), VmValue::Int(value));
+        self.dict_insert(key.to_string(), VmValue::Int(value));
     }
 }
 

--- a/crates/harn-vm/src/value/core.rs
+++ b/crates/harn-vm/src/value/core.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::{future::Future, pin::Pin};
@@ -28,6 +28,19 @@ pub type VmAsyncBuiltinFn = Arc<
 >;
 
 type Shared<T> = Arc<T>;
+
+/// Backing store for [`VmValue::Dict`]: a persistent, ordered, structurally
+/// shared map.
+///
+/// Replacing the former `BTreeMap` with `imbl::OrdMap` turns the copy-on-write
+/// `Arc::make_mut` clone — performed on every dict mutation whenever the value
+/// is aliased (on the stack, in another local, captured by a closure) — from an
+/// O(n) deep copy of every key and entry into an O(log n) path copy. Ordering
+/// and the read API (`get` / `iter` / `keys` / `values` / `contains_key` /
+/// `range` / `len`) match `BTreeMap`, so dict reads are unchanged. The `Arc`
+/// wrapper is retained so reference identity (`Arc::ptr_eq`) — used by the `===`
+/// operator and `value_identity_key` — keeps its current semantics.
+pub type DictMap = imbl::OrdMap<String, VmValue>;
 
 /// Character count with a byte-length fast path for ASCII text.
 ///
@@ -70,7 +83,7 @@ impl StructLayout {
         }
     }
 
-    pub fn from_map(struct_name: impl Into<String>, fields: &BTreeMap<String, VmValue>) -> Self {
+    pub fn from_map(struct_name: impl Into<String>, fields: &crate::value::DictMap) -> Self {
         Self::new(struct_name, fields.keys().cloned().collect())
     }
 
@@ -153,7 +166,7 @@ pub enum VmValue {
     Bool(bool),
     Nil,
     List(Shared<Vec<VmValue>>),
-    Dict(Shared<BTreeMap<String, VmValue>>),
+    Dict(Shared<DictMap>),
     Closure(Shared<VmClosure>),
     /// Reference to a registered builtin function, used when a builtin name is
     /// referenced as a value (e.g. `snake_dict.rekey(snake_to_camel)`). The
@@ -272,6 +285,20 @@ impl VmValue {
         }))
     }
 
+    /// Construct a [`VmValue::Dict`] from any iterator of `(key, value)`
+    /// entries. Accepts the `BTreeMap` that most builders still assemble (it is
+    /// `IntoIterator<Item = (String, VmValue)>`) and collects it into the
+    /// persistent [`DictMap`], so callers keep their familiar map-building code
+    /// while the stored value gains structural sharing.
+    pub fn dict(entries: impl IntoIterator<Item = (String, VmValue)>) -> Self {
+        VmValue::Dict(Shared::new(entries.into_iter().collect::<DictMap>()))
+    }
+
+    /// Construct a [`VmValue::Dict`] from an already-built [`DictMap`].
+    pub fn dict_map(map: DictMap) -> Self {
+        VmValue::Dict(Shared::new(map))
+    }
+
     pub fn channel(handle: VmChannelHandle) -> Self {
         VmValue::Channel(Shared::new(handle))
     }
@@ -306,7 +333,7 @@ impl VmValue {
 
     pub fn struct_instance(
         struct_name: impl Into<Shared<str>>,
-        fields: BTreeMap<String, VmValue>,
+        fields: crate::value::DictMap,
     ) -> Self {
         Self::struct_instance_from_map(struct_name.into().to_string(), fields)
     }
@@ -406,7 +433,7 @@ impl VmValue {
         }
     }
 
-    pub fn struct_fields_map(&self) -> Option<BTreeMap<String, VmValue>> {
+    pub fn struct_fields_map(&self) -> Option<crate::value::DictMap> {
         match self {
             VmValue::StructInstance { layout, fields } => {
                 Some(struct_fields_to_map(layout, fields))
@@ -417,7 +444,7 @@ impl VmValue {
 
     pub fn struct_instance_from_map(
         struct_name: impl Into<String>,
-        fields: BTreeMap<String, VmValue>,
+        fields: crate::value::DictMap,
     ) -> Self {
         let layout = Shared::new(StructLayout::from_map(struct_name, &fields));
         let slots = layout
@@ -434,7 +461,7 @@ impl VmValue {
     pub fn struct_instance_with_layout(
         struct_name: impl Into<String>,
         field_names: Vec<String>,
-        field_values: BTreeMap<String, VmValue>,
+        field_values: crate::value::DictMap,
     ) -> Self {
         let layout = Shared::new(StructLayout::new(struct_name, field_names));
         let fields = layout
@@ -657,8 +684,8 @@ impl VmValue {
         }
     }
 
-    /// Get the value as a BTreeMap reference, if it's a Dict.
-    pub fn as_dict(&self) -> Option<&BTreeMap<String, VmValue>> {
+    /// Get the value as a [`DictMap`] reference, if it's a Dict.
+    pub fn as_dict(&self) -> Option<&DictMap> {
         if let VmValue::Dict(d) = self {
             Some(d)
         } else {
@@ -686,7 +713,7 @@ impl VmValue {
 pub fn struct_fields_to_map(
     layout: &StructLayout,
     fields: &[Option<VmValue>],
-) -> BTreeMap<String, VmValue> {
+) -> crate::value::DictMap {
     layout
         .field_names()
         .iter()

--- a/crates/harn-vm/src/value/env.rs
+++ b/crates/harn-vm/src/value/env.rs
@@ -78,7 +78,7 @@ impl Scope {
     #[inline]
     fn empty() -> Self {
         Self {
-            vars: Arc::new(BTreeMap::new()),
+            vars: Arc::new(std::collections::BTreeMap::new()),
         }
     }
 }
@@ -147,8 +147,8 @@ impl VmEnv {
         Ok(())
     }
 
-    pub fn all_variables(&self) -> BTreeMap<String, VmValue> {
-        let mut vars = BTreeMap::new();
+    pub fn all_variables(&self) -> crate::value::DictMap {
+        let mut vars = crate::value::DictMap::new();
         for scope in &self.scopes {
             for (name, (value, _)) in scope.vars.iter() {
                 vars.insert(name.clone(), value.clone());

--- a/crates/harn-vm/src/value/mod.rs
+++ b/crates/harn-vm/src/value/mod.rs
@@ -7,9 +7,9 @@ mod structural;
 
 pub type VmMutex<T> = parking_lot::Mutex<T>;
 
-pub use build::VmDictExt;
+pub use build::{DictRetain, VmDictExt};
 pub use core::{
-    string_char_count, struct_fields_to_map, StructLayout, VmAsyncBuiltinFn, VmBuiltinFn,
+    string_char_count, struct_fields_to_map, DictMap, StructLayout, VmAsyncBuiltinFn, VmBuiltinFn,
     VmBuiltinRefId, VmEnumVariant, VmValue,
 };
 pub use env::{closest_match, ModuleFunctionRegistry, ModuleState, VmClosure, VmEnv};

--- a/crates/harn-vm/src/value/tests.rs
+++ b/crates/harn-vm/src/value/tests.rs
@@ -41,9 +41,12 @@ fn list(items: Vec<VmValue>) -> VmValue {
 }
 
 fn dict(pairs: Vec<(&str, VmValue)>) -> VmValue {
-    VmValue::Dict(std::sync::Arc::new(
-        pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
-    ))
+    VmValue::dict(
+        pairs
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect::<crate::value::DictMap>(),
+    )
 }
 
 #[test]

--- a/crates/harn-vm/src/vm/debug.rs
+++ b/crates/harn-vm/src/vm/debug.rs
@@ -18,7 +18,7 @@ pub enum DebugAction {
 #[derive(Debug, Clone)]
 pub struct DebugState {
     pub line: usize,
-    pub variables: std::collections::BTreeMap<String, VmValue>,
+    pub variables: crate::value::DictMap,
     pub frame_name: String,
     pub frame_depth: usize,
 }

--- a/crates/harn-vm/src/vm/interrupts.rs
+++ b/crates/harn-vm/src/vm/interrupts.rs
@@ -37,7 +37,7 @@ impl Vm {
             handler,
         });
 
-        Ok(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        Ok(VmValue::dict(BTreeMap::from([
             ("handle".to_string(), VmValue::Int(handle)),
             (
                 "signals".to_string(),
@@ -49,7 +49,7 @@ impl Vm {
                 )),
             ),
             ("once".to_string(), VmValue::Bool(once)),
-        ]))))
+        ])))
     }
 
     pub(crate) fn unregister_interrupt_handler(&mut self, handle: &VmValue) -> Result<(), VmError> {

--- a/crates/harn-vm/src/vm/iter.rs
+++ b/crates/harn-vm/src/vm/iter.rs
@@ -4,7 +4,7 @@
 //! iterator; once `next` returns `None` the variant is replaced with
 //! `Exhausted`.
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::VecDeque;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -65,7 +65,7 @@ pub enum VmIter {
     },
     /// Snapshot over a dict; yields `Pair(key, value)` items.
     Dict {
-        entries: Arc<BTreeMap<String, VmValue>>,
+        entries: Arc<crate::value::DictMap>,
         keys: Vec<String>,
         idx: usize,
     },

--- a/crates/harn-vm/src/vm/methods/dict.rs
+++ b/crates/harn-vm/src/vm/methods/dict.rs
@@ -5,7 +5,7 @@ use crate::value::{VmError, VmValue};
 
 impl crate::vm::Vm {
     pub(super) fn call_dict_method_sync(
-        map: &Arc<BTreeMap<String, VmValue>>,
+        map: &Arc<crate::value::DictMap>,
         method: &str,
         args: &[VmValue],
     ) -> Option<Result<VmValue, VmError>> {
@@ -39,7 +39,7 @@ impl crate::vm::Vm {
                     }
                     let mut result = (**map).clone();
                     result.extend(other.iter().map(|(k, v)| (k.clone(), v.clone())));
-                    Ok(VmValue::Dict(std::sync::Arc::new(result)))
+                    Ok(VmValue::dict(result))
                 } else {
                     Ok(VmValue::Dict(Arc::clone(map)))
                 }
@@ -54,7 +54,7 @@ impl crate::vm::Vm {
                 let key = args.first().map(|a| a.display()).unwrap_or_default();
                 let mut result = (**map).clone();
                 result.remove(&key);
-                Ok(VmValue::Dict(std::sync::Arc::new(result)))
+                Ok(VmValue::dict(result))
             }
             "get" => {
                 let key = args.first().map(|a| a.display()).unwrap_or_default();
@@ -75,7 +75,7 @@ impl crate::vm::Vm {
 
     pub(super) async fn call_dict_method(
         &mut self,
-        map: &Arc<BTreeMap<String, VmValue>>,
+        map: &Arc<crate::value::DictMap>,
         method: &str,
         args: &[VmValue],
     ) -> Result<VmValue, VmError> {
@@ -99,7 +99,7 @@ impl crate::vm::Vm {
                     let mapped = self.call_callable_one(callable, v).await?;
                     result.insert(k.clone(), mapped);
                 }
-                Ok(VmValue::Dict(std::sync::Arc::new(result)))
+                Ok(VmValue::dict(result))
             }
             "rekey" | "map_keys" => {
                 let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
@@ -112,7 +112,7 @@ impl crate::vm::Vm {
                     let new_key_str = new_key.display();
                     result.insert(new_key_str, v.clone());
                 }
-                Ok(VmValue::Dict(std::sync::Arc::new(result)))
+                Ok(VmValue::dict(result))
             }
             "filter" => {
                 let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
@@ -125,7 +125,7 @@ impl crate::vm::Vm {
                         result.insert(k.clone(), v.clone());
                     }
                 }
-                Ok(VmValue::Dict(std::sync::Arc::new(result)))
+                Ok(VmValue::dict(result))
             }
             _ => {
                 if let Some(callable) = map.get(method).filter(|v| Self::is_callable_value(v)) {
@@ -137,16 +137,16 @@ impl crate::vm::Vm {
         }
     }
 
-    fn dict_entries(map: &BTreeMap<String, VmValue>) -> Vec<VmValue> {
+    fn dict_entries(map: &crate::value::DictMap) -> Vec<VmValue> {
         map.iter()
             .map(|(k, v)| {
-                VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+                VmValue::dict(BTreeMap::from([
                     (
                         "key".to_string(),
                         VmValue::String(std::sync::Arc::from(k.as_str())),
                     ),
                     ("value".to_string(), v.clone()),
-                ])))
+                ]))
             })
             .collect()
     }

--- a/crates/harn-vm/src/vm/methods/generator.rs
+++ b/crates/harn-vm/src/vm/methods/generator.rs
@@ -14,7 +14,7 @@ impl crate::vm::Vm {
                     let mut dict = BTreeMap::new();
                     dict.insert("value".to_string(), VmValue::Nil);
                     dict.insert("done".to_string(), VmValue::Bool(true));
-                    Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+                    Ok(VmValue::dict(dict))
                 } else {
                     let rx = gen.receiver.clone();
                     let mut guard = rx.lock().await;
@@ -23,7 +23,7 @@ impl crate::vm::Vm {
                             let mut dict = BTreeMap::new();
                             dict.insert("done".to_string(), VmValue::Bool(false));
                             dict.insert("value".to_string(), val);
-                            Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+                            Ok(VmValue::dict(dict))
                         }
                         Some(Err(error)) => {
                             gen.mark_done();
@@ -34,7 +34,7 @@ impl crate::vm::Vm {
                             let mut dict = BTreeMap::new();
                             dict.insert("value".to_string(), VmValue::Nil);
                             dict.insert("done".to_string(), VmValue::Bool(true));
-                            Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+                            Ok(VmValue::dict(dict))
                         }
                     }
                 }
@@ -56,7 +56,7 @@ impl crate::vm::Vm {
                     let mut dict = BTreeMap::new();
                     dict.insert("value".to_string(), VmValue::Nil);
                     dict.insert("done".to_string(), VmValue::Bool(true));
-                    Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+                    Ok(VmValue::dict(dict))
                 } else {
                     let rx = stream.receiver.clone();
                     let mut guard = rx.lock().await;
@@ -65,7 +65,7 @@ impl crate::vm::Vm {
                             let mut dict = BTreeMap::new();
                             dict.insert("done".to_string(), VmValue::Bool(false));
                             dict.insert("value".to_string(), val);
-                            Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+                            Ok(VmValue::dict(dict))
                         }
                         Some(Err(error)) => {
                             stream.mark_done();
@@ -76,7 +76,7 @@ impl crate::vm::Vm {
                             let mut dict = BTreeMap::new();
                             dict.insert("value".to_string(), VmValue::Nil);
                             dict.insert("done".to_string(), VmValue::Bool(true));
-                            Ok(VmValue::Dict(std::sync::Arc::new(dict)))
+                            Ok(VmValue::dict(dict))
                         }
                     }
                 }

--- a/crates/harn-vm/src/vm/methods/harness.rs
+++ b/crates/harn-vm/src/vm/methods/harness.rs
@@ -8,7 +8,6 @@
 //! opaque tool rejection.
 
 use crate::value::VmDictExt;
-use std::collections::BTreeMap;
 use std::time::Duration;
 
 use crate::harness::{vm_string, HarnessKind, HarnessMode, VmHarness};
@@ -1012,7 +1011,7 @@ impl crate::vm::Vm {
         };
         if let Some((http_method, has_body)) = verb {
             let url = string_arg(args, 0, &format!("HarnessNet.{method}"))?.to_string();
-            let mut options: BTreeMap<String, VmValue> = BTreeMap::new();
+            let mut options: crate::value::DictMap = crate::value::DictMap::new();
             if has_body {
                 match (args.get(1), args.get(2)) {
                     (Some(VmValue::Dict(d)), None) => options = (**d).clone(),
@@ -1037,7 +1036,7 @@ impl crate::vm::Vm {
                 let url = string_arg(args, 1, "HarnessNet.request")?.to_string();
                 let options = match args.get(2) {
                     Some(VmValue::Dict(d)) => (**d).clone(),
-                    _ => BTreeMap::new(),
+                    _ => crate::value::DictMap::new(),
                 };
                 crate::http::execute_http_request(&http_method.to_uppercase(), &url, &options)
                     .await
@@ -1212,10 +1211,7 @@ fn state_counts(state: &VmValue) -> Result<UnsettledCounts, VmError> {
     })
 }
 
-fn state_bucket_len(
-    dict: &std::collections::BTreeMap<String, VmValue>,
-    key: &str,
-) -> Result<usize, VmError> {
+fn state_bucket_len(dict: &crate::value::DictMap, key: &str) -> Result<usize, VmError> {
     match dict.get(key) {
         Some(VmValue::List(items)) => Ok(items.len()),
         Some(other) => Err(VmError::TypeError(format!(
@@ -1779,7 +1775,7 @@ fn tag_sandbox_denied(error: VmError) -> VmError {
 
 const HARN_CAP_201_CODE: &str = "HARN-CAP-201";
 
-fn is_egress_blocked_dict(dict: &std::collections::BTreeMap<String, VmValue>) -> bool {
+fn is_egress_blocked_dict(dict: &crate::value::DictMap) -> bool {
     matches!(
         dict.get("type"),
         Some(VmValue::String(value)) if value.as_ref() == "EgressBlocked"
@@ -1787,8 +1783,8 @@ fn is_egress_blocked_dict(dict: &std::collections::BTreeMap<String, VmValue>) ->
 }
 
 fn tag_egress_dict(
-    dict: std::sync::Arc<std::collections::BTreeMap<String, VmValue>>,
-) -> std::sync::Arc<std::collections::BTreeMap<String, VmValue>> {
+    dict: std::sync::Arc<crate::value::DictMap>,
+) -> std::sync::Arc<crate::value::DictMap> {
     let mut next = (*dict).clone();
     if matches!(
         next.get("code"),
@@ -1963,7 +1959,7 @@ fn mock_read_line_value(state: &crate::harness::MockHarnessState, args: &[VmValu
                 out.insert("ok".to_string(), VmValue::Bool(true));
                 out.put_str("status", "ok");
                 out.put_str("value", line);
-                VmValue::Dict(std::sync::Arc::new(out))
+                VmValue::dict(out)
             } else {
                 VmValue::String(std::sync::Arc::from(line))
             }
@@ -1973,7 +1969,7 @@ fn mock_read_line_value(state: &crate::harness::MockHarnessState, args: &[VmValu
                 let mut out = std::collections::BTreeMap::new();
                 out.insert("ok".to_string(), VmValue::Bool(false));
                 out.put_str("status", "eof");
-                VmValue::Dict(std::sync::Arc::new(out))
+                VmValue::dict(out)
             } else {
                 VmValue::Nil
             }

--- a/crates/harn-vm/src/vm/methods/iter.rs
+++ b/crates/harn-vm/src/vm/methods/iter.rs
@@ -211,7 +211,7 @@ impl crate::vm::Vm {
                         }
                     }
                 }
-                Ok(VmValue::Dict(std::sync::Arc::new(map)))
+                Ok(VmValue::dict(map))
             }
             "count" => {
                 let mut n: i64 = 0;

--- a/crates/harn-vm/src/vm/methods/list.rs
+++ b/crates/harn-vm/src/vm/methods/list.rs
@@ -74,10 +74,10 @@ impl crate::vm::Vm {
                     .iter()
                     .enumerate()
                     .map(|(i, v)| {
-                        VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+                        VmValue::dict(BTreeMap::from([
                             ("index".to_string(), VmValue::Int(i as i64)),
                             ("value".to_string(), v.clone()),
-                        ])))
+                        ]))
                     })
                     .collect();
                 Ok(VmValue::List(std::sync::Arc::new(result)))
@@ -291,7 +291,7 @@ impl crate::vm::Vm {
                 // `String`, and the previous `display()` path collapsed
                 // `Int(1)` and `String("1")` into the same bucket — the
                 // exact problem #2467 fixed for `count_by` / `group_by`.
-                let mut counts: BTreeMap<String, VmValue> = BTreeMap::new();
+                let mut counts: crate::value::DictMap = crate::value::DictMap::new();
                 let mut error: Option<VmError> = None;
                 for item in items.iter() {
                     let bucket = match item {
@@ -317,7 +317,7 @@ impl crate::vm::Vm {
                 if let Some(err) = error {
                     Err(err)
                 } else {
-                    Ok(VmValue::Dict(std::sync::Arc::new(counts)))
+                    Ok(VmValue::dict(counts))
                 }
             }
             "to_list" => Ok(VmValue::List(Arc::clone(items))),
@@ -499,11 +499,11 @@ impl crate::vm::Vm {
                         crate::stdlib::collections::string_discriminator(&key, "group_by")?;
                     groups.entry(key_str).or_default().push(item.clone());
                 }
-                let result: BTreeMap<String, VmValue> = groups
+                let result: crate::value::DictMap = groups
                     .into_iter()
                     .map(|(k, v)| (k, VmValue::List(std::sync::Arc::new(v))))
                     .collect();
-                Ok(VmValue::Dict(std::sync::Arc::new(result)))
+                Ok(VmValue::dict(result))
             }
             "min_by" => {
                 if items.is_empty() {
@@ -579,7 +579,7 @@ impl crate::vm::Vm {
             }
             "count_by" => {
                 let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
-                    return Ok(VmValue::Dict(std::sync::Arc::new(BTreeMap::new())));
+                    return Ok(VmValue::dict(BTreeMap::new()));
                 };
                 let mut counts: BTreeMap<String, i64> = BTreeMap::new();
                 for item in items.iter() {
@@ -588,12 +588,12 @@ impl crate::vm::Vm {
                         crate::stdlib::collections::string_discriminator(&key, "count_by")?;
                     *counts.entry(bucket).or_insert(0) += 1;
                 }
-                Ok(VmValue::Dict(std::sync::Arc::new(
+                Ok(VmValue::dict(
                     counts
                         .into_iter()
                         .map(|(k, v)| (k, VmValue::Int(v)))
-                        .collect(),
-                )))
+                        .collect::<crate::value::DictMap>(),
+                ))
             }
             _ => Err(VmError::Runtime(format!("list has no method `{method}`"))),
         }

--- a/crates/harn-vm/src/vm/ops/arithmetic.rs
+++ b/crates/harn-vm/src/vm/ops/arithmetic.rs
@@ -491,7 +491,7 @@ impl super::super::Vm {
                         result.extend(entries.iter().map(|(k, v)| (k.clone(), v.clone())));
                     }
                 }
-                Ok(VmValue::Dict(std::sync::Arc::new(result)))
+                Ok(VmValue::dict(result))
             }
             (a, b) => Err(VmError::TypeError(format!(
                 "Cannot add {} and {}",

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -74,11 +74,11 @@ impl super::super::Vm {
             },
         );
         payload.put_str("persona", persona.unwrap_or(""));
-        payload.insert("step".to_string(), VmValue::Dict(std::sync::Arc::new(step)));
+        payload.insert("step".to_string(), VmValue::dict(step));
         if let Some(output) = output {
             payload.insert("output".to_string(), output);
         }
-        VmValue::Dict(std::sync::Arc::new(payload))
+        VmValue::dict(payload)
     }
 
     fn parse_step_pre_hook_result(
@@ -215,26 +215,24 @@ impl super::super::Vm {
     }
 
     fn step_hook_denied(step_name: &str, reason: String) -> VmError {
-        VmError::Thrown(VmValue::Dict(std::sync::Arc::new(
-            std::collections::BTreeMap::from([
-                (
-                    "category".to_string(),
-                    VmValue::String(std::sync::Arc::from("hook_denied")),
-                ),
-                (
-                    "event".to_string(),
-                    VmValue::String(std::sync::Arc::from("PreStep")),
-                ),
-                (
-                    "reason".to_string(),
-                    VmValue::String(std::sync::Arc::from(reason)),
-                ),
-                (
-                    "step".to_string(),
-                    VmValue::String(std::sync::Arc::from(step_name.to_string())),
-                ),
-            ]),
-        )))
+        VmError::Thrown(VmValue::dict(std::collections::BTreeMap::from([
+            (
+                "category".to_string(),
+                VmValue::String(std::sync::Arc::from("hook_denied")),
+            ),
+            (
+                "event".to_string(),
+                VmValue::String(std::sync::Arc::from("PreStep")),
+            ),
+            (
+                "reason".to_string(),
+                VmValue::String(std::sync::Arc::from(reason)),
+            ),
+            (
+                "step".to_string(),
+                VmValue::String(std::sync::Arc::from(step_name.to_string())),
+            ),
+        ])))
     }
 
     pub(crate) async fn run_step_post_hooks_for_current_frame(

--- a/crates/harn-vm/src/vm/ops/collections.rs
+++ b/crates/harn-vm/src/vm/ops/collections.rs
@@ -268,7 +268,7 @@ impl super::super::Vm {
                 map.insert(key.display(), value);
             }
         }
-        self.stack.push(VmValue::Dict(std::sync::Arc::new(map)));
+        self.stack.push(VmValue::dict(map));
     }
 
     pub(super) fn execute_subscript(&mut self, optional: bool) -> Result<(), VmError> {
@@ -496,7 +496,7 @@ impl super::super::Vm {
                 VmValue::Dict(map) => {
                     let mut new_map = (*map).clone();
                     new_map.insert(prop_name.to_string(), new_value);
-                    assign_value(self, VmValue::Dict(std::sync::Arc::new(new_map)))?;
+                    assign_value(self, VmValue::dict(new_map))?;
                 }
                 VmValue::StructInstance { .. } => {
                     let new_obj = obj
@@ -578,8 +578,7 @@ impl super::super::Vm {
                     let key = index.display();
                     let mut new_map = Arc::try_unwrap(map).unwrap_or_else(|map| (*map).clone());
                     new_map.insert(key, new_value);
-                    self.env
-                        .assign(var_name, VmValue::Dict(std::sync::Arc::new(new_map)))?;
+                    self.env.assign(var_name, VmValue::dict(new_map))?;
                 }
                 other => return Err(Self::subscript_assign_type_error(&other)),
             }

--- a/crates/harn-vm/src/vm/ops/iter.rs
+++ b/crates/harn-vm/src/vm/ops/iter.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crate::value::{VmError, VmValue};
@@ -134,10 +133,10 @@ impl super::super::Vm {
                     let entry_key = VmValue::String(std::sync::Arc::from(key.as_str()));
                     *idx += 1;
                     self.stack
-                        .push(VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+                        .push(VmValue::dict(crate::value::DictMap::from_iter([
                             ("key".to_string(), entry_key),
                             ("value".to_string(), value),
-                        ]))));
+                        ])));
                 } else {
                     self.iterators.pop();
                     let frame = self.frames.last_mut().unwrap();
@@ -371,7 +370,7 @@ mod tests {
     #[test]
     fn iter_init_dict_keeps_shared_entries_and_snapshots_keys() {
         run_iter_init_test(async {
-            let entries = Arc::new(BTreeMap::from([
+            let entries = Arc::new(crate::value::DictMap::from_iter([
                 ("a".to_string(), VmValue::Int(1)),
                 ("b".to_string(), VmValue::Int(2)),
             ]));

--- a/crates/harn-vm/src/vm/ops/parallel.rs
+++ b/crates/harn-vm/src/vm/ops/parallel.rs
@@ -393,7 +393,7 @@ impl super::super::Vm {
                 );
                 dict.insert("succeeded".to_string(), VmValue::Int(succeeded));
                 dict.insert("failed".to_string(), VmValue::Int(failed));
-                self.stack.push(VmValue::Dict(std::sync::Arc::new(dict)));
+                self.stack.push(VmValue::dict(dict));
             }
             _ => self.stack.push(VmValue::Nil),
         }

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -113,7 +113,7 @@ pub(crate) enum IterState {
         idx: usize,
     },
     Dict {
-        entries: Arc<BTreeMap<String, VmValue>>,
+        entries: Arc<crate::value::DictMap>,
         keys: Vec<String>,
         idx: usize,
     },
@@ -274,7 +274,7 @@ pub struct Vm {
     pub(crate) project_root: Option<std::path::PathBuf>,
     /// Global constants (e.g. `pi`, `e`). Checked as a fallback in `GetVar`
     /// after the environment, so user-defined variables can shadow them.
-    pub(crate) globals: Arc<BTreeMap<String, VmValue>>,
+    pub(crate) globals: Arc<crate::value::DictMap>,
     /// Optional debugger hook invoked when execution advances to a new source line.
     pub(crate) debug_hook: Option<parking_lot::Mutex<Box<DebugHook>>>,
     /// Effective runtime ceilings for this VM execution.
@@ -299,7 +299,7 @@ pub struct VmBaseline {
     source_file: Option<String>,
     source_text: Option<String>,
     project_root: Option<std::path::PathBuf>,
-    globals: Arc<BTreeMap<String, VmValue>>,
+    globals: Arc<crate::value::DictMap>,
     denied_builtins: Arc<HashSet<String>>,
     runtime_limits: RuntimeLimits,
 }
@@ -439,7 +439,7 @@ impl Vm {
         }
     }
 
-    pub(crate) fn visible_variables(&self) -> BTreeMap<String, VmValue> {
+    pub(crate) fn visible_variables(&self) -> crate::value::DictMap {
         let mut vars = self.env.all_variables();
         let Some(frame) = self.frames.last() else {
             return vars;
@@ -611,7 +611,7 @@ impl Vm {
             error_stack_trace: Vec::new(),
             yield_sender: None,
             project_root: None,
-            globals: Arc::new(BTreeMap::new()),
+            globals: Arc::new(crate::value::DictMap::new()),
             debug_hook: None,
             runtime_limits: RuntimeLimits::default(),
         }

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -1800,18 +1800,18 @@ fn test_host_signal_token_dispatches_matching_signal() {
             out.push_str("[harn] int\n");
             Ok(VmValue::Nil)
         });
-        let term_options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        let term_options = VmValue::dict(BTreeMap::from([(
             "signals".to_string(),
             VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                 std::sync::Arc::from("SIGTERM"),
             )])),
-        )])));
-        let int_options = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        )]));
+        let int_options = VmValue::dict(BTreeMap::from([(
             "signals".to_string(),
             VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                 std::sync::Arc::from("SIGINT"),
             )])),
-        )])));
+        )]));
         vm.register_interrupt_handler(
             VmValue::BuiltinRef(std::sync::Arc::from("term_marker")),
             Some(&term_options),

--- a/crates/harn-vm/src/workspace_anchor.rs
+++ b/crates/harn-vm/src/workspace_anchor.rs
@@ -259,10 +259,10 @@ mod tests {
 
     #[test]
     fn parse_anchor_dict_accepts_minimal_shape() {
-        let dict = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        let dict = VmValue::dict(BTreeMap::from([(
             "primary".to_string(),
             VmValue::String(std::sync::Arc::from("/workspace/main")),
-        )])));
+        )]));
         let anchor = parse_anchor_dict(&dict).expect("parse minimal");
         assert_eq!(anchor.primary, PathBuf::from("/workspace/main"));
         assert!(anchor.additional_roots.is_empty());
@@ -271,14 +271,14 @@ mod tests {
 
     #[test]
     fn parse_anchor_dict_rejects_missing_primary() {
-        let dict = VmValue::Dict(std::sync::Arc::new(BTreeMap::new()));
+        let dict = VmValue::dict(BTreeMap::new());
         let err = parse_anchor_dict(&dict).expect_err("missing primary should fail");
         assert!(err.contains("primary"));
     }
 
     #[test]
     fn parse_anchor_dict_accepts_additional_roots() {
-        let roots = vec![VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        let roots = vec![VmValue::dict(BTreeMap::from([
             (
                 "path".to_string(),
                 VmValue::String(std::sync::Arc::from("/workspace/lib")),
@@ -291,8 +291,8 @@ mod tests {
                 "mounted_at".to_string(),
                 VmValue::String(std::sync::Arc::from("2026-05-23T00:00:00Z")),
             ),
-        ])))];
-        let dict = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        ]))];
+        let dict = VmValue::dict(BTreeMap::from([
             (
                 "primary".to_string(),
                 VmValue::String(std::sync::Arc::from("/workspace/main")),
@@ -301,7 +301,7 @@ mod tests {
                 "additional_roots".to_string(),
                 VmValue::List(std::sync::Arc::new(roots)),
             ),
-        ])));
+        ]));
         let anchor = parse_anchor_dict(&dict).expect("parse with roots");
         assert_eq!(anchor.additional_roots.len(), 1);
         assert_eq!(anchor.additional_roots[0].mount_mode, MountMode::Extend);
@@ -309,11 +309,11 @@ mod tests {
 
     #[test]
     fn parse_anchor_dict_uses_supplied_default_mount_mode() {
-        let roots = vec![VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        let roots = vec![VmValue::dict(BTreeMap::from([(
             "path".to_string(),
             VmValue::String(std::sync::Arc::from("/workspace/lib")),
-        )])))];
-        let dict = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([
+        )]))];
+        let dict = VmValue::dict(BTreeMap::from([
             (
                 "primary".to_string(),
                 VmValue::String(std::sync::Arc::from("/workspace/main")),
@@ -322,7 +322,7 @@ mod tests {
                 "additional_roots".to_string(),
                 VmValue::List(std::sync::Arc::new(roots)),
             ),
-        ])));
+        ]));
         let anchor =
             parse_anchor_dict_with_default_mount_mode(&dict, MountMode::Extend).expect("parse");
         assert_eq!(anchor.additional_roots[0].mount_mode, MountMode::Extend);
@@ -330,10 +330,10 @@ mod tests {
 
     #[test]
     fn parse_workspace_policy_accepts_default_mount_mode() {
-        let dict = VmValue::Dict(std::sync::Arc::new(BTreeMap::from([(
+        let dict = VmValue::dict(BTreeMap::from([(
             "default_mount_mode".to_string(),
             VmValue::String(std::sync::Arc::from("sandboxed")),
-        )])));
+        )]));
         let policy = parse_workspace_policy_dict(&dict).expect("parse policy");
         assert_eq!(policy.default_mount_mode, MountMode::Sandboxed);
     }

--- a/perf/llm/bench_llm_options_roundtrip.rs
+++ b/perf/llm/bench_llm_options_roundtrip.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::hint::black_box;
 use std::sync::Arc;
 
@@ -11,14 +10,14 @@ const KEY_COUNTS: [usize; 4] = [1, 5, 25, 100];
 struct Fixture {
     key_count: usize,
     args: Vec<VmValue>,
-    options: Option<BTreeMap<String, VmValue>>,
+    options: Option<harn_vm::value::DictMap>,
 }
 
 fn string(value: &str) -> VmValue {
     VmValue::String(Arc::from(value))
 }
 
-fn dict(entries: BTreeMap<String, VmValue>) -> VmValue {
+fn dict(entries: harn_vm::value::DictMap) -> VmValue {
     VmValue::Dict(Arc::new(entries))
 }
 
@@ -37,13 +36,13 @@ fn override_value(index: usize) -> VmValue {
 }
 
 fn provider_overrides() -> VmValue {
-    let mut overrides = BTreeMap::new();
+    let mut overrides = harn_vm::value::DictMap::new();
     overrides.insert("override_000".to_string(), override_value(0));
     dict(overrides)
 }
 
-fn build_options(key_count: usize) -> BTreeMap<String, VmValue> {
-    let mut options = BTreeMap::new();
+fn build_options(key_count: usize) -> harn_vm::value::DictMap {
+    let mut options = harn_vm::value::DictMap::new();
     options.insert("provider".to_string(), string("mock"));
 
     if key_count >= 2 {


### PR DESCRIPTION
## Summary

Dict values were `Arc<BTreeMap<String, VmValue>>`. Mutating an aliased dict
(`dict[key] = value`, property assignment) goes through `Arc::make_mut`, which
**deep-clones the entire `BTreeMap`** — every key `String` and every entry — an
O(n) allocation storm that dominates mutation-heavy workloads (a VM microbench
recorded ~7,584 allocations/iteration).

This swaps the backing store to **`imbl::OrdMap`** (a persistent, structurally
shared B-tree) behind the same `Arc`:

- `Arc::make_mut` now clones the `OrdMap` in O(1) (a structural-sharing refcount
  bump) and the subsequent insert path-copies O(log n) nodes — so dict mutation
  drops from **O(n) → O(log n) allocations**.
- The `Arc` wrapper is retained, so reference identity (`Arc::ptr_eq`, used by
  the `===` operator and `value_identity_key`) keeps its semantics.
- `OrdMap` is ordered, so **dict key ordering, iteration, equality, identity,
  and the entire read/write API are byte-for-byte unchanged**.

### Design

Construction routes through new `VmValue::dict()` / `dict_map()` chokepoints.
`dict()` accepts any `IntoIterator<Item = (String, VmValue)>`, so the `BTreeMap`
that builders still assemble (via `VmDictExt::put_*`) is collected into the
persistent store **at the value boundary** — call sites keep their familiar
map-building code. `VmDictExt` is now generic over both map types via a shared
`DictInsert` trait, and a `DictRetain` extension provides `OrdMap`'s missing
in-place `retain`. The dict payload type flows through the codebase as the
`DictMap` alias.

### Concurrency / expressiveness

`imbl::OrdMap<String, VmValue>` with the default `ArcK` pool is `Send + Sync`,
so the VM's `Send`/`Sync` bounds, async dispatch, channels, `parallel` / `spawn`,
and multithreaded workers are all untouched. This is purely a backing-store swap
— no async/sync or multithreading capability is traded away.

## Verification

- `cargo check --workspace --all-targets` — clean (0 errors, 0 warnings)
- `cargo clippy --workspace --all-targets` — clean
- `cargo test -p harn-vm --lib` — **3,699 passed**; the only 3 failures are the
  pre-existing environment-capability tests (Landlock sandbox, overlayfs write
  injection, git commit signing) that require host capabilities unavailable in
  this sandbox and pass in CI.
- Rebased onto current `main`, so it composes cleanly with the merged value
  representation shrink (#3301).

This is the third in the VM performance series after the mimalloc allocator
(#3300) and the 32→24 byte value shrink (#3301).

https://claude.ai/code/session_01Hg27rCwZSvFbXJtF97kNxV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hg27rCwZSvFbXJtF97kNxV)_