### PR TITLE
feat(llm): gpt-oss reasoning capability rows for fireworks/deepinfra/sambanova

### DIFF
--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -2210,6 +2210,47 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
     }
 
     #[test]
+    fn fireworks_deepinfra_sambanova_gpt_oss_require_reasoning_for_tools() {
+        // gpt-oss (Harmony) calls tools INSIDE the chain-of-thought channel, so
+        // reasoning-off breaks tool calling. The fireworks/deepinfra/sambanova
+        // catch-all rules carry no reasoning fields, so without a dedicated
+        // `*gpt-oss*` row gpt-oss would fall through to reasoning-OFF and the
+        // eval loop would bill a noncommittal. These rows mirror the Cerebras
+        // gpt-oss capability row. Regression guard for that resolution.
+        reset();
+        for (provider, model) in [
+            ("fireworks", "accounts/fireworks/models/gpt-oss-120b"),
+            ("deepinfra", "openai/gpt-oss-120b"),
+            ("sambanova", "gpt-oss-120b"),
+        ] {
+            let caps = lookup(provider, model);
+            assert!(
+                caps.reasoning_required_for_tools,
+                "{provider}/{model}: reasoning_required_for_tools must be true"
+            );
+            assert!(
+                caps.reasoning_effort_supported,
+                "{provider}/{model}: reasoning_effort_supported must be true"
+            );
+            assert_eq!(
+                caps.reasoning_effort_levels,
+                vec!["low", "medium", "high"],
+                "{provider}/{model}: effort levels"
+            );
+            assert_eq!(caps.thinking_modes, vec!["effort"], "{provider}/{model}");
+            assert_eq!(
+                caps.preferred_tool_format.as_deref(),
+                Some("native"),
+                "{provider}/{model}: native tools"
+            );
+            assert_eq!(
+                caps.thinking_block_style, "reasoning_summary",
+                "{provider}/{model}"
+            );
+        }
+    }
+
+    #[test]
     fn cerebras_glm_47_supports_reasoning_none() {
         // Cerebras documents GLM 4.7's no-reasoning value as
         // reasoning_effort="none"; the older disable_reasoning knob is

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -1540,6 +1540,35 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
 
+# Fireworks-hosted GPT-OSS (`accounts/fireworks/models/gpt-oss-120b`) is the
+# same Harmony model as cerebras/groq/openrouter gpt-oss-120b. Without this
+# row gpt-oss would fall through to no fireworks-specific reasoning rule, so
+# `reasoning_required_for_tools` resolves OFF and the eval loop bills a
+# noncommittal (tools never fire inside the chain-of-thought channel). Mirror
+# the Cerebras gpt-oss capability row: NATIVE tool calls (gpt-oss emits a bare
+# `{"tool":..,"arguments":..}` dialect that the fenced-JSON/text parsers do
+# not recognize, so native is the only working channel), reasoning-effort
+# thinking with {low, medium, high}, and `reasoning_required_for_tools = true`
+# so an auto "off" floors to the lowest accepted effort rather than disabling
+# the channel tools call from. Must NOT carry a Qwen-style
+# `auto_reasoning_overrides = "off"` — that would break tool calling.
+[[provider.fireworks]]
+model_match = "*gpt-oss*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["effort"]
+reasoning_effort_supported = true
+reasoning_effort_levels = ["low", "medium", "high"]
+reasoning_required_for_tools = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "reasoning_summary"
+
 [[provider.fireworks]]
 model_match = "*qwen3.6*"
 native_tools = true
@@ -2162,6 +2191,32 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
 
+# DeepInfra-hosted GPT-OSS is the same Harmony model as cerebras/fireworks
+# gpt-oss-120b. Placed BEFORE the catch-all `*` rule (first match wins) so it
+# does not fall through to the non-reasoning default — without it
+# `reasoning_required_for_tools` resolves OFF and the eval loop bills a
+# noncommittal because gpt-oss calls tools INSIDE the chain-of-thought channel.
+# Mirror the Cerebras gpt-oss row: NATIVE tools, reasoning-effort thinking
+# {low, medium, high}, `reasoning_required_for_tools = true`. Must NOT carry a
+# Qwen-style `auto_reasoning_overrides = "off"`.
+[[provider.deepinfra]]
+model_match = "*gpt-oss*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["effort"]
+reasoning_effort_supported = true
+reasoning_effort_levels = ["low", "medium", "high"]
+reasoning_required_for_tools = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "reasoning_summary"
+
 [[provider.deepinfra]]
 model_match = "*"
 native_tools = true
@@ -2213,6 +2268,32 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "none"
+
+# SambaNova-hosted GPT-OSS is the same Harmony model as cerebras/fireworks
+# gpt-oss-120b. Placed BEFORE the catch-all `*` rule (first match wins) so it
+# does not fall through to the non-reasoning default — without it
+# `reasoning_required_for_tools` resolves OFF and the eval loop bills a
+# noncommittal because gpt-oss calls tools INSIDE the chain-of-thought channel.
+# Mirror the Cerebras gpt-oss row: NATIVE tools, reasoning-effort thinking
+# {low, medium, high}, `reasoning_required_for_tools = true`. Must NOT carry a
+# Qwen-style `auto_reasoning_overrides = "off"`.
+[[provider.sambanova]]
+model_match = "*gpt-oss*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["effort"]
+reasoning_effort_supported = true
+reasoning_effort_levels = ["low", "medium", "high"]
+reasoning_required_for_tools = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "reasoning_summary"
 
 [[provider.sambanova]]
 model_match = "*"

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/30-qwen-routed.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/30-qwen-routed.toml
@@ -47,6 +47,35 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
 
+# Fireworks-hosted GPT-OSS (`accounts/fireworks/models/gpt-oss-120b`) is the
+# same Harmony model as cerebras/groq/openrouter gpt-oss-120b. Without this
+# row gpt-oss would fall through to no fireworks-specific reasoning rule, so
+# `reasoning_required_for_tools` resolves OFF and the eval loop bills a
+# noncommittal (tools never fire inside the chain-of-thought channel). Mirror
+# the Cerebras gpt-oss capability row: NATIVE tool calls (gpt-oss emits a bare
+# `{"tool":..,"arguments":..}` dialect that the fenced-JSON/text parsers do
+# not recognize, so native is the only working channel), reasoning-effort
+# thinking with {low, medium, high}, and `reasoning_required_for_tools = true`
+# so an auto "off" floors to the lowest accepted effort rather than disabling
+# the channel tools call from. Must NOT carry a Qwen-style
+# `auto_reasoning_overrides = "off"` — that would break tool calling.
+[[provider.fireworks]]
+model_match = "*gpt-oss*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["effort"]
+reasoning_effort_supported = true
+reasoning_effort_levels = ["low", "medium", "high"]
+reasoning_required_for_tools = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "reasoning_summary"
+
 [[provider.fireworks]]
 model_match = "*qwen3.6*"
 native_tools = true

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/36-deepinfra.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/36-deepinfra.toml
@@ -38,6 +38,32 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
 
+# DeepInfra-hosted GPT-OSS is the same Harmony model as cerebras/fireworks
+# gpt-oss-120b. Placed BEFORE the catch-all `*` rule (first match wins) so it
+# does not fall through to the non-reasoning default — without it
+# `reasoning_required_for_tools` resolves OFF and the eval loop bills a
+# noncommittal because gpt-oss calls tools INSIDE the chain-of-thought channel.
+# Mirror the Cerebras gpt-oss row: NATIVE tools, reasoning-effort thinking
+# {low, medium, high}, `reasoning_required_for_tools = true`. Must NOT carry a
+# Qwen-style `auto_reasoning_overrides = "off"`.
+[[provider.deepinfra]]
+model_match = "*gpt-oss*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["effort"]
+reasoning_effort_supported = true
+reasoning_effort_levels = ["low", "medium", "high"]
+reasoning_required_for_tools = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "reasoning_summary"
+
 [[provider.deepinfra]]
 model_match = "*"
 native_tools = true

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/37-sambanova.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/37-sambanova.toml
@@ -35,6 +35,32 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "none"
 
+# SambaNova-hosted GPT-OSS is the same Harmony model as cerebras/fireworks
+# gpt-oss-120b. Placed BEFORE the catch-all `*` rule (first match wins) so it
+# does not fall through to the non-reasoning default — without it
+# `reasoning_required_for_tools` resolves OFF and the eval loop bills a
+# noncommittal because gpt-oss calls tools INSIDE the chain-of-thought channel.
+# Mirror the Cerebras gpt-oss row: NATIVE tools, reasoning-effort thinking
+# {low, medium, high}, `reasoning_required_for_tools = true`. Must NOT carry a
+# Qwen-style `auto_reasoning_overrides = "off"`.
+[[provider.sambanova]]
+model_match = "*gpt-oss*"
+native_tools = true
+preferred_tool_format = "native"
+structured_output = "native"
+thinking_modes = ["effort"]
+reasoning_effort_supported = true
+reasoning_effort_levels = ["low", "medium", "high"]
+reasoning_required_for_tools = true
+text_tool_wire_format_supported = true
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+structured_output_mode = "native_json"
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "reasoning_summary"
+
 [[provider.sambanova]]
 model_match = "*"
 native_tools = true

--- a/docs/provider-support.json
+++ b/docs/provider-support.json
@@ -444,15 +444,15 @@
         "FIREWORKS_API_KEY"
       ],
       "recommended": {
-        "selector": "fireworks:*qwen3.6*",
+        "selector": "fireworks:*gpt-oss*",
         "provider": "fireworks",
-        "model": "*qwen3.6*",
+        "model": "*gpt-oss*",
         "display_name": null,
         "tool_format": "native",
         "harn_options": [
           "provider = \"fireworks\"",
           "tool_format = \"native\"",
-          "structured_output_mode = \"delimited\""
+          "structured_output_mode = \"native_json\""
         ]
       },
       "capabilities": {
@@ -461,11 +461,11 @@
         "preferred_tool_format": "native",
         "tool_mode_parity": "unknown",
         "structured_output_transport": "native",
-        "structured_output_mode": "delimited",
+        "structured_output_mode": "native_json",
         "streaming": true,
         "reasoning_knobs": [
-          "disable_directive:/no_think",
-          "enabled"
+          "effort",
+          "reasoning_effort"
         ],
         "prompt_or_context_cache": false,
         "usage_accounting_confidence": "provider_default"

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -49,11 +49,13 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `dashscope` | `qwen*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `deepinfra` | `*deepseek*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `deepinfra` | `*qwen3.6*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `deepinfra` | `*gpt-oss*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
 | `deepinfra` | `*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `deepseek` | `deepseek-v4-pro*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `deepseek` | `deepseek-v4-flash*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `deepseek` | `deepseek-chat*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | yes |
 | `deepseek` | `deepseek-reasoner*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `fireworks` | `*gpt-oss*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
 | `fireworks` | `*qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `fireworks` | `*qwen3p6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `fireworks` | `*qwen*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
@@ -153,6 +155,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `openrouter` | `stepfun/step-3.7-flash` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `interchangeable` | yes | yes |
 | `sambanova` | `*deepseek*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `sambanova` | `*llama*` | `any` | no | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
+| `sambanova` | `*gpt-oss*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
 | `sambanova` | `*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `together` | `Qwen/Qwen3.7-Max` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `together` | `qwen/qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |

--- a/docs/src/provider-support.md
+++ b/docs/src/provider-support.md
@@ -19,7 +19,7 @@ No benchmark summary is baked into this checked-in page. To layer local empirica
 | `Dashscope` | OpenAI-compatible chat completions | `dashscope:qwen3.6*` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `provider_default` | `not_recorded` |
 | `Deepinfra` | OpenAI-compatible chat completions | `deepinfra:deepinfra/Qwen/Qwen3.6-35B-A3B` | `native` | yes | yes | `native` / `native_json` | `enabled` | no | `high` | `not_recorded` |
 | `Deepseek` | OpenAI-compatible chat completions | `deepseek:deepseek-v4-flash` | `native` | yes | yes | `native` / `native_json` | `enabled` | yes | `high` | `not_recorded` |
-| `Fireworks` | OpenAI-compatible chat completions | `fireworks:*qwen3.6*` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `provider_default` | `not_recorded` |
+| `Fireworks` | OpenAI-compatible chat completions | `fireworks:*gpt-oss*` | `native` | yes | yes | `native` / `native_json` | `effort,reasoning_effort` | no | `provider_default` | `not_recorded` |
 | `Gemini API` | Gemini generateContent | `gemini:gemini-2.5-flash` | `native` | yes | yes | `native` / `native_json` | `adaptive,effort,enabled` | yes | `medium` | `not_recorded` |
 | `Groq` | OpenAI-compatible chat completions | `groq:llama-3.1-8b-instant` | `native` | yes | yes | `native` / `native_json` | none | no | `high` | `not_recorded` |
 | `Huggingface` | OpenAI-compatible chat completions | `huggingface:qwen/qwen3.6*` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `provider_default` | `not_recorded` |


### PR DESCRIPTION
## Why

harn main carries gpt-oss (Harmony) reasoning capability rows only for **cerebras/groq/openrouter**. **Fireworks, DeepInfra, and SambaNova** had no gpt-oss-specific rule, so their gpt-oss routes fell through to either no provider rule (fireworks) or the non-reasoning catch-all `*` rule (deepinfra/sambanova). That resolved `reasoning_required_for_tools` **OFF**.

Because gpt-oss calls tools **inside the chain-of-thought channel**, reasoning-off breaks tool calling and the eval loop bills a noncommittal. This blocks using a high-TPM Fireworks gpt-oss route for honest eval baselines (the Cerebras 250K-TPM route is request-rate-throttled to ~4.4 req/min for this footprint-heavy workload → unusable for N=5).

## What

Add a `*gpt-oss*` capability row for fireworks/deepinfra/sambanova mirroring the **Cerebras gpt-oss** row:
- `native_tools` / `preferred_tool_format = "native"` — gpt-oss emits a bare `{"tool":..,"arguments":..}` dialect the fenced-JSON/text parsers do not recognize, so native is the only working channel.
- `thinking_modes = ["effort"]`, `reasoning_effort_supported = true`, `reasoning_effort_levels = ["low","medium","high"]`.
- `reasoning_required_for_tools = true` — an auto "off" floors to the lowest accepted effort instead of disabling the channel tools call from.
- **No** Qwen-style `auto_reasoning_overrides` (that would break tool calling).
- deepinfra/sambanova rows placed **before** their catch-all `*` rule (first-match-wins).

Regenerated `capabilities.toml` + provider matrix + provider support artifacts; all `check-provider-*` gates pass. New regression test `fireworks_deepinfra_sambanova_gpt_oss_require_reasoning_for_tools`.

## Verification

- `make check-provider-capabilities check-provider-matrix check-provider-support` → all OK
- `cargo nextest run -p harn-vm` → **3861 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)