### PR TITLE
fix(llm): strip prior-turn assistant `reasoning` from openai-compat wire (Fireworks 400)

### DIFF
--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -124,6 +124,22 @@ impl OpenAiCompatibleProvider {
         }
         msgs.extend(opts.messages.iter().cloned().map(|mut message| {
             if let Some(object) = message.as_object_mut() {
+                // The durable transcript stores a prior assistant turn's
+                // private reasoning as a top-level `reasoning` field (see
+                // `build_assistant_response_message`). That field is for
+                // host/run-record storage only — no provider consumes a prior
+                // assistant message's `reasoning` on the chat-completions wire.
+                // Strict OpenAI-compat providers (e.g. Fireworks) reject any
+                // unknown top-level message field with HTTP 400 `Extra inputs
+                // are not permitted, field: 'messages[N].reasoning'`, which is
+                // terminal and non-retryable. Tolerant providers (Cerebras,
+                // groq, OpenRouter, DeepInfra, SambaNova) silently ignore it.
+                // Drop it here at the single, comprehensive wire boundary so the
+                // request is portable across every strict provider; reasoning
+                // continuity that DOES matter rides separate, typed channels
+                // (Gemini `thoughtSignature`, Anthropic signed thinking blocks,
+                // the OpenAI Responses reasoning items API).
+                object.remove("reasoning");
                 if let Some(content) = object.get("content").cloned() {
                     let content = if remap_tool_call {
                         remap_tool_call_content(&content)
@@ -1774,6 +1790,48 @@ thinking_modes = ["enabled"]
             serialized.contains("[[CALL]]") && serialized.contains("[[/CALL]]"),
             "non-special wire delimiters must be present: {serialized}"
         );
+    }
+
+    #[test]
+    fn build_request_body_strips_prior_assistant_reasoning_field() {
+        // The durable transcript carries a prior assistant turn's private
+        // reasoning as a top-level `messages[N].reasoning` field. Strict
+        // OpenAI-compat providers (Fireworks) reject any unknown top-level
+        // message field with a terminal HTTP 400
+        // `Extra inputs are not permitted, field: 'messages[N].reasoning'`.
+        // No provider consumes this field on the chat-completions wire, so it
+        // must be dropped at the request boundary for every provider.
+        let mut payload = base_request_payload();
+        payload.provider = "fireworks".to_string();
+        payload.model = "accounts/fireworks/models/gpt-oss-120b".to_string();
+        payload.messages = vec![
+            json!({"role": "user", "content": "hello"}),
+            json!({
+                "role": "assistant",
+                "content": "",
+                "reasoning": "let me inspect the file before editing",
+                "tool_calls": [{
+                    "id": "call_001",
+                    "type": "function",
+                    "function": {"name": "read", "arguments": "{\"path\":\"main.rs\"}"},
+                }],
+            }),
+            json!({"role": "user", "content": "continue"}),
+        ];
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        let messages = body["messages"].as_array().expect("messages array");
+        for message in messages {
+            assert!(
+                message.get("reasoning").is_none(),
+                "outgoing message must not carry a `reasoning` field: {message}"
+            );
+        }
+        // The rest of the assistant turn (tool_calls + role) must survive intact.
+        let assistant = messages
+            .iter()
+            .find(|message| message["role"] == "assistant")
+            .expect("assistant message preserved");
+        assert_eq!(assistant["tool_calls"][0]["id"], "call_001");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

harn re-serializes a prior assistant turn's private `reasoning` content back into the OUTGOING request messages. `build_assistant_response_message` (crates/harn-vm/src/llm/tools/messages.rs:145) stamps a top-level `reasoning` field onto the durable assistant message; that same message object flows into the next turn's `opts.messages` and the openai-compat `build_request_body` mapping only rewrites `content`, so the top-level `reasoning` key passes straight to the wire as `messages[N].reasoning`.

Strict OpenAI-compat providers reject unknown top-level message fields. **Fireworks returns a terminal, non-retryable HTTP 400** `Extra inputs are not permitted, field: 'messages[N].reasoning'` and the agent dies (verified in a real eval head-to-head + raw-curl probe). Tolerant providers (Cerebras, groq, OpenRouter, DeepInfra, SambaNova) return HTTP 200 and silently ignore it.

## Truth-seek: is the echo load-bearing?

**No.** The per-message top-level `reasoning` field is set in exactly one place (messages.rs) and read **nowhere** on any request path. No provider's request builder or response parser consumes a prior assistant message's `reasoning` field on the chat-completions wire. Real reasoning continuity rides separate, typed channels:
- Gemini `thoughtSignature` (handled per-tool-call in `build_assistant_tool_message`)
- Anthropic signed thinking content blocks
- the OpenAI Responses reasoning-items API

The top-level `reasoning` field exists purely for durable transcript / run-record storage and leaks onto the chat-completions wire as a side effect. The only `body["reasoning"]` writers are request-CONFIG directives (openrouter/enabled/responses) controlling reasoning *generation*, unrelated to the per-message echo.

## Fix (simplest robust path)

Because the echo is not load-bearing on any provider, **no per-provider capability flag is needed.** Drop the field unconditionally at the single comprehensive wire boundary in `build_request_body` — the same closure that already remaps the assistant history. This fixes Fireworks and removes a latent footgun for every strict OpenAI-compat provider, with one line plus a comment. The durable transcript (and its stored reasoning) is untouched, so `assistant_response_message_preserves_reasoning` still holds.

## Verify

- New regression test `build_request_body_strips_prior_assistant_reasoning_field`: a Fireworks gpt-oss request omits `messages[].reasoning` while preserving role + `tool_calls`.
- `cargo nextest run -p harn-vm`: **3862 passed, 0 failed.**
- No capability TOMLs touched, so the provider-matrix/support/capabilities make targets are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)