### PR TITLE
feat(llm): opinionated provider-route policy (pin gpt-oss to clean OpenRouter sub-providers) + compile-time footgun-validation gate

### DIFF
--- a/changelog.d/opinionated-provider-route-policy.added.md
+++ b/changelog.d/opinionated-provider-route-policy.added.md
@@ -1,0 +1,20 @@
+- **Opinionated provider-route policy: gpt-oss on OpenRouter is now pinned to
+  clean sub-providers, plus a compile-time footgun-validation gate.** OpenRouter
+  routes `openai/gpt-oss-120b` across a ~17-upstream sub-provider lottery, and
+  some upstreams mis-serialize the Harmony tool call even with reasoning ON
+  (billed-noncommittal: 0 tool_calls), so the route was a runtime footgun even
+  after the reasoning fix. Two declarative pieces close it: (1) a new
+  `openrouter_provider_order` capability field (the allowlist counterpart to
+  `provider_route_denylist`) materializes to the OpenRouter request body's
+  `provider: { order: [...], allow_fallbacks: false }`, and the
+  `openai/gpt-oss-*` OpenRouter row pins it to `["Cerebras", "Groq"]` — the
+  upstreams that served Harmony tool calls cleanly in a live 2026-06-13 probe
+  (order-pinned requests gave 0 billed-noncommittal; Together was flaky 1/3);
+  (2) a data-driven footgun gate (`harn providers build-capabilities --check` /
+  `make check-provider-capabilities`) that FAILS the build on known-footgun
+  provider/model/config combos — a `reasoning_required_for_tools` route that
+  also forces a tool task to reasoning-off, and a `reasoning_required_for_tools`
+  OpenRouter route with no clean-sub-provider pin. The gate reads the
+  capability matrix's own invariants (no hard-coded model-name patterns), so a
+  new footgun route is caught the moment it forgets a pin. The blessed-vs-
+  forbidden policy is documented in the `capabilities.toml` base shard.

--- a/crates/harn-cli/src/commands/providers/build.rs
+++ b/crates/harn-cli/src/commands/providers/build.rs
@@ -144,8 +144,21 @@ fn generated_provider_capabilities(source_dir: &Path) -> Result<GeneratedProvide
         body.push('\n');
     }
 
-    toml::from_str::<harn_vm::llm::capabilities::CapabilitiesFile>(&body)
+    let parsed = toml::from_str::<harn_vm::llm::capabilities::CapabilitiesFile>(&body)
         .map_err(|error| format!("generated provider capabilities do not parse: {error}"))?;
+
+    // Opinionated footgun gate: refuse to generate (or pass --check on) a
+    // capability matrix that declares a known-footgun provider/model/config
+    // combo (e.g. a tool route with reasoning forced off, or an OpenRouter
+    // Harmony tool route with no clean-sub-provider pin). Data-driven over the
+    // matrix — see harn_vm::llm::capability_audit.
+    let audit = harn_vm::llm::capability_audit::audit_capabilities(&parsed);
+    if !audit.is_clean() {
+        return Err(format!(
+            "capability matrix footgun check failed:\n{}",
+            audit.render()
+        ));
+    }
 
     Ok(GeneratedProviderConfig {
         body,

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -460,6 +460,25 @@ pub struct ProviderRule {
     /// natively. Only consulted for the `openrouter` provider.
     #[serde(default)]
     pub provider_route_denylist: Option<Vec<String>>,
+    /// OpenRouter upstream provider names this `(provider, model)` row is
+    /// PINNED to, in preference order. Materialized into the request body's
+    /// `provider.order` array with `allow_fallbacks = false` (see
+    /// [`crate::llm::providers::openai_compat::apply_openrouter_provider_order`]),
+    /// so OpenRouter only ever routes the model to these known-clean upstreams
+    /// and never silently falls back to a sketchier one. This is the
+    /// *allowlist* counterpart to [`Self::provider_route_denylist`]: prefer it
+    /// when the bad upstreams are intermittent / hard to enumerate but the
+    /// clean ones are few and stable. The canonical case is OpenRouter's
+    /// `openai/gpt-oss-*` route, which fans out across ~17 upstreams in a
+    /// sub-provider lottery; some mis-serialize the Harmony tool call even with
+    /// reasoning ON (billed-noncommittal: 0 tool_calls), while Cerebras and
+    /// Groq serve it cleanly. Only consulted for the `openrouter` provider. An
+    /// empty / unset list means "no pin" (free OpenRouter routing). When both a
+    /// pin and a denylist are present the pin wins (a closed allowlist already
+    /// excludes everything not on it). Validated by the footgun gate in
+    /// [`crate::llm::capability_audit`].
+    #[serde(default)]
+    pub openrouter_provider_order: Option<Vec<String>>,
 }
 
 /// Resolved capabilities for a `(provider, model)` pair. Unset rule
@@ -541,6 +560,10 @@ pub struct Capabilities {
     /// row. See [`ProviderRule::provider_route_denylist`]. Empty means "no
     /// route restriction".
     pub provider_route_denylist: Vec<String>,
+    /// OpenRouter upstream provider names this row is PINNED to (allowlist), in
+    /// preference order. See [`ProviderRule::openrouter_provider_order`]. Empty
+    /// means "no pin" (free OpenRouter routing).
+    pub openrouter_provider_order: Vec<String>,
 }
 
 impl Default for Capabilities {
@@ -610,6 +633,7 @@ impl Default for Capabilities {
             thinking_disable_directive: None,
             auto_reasoning_overrides: BTreeMap::new(),
             provider_route_denylist: Vec::new(),
+            openrouter_provider_order: Vec::new(),
         }
     }
 }
@@ -722,6 +746,12 @@ fn builtin() -> &'static CapabilitiesFile {
         toml::from_str::<CapabilitiesFile>(BUILTIN_TOML)
             .expect("capabilities.toml must parse at build time")
     })
+}
+
+/// The shipped (built-in) capability matrix. Public so the footgun gate in
+/// [`crate::llm::capability_audit`] can audit exactly what Harn ships.
+pub fn builtin_file() -> &'static CapabilitiesFile {
+    builtin()
 }
 
 /// Install project-level overrides for the current thread. Usually
@@ -1256,6 +1286,7 @@ fn defaults_to_caps(defaults: &ProviderDefaults) -> Capabilities {
         thinking_disable_directive: None,
         auto_reasoning_overrides: None,
         provider_route_denylist: None,
+        openrouter_provider_order: None,
     };
     let mut caps = rule_to_caps(&empty, defaults);
     caps.preferred_tool_format = None;
@@ -1374,6 +1405,7 @@ fn rule_to_caps(rule: &ProviderRule, defaults: &ProviderDefaults) -> Capabilitie
         thinking_disable_directive: rule.thinking_disable_directive.clone(),
         auto_reasoning_overrides: rule.auto_reasoning_overrides.clone().unwrap_or_default(),
         provider_route_denylist: rule.provider_route_denylist.clone().unwrap_or_default(),
+        openrouter_provider_order: rule.openrouter_provider_order.clone().unwrap_or_default(),
     }
 }
 

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -139,6 +139,49 @@
 #                     whenever the resolved `thinking` config is `Disabled`,
 #                     so script authors don't need to know provider-specific
 #                     prompt directives. Idempotent — never injected twice.
+#   provider_route_denylist:
+#                     [openrouter only] DENYLIST of upstream sub-providers to
+#                     exclude for this route. Materialized into the request
+#                     body's `provider.ignore`. Use when a SPECIFIC upstream is
+#                     positively known to mis-serve a route while others are
+#                     fine (e.g. Ambient billing reasoning tokens then finishing
+#                     with empty tool_calls for qwen3.6). Prefer the allowlist
+#                     (openrouter_provider_order) when the bad upstreams are
+#                     intermittent/hard to enumerate.
+#   openrouter_provider_order:
+#                     [openrouter only] ALLOWLIST of upstream sub-providers this
+#                     route is PINNED to, in preference order. Materialized into
+#                     `provider.order` + `allow_fallbacks:false`, so OpenRouter
+#                     only ever routes to these known-clean upstreams. Use this
+#                     for routes on OpenRouter's sub-provider lottery where the
+#                     bad upstreams are intermittent (e.g. openai/gpt-oss-*,
+#                     pinned to ["Cerebras","Groq"]). When both a pin and a
+#                     denylist are set the pin wins (a closed allowlist already
+#                     excludes everything else).
+#
+# OPINIONATED PROVIDER/MODEL/CONFIG POLICY (enforced by the footgun gate in
+# crate::llm::capability_audit, wired into `providers build-capabilities
+# --check` / `make check-provider-capabilities`). Harn refuses to ship a matrix
+# that declares a known footgun, so harness authors can't reach these states:
+#
+#   * FORBIDDEN: reasoning_required_for_tools = true together with an
+#     auto_reasoning_overrides that forces a tool task (agent/code/verify) to
+#     "off". The two are contradictory — a model that calls tools inside its
+#     reasoning channel emits 0 tool_calls (billed-noncommittal) when reasoning
+#     is off. (The opposite Qwen quirk — reasoning-OFF-for-tools WITHOUT the
+#     required-for-tools flag — is legitimate and allowed.)
+#
+#   * FORBIDDEN: an `openrouter` route with reasoning_required_for_tools = true
+#     (a Harmony-style tool route on the sub-provider lottery) that declares no
+#     openrouter_provider_order pin. Some OpenRouter upstreams mis-serialize the
+#     Harmony tool call even with reasoning ON, so such a route MUST pin a
+#     closed allowlist of known-clean upstreams.
+#
+#   * BLESSED (live-probed 2026-06-13, openai/gpt-oss-120b, reasoning effort
+#     low): Cerebras and Groq serve Harmony tool calls cleanly (order-pinned
+#     requests gave 0 billed-noncommittal); Together was flaky (1/3); the
+#     free OpenRouter lottery fans out across ~17 upstreams. Hence the
+#     openai/gpt-oss-* OpenRouter row is pinned to ["Cerebras","Groq"].
 
 # --- source: 10-defaults/provider-defaults.toml ---
 [provider_defaults.anthropic]
@@ -3447,6 +3490,23 @@ thinking_block_style = "none"
 # `reasoning:{enabled:false}` disable directive on the wire, and the
 # required-for-tools flag keeps the auto policy from flooring tool tasks to off.
 # Must NOT carry a Qwen-style `auto_reasoning_overrides = "off"`.
+#
+# SECOND footgun — the OpenRouter sub-provider lottery. `openai/gpt-oss-120b`
+# fans out across ~17 upstreams on OpenRouter; even with reasoning ON, some
+# mis-serialize the Harmony tool call and finish billed-noncommittal (0
+# tool_calls). The bad upstreams are intermittent and hard to enumerate, so we
+# ALLOWLIST the known-clean ones instead of denylisting the bad ones.
+# `openrouter_provider_order = ["Cerebras", "Groq"]` materializes to
+# `provider: { order: ["Cerebras","Groq"], allow_fallbacks: false }`, so the
+# route only ever lands on those two upstreams. Live OpenRouter probe
+# (openai/gpt-oss-120b, 2026-06-13, reasoning effort=low, weather-tool request):
+#   - free routing (lottery) x12          -> Groq, 12/12 clean tool calls
+#   - order=[Cerebras,Groq] pin x6        -> Cerebras, 6/6 clean, 0 noncommittal
+#   - Cerebras-only pin x3 / Groq-only x3 -> 6/6 clean
+#   - Together pin x3                      -> 1/3 clean (2 "Provider returned
+#                                             error") -> NOT allowlisted
+# Cerebras and Groq are the blessed upstreams. The footgun gate (capability
+# audit) requires this pin on any reasoning_required_for_tools OpenRouter route.
 [[provider.openrouter]]
 model_match = "openai/gpt-oss-*"
 native_tools = true
@@ -3457,6 +3517,7 @@ reasoning_effort_supported = true
 reasoning_effort_levels = ["low", "medium", "high"]
 reasoning_disable_supported = false
 reasoning_required_for_tools = true
+openrouter_provider_order = ["Cerebras", "Groq"]
 text_tool_wire_format_supported = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true

--- a/crates/harn-vm/src/llm/capability_audit.rs
+++ b/crates/harn-vm/src/llm/capability_audit.rs
@@ -1,0 +1,280 @@
+//! Compile-time footgun gate for the capability matrix.
+//!
+//! Harn is *opinionated* about provider/model/config combinations: a few
+//! combos are known footguns that silently break tool calling at runtime, and
+//! the only durable place to forbid them is the declarative matrix itself —
+//! before a harness author can ship a misconfigured route.
+//!
+//! This audit walks the parsed [`CapabilitiesFile`] and flags
+//! provider+model+config combinations that the matrix declares as invariants,
+//! NOT hard-coded model-name patterns. It generalizes the
+//! `reasoning_required_for_tools` precedent (a tool-using model that calls
+//! tools inside its reasoning channel) into a small set of data-driven rules:
+//!
+//!   * **reasoning-off-for-tools contradiction** — a row that declares
+//!     `reasoning_required_for_tools = true` must not also pin a tool task
+//!     (`agent` / `code` / `verify`) to reasoning `"off"` via
+//!     `auto_reasoning_overrides`. That is the self-inflicted
+//!     billed-noncommittal failure #3305 fixed at its root; declaring both is a
+//!     direct contradiction.
+//!
+//!   * **lottery-route without a clean pin** — an OpenRouter row that declares
+//!     `reasoning_required_for_tools = true` is a Harmony-style tool route on a
+//!     sub-provider-lottery provider. Some OpenRouter upstreams mis-serialize
+//!     the Harmony tool call even with reasoning ON, so such a row MUST pin a
+//!     closed allowlist of known-clean upstreams via `openrouter_provider_order`
+//!     (materialized to `provider.order` + `allow_fallbacks:false`). Without a
+//!     pin the route can silently land on a sketchy upstream.
+//!
+//! Both checks are driven entirely by capability-row fields, so adding a new
+//! footgun route is a data edit (set the flag / forget the pin) rather than a
+//! code change — and forgetting the pin trips this gate.
+//!
+//! The audit is wired into `harn providers build-capabilities --check` (see
+//! `harn-cli`), which runs under `make check-provider-capabilities` /
+//! `make check-provider-matrix`, so the matrix cannot drift into a footgun
+//! state without failing CI.
+
+use crate::llm::capabilities::CapabilitiesFile;
+
+/// Tool-bearing reasoning tasks. These are the tasks whose auto reasoning level
+/// must never resolve to `"off"` on a route that calls tools in its reasoning
+/// channel. Mirrors the guarded set in
+/// [`crate::llm::reasoning_policy`].
+const TOOL_TASKS: [&str; 3] = ["agent", "code", "verify"];
+
+/// A single footgun finding: a capability row that violates an opinionated
+/// provider/model/config invariant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilityFootgun {
+    /// Provider id whose rule list contains the offending row.
+    pub provider: String,
+    /// The row's `model_match` pattern.
+    pub model_match: String,
+    /// Human-readable explanation + the declarative fix.
+    pub message: String,
+}
+
+/// Result of auditing a [`CapabilitiesFile`] for footgun combinations.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CapabilityAuditReport {
+    pub footguns: Vec<CapabilityFootgun>,
+}
+
+impl CapabilityAuditReport {
+    pub fn is_clean(&self) -> bool {
+        self.footguns.is_empty()
+    }
+
+    /// One line per finding, suitable for CLI/CI output.
+    pub fn render(&self) -> String {
+        self.footguns
+            .iter()
+            .map(|footgun| {
+                format!(
+                    "provider.{} model_match=\"{}\": {}",
+                    footgun.provider, footgun.model_match, footgun.message
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+/// Audit the in-memory capability matrix for footgun provider/model/config
+/// combinations. Pure over the parsed file — no I/O, no model-name patterns.
+pub fn audit_capabilities(file: &CapabilitiesFile) -> CapabilityAuditReport {
+    let mut report = CapabilityAuditReport::default();
+    for (provider, rules) in &file.provider {
+        for rule in rules {
+            let reasoning_required_for_tools = rule.reasoning_required_for_tools.unwrap_or(false);
+
+            // Footgun 1: reasoning-off-for-tools contradiction. A route that
+            // calls tools inside its reasoning channel must not also force a
+            // tool task to reasoning-off.
+            if reasoning_required_for_tools {
+                if let Some(overrides) = &rule.auto_reasoning_overrides {
+                    let offending: Vec<&str> = TOOL_TASKS
+                        .iter()
+                        .copied()
+                        .filter(|task| {
+                            overrides
+                                .get(*task)
+                                .map(|level| level.eq_ignore_ascii_case("off"))
+                                .unwrap_or(false)
+                        })
+                        .collect();
+                    if !offending.is_empty() {
+                        report.footguns.push(CapabilityFootgun {
+                            provider: provider.clone(),
+                            model_match: rule.model_match.clone(),
+                            message: format!(
+                                "declares reasoning_required_for_tools = true but also pins \
+                                 auto_reasoning_overrides {{ {} = \"off\" }}; this route calls \
+                                 tools inside its reasoning channel, so forcing reasoning off \
+                                 for a tool task is the billed-noncommittal failure (0 \
+                                 tool_calls). Remove the \"off\" override(s) for tool tasks.",
+                                offending.join("/")
+                            ),
+                        });
+                    }
+                }
+            }
+
+            // Footgun 2: lottery-route without a clean sub-provider pin. An
+            // OpenRouter Harmony-style tool route must allowlist known-clean
+            // upstreams or it can silently land on a mis-serializing one.
+            if provider == "openrouter" && reasoning_required_for_tools {
+                let pinned = rule
+                    .openrouter_provider_order
+                    .as_ref()
+                    .map(|order| !order.is_empty())
+                    .unwrap_or(false);
+                if !pinned {
+                    report.footguns.push(CapabilityFootgun {
+                        provider: provider.clone(),
+                        model_match: rule.model_match.clone(),
+                        message: "is an OpenRouter route with \
+                            reasoning_required_for_tools = true (a Harmony-style tool route on \
+                            the OpenRouter sub-provider lottery) but declares no \
+                            openrouter_provider_order pin. Some OpenRouter upstreams \
+                            mis-serialize the tool call even with reasoning ON. Pin a closed \
+                            allowlist of known-clean upstreams, e.g. \
+                            openrouter_provider_order = [\"Cerebras\", \"Groq\"]."
+                            .to_string(),
+                    });
+                }
+            }
+        }
+    }
+    report
+}
+
+/// Audit the built-in (shipped) capability matrix. Convenience entry point for
+/// the CLI gate.
+pub fn audit_builtin() -> CapabilityAuditReport {
+    audit_capabilities(crate::llm::capabilities::builtin_file())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::capabilities::parse_capabilities_toml;
+
+    fn audit_toml(src: &str) -> CapabilityAuditReport {
+        audit_capabilities(&parse_capabilities_toml(src).expect("parses"))
+    }
+
+    #[test]
+    fn shipped_matrix_has_no_footguns() {
+        let report = audit_builtin();
+        assert!(
+            report.is_clean(),
+            "shipped capability matrix has footguns:\n{}",
+            report.render()
+        );
+    }
+
+    #[test]
+    fn flags_reasoning_off_for_tools_contradiction() {
+        let report = audit_toml(
+            r#"
+[[provider.someprov]]
+model_match = "harmony-*"
+reasoning_required_for_tools = true
+auto_reasoning_overrides = { agent = "off" }
+"#,
+        );
+        assert_eq!(report.footguns.len(), 1, "{}", report.render());
+        assert_eq!(report.footguns[0].provider, "someprov");
+        assert!(report.footguns[0].message.contains("billed-noncommittal"));
+    }
+
+    #[test]
+    fn flags_lottery_route_without_pin() {
+        let report = audit_toml(
+            r#"
+[[provider.openrouter]]
+model_match = "vendor/harmony-*"
+reasoning_required_for_tools = true
+reasoning_effort_levels = ["low", "medium", "high"]
+"#,
+        );
+        assert_eq!(report.footguns.len(), 1, "{}", report.render());
+        assert!(report.footguns[0]
+            .message
+            .contains("openrouter_provider_order"));
+    }
+
+    #[test]
+    fn pinned_lottery_route_is_clean() {
+        let report = audit_toml(
+            r#"
+[[provider.openrouter]]
+model_match = "vendor/harmony-*"
+reasoning_required_for_tools = true
+openrouter_provider_order = ["Cerebras", "Groq"]
+"#,
+        );
+        assert!(report.is_clean(), "{}", report.render());
+    }
+
+    #[test]
+    fn empty_pin_is_treated_as_no_pin() {
+        let report = audit_toml(
+            r#"
+[[provider.openrouter]]
+model_match = "vendor/harmony-*"
+reasoning_required_for_tools = true
+openrouter_provider_order = []
+"#,
+        );
+        assert_eq!(report.footguns.len(), 1, "{}", report.render());
+    }
+
+    #[test]
+    fn non_openrouter_required_route_does_not_need_a_pin() {
+        // Groq/Cerebras/Together gpt-oss rows require reasoning for tools but
+        // are NOT on the OpenRouter lottery, so they must not be flagged for a
+        // missing pin.
+        let report = audit_toml(
+            r#"
+[[provider.groq]]
+model_match = "*gpt-oss-*"
+reasoning_required_for_tools = true
+reasoning_effort_levels = ["low", "medium", "high"]
+"#,
+        );
+        assert!(report.is_clean(), "{}", report.render());
+    }
+
+    #[test]
+    fn qwen_style_off_override_without_required_flag_is_clean() {
+        // The Qwen quirk (reasoning-OFF-for-tools, no required-for-tools flag)
+        // is a legitimate config and must NOT be flagged.
+        let report = audit_toml(
+            r#"
+[[provider.ollama]]
+model_match = "qwen3.6*"
+auto_reasoning_overrides = { agent = "off" }
+"#,
+        );
+        assert!(report.is_clean(), "{}", report.render());
+    }
+
+    #[test]
+    fn ordinary_models_are_clean() {
+        let report = audit_toml(
+            r#"
+[[provider.openrouter]]
+model_match = "anthropic/claude-*"
+native_tools = true
+
+[[provider.openai]]
+model_match = "gpt-*"
+native_tools = true
+"#,
+        );
+        assert!(report.is_clean(), "{}", report.render());
+    }
+}

--- a/crates/harn-vm/src/llm/capability_sources/00-base.toml
+++ b/crates/harn-vm/src/llm/capability_sources/00-base.toml
@@ -135,3 +135,46 @@
 #                     whenever the resolved `thinking` config is `Disabled`,
 #                     so script authors don't need to know provider-specific
 #                     prompt directives. Idempotent — never injected twice.
+#   provider_route_denylist:
+#                     [openrouter only] DENYLIST of upstream sub-providers to
+#                     exclude for this route. Materialized into the request
+#                     body's `provider.ignore`. Use when a SPECIFIC upstream is
+#                     positively known to mis-serve a route while others are
+#                     fine (e.g. Ambient billing reasoning tokens then finishing
+#                     with empty tool_calls for qwen3.6). Prefer the allowlist
+#                     (openrouter_provider_order) when the bad upstreams are
+#                     intermittent/hard to enumerate.
+#   openrouter_provider_order:
+#                     [openrouter only] ALLOWLIST of upstream sub-providers this
+#                     route is PINNED to, in preference order. Materialized into
+#                     `provider.order` + `allow_fallbacks:false`, so OpenRouter
+#                     only ever routes to these known-clean upstreams. Use this
+#                     for routes on OpenRouter's sub-provider lottery where the
+#                     bad upstreams are intermittent (e.g. openai/gpt-oss-*,
+#                     pinned to ["Cerebras","Groq"]). When both a pin and a
+#                     denylist are set the pin wins (a closed allowlist already
+#                     excludes everything else).
+#
+# OPINIONATED PROVIDER/MODEL/CONFIG POLICY (enforced by the footgun gate in
+# crate::llm::capability_audit, wired into `providers build-capabilities
+# --check` / `make check-provider-capabilities`). Harn refuses to ship a matrix
+# that declares a known footgun, so harness authors can't reach these states:
+#
+#   * FORBIDDEN: reasoning_required_for_tools = true together with an
+#     auto_reasoning_overrides that forces a tool task (agent/code/verify) to
+#     "off". The two are contradictory — a model that calls tools inside its
+#     reasoning channel emits 0 tool_calls (billed-noncommittal) when reasoning
+#     is off. (The opposite Qwen quirk — reasoning-OFF-for-tools WITHOUT the
+#     required-for-tools flag — is legitimate and allowed.)
+#
+#   * FORBIDDEN: an `openrouter` route with reasoning_required_for_tools = true
+#     (a Harmony-style tool route on the sub-provider lottery) that declares no
+#     openrouter_provider_order pin. Some OpenRouter upstreams mis-serialize the
+#     Harmony tool call even with reasoning ON, so such a route MUST pin a
+#     closed allowlist of known-clean upstreams.
+#
+#   * BLESSED (live-probed 2026-06-13, openai/gpt-oss-120b, reasoning effort
+#     low): Cerebras and Groq serve Harmony tool calls cleanly (order-pinned
+#     requests gave 0 billed-noncommittal); Together was flaky (1/3); the
+#     free OpenRouter lottery fans out across ~17 upstreams. Hence the
+#     openai/gpt-oss-* OpenRouter row is pinned to ["Cerebras","Groq"].

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/99-openrouter-new-families.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/99-openrouter-new-families.toml
@@ -77,6 +77,23 @@ thinking_block_style = "none"
 # `reasoning:{enabled:false}` disable directive on the wire, and the
 # required-for-tools flag keeps the auto policy from flooring tool tasks to off.
 # Must NOT carry a Qwen-style `auto_reasoning_overrides = "off"`.
+#
+# SECOND footgun — the OpenRouter sub-provider lottery. `openai/gpt-oss-120b`
+# fans out across ~17 upstreams on OpenRouter; even with reasoning ON, some
+# mis-serialize the Harmony tool call and finish billed-noncommittal (0
+# tool_calls). The bad upstreams are intermittent and hard to enumerate, so we
+# ALLOWLIST the known-clean ones instead of denylisting the bad ones.
+# `openrouter_provider_order = ["Cerebras", "Groq"]` materializes to
+# `provider: { order: ["Cerebras","Groq"], allow_fallbacks: false }`, so the
+# route only ever lands on those two upstreams. Live OpenRouter probe
+# (openai/gpt-oss-120b, 2026-06-13, reasoning effort=low, weather-tool request):
+#   - free routing (lottery) x12          -> Groq, 12/12 clean tool calls
+#   - order=[Cerebras,Groq] pin x6        -> Cerebras, 6/6 clean, 0 noncommittal
+#   - Cerebras-only pin x3 / Groq-only x3 -> 6/6 clean
+#   - Together pin x3                      -> 1/3 clean (2 "Provider returned
+#                                             error") -> NOT allowlisted
+# Cerebras and Groq are the blessed upstreams. The footgun gate (capability
+# audit) requires this pin on any reasoning_required_for_tools OpenRouter route.
 [[provider.openrouter]]
 model_match = "openai/gpt-oss-*"
 native_tools = true
@@ -87,6 +104,7 @@ reasoning_effort_supported = true
 reasoning_effort_levels = ["low", "medium", "high"]
 reasoning_disable_supported = false
 reasoning_required_for_tools = true
+openrouter_provider_order = ["Cerebras", "Groq"]
 text_tool_wire_format_supported = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true

--- a/crates/harn-vm/src/llm/mod.rs
+++ b/crates/harn-vm/src/llm/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod autonomy_budget;
 pub(crate) mod cache;
 mod call;
 pub mod capabilities;
+pub mod capability_audit;
 pub(crate) mod compass_router;
 pub(crate) mod config_builtins;
 pub(crate) mod content;

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -266,8 +266,20 @@ impl OpenAiCompatibleProvider {
         // empty tool_calls) while still advertising the model. We merge those
         // names into the request body's `provider.ignore` so OpenRouter reroutes
         // to a healthy upstream. Pure capability lookup — no model-name branch.
-        if opts.provider == "openrouter" && !caps.provider_route_denylist.is_empty() {
-            apply_openrouter_route_denylist(&mut body, &caps.provider_route_denylist);
+        // Data-driven OpenRouter upstream pin (allowlist). When the row pins a
+        // closed set of known-clean upstreams, route ONLY to them in order with
+        // `allow_fallbacks:false` so OpenRouter never silently falls back to a
+        // sketchier upstream that mis-serializes the route. The canonical case
+        // is `openai/gpt-oss-*`, pinned to Cerebras/Groq (clean for Harmony
+        // tool calls). A closed allowlist already excludes everything not on it,
+        // so the pin takes precedence over `provider_route_denylist` when both
+        // are present. Pure capability lookup — no model-name branch.
+        if opts.provider == "openrouter" {
+            if !caps.openrouter_provider_order.is_empty() {
+                apply_openrouter_provider_order(&mut body, &caps.openrouter_provider_order);
+            } else if !caps.provider_route_denylist.is_empty() {
+                apply_openrouter_route_denylist(&mut body, &caps.provider_route_denylist);
+            }
         }
         if let Some(ref tools) = opts.native_tools {
             if !tools.is_empty() {
@@ -502,6 +514,51 @@ pub(crate) fn apply_openrouter_route_denylist(body: &mut serde_json::Value, deny
             ignore_arr.push(serde_json::Value::String(name.clone()));
         }
     }
+}
+
+/// Pin the OpenRouter request body to a closed, ordered allowlist of upstream
+/// providers: sets `provider.order` to `order` and `provider.allow_fallbacks`
+/// to `false`, so OpenRouter routes the model only to those upstreams (in
+/// preference order) and never silently falls back to one not on the list.
+/// This is the wire materialization of the capability-row
+/// `openrouter_provider_order` — provider-agnostic data plumbing with no
+/// model-specific logic; the caller decides whether a pin applies by consulting
+/// the capability matrix. A pre-existing `provider.order` (e.g. a caller
+/// override) is left untouched; `allow_fallbacks` is always forced to `false`
+/// so the pin is genuinely closed. No-op when `order` is empty.
+pub(crate) fn apply_openrouter_provider_order(body: &mut serde_json::Value, order: &[String]) {
+    if order.is_empty() {
+        return;
+    }
+    if !body.is_object() {
+        return;
+    }
+    let provider = body
+        .as_object_mut()
+        .expect("body is an object")
+        .entry("provider".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    let Some(provider_obj) = provider.as_object_mut() else {
+        return;
+    };
+    // Only set the order when the caller has not already pinned one; respect an
+    // explicit caller override rather than clobbering it.
+    if !provider_obj.contains_key("order") {
+        provider_obj.insert(
+            "order".to_string(),
+            serde_json::Value::Array(
+                order
+                    .iter()
+                    .map(|name| serde_json::Value::String(name.clone()))
+                    .collect(),
+            ),
+        );
+    }
+    // A closed allowlist must not fall back off-list.
+    provider_obj.insert(
+        "allow_fallbacks".to_string(),
+        serde_json::Value::Bool(false),
+    );
 }
 
 fn normalize_tool_choice_for_capabilities(
@@ -1851,6 +1908,87 @@ thinking_modes = ["enabled"]
         assert!(
             other_body.get("provider").is_none(),
             "non-openrouter provider must not receive provider.ignore: {other_body}"
+        );
+    }
+
+    #[test]
+    fn provider_order_pins_closed_allowlist() {
+        let mut body = json!({"model": "openai/gpt-oss-120b"});
+        apply_openrouter_provider_order(&mut body, &["Cerebras".to_string(), "Groq".to_string()]);
+        assert_eq!(body["provider"]["order"], json!(["Cerebras", "Groq"]));
+        assert_eq!(body["provider"]["allow_fallbacks"], json!(false));
+    }
+
+    #[test]
+    fn provider_order_respects_caller_order_but_forces_closed() {
+        // A caller-supplied order is preserved; allow_fallbacks is still forced
+        // false so the pin is genuinely closed.
+        let mut body = json!({
+            "model": "openai/gpt-oss-120b",
+            "provider": { "order": ["Groq"], "allow_fallbacks": true }
+        });
+        apply_openrouter_provider_order(&mut body, &["Cerebras".to_string(), "Groq".to_string()]);
+        assert_eq!(body["provider"]["order"], json!(["Groq"]));
+        assert_eq!(body["provider"]["allow_fallbacks"], json!(false));
+    }
+
+    #[test]
+    fn provider_order_noop_for_empty() {
+        let mut body = json!({"model": "openai/gpt-oss-120b"});
+        apply_openrouter_provider_order(&mut body, &[]);
+        assert!(body.get("provider").is_none());
+    }
+
+    #[test]
+    fn build_request_body_pins_gpt_oss_openrouter_to_clean_subproviders() {
+        // The openrouter openai/gpt-oss-* capability row carries
+        // openrouter_provider_order = ["Cerebras", "Groq"]; build_request_body
+        // must materialize it into provider.order + allow_fallbacks:false so the
+        // sub-provider lottery only lands on known-clean upstreams.
+        let mut payload = base_request_payload();
+        payload.provider = "openrouter".to_string();
+        payload.model = "openai/gpt-oss-120b".to_string();
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        assert_eq!(
+            body["provider"]["order"],
+            json!(["Cerebras", "Groq"]),
+            "gpt-oss openrouter body must pin the clean upstream order: {body}"
+        );
+        assert_eq!(
+            body["provider"]["allow_fallbacks"],
+            json!(false),
+            "gpt-oss openrouter pin must be closed (no fallbacks): {body}"
+        );
+    }
+
+    #[test]
+    fn build_request_body_does_not_pin_other_openrouter_models() {
+        // A non-gpt-oss openrouter model must not receive a provider.order pin —
+        // the allowlist is row-scoped, so unrelated routes keep free routing.
+        let mut payload = base_request_payload();
+        payload.provider = "openrouter".to_string();
+        payload.model = "anthropic/claude-sonnet-4.5".to_string();
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        let order = body
+            .get("provider")
+            .and_then(|provider| provider.get("order"));
+        assert!(
+            order.is_none(),
+            "non-gpt-oss openrouter route must not be pinned: {body}"
+        );
+    }
+
+    #[test]
+    fn build_request_body_does_not_pin_gpt_oss_on_other_providers() {
+        // gpt-oss served by a NON-openrouter provider (groq/cerebras direct)
+        // must NOT get a provider.order block — the pin is openrouter-scoped.
+        let mut payload = base_request_payload();
+        payload.provider = "groq".to_string();
+        payload.model = "openai/gpt-oss-120b".to_string();
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        assert!(
+            body.get("provider").is_none(),
+            "non-openrouter gpt-oss route must not be pinned: {body}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Makes Harn **opinionated** about the OpenRouter `openai/gpt-oss-*` route so harness authors can't hit the sub-provider-lottery footgun, declaratively in the capabilities TOML family. Builds directly on #3305's `reasoning_required_for_tools` precedent (this PR is **stacked on #3305** — base is `agent/gpt-oss-reasoning-fix`; will retarget to `main` + rebase once #3305 lands).

### The footgun
OpenRouter routes `openai/gpt-oss-120b` across a ~17-upstream sub-provider lottery. #3305 fixed the *reasoning-off* footgun (gpt-oss calls tools inside the Harmony reasoning channel). The **second** footgun: even with reasoning ON, some OpenRouter upstreams mis-serialize the Harmony tool call and finish billed-noncommittal (0 tool_calls). The bad upstreams are intermittent/hard to enumerate, so we **allowlist** the clean ones.

## 1. Runtime route policy (declarative)
- New capability field `openrouter_provider_order` — the allowlist counterpart to `provider_route_denylist`. Materializes into the OpenRouter request body `provider: { order: [...], allow_fallbacks: false }` via `apply_openrouter_provider_order` in `openai_compat.rs`. Pure capability lookup, no model-name branch. When both a pin and a denylist are present, the pin wins (a closed allowlist already excludes everything else).
- The `openai/gpt-oss-*` OpenRouter row is pinned to `["Cerebras", "Groq"]`.

### Live probe (2026-06-13, `openai/gpt-oss-120b`, reasoning effort=low, weather-tool request)
| route | result |
|---|---|
| free routing (lottery) ×12 | all Groq, **12/12 clean** tool calls |
| `order:[Cerebras,Groq], allow_fallbacks:false` ×6 | all Cerebras, **6/6 clean, 0 billed-noncommittal** |
| Cerebras-only ×3 / Groq-only ×3 | **6/6 clean** |
| Together pin ×3 | **1/3** (2× "Provider returned error") → NOT allowlisted |
| reasoning disabled (control) | OpenRouter hard-errors "Reasoning is mandatory" (confirms #3305's `reasoning_disable_supported=false`) |

Cerebras + Groq are the blessed upstreams; the order-pin gives **0 billed-noncommittal**.

## 2. Compile-time footgun gate
New data-driven `capability_audit` module wired into `harn providers build-capabilities --check` / `make check-provider-capabilities`. FAILS the build on known-footgun combos (reads the matrix's own invariants — no hard-coded model-name patterns):
- a `reasoning_required_for_tools` route that also forces a tool task (agent/code/verify) to reasoning `"off"` (direct contradiction);
- a `reasoning_required_for_tools` **OpenRouter** route with no `openrouter_provider_order` pin (a lottery route with no clean pin).

Adversarially verified: removing the pin from the gpt-oss row makes `build-capabilities --check` fail loudly with a remediation message; restoring it passes. Opinionated policy (blessed vs forbidden combos + why) documented in the `capabilities.toml` base shard (`00-base.toml`).

## 3. Tests + artifacts
- `capability_audit` unit tests: flags both footguns, accepts pinned routes, accepts the legit Qwen reasoning-off quirk, accepts non-OpenRouter required routes, `shipped_matrix_has_no_footguns`.
- `openai_compat` tests: `apply_openrouter_provider_order` (pin closed, respects caller order, no-op on empty); `build_request_body` pins gpt-oss OR to Cerebras/Groq, does NOT pin other OR models or gpt-oss on other providers.
- All derived artifacts regenerated (capabilities.toml / providers.toml / provider-matrix.md / provider-catalog spec) — only capabilities.toml changed (the field is capability-internal); all `check-provider-*` gates pass (no drift).
- Green: `make conformance` (1619/1619), `cargo nextest -p harn-vm` (3846/3846), `cargo nextest -p harn-cli providers` (30/30), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)