### PR TITLE
docs(llm): rate limiter charges GROSS tokens by design (matches provider TPM enforcement)

### DIFF
--- a/changelog.d/3310.changed.md
+++ b/changelog.d/3310.changed.md
@@ -1,0 +1,7 @@
+- **Documented the rate limiter's gross-token accounting.** The LLM rate
+  limiter counts GROSS prompt tokens against TPM by design — prompt-cached
+  tokens are intentionally NOT netted out, because provider TPM enforcement is
+  on gross tokens regardless of cache hits (verified live against Cerebras
+  gpt-oss-120b: with 6400/6482 prompt tokens served from cache, the per-minute
+  token budget still decremented by the full gross prompt). Comment-only at the
+  charge site in `rate_limit.rs`; no behavior change.

--- a/crates/harn-vm/src/llm/rate_limit.rs
+++ b/crates/harn-vm/src/llm/rate_limit.rs
@@ -35,6 +35,23 @@ struct RateLimitRequest {
 }
 
 impl RateLimitRequest {
+    /// Charge GROSS projected tokens against TPM — this is intentional, not a
+    /// bug, and must not be "optimized" to net out prompt-cached tokens.
+    ///
+    /// `projected_input_tokens` is the whole prompt (system + every message +
+    /// tools) with no subtraction for prompt-cached prefixes. A reasonable
+    /// instinct is that re-sending a cached transcript prefix shouldn't count
+    /// against the per-minute token budget. It does: provider TPM enforcement
+    /// is on GROSS prompt tokens regardless of cache hits. Verified live
+    /// (2026-06-12) against Cerebras gpt-oss-120b — with 6400/6482 prompt
+    /// tokens served from cache (usage.prompt_tokens_details.cached_tokens),
+    /// the x-ratelimit-remaining-tokens-minute header still decremented by the
+    /// full ~6480 gross prompt tokens. Caching reduces BILLED cost (see
+    /// cost.rs, which does net out cache_read_tokens for dollars), not the rate
+    /// limit. Netting cached tokens out here would make the proactive limiter
+    /// UNDER-throttle and provoke provider 429s. The lever for cache-heavy,
+    /// growing-transcript workloads is footprint reduction (compaction / fewer
+    /// turns), not limiter accounting.
     fn for_llm_call(opts: &super::api::LlmCallOptions) -> Self {
         let projection = super::cost::project_llm_call_cost(opts, 0.0);
         Self {


### PR DESCRIPTION
## Summary

Documents — at the charge site in `crates/harn-vm/src/llm/rate_limit.rs` — that the proactive sliding-window limiter charges **gross** projected input tokens against TPM **by design**, and must not be "optimized" to net out prompt-cached tokens.

This is a comment-only change (no behavior change). It records the answer to a recurring question: *does the limiter over-throttle by counting prompt-cached tokens the provider doesn't rate-limit?*

## Finding (verified live)

**No — gross accounting matches the provider.** Probed live 2026-06-12 against Cerebras `gpt-oss-120b`:
- The prompt IS cached: `usage.prompt_tokens_details.cached_tokens` returned **6400 / 6482** on a repeated prefix.
- The `x-ratelimit-remaining-tokens-minute` response header still decremented by the **full ~6480 gross** prompt tokens.

So provider TPM enforcement is on gross prompt tokens regardless of cache hits. Caching reduces **billed cost** (`cost.rs` already nets out `cache_read_tokens` for dollars), not the rate limit. Netting cached tokens out of the limiter would make it **under-throttle** and provoke 429s. The lever for cache-heavy, growing-transcript workloads is footprint reduction (compaction / fewer turns), not limiter accounting.

## Why document instead of "fix"

The instinct to subtract cached tokens is reasonable but wrong, and would be a latent 429 bug if someone acts on it later. The comment captures the live evidence so the gross-vs-net question is settled at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)