### PR TITLE
refactor(vm): dedup the persistence-layer VmValue→JSON serializer

### DIFF
--- a/crates/harn-vm/src/checkpoint.rs
+++ b/crates/harn-vm/src/checkpoint.rs
@@ -131,26 +131,7 @@ fn with_state<R>(
     })
 }
 
-fn vm_to_json(val: &VmValue) -> serde_json::Value {
-    match val {
-        VmValue::String(s) => serde_json::Value::String(s.to_string()),
-        VmValue::Int(n) => serde_json::json!(*n),
-        VmValue::Float(n) => serde_json::json!(*n),
-        // Decimal serializes as a string to preserve exact precision.
-        VmValue::Decimal(d) => serde_json::json!(d.to_string()),
-        VmValue::Bool(b) => serde_json::Value::Bool(*b),
-        VmValue::Nil => serde_json::Value::Null,
-        VmValue::List(items) => serde_json::Value::Array(items.iter().map(vm_to_json).collect()),
-        VmValue::Dict(map) => {
-            let obj: serde_json::Map<String, serde_json::Value> = map
-                .iter()
-                .map(|(k, v)| (k.clone(), vm_to_json(v)))
-                .collect();
-            serde_json::Value::Object(obj)
-        }
-        _ => serde_json::Value::Null,
-    }
-}
+use crate::value::vm_to_storage_json as vm_to_json;
 
 fn json_to_vm(jv: &serde_json::Value) -> VmValue {
     match jv {

--- a/crates/harn-vm/src/metadata.rs
+++ b/crates/harn-vm/src/metadata.rs
@@ -471,26 +471,7 @@ fn namespace_path_component(namespace: &str) -> String {
     }
 }
 
-fn vm_to_json(val: &VmValue) -> serde_json::Value {
-    match val {
-        VmValue::String(s) => serde_json::Value::String(s.to_string()),
-        VmValue::Int(n) => serde_json::json!(*n),
-        VmValue::Float(n) => serde_json::json!(*n),
-        // Decimal serializes as a string to preserve exact precision.
-        VmValue::Decimal(d) => serde_json::json!(d.to_string()),
-        VmValue::Bool(b) => serde_json::Value::Bool(*b),
-        VmValue::Nil => serde_json::Value::Null,
-        VmValue::List(items) => serde_json::Value::Array(items.iter().map(vm_to_json).collect()),
-        VmValue::Dict(map) => {
-            let obj: serde_json::Map<String, serde_json::Value> = map
-                .iter()
-                .map(|(k, v)| (k.clone(), vm_to_json(v)))
-                .collect();
-            serde_json::Value::Object(obj)
-        }
-        _ => serde_json::Value::Null,
-    }
-}
+use crate::value::vm_to_storage_json as vm_to_json;
 
 fn json_to_vm(jv: &serde_json::Value) -> VmValue {
     match jv {

--- a/crates/harn-vm/src/store.rs
+++ b/crates/harn-vm/src/store.rs
@@ -89,27 +89,7 @@ impl StoreState {
     }
 }
 
-fn vm_to_json(val: &VmValue) -> serde_json::Value {
-    match val {
-        VmValue::String(s) => serde_json::Value::String(s.to_string()),
-        VmValue::Int(n) => serde_json::json!(*n),
-        VmValue::Float(n) => serde_json::json!(*n),
-        // Decimal serializes as a string to preserve exact precision (JSON
-        // numbers are binary floats); read back via `decimal(...)`.
-        VmValue::Decimal(d) => serde_json::json!(d.to_string()),
-        VmValue::Bool(b) => serde_json::Value::Bool(*b),
-        VmValue::Nil => serde_json::Value::Null,
-        VmValue::List(items) => serde_json::Value::Array(items.iter().map(vm_to_json).collect()),
-        VmValue::Dict(map) => {
-            let obj: serde_json::Map<String, serde_json::Value> = map
-                .iter()
-                .map(|(k, v)| (k.clone(), vm_to_json(v)))
-                .collect();
-            serde_json::Value::Object(obj)
-        }
-        _ => serde_json::Value::Null,
-    }
-}
+use crate::value::vm_to_storage_json as vm_to_json;
 
 fn json_to_vm(jv: &serde_json::Value) -> VmValue {
     match jv {

--- a/crates/harn-vm/src/value/mod.rs
+++ b/crates/harn-vm/src/value/mod.rs
@@ -4,6 +4,7 @@ mod env;
 mod error;
 mod handles;
 pub(crate) mod recursion;
+mod storage_json;
 mod structural;
 
 pub type VmMutex<T> = parking_lot::Mutex<T>;
@@ -22,6 +23,7 @@ pub use handles::{
     VmAtomicHandle, VmChannelCloseState, VmChannelHandle, VmGenerator, VmJoinHandle, VmRange,
     VmRngHandle, VmStream, VmStreamCancel, VmSyncPermitHandle, VmTaskHandle,
 };
+pub(crate) use storage_json::vm_to_storage_json;
 pub use structural::{
     compare_values, dedup_values, try_compare_values, value_identity_key,
     value_structural_hash_key, values_equal, values_identical,

--- a/crates/harn-vm/src/value/storage_json.rs
+++ b/crates/harn-vm/src/value/storage_json.rs
@@ -1,0 +1,38 @@
+//! Lossy `VmValue` → JSON conversion for persistence layers (store /
+//! checkpoint / metadata).
+//!
+//! This is deliberately narrower than [`crate::stdlib::json`]'s converters: it
+//! covers the scalar / list / dict shapes those persistence paths actually
+//! store and maps every other value kind (closures, handles, …) to `null`
+//! rather than to a display string, because a persisted record should not carry
+//! a stringified handle. The three persistence modules previously each kept an
+//! identical private copy of this function; they now share this one.
+
+use crate::value::VmValue;
+
+/// Serialize `val` to JSON for persistence: scalars/list/dict are preserved,
+/// `Decimal` becomes a precision-preserving string (read back via
+/// `decimal(...)`), and any non-data value kind becomes `null`.
+pub(crate) fn vm_to_storage_json(val: &VmValue) -> serde_json::Value {
+    match val {
+        VmValue::String(s) => serde_json::Value::String(s.to_string()),
+        VmValue::Int(n) => serde_json::json!(*n),
+        VmValue::Float(n) => serde_json::json!(*n),
+        // Decimal serializes as a string to preserve exact precision (JSON
+        // numbers are binary floats); read back via `decimal(...)`.
+        VmValue::Decimal(d) => serde_json::json!(d.to_string()),
+        VmValue::Bool(b) => serde_json::Value::Bool(*b),
+        VmValue::Nil => serde_json::Value::Null,
+        VmValue::List(items) => {
+            serde_json::Value::Array(items.iter().map(vm_to_storage_json).collect())
+        }
+        VmValue::Dict(map) => {
+            let obj: serde_json::Map<String, serde_json::Value> = map
+                .iter()
+                .map(|(k, v)| (k.clone(), vm_to_storage_json(v)))
+                .collect();
+            serde_json::Value::Object(obj)
+        }
+        _ => serde_json::Value::Null,
+    }
+}


### PR DESCRIPTION
`store.rs`, `checkpoint.rs`, and `metadata.rs` each carried a byte-identical private `vm_to_json` — a lossy VmValue→JSON converter (scalars/list/dict preserved, every other kind → `null`; distinct from `stdlib::json`'s `_ => display()` converters). The decimal work had to add the same `Decimal` arm to all three copies — exactly the divergence hazard this removes.

Extract one `value::vm_to_storage_json`; the three persistence modules import it. **No behavior change** (the copies were identical). harn-vm lib 3745/0, clippy `-D warnings` + fmt clean.

Internal refactor, no user-visible change → `no-changelog-needed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)