### PR TITLE
fix(llm): floor structured judge max_tokens + length_truncation integrity category

### DIFF
--- a/changelog.d/structured-judge-truncation-integrity.fixed.md
+++ b/changelog.d/structured-judge-truncation-integrity.fixed.md
@@ -1,0 +1,19 @@
+- **Structured judge/router calls no longer silently truncate into a dead-judge
+  fall-through, and a truncation is now its own integrity category.** A
+  `safe_structured_call` (judge / router / cheap-classifier) that went out with
+  a tiny `max_tokens` budget truncated mid-object on a reasoning model — gpt-oss
+  on Cerebras emits its structured output *inside* the reasoning channel, so the
+  reasoning and the JSON share the same output budget — and the unparseable
+  result was classified as a generic `missing_json` miss indistinguishable from
+  a model that just returned prose. Two provider-generic fixes: (1)
+  `safe_structured_call` now floors a structured call's `max_tokens` to 512 (it
+  only RAISES an unset/too-small budget; an explicit larger value such as a
+  1200-token rubric judge is untouched), so a small verdict object always has
+  room to finish; live-probed against `cerebras gpt-oss-120b`, a historical
+  `max_tokens: 180` call (which produced zero JSON, 180/180 tokens spent on
+  reasoning) now returns clean bounded JSON at ~207 tokens with `stop_reason=
+  stop`. (2) A token-limit truncation gets its own `error_category:
+  "length_truncation"` on the result envelope (kept even after a failed repair
+  pass) so a caller can detect a DEAD structured call — one that fell through to
+  a deterministic grader without ever rendering a verdict — instead of laundering
+  it as an ordinary abstention.

--- a/crates/harn-stdlib/src/stdlib/llm/safe.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/safe.harn
@@ -289,6 +289,16 @@ pub fn schema_retry_nudge_for(schema, hint) {
  *   repair.max_tokens-> 600
  *   repair.temperature -> 0.0
  *   schema_retry_nudge -> derived via `schema_retry_nudge_for`
+ *   max_tokens       -> floored to `STRUCTURED_MIN_MAX_TOKENS` (512)
+ *
+ * The `max_tokens` FLOOR is a measurement-integrity guard, not a tuning knob:
+ * a judge/router structured call that goes out with a tiny budget (e.g. the
+ * historical `max_tokens: 180` completion-judge default) truncates mid-object
+ * on a reasoning model — which spends part of the same output budget on its
+ * reasoning channel — yielding unparseable JSON and a silent dead-judge
+ * fall-through. Flooring (never lowering) the budget keeps the JSON bounded by
+ * the schema yet large enough to finish. Provider-generic: it never inspects
+ * the provider or model.
  *
  * @effects: []
  * @errors: []
@@ -304,8 +314,22 @@ pub fn safe_structured_call(prompt, schema, options) {
   return __augment_envelope(envelope)
 }
 
+/**
+ * Minimum output-token budget for a structured judge/router call. A call that
+ * goes out under this floor risks truncating its JSON mid-object on a reasoning
+ * model (the reasoning channel shares the same `max_tokens` budget), which then
+ * masquerades as a dead-judge abstention. The floor only RAISES an unset or
+ * too-small budget; an explicit larger `max_tokens` (e.g. a 1200-token rubric
+ * judge) is left untouched.
+ */
+let STRUCTURED_MIN_MAX_TOKENS = 512
+
 fn __apply_judge_defaults(schema, options) {
   var resolved = options
+  let requested_max_tokens = to_int(resolved?.max_tokens ?? 0) ?? 0
+  if requested_max_tokens < STRUCTURED_MIN_MAX_TOKENS {
+    resolved = resolved + {max_tokens: STRUCTURED_MIN_MAX_TOKENS}
+  }
   if resolved?.temperature == nil {
     resolved = resolved + {temperature: 0.0}
   }

--- a/crates/harn-vm/src/llm/structured_envelope.rs
+++ b/crates/harn-vm/src/llm/structured_envelope.rs
@@ -144,12 +144,16 @@ pub(crate) async fn run_structured_envelope(
             // Repair didn't recover — fall through to the main-call
             // failure envelope, but mark the category as repair_failed
             // so callers can distinguish "tried repair, didn't help"
-            // from "repair was disabled".
-            return Ok(envelope_failure(
-                &main_outcome,
-                EnvelopeFailureKind::RepairFailed,
-                false,
-            ));
+            // from "repair was disabled". A token-limit truncation keeps its
+            // own integrity category even after a failed repair: the root
+            // cause is an under-budgeted call, and masking it as repair_failed
+            // would hide a dead-judge truncation from the meter.
+            let kind = if outcome_hit_token_limit(&main_outcome) {
+                EnvelopeFailureKind::LengthTruncation
+            } else {
+                EnvelopeFailureKind::RepairFailed
+            };
+            return Ok(envelope_failure(&main_outcome, kind, false));
         }
     }
 
@@ -235,6 +239,19 @@ fn prompt_with_schema_contract(prompt: &str, schema: &VmValue) -> String {
 }
 
 fn classify_main_failure(outcome: &SchemaLoopOutcome) -> EnvelopeFailureKind {
+    // A token-limit truncation is a MEASUREMENT-INTEGRITY signal, not an
+    // ordinary "the model returned prose instead of JSON" miss: the request
+    // ran out of `max_tokens` mid-object, so the JSON is unparseable purely
+    // because it was cut off. `structured_output_errors` (the schema-retry
+    // loop) already appends the canonical truncation marker derived from a
+    // provider-agnostic `is_length_truncation(stop_reason)` check, so we key
+    // off that marker here rather than re-inspecting the raw stop_reason.
+    // Surfacing it as its own category lets judge/router callers distinguish a
+    // DEAD (truncated) judge — which silently falls through to a deterministic
+    // grader — from a model that genuinely could not produce a verdict.
+    if outcome_hit_token_limit(outcome) {
+        return EnvelopeFailureKind::LengthTruncation;
+    }
     let has_data = outcome
         .vm_result
         .as_dict()
@@ -244,6 +261,19 @@ fn classify_main_failure(outcome: &SchemaLoopOutcome) -> EnvelopeFailureKind {
     } else {
         EnvelopeFailureKind::MissingJson
     }
+}
+
+/// Whether the structured failure was caused by the response running out of
+/// output-token budget mid-JSON. Detected from the canonical truncation marker
+/// `structured_output_errors` appends (see `call.rs::structured_output_errors`),
+/// which is itself derived from the provider-agnostic
+/// `is_length_truncation(stop_reason)` classifier — so this stays correct across
+/// every provider's stop_reason spelling without a per-provider branch here.
+fn outcome_hit_token_limit(outcome: &SchemaLoopOutcome) -> bool {
+    outcome
+        .errors
+        .iter()
+        .any(|e| e.contains("hit the token limit"))
 }
 
 /// Returned-`{enabled, ...overrides}`-dict-or-`nil` repair config.
@@ -361,6 +391,12 @@ enum EnvelopeFailureKind {
     SchemaValidation,
     /// Repair pass was attempted and also failed.
     RepairFailed,
+    /// The response was truncated by the `max_tokens` budget before it could
+    /// emit complete JSON — a measurement-integrity signal distinct from a
+    /// model that returned no JSON at all. Callers (judges/routers) use this to
+    /// detect a DEAD structured call instead of treating the truncation as an
+    /// ordinary abstention.
+    LengthTruncation,
 }
 
 impl EnvelopeFailureKind {
@@ -369,6 +405,7 @@ impl EnvelopeFailureKind {
             EnvelopeFailureKind::MissingJson => "missing_json",
             EnvelopeFailureKind::SchemaValidation => "schema_validation",
             EnvelopeFailureKind::RepairFailed => "repair_failed",
+            EnvelopeFailureKind::LengthTruncation => "length_truncation",
         }
     }
 }
@@ -554,6 +591,39 @@ pub(crate) async fn llm_call_structured_result_impl(
 mod tests {
     use super::*;
     use crate::value::VmDictExt;
+
+    fn outcome_with_errors(errors: Vec<&str>) -> SchemaLoopOutcome {
+        SchemaLoopOutcome {
+            vm_result: VmValue::dict(crate::value::DictMap::new()),
+            raw_text: String::from("{\"verdict\":\"do"),
+            errors: errors.into_iter().map(String::from).collect(),
+            attempts: 1,
+            schema_retries_budget: 2,
+            output_validation_mode: String::from("error"),
+        }
+    }
+
+    #[test]
+    fn token_limit_truncation_gets_its_own_integrity_category() {
+        // The canonical marker `structured_output_errors` appends on a length
+        // stop_reason must be classified as `length_truncation`, NOT lumped
+        // into the generic `missing_json` bucket — otherwise a dead (truncated)
+        // judge is invisible to the meter.
+        let outcome = outcome_with_errors(vec![
+            "response did not contain parseable JSON",
+            "response hit the token limit before producing complete JSON",
+        ]);
+        assert!(outcome_hit_token_limit(&outcome));
+        let kind = classify_main_failure(&outcome);
+        assert_eq!(kind.category(), "length_truncation");
+    }
+
+    #[test]
+    fn non_truncation_missing_json_stays_missing_json() {
+        let outcome = outcome_with_errors(vec!["response did not contain parseable JSON"]);
+        assert!(!outcome_hit_token_limit(&outcome));
+        assert_eq!(classify_main_failure(&outcome).category(), "missing_json");
+    }
 
     #[test]
     fn repair_prompt_includes_raw_text_and_errors() {


### PR DESCRIPTION
## Problem (measurement-honesty defect #22)

Structured judge/router/cheap-classifier calls (`safe_structured_call`) for
`cerebras gpt-oss-120b` truncated mid-JSON and emitted unparseable output, so
the judge/agreement column was effectively DEAD — trials passed only via the
deterministic E2 re-exec while the report still showed a judge "agreement" the
judge never actually rendered.

**Root cause (confirmed by live probe).** A judge call went out with a tiny
`max_tokens` (the Burin completion judge's historical `180`). gpt-oss on Cerebras
performs its structured output *inside* the Harmony reasoning channel, so the
reasoning trace and the JSON share the same output budget; 180 tokens were spent
entirely on reasoning and the response stopped (`stop_reason=length`) before any
JSON was emitted. The resulting failure was classified as a generic
`missing_json` miss — indistinguishable from a model that simply returned prose —
so the dead-judge fall-through was invisible to the meter.

## Fix (provider-generic)

1. **`max_tokens` floor.** `safe_structured_call` floors a structured call's
   `max_tokens` to **512** (`STRUCTURED_MIN_MAX_TOKENS`). It only RAISES an
   unset/too-small budget; an explicit larger value (e.g. the 1200-token rubric
   judge) is left untouched. No provider/model branch.
2. **`length_truncation` integrity category.** A token-limit truncation now gets
   its own `error_category: "length_truncation"` on the result envelope (kept
   even after a failed repair pass), keyed off the canonical
   `is_length_truncation(stop_reason)` marker the schema-retry loop already
   appends. Callers can now distinguish a DEAD (truncated) structured call from
   an ordinary abstention. Burin's eval harness consumes this in a companion PR
   to surface a `judge_dead` counter in the trial JSON / report.

## Live-spend proof (`cerebras gpt-oss-120b`, real key)

```
# direct call, historical max_tokens=180:
ok=false  error_category=length_truncation  output_tokens=180  raw_text=(empty)

# through safe_structured_call, caller passes max_tokens=180 (floored to 512):
ok=true   error_category=nil  verdict=done  output_tokens=207   <- clean, stop_reason=stop
```

## Tests

- New unit tests in `structured_envelope.rs`: truncation → `length_truncation`;
  non-truncation missing JSON stays `missing_json`.
- `cargo test -p harn-vm --lib llm::` — 1017 passed.
- `harn test conformance --filter llm_call_structured` + `safe_structured_call_basics` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)