### PR TITLE
fix(llm): recover gpt-oss harmony `tool`-key channel-leak + persist clean turn

### DIFF
--- a/changelog.d/gpt-oss-harmony-content-leak.fixed.md
+++ b/changelog.d/gpt-oss-harmony-content-leak.fixed.md
@@ -1,0 +1,13 @@
+- **gpt-oss / Harmony channel leaks no longer pollute conversation history.**
+  On ~23% of gpt-oss-120b turns the provider fails to split its harmony
+  channels and collapses the analysis reasoning plus the inline tool call into
+  the assistant `content` (empty `reasoning` field, empty native `tool_calls`).
+  The bare `{"tool":..,"arguments":..}` dialect emitted in that case is now
+  recovered (the native-JSON parser accepts `tool` as a `name` alias, in both
+  the acceptance gate and the extractor — previously the call was dropped and
+  the loop saw a stall), and the persisted assistant turn is rebuilt into the
+  canonical shape a non-leaked turn produces: structured `tool_calls`, the
+  leaked trace moved to the private `reasoning` field (stripped from the wire by
+  the prior-turn reasoning fix), and empty `content`. This stops the model's raw
+  chain-of-thought — including "game the verifier" plans — from being
+  re-serialized into every later request and wasting input tokens.

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -905,14 +905,72 @@ fn assistant_message_from_llm_result(llm_result: &VmValue) -> VmValue {
         .iter()
         .map(vm_to_json)
         .collect::<Vec<_>>();
+    let thinking = dict_get(llm_result, "thinking").map(|v| v.display());
     if native_calls_json.is_empty() {
+        // gpt-oss / harmony channel-leak backstop. A native-tools model is
+        // supposed to split its harmony channels at the wire: analysis ->
+        // `reasoning`, commentary/tool -> `tool_calls`, final -> `content`. On
+        // ~23% of gpt-oss-120b turns the provider FAILS to split and collapses
+        // the analysis reasoning AND the inline tool-call JSON into a single
+        // `content` blob (empty `reasoning` field, empty `tool_calls`). The
+        // tagged-parser merge in `vm_build_llm_result` recovers the call into
+        // the unified `tool_calls` (the `tool`-key dialect now recovers too,
+        // see native_json.rs), but the recovered prose is discarded, so the
+        // dirty `text` would still be persisted verbatim. Replaying that raw
+        // blob back into history wastes input tokens AND re-feeds the model its
+        // own private chain-of-thought (incl. "game the verifier" plans) on
+        // every later turn.
+        //
+        // For a native-tools model the canonical persisted shape is structured
+        // `tool_calls` + a private `reasoning` trace + a clean `content` (this
+        // is exactly what a NON-leaked gpt-oss turn produces, and what the
+        // native-calls-present branch below builds). So we reconstruct that
+        // shape: move the leaked blob into the private `reasoning` field (it is
+        // analysis CoT, not a committed answer — clean tool-call turns carry no
+        // `content`), attach the recovered call to `tool_calls`, and leave
+        // `content` empty. The next request's openai-compat wire already strips
+        // prior-turn `reasoning` (harn#3319), so nothing dirty is re-fed.
+        //
+        // Pure text-format models (`native_tools == false`, e.g. local
+        // llamacpp) legitimately keep their calls inline in `content` for the
+        // NEXT turn's text parser to re-read, so those keep the verbatim-text
+        // path below.
+        let caps = crate::llm::capabilities::lookup(&provider, &model);
+        if caps.native_tools {
+            let recovered_calls = list_items(
+                &dict_get(llm_result, "tool_calls")
+                    .cloned()
+                    .unwrap_or(VmValue::Nil),
+            )
+            .iter()
+            .map(vm_to_json)
+            .collect::<Vec<_>>();
+            if !recovered_calls.is_empty() {
+                // A call was recovered from the dirty content. The accompanying
+                // prose is private analysis CoT — route it to `reasoning`
+                // (preferring the wire `thinking` field when the provider did
+                // populate it) and keep `content` empty, matching a clean turn.
+                let reasoning = thinking
+                    .as_deref()
+                    .filter(|t| !t.is_empty())
+                    .unwrap_or(text.as_str());
+                let msg = build_assistant_response_message(
+                    "",
+                    &[],
+                    &recovered_calls,
+                    Some(reasoning),
+                    &provider,
+                    &model,
+                );
+                return json_to_vm(&msg);
+            }
+        }
         let mut msg = crate::value::DictMap::new();
         msg.put_str("role", "assistant");
         msg.put_str("content", text);
         return VmValue::dict(msg);
     }
 
-    let thinking = dict_get(llm_result, "thinking").map(|v| v.display());
     let msg = build_assistant_response_message(
         &text,
         &[],

--- a/crates/harn-vm/src/llm/agent_session_host_tests.rs
+++ b/crates/harn-vm/src/llm/agent_session_host_tests.rs
@@ -51,6 +51,64 @@ fn native_tool_calls_replay_with_openai_wire_shape() {
 }
 
 #[test]
+fn gpt_oss_harmony_leak_persists_clean_reasoning_and_tool_calls() {
+    // Guard: the test model must resolve to a native-tools route, or the
+    // backstop (which only fires for native-tools models) would no-op and the
+    // assertion below would silently pass for the wrong reason.
+    let caps = crate::llm::capabilities::lookup("fireworks", "gpt-oss-120b");
+    assert!(
+        caps.native_tools,
+        "test precondition: gpt-oss must be a native-tools route"
+    );
+
+    // Leak-shaped llm_result: the provider failed to split harmony channels, so
+    // the analysis reasoning AND the inline `tool`-key tool call collapsed into
+    // `content` (`text`). The wire `reasoning` field was EMPTY (so `thinking` is
+    // absent) and there were NO native tool calls. `vm_build_llm_result` then
+    // recovered the call out of the dirty text into the merged `tool_calls`
+    // (the `tool`-key dialect now parses). Persistence must rebuild the clean
+    // shape rather than replaying the raw blob.
+    let dirty = "We need to suppress warnings to make verification consider success. \
+                 First inspect the model.\n\n\
+                 {\"tool\":\"read\",\"arguments\":{\"path\":\"BatteryInfo.swift\"}}";
+    let result = crate::stdlib::json_to_vm_value(&json!({
+        "provider": "fireworks",
+        "model": "gpt-oss-120b",
+        "text": dirty,
+        "prose": dirty,
+        "native_tool_calls": [],
+        "tool_calls": [{
+            "id": "native_fallback",
+            "name": "read",
+            "arguments": {"path": "BatteryInfo.swift"}
+        }],
+    }));
+
+    let message = vm_to_json(&assistant_message_from_llm_result(&result));
+
+    assert_eq!(message["role"], "assistant");
+    // Content must be EMPTY — the dirty blob must not be persisted verbatim.
+    assert_eq!(
+        message["content"], "",
+        "leaked reasoning/JSON must not stay in content"
+    );
+    // The recovered call must be attached as a structured tool call.
+    assert_eq!(message["tool_calls"][0]["function"]["name"], "read");
+    // The leaked reasoning trace is preserved privately in `reasoning`, not in
+    // `content`, so it is available for transcripts but stripped from the wire.
+    assert_eq!(message["reasoning"], json!(dirty));
+    // And the dirty blob (incl. the "game the verifier" plan) is gone from the
+    // public content surface.
+    assert!(
+        !message["content"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("suppress warnings"),
+        "verifier-gaming CoT leaked into persisted content"
+    );
+}
+
+#[test]
 fn initial_user_content_preserves_multimodal_blocks() {
     let mut opts = crate::value::DictMap::new();
     opts.insert(

--- a/crates/harn-vm/src/llm/tools/parse/native_json.rs
+++ b/crates/harn-vm/src/llm/tools/parse/native_json.rs
@@ -34,8 +34,14 @@ pub(crate) fn parse_native_json_tool_calls(
             .get("function")
             .and_then(|function| function.as_object())
             .unwrap_or(item_obj);
+        // Canonical key is `name`. Accept `tool` as an alias so the bare
+        // `{"tool":..,"arguments":..}` dialect gpt-oss / Harmony emits when its
+        // native channel leaks into `content` is recovered (the fenced-JSON
+        // parser already honors this alias). Without it, a leaked gpt-oss call
+        // is silently dropped and the dirty content is persisted verbatim.
         let name = func
             .get("name")
+            .or_else(|| func.get("tool"))
             .and_then(|name| name.as_str())
             .unwrap_or("");
         if name.is_empty() {
@@ -126,10 +132,17 @@ fn find_native_json_items(text: &str) -> Option<Vec<serde_json::Value>> {
             item.get(key)
                 .is_some_and(|slot| slot.is_object() || slot.is_string())
         };
+        // `tool` is accepted as a `name` alias for the gpt-oss / Harmony
+        // `{"tool":..,"arguments":..}` channel-leak dialect (mirrors the
+        // extractor and the fenced-JSON parser).
+        let name_slot_present = |item: &serde_json::Value| {
+            item.get("name").is_some_and(serde_json::Value::is_string)
+                || item.get("tool").is_some_and(serde_json::Value::is_string)
+        };
         if items.iter().any(|item| {
             item.get("function")
                 .is_some_and(serde_json::Value::is_object)
-                || (item.get("name").is_some_and(serde_json::Value::is_string)
+                || (name_slot_present(item)
                     && (args_slot_present(item, "arguments")
                         || args_slot_present(item, "parameters")))
         }) {

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -596,6 +596,24 @@ fn native_json_fallback_parses_flat_jsonrpc_envelope() {
 }
 
 #[test]
+fn native_json_fallback_parses_gpt_oss_tool_key_dialect() {
+    // gpt-oss / Harmony channel-leak shape: when the native channel collapses
+    // into `content`, the model emits its bare `{"tool":..,"arguments":..}`
+    // dialect inline after a reasoning preamble (no `function`, no `name`,
+    // `tool` instead). Before the `tool`-key alias the acceptance gate dropped
+    // it entirely (zero parsed calls), so the call was lost and the dirty
+    // content was persisted verbatim. `tool` must map to `name`.
+    let known = known_tools_set();
+    let text = "We should inspect the model first.\n\n\
+                {\"tool\":\"read\",\"arguments\":{\"path\":\"BatteryInfo.swift\"}}";
+    let (calls, errors) = parse_native_json_tool_calls(text, &known);
+    assert!(errors.is_empty(), "no errors expected: {errors:?}");
+    assert_eq!(calls.len(), 1, "tool-key dialect should parse: {calls:?}");
+    assert_eq!(calls[0]["name"], json!("read"));
+    assert_eq!(calls[0]["arguments"]["path"], json!("BatteryInfo.swift"));
+}
+
+#[test]
 fn native_json_fallback_parses_flat_envelope_with_string_encoded_arguments() {
     // Regression: OpenAI's on-the-wire flat shape encodes `arguments` as a JSON
     // STRING (`{"name":"read","arguments":"{\"path\":\"a\"}"}`), which local


### PR DESCRIPTION
## Problem

Adversarial JSONL audit (or-gpt-oss-120b proxy transcripts; the Fireworks corpus was destroyed by the teardown-race sibling fix): on ~23% of gpt-oss-120b turns the provider **fails to split its harmony channels**. A CLEAN turn has `reasoning` populated + `tool_calls` populated + `content` empty. A LEAK turn has `reasoning` EMPTY + native `tool_calls` EMPTY + `content` = raw analysis reasoning followed by the model's inline bare-JSON tool call.

That dirty `content` was being persisted verbatim into history and re-serialized into every later request, which (a) wastes ~5-9% input tokens and (b) re-feeds the model its own private chain-of-thought — including verifier-gaming plans (cpp idx84: persisted `"We need to suppress warnings to make verification consider success…"`) — a behavior-corruption risk.

## Root cause (two compounding defects)

1. **The call was not even recoverable.** gpt-oss emits a bare `{"tool":..,"arguments":..}` dialect when its native channel leaks. The loop-path tagged parser routes bare JSON to `parse_native_json_tool_calls`, but `find_native_json_items` / the extractor only honored the `name`/`function` keys (the fenced-JSON parser already accepted `tool`, but it is not on the loop turn path). So the leaked call was dropped entirely — zero parsed calls — and the loop read it as a stall.

2. **The dirty content was persisted.** `assistant_message_from_llm_result` (the per-turn persistence seam) persisted raw `content` verbatim whenever native `tool_calls` was empty, dropping reasoning and keeping the inline JSON.

## Fix (harn owns tool-call parsing + transcript persistence)

- `native_json.rs`: accept `tool` as a `name` alias in both the acceptance gate and the extractor, mirroring the fenced-JSON parser. The leaked call now parses into the merged `tool_calls`.
- `agent_session_host.rs`: for a native-tools route whose native `tool_calls` is empty but where a call was recovered, rebuild the canonical shape a non-leaked turn produces — structured `tool_calls`, the leaked trace moved to the private `reasoning` field (stripped from the openai-compat wire by #3319), and empty `content`. Pure text-format models (`native_tools == false`, e.g. local llamacpp) keep the verbatim-inline path so their next-turn text parser can re-read the call.

## Tests

- `native_json_fallback_parses_gpt_oss_tool_key_dialect` — leak-shaped bare `tool`-key JSON after a reasoning preamble parses to one call.
- `gpt_oss_harmony_leak_persists_clean_reasoning_and_tool_calls` — leak-shaped llm_result for the `fireworks/gpt-oss-120b` native route persists `content == ""`, `tool_calls[0].function.name == "read"`, `reasoning == <leaked trace>`, and the verifier-gaming CoT is gone from content.

`cargo nextest run -p harn-vm`: 3864 passed, 0 failed. fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)