### PR TITLE
[codex] fix portal input validation

### DIFF
--- a/changelog.d/portal-input-validation.fixed.md
+++ b/changelog.d/portal-input-validation.fixed.md
@@ -1,0 +1,3 @@
+- **Portal input validation.** Runs-page URL params now fall back to valid
+  filters, sort order, page, and row-count values, and launch env overrides now
+  reject non-object JSON and non-string values before submitting.

--- a/crates/harn-cli/portal/src/App.test.tsx
+++ b/crates/harn-cli/portal/src/App.test.tsx
@@ -1,10 +1,11 @@
-import { render, screen, waitFor } from "@testing-library/react"
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { IntlProvider } from "react-intl"
 import { MemoryRouter } from "react-router-dom"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { App } from "./App"
+import { RunsPage } from "./pages/RunsPage"
 
 const runsPayload = {
   stats: {
@@ -161,10 +162,33 @@ const detailPayload = {
 }
 
 afterEach(() => {
+  cleanup()
   vi.unstubAllGlobals()
 })
 
 describe("App", () => {
+  it("normalizes malformed runs query params before fetching", async () => {
+    const fetchMock = vi.fn(async (input: string) => {
+      if (input.startsWith("/api/runs")) {
+        return { ok: true, json: async () => ({ ...runsPayload, runs: [] }) }
+      }
+      throw new Error(`unexpected fetch ${input}`)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    render(
+      <MemoryRouter initialEntries={["/runs?page=1.5&page_size=37&status=bogus&sort=weird"]}>
+        <IntlProvider locale="en">
+          <RunsPage />
+        </IntlProvider>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/runs?status=all&sort=newest&page=1&page_size=25")
+    })
+  })
+
   it("shows a paginated runs page and navigates into run detail", async () => {
     const fetchMock = vi.fn(async (input: string) => {
       if (input.startsWith("/api/runs")) {

--- a/crates/harn-cli/portal/src/components/LaunchPanel.test.tsx
+++ b/crates/harn-cli/portal/src/components/LaunchPanel.test.tsx
@@ -1,9 +1,13 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { IntlProvider } from "react-intl"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { LaunchPanel } from "./LaunchPanel"
+
+afterEach(() => {
+  cleanup()
+})
 
 describe("LaunchPanel", () => {
   it("submits playground launches with provider, model, and env overrides", async () => {
@@ -163,5 +167,55 @@ describe("LaunchPanel", () => {
       source: undefined,
       task: "Summarize the repository in a few bullets.",
     })
+  })
+
+  it("rejects null env JSON before launching", async () => {
+    const onLaunch = vi.fn(async () => {})
+
+    render(
+      <IntlProvider locale="en">
+        <LaunchPanel
+          meta={{ workspace_root: "/workspace/harn", run_dir: ".harn-runs/portal-demo" }}
+          llmOptions={null}
+          targets={[]}
+          jobs={[]}
+          onLaunch={onLaunch}
+          onOpenRun={() => {}}
+        />
+      </IntlProvider>,
+    )
+
+    fireEvent.change(screen.getByLabelText("Env JSON overrides"), {
+      target: { value: "null" },
+    })
+    await userEvent.click(screen.getAllByRole("button", { name: "Run now" }).at(-1)!)
+
+    expect(await screen.findByText("Env JSON must be an object")).toBeInTheDocument()
+    expect(onLaunch).not.toHaveBeenCalled()
+  })
+
+  it("rejects non-string env JSON values before launching", async () => {
+    const onLaunch = vi.fn(async () => {})
+
+    render(
+      <IntlProvider locale="en">
+        <LaunchPanel
+          meta={{ workspace_root: "/workspace/harn", run_dir: ".harn-runs/portal-demo" }}
+          llmOptions={null}
+          targets={[]}
+          jobs={[]}
+          onLaunch={onLaunch}
+          onOpenRun={() => {}}
+        />
+      </IntlProvider>,
+    )
+
+    fireEvent.change(screen.getByLabelText("Env JSON overrides"), {
+      target: { value: '{"OPENAI_API_KEY":123}' },
+    })
+    await userEvent.click(screen.getAllByRole("button", { name: "Run now" }).at(-1)!)
+
+    expect(await screen.findByText("Env JSON values must be strings")).toBeInTheDocument()
+    expect(onLaunch).not.toHaveBeenCalled()
   })
 })

--- a/crates/harn-cli/portal/src/components/LaunchPanel.tsx
+++ b/crates/harn-cli/portal/src/components/LaunchPanel.tsx
@@ -129,6 +129,27 @@ type LaunchPanelProps = {
   onOpenRun: (path: string) => void
 }
 
+function parseEnvOverrides(envJson: string): Record<string, string> {
+  const trimmed = envJson.trim()
+  if (!trimmed) {
+    return {}
+  }
+
+  const parsed = JSON.parse(trimmed) as unknown
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Env JSON must be an object")
+  }
+
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof value !== "string") {
+      throw new Error("Env JSON values must be strings")
+    }
+    env[key] = value
+  }
+  return env
+}
+
 export function LaunchPanel({ meta, llmOptions, targets, jobs, onLaunch, onOpenRun }: LaunchPanelProps) {
   const intl = useIntl()
   const [mode, setMode] = useState<"file" | "source" | "playground">("playground")
@@ -189,10 +210,7 @@ export function LaunchPanel({ meta, llmOptions, targets, jobs, onLaunch, onOpenR
     setSubmitting(true)
     setError(null)
     try {
-      const env = envJson.trim() ? (JSON.parse(envJson) as Record<string, string>) : {}
-      if (typeof env !== "object" || Array.isArray(env)) {
-        throw new Error("Env JSON must be an object")
-      }
+      const env = parseEnvOverrides(envJson)
       if (selectedProvider?.base_url_env && endpointUrl.trim()) {
         env[selectedProvider.base_url_env] = endpointUrl.trim()
       }

--- a/crates/harn-cli/portal/src/pages/RunsPage.tsx
+++ b/crates/harn-cli/portal/src/pages/RunsPage.tsx
@@ -45,9 +45,25 @@ const messages = defineMessages({
   pageSummary: { id: "portal.runsPage.pageSummary", defaultMessage: "Page {page} of {total}" },
 })
 
-function readNumber(value: string | null, fallback: number) {
+const RUN_STATUS_FILTERS = ["all", "active", "completed", "failed"] as const satisfies readonly RunStatusFilter[]
+const RUN_SORT_ORDERS = ["newest", "oldest", "duration"] as const satisfies readonly RunSortOrder[]
+const RUN_PAGE_SIZES = [25, 50, 100] as const
+
+function readChoice<T extends string>(value: string | null, allowed: readonly T[], fallback: T): T {
+  return value && (allowed as readonly string[]).includes(value) ? (value as T) : fallback
+}
+
+function readPositiveInteger(value: string | null, fallback: number) {
+  if (!value || !/^\d+$/.test(value)) {
+    return fallback
+  }
   const parsed = Number(value)
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function readPageSize(value: string | null) {
+  const parsed = readPositiveInteger(value, 25)
+  return (RUN_PAGE_SIZES as readonly number[]).includes(parsed) ? parsed : 25
 }
 
 export function RunsPage() {
@@ -55,10 +71,10 @@ export function RunsPage() {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const q = searchParams.get("q") ?? ""
-  const status = (searchParams.get("status") as RunStatusFilter | null) ?? "all"
-  const sort = (searchParams.get("sort") as RunSortOrder | null) ?? "newest"
-  const page = readNumber(searchParams.get("page"), 1)
-  const pageSize = readNumber(searchParams.get("page_size"), 25)
+  const status = readChoice(searchParams.get("status"), RUN_STATUS_FILTERS, "all")
+  const sort = readChoice(searchParams.get("sort"), RUN_SORT_ORDERS, "newest")
+  const page = readPositiveInteger(searchParams.get("page"), 1)
+  const pageSize = readPageSize(searchParams.get("page_size"))
   const skill = searchParams.get("skill") ?? ""
   const { runs, filteredCount, pagination, loading, lastError, lastRefreshAt, loadRuns } = useRunsData({
     q,


### PR DESCRIPTION
## Summary
- normalize malformed runs-page URL params before fetching persisted runs
- validate launch env override JSON as a non-null object with string values
- add regression coverage for malformed runs params and invalid launch env JSON
- add a changelog fragment for the portal fixes

## Root Cause
The runs page trusted URL query params via type assertions and `Number`, which let invalid enum values, fractional pages, and unsupported row counts reach the API/UI. The launch panel cast parsed env JSON to `Record<string, string>` without rejecting `null` or non-string values.

## Validation
- `npm run portal:test`
- `npm run portal:lint`
- `npm run portal:build`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `.github/scripts/changelog-fragment-check.sh`
- pre-commit and pre-push hooks passed