### PR TITLE
feat(code_index): additive read-only secondary roots for dependency symbols

### DIFF
--- a/changelog.d/code-index-readonly-roots.added.md
+++ b/changelog.d/code-index-readonly-roots.added.md
@@ -1,0 +1,14 @@
+- **`code_index` gains additive, read-only secondary roots so dependency/SDK
+  symbols are discoverable without clobbering the project index.**
+  `hostlib_code_index_rebuild({root})` still owns exactly one writable root and
+  flips its slot wholesale, so indexing a dependency root through it would
+  destroy the project index. The new `hostlib_code_index_add_readonly_roots({roots, replace?})`
+  builds each extra root into a parallel, read-only `IndexState` that lives
+  beside the primary. `hostlib_code_index_query` now merges hits from every
+  read-only root (each tagged with a `root` field; primary hits carry
+  `root: null`), and `hostlib_code_index_read_range` falls back to the
+  read-only roots so a symbol discovered in a dependency root can be read back.
+  No mutating builtin (`version_record`, `reindex_file`, `rename_symbol`,
+  locks) ever touches the read-only set — writes to a dependency-root path stay
+  rejected exactly as before. Adding the same root twice is idempotent.
+  Enables the deferred burin dependency-grounding wiring (burin #2403 follow-up).

--- a/crates/harn-hostlib/schemas/code_index/add_readonly_roots.request.json
+++ b/crates/harn-hostlib/schemas/code_index/add_readonly_roots.request.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/code_index/add_readonly_roots.request.json",
+  "title": "code_index.add_readonly_roots request",
+  "description": "Index one or more dependency/SDK roots as additive, READ-ONLY secondary roots. They are merged into `query`/`read_range` results so library API symbols become discoverable, but they never clobber the project index built by `rebuild` and are never mutated by any write builtin (version_record, reindex_file, rename_symbol, locks).",
+  "type": "object",
+  "properties": {
+    "roots": {
+      "type": "array",
+      "description": "Dependency/SDK directory roots to index read-only. Each must exist and be a directory.",
+      "items": { "type": "string" }
+    },
+    "replace": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, clear the existing read-only set before adding, so the whole dependency fan-out can be swapped without accumulating stale roots."
+    }
+  },
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/code_index/add_readonly_roots.response.json
+++ b/crates/harn-hostlib/schemas/code_index/add_readonly_roots.response.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/code_index/add_readonly_roots.response.json",
+  "title": "code_index.add_readonly_roots response",
+  "type": "object",
+  "properties": {
+    "roots": {
+      "type": "array",
+      "description": "One entry per root added/refreshed in this call.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "root": { "type": "string", "description": "Canonicalised absolute path of the indexed read-only root." },
+          "files_indexed": { "type": "integer", "description": "Files ingested from this root." }
+        },
+        "required": ["root", "files_indexed"],
+        "additionalProperties": false
+      }
+    },
+    "readonly_root_count": { "type": "integer", "description": "Total number of read-only roots now resident." },
+    "readonly_files_indexed": { "type": "integer", "description": "Total files across all resident read-only roots." }
+  },
+  "required": ["roots", "readonly_root_count", "readonly_files_indexed"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/code_index/query.response.json
+++ b/crates/harn-hostlib/schemas/code_index/query.response.json
@@ -21,9 +21,13 @@
       "properties": {
         "path": { "type": "string" },
         "score": { "type": "number" },
-        "match_count": { "type": "integer", "minimum": 0 }
+        "match_count": { "type": "integer", "minimum": 0 },
+        "root": {
+          "type": ["string", "null"],
+          "description": "Absolute path of the read-only dependency root this hit came from (#2403 follow-up), or null for a primary-workspace hit."
+        }
       },
-      "required": ["path", "score", "match_count"],
+      "required": ["path", "score", "match_count", "root"],
       "additionalProperties": false
     }
   }

--- a/crates/harn-hostlib/src/code_index/builtins.rs
+++ b/crates/harn-hostlib/src/code_index/builtins.rs
@@ -79,7 +79,16 @@ pub(super) const BUILTIN_FRESHNESS: &str = "hostlib_code_index_freshness";
 
 // === Search / rebuild / stats ===
 
-pub(super) fn run_query(index: &SharedIndex, args: &[VmValue]) -> Result<VmValue, HostlibError> {
+/// Shared body for `query`. When `readonly` is supplied, hits from every
+/// read-only secondary root (issue #2403 follow-up) are merged in after the
+/// primary index so library/dependency symbols are discoverable without
+/// clobbering the project index. Primary hits keep `root: nil`; read-only
+/// hits carry the absolute path of their dependency root.
+pub(super) fn run_query_merged(
+    index: &SharedIndex,
+    readonly: Option<&super::readonly::ReadonlyRoots>,
+    args: &[VmValue],
+) -> Result<VmValue, HostlibError> {
     let raw = dict_arg(BUILTIN_QUERY, args)?;
     let dict = raw.as_ref();
     let needle = require_string(BUILTIN_QUERY, dict, "needle")?;
@@ -94,33 +103,25 @@ pub(super) fn run_query(index: &SharedIndex, args: &[VmValue]) -> Result<VmValue
     let max_results = optional_positive_usize(BUILTIN_QUERY, dict, "max_results")?.unwrap_or(100);
     let scope = optional_string_list(BUILTIN_QUERY, dict, "scope")?;
 
-    let guard = index.lock().expect("code_index mutex poisoned");
-    let Some(state) = guard.as_ref() else {
-        return Ok(empty_query_response());
-    };
-
-    let candidate_ids = candidates_for(state, &needle);
     let mut hits: Vec<Hit> = Vec::new();
-    for id in candidate_ids {
-        let Some(file) = state.files.get(&id) else {
-            continue;
-        };
-        if !scope_allows(&scope, &file.relative_path) {
-            continue;
+    {
+        let guard = index.lock().expect("code_index mutex poisoned");
+        if let Some(state) = guard.as_ref() {
+            collect_hits_scoped(state, &needle, case_sensitive, &scope, &mut hits);
         }
-        let Some(text) = read_file_text(&state.root, &file.relative_path) else {
-            continue;
-        };
-        let count = count_matches(&text, &needle, case_sensitive);
-        if count == 0 {
-            continue;
-        }
-        hits.push(Hit {
-            path: file.relative_path.clone(),
-            score: count as f64,
-            match_count: count,
-        });
     }
+    if let Some(readonly) = readonly {
+        // Dependency roots ignore `scope` (it is a project-relative
+        // restriction) — they are an additive symbol-discovery surface.
+        if scope.is_empty() {
+            hits.extend(super::readonly::query_readonly_hits(
+                readonly,
+                &needle,
+                case_sensitive,
+            ));
+        }
+    }
+
     hits.sort_by(|a, b| {
         b.match_count
             .cmp(&a.match_count)
@@ -137,6 +138,57 @@ pub(super) fn run_query(index: &SharedIndex, args: &[VmValue]) -> Result<VmValue
         ),
         ("truncated", VmValue::Bool(truncated)),
     ]))
+}
+
+/// Score `needle` against every file in `state`, honoring `scope`, and push
+/// matching files onto `hits`. Hits are tagged with the index's root only
+/// when it is a read-only secondary root (the caller passes the primary
+/// index with an empty `scope` to leave `root: nil`).
+fn collect_hits_scoped(
+    state: &IndexState,
+    needle: &str,
+    case_sensitive: bool,
+    scope: &[String],
+    hits: &mut Vec<Hit>,
+) {
+    let candidate_ids = candidates_for(state, needle);
+    for id in candidate_ids {
+        let Some(file) = state.files.get(&id) else {
+            continue;
+        };
+        if !scope_allows(scope, &file.relative_path) {
+            continue;
+        }
+        let Some(text) = read_file_text(&state.root, &file.relative_path) else {
+            continue;
+        };
+        let count = count_matches(&text, needle, case_sensitive);
+        if count == 0 {
+            continue;
+        }
+        hits.push(Hit {
+            path: file.relative_path.clone(),
+            match_count: count,
+            root: None,
+        });
+    }
+}
+
+/// Read-only entry point used by [`super::readonly::query_readonly_hits`]:
+/// score `needle` against `state` (a dependency root) with no scope filter
+/// and tag every hit with the root's absolute path.
+pub(super) fn collect_hits_into(
+    state: &IndexState,
+    needle: &str,
+    case_sensitive: bool,
+    hits: &mut Vec<Hit>,
+) {
+    let before = hits.len();
+    collect_hits_scoped(state, needle, case_sensitive, &[], hits);
+    let root = state.root.to_string_lossy().to_string();
+    for hit in &mut hits[before..] {
+        hit.root = Some(root.clone());
+    }
 }
 
 pub(super) fn run_rebuild(index: &SharedIndex, args: &[VmValue]) -> Result<VmValue, HostlibError> {
@@ -396,8 +448,15 @@ pub(super) fn run_file_hash(
 
 // === Cached reads ===
 
-pub(super) fn run_read_range(
+/// Shared body for `read_range`. When `readonly` is supplied, a path that
+/// is not inside the primary workspace root is resolved against the
+/// read-only secondary roots (issue #2403 follow-up) so a symbol
+/// discovered in a dependency root can be read back. Resolution stays
+/// confined to a known indexed root in every case — arbitrary host paths
+/// are still rejected.
+pub(super) fn run_read_range_merged(
     index: &SharedIndex,
+    readonly: Option<&super::readonly::ReadonlyRoots>,
     args: &[VmValue],
 ) -> Result<VmValue, HostlibError> {
     let raw = dict_arg(BUILTIN_READ_RANGE, args)?;
@@ -405,20 +464,30 @@ pub(super) fn run_read_range(
     let path = require_string(BUILTIN_READ_RANGE, dict, "path")?;
     let start = optional_positive_i64(BUILTIN_READ_RANGE, dict, "start")?;
     let end = optional_positive_i64(BUILTIN_READ_RANGE, dict, "end")?;
-    let guard = index.lock().expect("code_index mutex poisoned");
-    let abs = match guard.as_ref() {
-        Some(state) => {
-            state
-                .absolute_path(&path)
+    let abs =
+        match readonly {
+            Some(readonly) => super::readonly::resolve_read_path(index, readonly, &path)
                 .ok_or_else(|| HostlibError::InvalidParameter {
                     builtin: BUILTIN_READ_RANGE,
                     param: "path",
-                    message: "path must stay within the indexed workspace root".to_string(),
-                })?
-        }
-        None => PathBuf::from(&path),
-    };
-    drop(guard);
+                    message: "path must stay within the indexed workspace root or a read-only \
+                          dependency root"
+                        .to_string(),
+                })?,
+            None => {
+                let guard = index.lock().expect("code_index mutex poisoned");
+                match guard.as_ref() {
+                    Some(state) => state.absolute_path(&path).ok_or_else(|| {
+                        HostlibError::InvalidParameter {
+                            builtin: BUILTIN_READ_RANGE,
+                            param: "path",
+                            message: "path must stay within the indexed workspace root".to_string(),
+                        }
+                    })?,
+                    None => PathBuf::from(&path),
+                }
+            }
+        };
 
     let content_result = match crate::fs::read_to_string(&abs, None) {
         Some(result) => result,
@@ -1215,22 +1284,31 @@ fn scope_allows(scope: &[String], relative: &str) -> bool {
         .any(|s| relative == s || relative.starts_with(&format!("{s}/")) || s.is_empty())
 }
 
-struct Hit {
-    path: String,
-    score: f64,
-    match_count: u64,
+pub(super) struct Hit {
+    pub(super) path: String,
+    pub(super) match_count: u64,
+    /// Absolute path of the read-only dependency root this hit came from,
+    /// or `None` for a primary-workspace hit (issue #2403 follow-up).
+    pub(super) root: Option<String>,
 }
 
 fn hit_to_value(hit: Hit) -> VmValue {
     let Hit {
         path,
-        score,
         match_count,
+        root,
     } = hit;
     build_dict([
         ("path", str_value(&path)),
-        ("score", VmValue::Float(score)),
+        ("score", VmValue::Float(match_count as f64)),
         ("match_count", VmValue::Int(match_count as i64)),
+        (
+            "root",
+            match root {
+                Some(r) => str_value(&r),
+                None => VmValue::Nil,
+            },
+        ),
     ])
 }
 
@@ -1246,13 +1324,6 @@ fn import_entry(module: &str, resolved: Option<&str>, kind: &str) -> VmValue {
     );
     map.insert("kind".into(), str_value(kind));
     VmValue::dict(map)
-}
-
-fn empty_query_response() -> VmValue {
-    build_dict([
-        ("results", VmValue::List(Arc::new(Vec::new()))),
-        ("truncated", VmValue::Bool(false)),
-    ])
 }
 
 fn empty_stats_response() -> VmValue {

--- a/crates/harn-hostlib/src/code_index/mod.rs
+++ b/crates/harn-hostlib/src/code_index/mod.rs
@@ -66,6 +66,7 @@ mod file_table;
 mod graph;
 mod imports;
 mod overlay;
+mod readonly;
 mod rename;
 mod snapshot;
 mod state;
@@ -89,6 +90,7 @@ pub use cypher::{CypherError, CypherRow, CypherValue};
 pub use file_table::{FileId, IndexedFile, IndexedSymbol};
 pub use graph::DepGraph;
 pub use overlay::{BranchOverlay, OverlayState};
+pub use readonly::ReadonlyRoots;
 pub use snapshot::{CodeIndexSnapshot, SnapshotMeta};
 pub use state::{BuildOutcome, IndexState};
 pub use symbol_graph::{Edge, EdgeKind, Node, NodeId, NodeKind, SymbolGraph};
@@ -106,6 +108,11 @@ pub use words::{WordHit, WordIndex};
 #[derive(Clone, Default)]
 pub struct CodeIndexCapability {
     index: SharedIndex,
+    /// Additive, read-only secondary roots (issue #2403 follow-up). Live
+    /// beside the primary slot; query/read_range merge them in but no
+    /// mutating builtin ever touches them, so indexing a dependency root
+    /// never clobbers the project index.
+    readonly: ReadonlyRoots,
     current_agent: Arc<Mutex<Option<AgentId>>>,
 }
 
@@ -115,6 +122,7 @@ impl CodeIndexCapability {
     pub fn new() -> Self {
         Self {
             index: Arc::new(Mutex::new(None)),
+            readonly: Arc::new(Mutex::new(Vec::new())),
             current_agent: Arc::new(Mutex::new(None)),
         }
     }
@@ -188,14 +196,21 @@ impl HostlibCapability for CodeIndexCapability {
     }
 
     fn register_builtins(&self, registry: &mut BuiltinRegistry) {
-        // Workspace queries (original 5).
-        register(
-            registry,
-            self.index.clone(),
-            builtins::BUILTIN_QUERY,
-            "query",
-            builtins::run_query,
-        );
+        // Workspace queries (original 5). `query` and `read_range` merge in
+        // the read-only secondary roots (issue #2403 follow-up), so they
+        // capture both the primary and the read-only cells.
+        {
+            let index = self.index.clone();
+            let readonly = self.readonly.clone();
+            let handler: SyncHandler =
+                Arc::new(move |args| builtins::run_query_merged(&index, Some(&readonly), args));
+            registry.register(RegisteredBuiltin {
+                name: builtins::BUILTIN_QUERY,
+                module: "code_index",
+                method: "query",
+                handler,
+            });
+        }
         register(
             registry,
             self.index.clone(),
@@ -224,6 +239,21 @@ impl HostlibCapability for CodeIndexCapability {
             "importers_of",
             builtins::run_importers_of,
         );
+
+        // Additive read-only secondary roots (issue #2403 follow-up).
+        // Captures the read-only cell directly — it never touches the
+        // primary index slot.
+        {
+            let readonly = self.readonly.clone();
+            let handler: SyncHandler =
+                Arc::new(move |args| readonly::run_add_readonly_roots(&readonly, args));
+            registry.register(RegisteredBuiltin {
+                name: readonly::BUILTIN_ADD_READONLY_ROOTS,
+                module: "code_index",
+                method: "add_readonly_roots",
+                handler,
+            });
+        }
 
         // File table accessors.
         register(
@@ -262,14 +292,22 @@ impl HostlibCapability for CodeIndexCapability {
             builtins::run_file_hash,
         );
 
-        // Cached read paths.
-        register(
-            registry,
-            self.index.clone(),
-            builtins::BUILTIN_READ_RANGE,
-            "read_range",
-            builtins::run_read_range,
-        );
+        // Cached read paths. `read_range` falls back to the read-only
+        // secondary roots (issue #2403 follow-up) so a symbol discovered in
+        // a dependency root can be read back.
+        {
+            let index = self.index.clone();
+            let readonly = self.readonly.clone();
+            let handler: SyncHandler = Arc::new(move |args| {
+                builtins::run_read_range_merged(&index, Some(&readonly), args)
+            });
+            registry.register(RegisteredBuiltin {
+                name: builtins::BUILTIN_READ_RANGE,
+                module: "code_index",
+                method: "read_range",
+                handler,
+            });
+        }
         register(
             registry,
             self.index.clone(),

--- a/crates/harn-hostlib/src/code_index/readonly.rs
+++ b/crates/harn-hostlib/src/code_index/readonly.rs
@@ -1,0 +1,164 @@
+//! Additive, read-only secondary roots for the code index (issue #2403
+//! follow-up).
+//!
+//! The primary [`IndexState`] (built by `hostlib_code_index_rebuild`) owns
+//! exactly one writable workspace root and flips its slot wholesale on
+//! every rebuild. That is correct for the project under edit, but it means
+//! a caller cannot also index *dependency* / SDK roots (e.g. the macOS
+//! IOKit headers that declare `kIOPSTimeToFullChargeKey`) without
+//! clobbering the project index.
+//!
+//! This module adds a parallel, **read-only** set of secondary
+//! [`IndexState`]s that live beside the primary in the capability. They are
+//! merged into path-based query results so library API symbols become
+//! discoverable, while staying entirely out of the project's writable
+//! scope:
+//!
+//! - They are never mutated by `version_record`, `reindex_file`,
+//!   `agent_*`, `lock_*`, or `rename_symbol` — those builtins only ever
+//!   touch the primary slot.
+//! - `read_range` will resolve a path inside a read-only root (so a symbol
+//!   discovered there can be read), but every *write* path (rename,
+//!   reindex, version log, locks) still rejects out-of-project paths
+//!   exactly as before, because those paths are not in the primary index.
+//!
+//! Concurrency mirrors the primary: a single `Arc<Mutex<Vec<IndexState>>>`
+//! cell, so the same serialised view is shared by every Harn VM wired
+//! against the capability.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use harn_vm::VmValue;
+
+use super::builtins::SharedIndex;
+use super::state::IndexState;
+use crate::error::HostlibError;
+use crate::tools::args::{build_dict, dict_arg, optional_bool, optional_string_list, str_value};
+
+/// Shared cell holding the read-only secondary indexes. Each entry is a
+/// fully-built [`IndexState`] anchored at one dependency root. Empty until
+/// `hostlib_code_index_add_readonly_roots` is called.
+pub type ReadonlyRoots = Arc<Mutex<Vec<IndexState>>>;
+
+pub(super) const BUILTIN_ADD_READONLY_ROOTS: &str = "hostlib_code_index_add_readonly_roots";
+
+/// Build and merge one or more dependency roots into the read-only set.
+///
+/// Idempotent per root: re-adding a root that is already present rebuilds
+/// that entry in place rather than appending a duplicate. `replace: true`
+/// clears the existing set first (so a caller can swap the whole dependency
+/// fan-out without accumulating stale roots).
+pub(super) fn run_add_readonly_roots(
+    readonly: &ReadonlyRoots,
+    args: &[VmValue],
+) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(BUILTIN_ADD_READONLY_ROOTS, args)?;
+    let dict = raw.as_ref();
+    let roots = optional_string_list(BUILTIN_ADD_READONLY_ROOTS, dict, "roots")?;
+    let replace = optional_bool(BUILTIN_ADD_READONLY_ROOTS, dict, "replace", false)?;
+
+    let mut guard = readonly.lock().expect("readonly roots mutex poisoned");
+    if replace {
+        guard.clear();
+    }
+
+    let mut added: Vec<VmValue> = Vec::with_capacity(roots.len());
+    let mut total_files: usize = 0;
+    for raw_root in roots {
+        let root = PathBuf::from(&raw_root);
+        if !root.exists() {
+            return Err(HostlibError::InvalidParameter {
+                builtin: BUILTIN_ADD_READONLY_ROOTS,
+                param: "roots",
+                message: format!("path `{}` does not exist", root.display()),
+            });
+        }
+        if !root.is_dir() {
+            return Err(HostlibError::InvalidParameter {
+                builtin: BUILTIN_ADD_READONLY_ROOTS,
+                param: "roots",
+                message: format!("path `{}` is not a directory", root.display()),
+            });
+        }
+        let (state, outcome) = IndexState::build_from_root(&root);
+        let files_indexed = outcome.files_indexed as i64;
+        total_files += state.files.len();
+        // Idempotent: replace any existing entry for the same canonical
+        // root rather than appending a duplicate.
+        let canonical = state.root.clone();
+        if let Some(slot) = guard.iter_mut().find(|s| s.root == canonical) {
+            *slot = state;
+        } else {
+            guard.push(state);
+        }
+        added.push(build_dict([
+            ("root", str_value(canonical.to_string_lossy().as_ref())),
+            ("files_indexed", VmValue::Int(files_indexed)),
+        ]));
+    }
+
+    Ok(build_dict([
+        ("roots", VmValue::List(Arc::new(added))),
+        ("readonly_root_count", VmValue::Int(guard.len() as i64)),
+        ("readonly_files_indexed", VmValue::Int(total_files as i64)),
+    ]))
+}
+
+/// Resolve `rel_or_abs` against the primary index first, then fall back to
+/// every read-only secondary root. Returns the canonical absolute path of
+/// the first index that contains the file. Used by `read_range` so a symbol
+/// discovered in a dependency root can be read back.
+pub(super) fn resolve_read_path(
+    primary: &SharedIndex,
+    readonly: &ReadonlyRoots,
+    path: &str,
+) -> Option<PathBuf> {
+    // Resolution order, preserving the pre-#2403 contract:
+    //   1. An *existing* file inside the primary workspace root.
+    //   2. An *existing* file inside any read-only dependency root.
+    //   3. As a fallback, the primary root's resolution even if the file
+    //      does not exist — so a missing in-workspace path still fails at
+    //      the read step with "file not found" exactly as before, rather
+    //      than being rejected as out-of-scope.
+    // `absolute_path` confines every candidate to a known root and accepts
+    // not-yet-existing paths (it is shared with write paths), so the
+    // existence filter is what lets a dependency-only path win over the
+    // phantom project path it would otherwise resolve to.
+    let primary_resolved = {
+        let guard = primary.lock().expect("code_index mutex poisoned");
+        guard.as_ref().and_then(|state| state.absolute_path(path))
+    };
+    if let Some(abs) = primary_resolved.as_ref().filter(|p| p.exists()) {
+        return Some(abs.clone());
+    }
+    {
+        let guard = readonly.lock().expect("readonly roots mutex poisoned");
+        if let Some(abs) = guard
+            .iter()
+            .find_map(|state| state.absolute_path(path).filter(|p| p.exists()))
+        {
+            return Some(abs);
+        }
+    }
+    primary_resolved
+}
+
+/// Run `query`-style scoring over every read-only secondary root, tagging
+/// each hit with its `root` so callers can disambiguate a dependency hit
+/// from a project hit. Returns hits already merged with whatever the
+/// primary index produced. Hits keep the same `path`/`score`/`match_count`
+/// shape as the primary query plus a `root` field; primary hits carry
+/// `root: nil`.
+pub(super) fn query_readonly_hits(
+    readonly: &ReadonlyRoots,
+    needle: &str,
+    case_sensitive: bool,
+) -> Vec<super::builtins::Hit> {
+    let guard = readonly.lock().expect("readonly roots mutex poisoned");
+    let mut hits: Vec<super::builtins::Hit> = Vec::new();
+    for state in guard.iter() {
+        super::builtins::collect_hits_into(state, needle, case_sensitive, &mut hits);
+    }
+    hits
+}

--- a/crates/harn-hostlib/src/schemas.rs
+++ b/crates/harn-hostlib/src/schemas.rs
@@ -314,6 +314,19 @@ pub const SCHEMAS: &[(&str, &str, SchemaKind, &str)] = &[
         SchemaKind::Response,
         include_str!("../schemas/code_index/importers_of.response.json"),
     ),
+    // code_index — additive read-only secondary roots (#2403 follow-up)
+    (
+        "code_index",
+        "add_readonly_roots",
+        SchemaKind::Request,
+        include_str!("../schemas/code_index/add_readonly_roots.request.json"),
+    ),
+    (
+        "code_index",
+        "add_readonly_roots",
+        SchemaKind::Response,
+        include_str!("../schemas/code_index/add_readonly_roots.response.json"),
+    ),
     // code_index — file table accessors
     (
         "code_index",

--- a/crates/harn-hostlib/tests/code_index.rs
+++ b/crates/harn-hostlib/tests/code_index.rs
@@ -520,3 +520,249 @@ fn query_recall_gold_fixture_rare_symbol_and_definition_burial() {
         "definition recovered by recall@3, order {ranked:?}"
     );
 }
+
+// === Additive read-only secondary roots (issue #2403 follow-up) ===
+
+/// Build a tiny "dependency/SDK" root containing a symbol that exists
+/// nowhere in the project, mimicking e.g. the macOS IOKit header that
+/// declares `kIOPSTimeToFullChargeKey`.
+fn write_dep_root() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    fs::create_dir_all(dir.path().join("IOKit")).unwrap();
+    fs::write(
+        dir.path().join("IOKit/IOPowerSources.h"),
+        "#define kIOPSTimeToFullChargeKey \"Time to Full Charge\"\n\
+         int IOPSGetTimeRemainingEstimate(void);\n",
+    )
+    .unwrap();
+    dir
+}
+
+/// Build a minimal project workspace with its own unique symbol.
+fn write_project_root() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    fs::create_dir_all(dir.path().join("src")).unwrap();
+    fs::write(
+        dir.path().join("src/battery.rs"),
+        "pub fn project_only_symbol() -> i32 { 7 }\n",
+    )
+    .unwrap();
+    dir
+}
+
+fn query_roots(registry: &BuiltinRegistry, needle: &str) -> Vec<(String, Option<String>)> {
+    let resp = call(
+        registry,
+        "hostlib_code_index_query",
+        dict(&[("needle", VmValue::String(Arc::from(needle)))]),
+    );
+    let d = extract_dict(&resp);
+    extract_list(d.get("results").unwrap())
+        .iter()
+        .map(|hit| {
+            let hd = extract_dict(hit);
+            let path = extract_str(hd.get("path").unwrap());
+            let root = match hd.get("root") {
+                Some(VmValue::String(s)) => Some(s.to_string()),
+                _ => None,
+            };
+            (path, root)
+        })
+        .collect()
+}
+
+#[test]
+fn readonly_roots_do_not_clobber_the_project_index() {
+    let project = write_project_root();
+    let dep = write_dep_root();
+    let (registry, _cap) = build_registry();
+    call(
+        &registry,
+        "hostlib_code_index_rebuild",
+        dict(&[(
+            "root",
+            VmValue::String(Arc::from(project.path().to_string_lossy().to_string())),
+        )]),
+    );
+
+    // Project symbol is discoverable before adding dep roots.
+    assert!(
+        !query_roots(&registry, "project_only_symbol").is_empty(),
+        "project symbol must be indexed by rebuild"
+    );
+
+    let add = call(
+        &registry,
+        "hostlib_code_index_add_readonly_roots",
+        dict(&[(
+            "roots",
+            VmValue::List(Arc::new(vec![VmValue::String(Arc::from(
+                dep.path().to_string_lossy().to_string(),
+            ))])),
+        )]),
+    );
+    assert_eq!(
+        extract_int(extract_dict(&add).get("readonly_root_count").unwrap()),
+        1
+    );
+
+    // The project index SURVIVES — adding a dep root did not flip the slot.
+    let project_hits = query_roots(&registry, "project_only_symbol");
+    assert!(
+        project_hits
+            .iter()
+            .any(|(p, root)| p == "src/battery.rs" && root.is_none()),
+        "project symbol must still resolve against the primary index after \
+         adding dep roots, got {project_hits:?}"
+    );
+    // stats still reflect the project, not the dependency.
+    let stats = extract_dict(&call(&registry, "hostlib_code_index_stats", VmValue::Nil));
+    assert_eq!(
+        extract_int(stats.get("indexed_files").unwrap()),
+        1,
+        "primary stats must count only project files"
+    );
+}
+
+#[test]
+fn symbol_only_in_dep_root_is_found_via_query() {
+    let project = write_project_root();
+    let dep = write_dep_root();
+    let (registry, _cap) = build_registry();
+    call(
+        &registry,
+        "hostlib_code_index_rebuild",
+        dict(&[(
+            "root",
+            VmValue::String(Arc::from(project.path().to_string_lossy().to_string())),
+        )]),
+    );
+
+    // Before adding the dep root, the SDK symbol is undiscoverable.
+    assert!(
+        query_roots(&registry, "kIOPSTimeToFullChargeKey").is_empty(),
+        "dep symbol must not resolve before the dep root is added"
+    );
+
+    call(
+        &registry,
+        "hostlib_code_index_add_readonly_roots",
+        dict(&[(
+            "roots",
+            VmValue::List(Arc::new(vec![VmValue::String(Arc::from(
+                dep.path().to_string_lossy().to_string(),
+            ))])),
+        )]),
+    );
+
+    let hits = query_roots(&registry, "kIOPSTimeToFullChargeKey");
+    assert_eq!(
+        hits.len(),
+        1,
+        "dep symbol must resolve via read-only root, got {hits:?}"
+    );
+    let (path, root) = &hits[0];
+    assert_eq!(path, "IOKit/IOPowerSources.h");
+    assert!(
+        root.as_deref()
+            .is_some_and(|r| r.contains(dep.path().file_name().unwrap().to_str().unwrap())),
+        "dep hit must be tagged with its dependency root, got {root:?}"
+    );
+
+    // And the discovered file is readable back through read_range.
+    let read = call(
+        &registry,
+        "hostlib_code_index_read_range",
+        dict(&[("path", VmValue::String(Arc::from(path.as_str())))]),
+    );
+    let content = extract_str(extract_dict(&read).get("content").unwrap());
+    assert!(content.contains("kIOPSTimeToFullChargeKey"));
+}
+
+#[test]
+fn dep_root_path_is_read_only_writes_are_rejected() {
+    let project = write_project_root();
+    let dep = write_dep_root();
+    let (registry, _cap) = build_registry();
+    call(
+        &registry,
+        "hostlib_code_index_rebuild",
+        dict(&[(
+            "root",
+            VmValue::String(Arc::from(project.path().to_string_lossy().to_string())),
+        )]),
+    );
+    call(
+        &registry,
+        "hostlib_code_index_add_readonly_roots",
+        dict(&[(
+            "roots",
+            VmValue::List(Arc::new(vec![VmValue::String(Arc::from(
+                dep.path().to_string_lossy().to_string(),
+            ))])),
+        )]),
+    );
+
+    // reindex_file is a WRITE path scoped to the primary index — a dep-root
+    // path must be rejected (it is not inside the project root).
+    let dep_abs = dep.path().join("IOKit/IOPowerSources.h");
+    let reindex = registry
+        .find("hostlib_code_index_reindex_file")
+        .expect("registered");
+    let result = (reindex.handler)(&[dict(&[(
+        "path",
+        VmValue::String(Arc::from(dep_abs.to_string_lossy().to_string())),
+    )])]);
+    assert!(
+        result.is_err(),
+        "reindex_file must reject a dependency-root path (read-only scope), got {result:?}"
+    );
+}
+
+#[test]
+fn add_readonly_roots_is_idempotent() {
+    let project = write_project_root();
+    let dep = write_dep_root();
+    let (registry, _cap) = build_registry();
+    call(
+        &registry,
+        "hostlib_code_index_rebuild",
+        dict(&[(
+            "root",
+            VmValue::String(Arc::from(project.path().to_string_lossy().to_string())),
+        )]),
+    );
+
+    let dep_val = VmValue::List(Arc::new(vec![VmValue::String(Arc::from(
+        dep.path().to_string_lossy().to_string(),
+    ))]));
+    let first = call(
+        &registry,
+        "hostlib_code_index_add_readonly_roots",
+        dict(&[("roots", dep_val.clone())]),
+    );
+    let second = call(
+        &registry,
+        "hostlib_code_index_add_readonly_roots",
+        dict(&[("roots", dep_val)]),
+    );
+
+    // Re-adding the same root must not append a duplicate.
+    assert_eq!(
+        extract_int(extract_dict(&first).get("readonly_root_count").unwrap()),
+        1
+    );
+    assert_eq!(
+        extract_int(extract_dict(&second).get("readonly_root_count").unwrap()),
+        1,
+        "re-adding the same dep root must be idempotent, not duplicated"
+    );
+
+    // The symbol still resolves exactly once.
+    let hits = query_roots(&registry, "kIOPSTimeToFullChargeKey");
+    assert_eq!(
+        hits.len(),
+        1,
+        "idempotent re-add must not duplicate hits, got {hits:?}"
+    );
+}

--- a/crates/harn-hostlib/tests/registration.rs
+++ b/crates/harn-hostlib/tests/registration.rs
@@ -104,6 +104,8 @@ fn code_index_capability_registers_documented_methods() {
             "hostlib_code_index_stats",
             "hostlib_code_index_imports_for",
             "hostlib_code_index_importers_of",
+            // Additive read-only secondary roots (#2403 follow-up).
+            "hostlib_code_index_add_readonly_roots",
             // File table accessors (#776).
             "hostlib_code_index_path_to_id",
             "hostlib_code_index_id_to_path",
@@ -436,9 +438,10 @@ fn install_default_wires_every_module_into_a_vm() {
         ]
     );
     // Builtin count: 15 ast (incl. apply_node + insert_at_anchor) +
-    // 27 code_index + 2 scanner + 4 fs + 4 fs_snapshot + 2 fs_watch
-    // + 14 tools + 1 hostlib_enable + 4 secret_store = 73.
-    assert!(registry.builtins().len() >= 73);
+    // 28 code_index (incl. add_readonly_roots, #2403 follow-up) + 2 scanner
+    // + 4 fs + 4 fs_snapshot + 2 fs_watch + 14 tools + 1 hostlib_enable
+    // + 4 secret_store = 74.
+    assert!(registry.builtins().len() >= 74);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`hostlib_code_index_rebuild({root})` builds from a **single** root and flips the index slot **wholesale**. Indexing a dependency/SDK root through it would **clobber** the project index. This is the exact constraint that forced burin PR #2403 to route library-API discovery (e.g. macOS IOKit `kIOPSTimeToFullChargeKey`) through `search` + `look_not_found` instead of the code index.

## Fix (root cause)

Give `code_index` an **additive, read-only** secondary-root capability so the project index and dependency roots can both be queried without one clobbering the other.

- **New builtin** `hostlib_code_index_add_readonly_roots({roots: [..], replace?})` — builds each dependency root into its own read-only `IndexState`, held in a parallel `Arc<Mutex<Vec<IndexState>>>` cell beside the primary slot. Idempotent per canonical root; `replace: true` swaps the whole dependency fan-out.
- **`query`** merges hits from every read-only root, each tagged with its `root` (primary hits carry `root: null`).
- **`read_range`** falls back to the read-only roots so a symbol discovered in a dependency root can be read back. Resolution order preserves the prior contract: existing in-project file → existing dep-root file → in-project phantom (so a genuinely-missing in-workspace path still errors `file not found`, and an out-of-all-roots path still errors `indexed workspace root`).

### Read-only by construction

No mutating builtin (`version_record`, `reindex_file`, `rename_symbol`, locks) ever touches the read-only set — they only ever operate on the primary slot. A write to a dependency-root path stays rejected exactly as before, because that path is not in the primary index.

## Tests

`cargo nextest run -p harn-hostlib` — **588 pass** (4 new + existing, incl. registration drift + schema-presence + `every_schema_parses`). New `code_index.rs` tests:

- project index **survives** after adding dep roots (no clobber; `stats` still counts only project files);
- a symbol that exists **only** in a dep root is found via `query` and readable via `read_range`;
- a dep-root path is **read-only** — the `reindex_file` write path rejects it;
- `add_readonly_roots` is **idempotent** (re-adding the same root does not duplicate).

`cargo clippy -p harn-hostlib --tests` clean; `cargo fmt` clean; pre-commit (markdownlint, rust prompt-prose ratchet, clippy) all pass.

## Burin follow-up (after this releases + repin)

Wire `codeindex.harn` to call `hostlib_code_index_add_readonly_roots` with resolved dependency roots, then prefer the merged `query`/`read_range` path over the search + `look_not_found` fallback from #2403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)