### PR TITLE
fix(llm): equal-jitter backoff, typed non-stream send errors, network circuit breaker

### DIFF
--- a/changelog.d/llm-retry-robustness.changed.md
+++ b/changelog.d/llm-retry-robustness.changed.md
@@ -1,0 +1,22 @@
+- **LLM retry/throttle layer is more robust under concurrency and network loss.**
+  Three deterministic, unit-tested hardenings to the outbound-LLM retry path:
+  - **Equal-jitter backoff.** Transient-error backoff was a fixed exponential
+    (`250/500/1000/2000/4000ms`) with zero jitter, so concurrent same-key
+    callers (e.g. `eval --concurrency K` alongside a live session) retried in
+    lockstep and re-stampeded the provider. Backoff now uses AWS "equal jitter"
+    (`wait = ceil/2 + rand(0, ceil/2)`, `ceil = 250 * 2^min(attempt, 4)`), which
+    desynchronizes retries while avoiding the near-zero waits of full jitter. A
+    small additive jitter is also layered on top of an honored provider
+    `Retry-After` so identical `Retry-After` values do not resume in unison.
+  - **Typed non-streaming send errors.** Streaming `req.send()` failures were
+    already classified by reqwest error kind, but non-streaming send failures
+    became a bare `"{provider} API error: {e}"` string that the retry layer
+    had to re-classify by substring. Both paths now share one reqwest-kind
+    classifier that tags timeouts/connection failures as typed
+    `ErrorCategory::Timeout` / `TransientNetwork` at the source.
+  - **Network-only circuit breaker.** A per-route, per-process breaker now opens
+    after sustained `NetworkError`/`Timeout` failures (laptop disconnect, DNS
+    failure, dropped link), fails fast for a short window, then admits a single
+    half-open probe and closes on success. It deliberately does **not** react to
+    429 (handled by the existing rate-limiter cooldown + `Retry-After`) or 5xx,
+    so it only stops the retry budget from burning against a truly dead link.

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -191,6 +191,30 @@ pub(super) fn is_retryable_llm_error(err: &VmError) -> bool {
         || lower.contains("eof")
 }
 
+/// Whether an LLM-call failure is a transport-level *network* failure
+/// (connection refused/reset, DNS failure, dropped link, request timeout) — the
+/// ONLY failures that feed the per-route network circuit breaker.
+///
+/// Deliberately excludes `RateLimit` (429): a 429 means the link is healthy and
+/// the provider is throttling us; that is handled by the rate limiter's cooldown
+/// and Retry-After, not by the breaker. `ServerError` (5xx) is likewise the
+/// provider's fault on a reachable link and must not trip the breaker either.
+pub(super) fn is_network_failure_llm_error(err: &VmError) -> bool {
+    let (category, message) = match err {
+        VmError::CategorizedError { category, message } => (category.clone(), message.clone()),
+        VmError::Thrown(crate::value::VmValue::String(s)) => {
+            (crate::value::classify_error_message(s), s.to_string())
+        }
+        VmError::Runtime(s) => (crate::value::classify_error_message(s), s.clone()),
+        _ => return false,
+    };
+    let reason = crate::llm::api::classify_llm_error(category, &message).reason;
+    matches!(
+        reason,
+        crate::llm::api::LlmErrorReason::NetworkError | crate::llm::api::LlmErrorReason::Timeout
+    )
+}
+
 /// A *thrown* provider response the agent loop should retry within the
 /// empty-completion budget rather than terminate on. Two shapes, both surfaced
 /// as a thrown error by the response/transport parsers:
@@ -1081,13 +1105,50 @@ fn llm_retry_backoff_ms(
     if crate::llm::providers::MockProvider::should_intercept(provider) {
         return 0;
     }
-    extract_retry_after_ms(error).unwrap_or_else(|| base_retry_backoff_ms(retry_config, attempt))
+    // Honor an explicit provider Retry-After, but still add a small jitter on
+    // top so concurrent same-key callers (eval --concurrency K plus a coexisting
+    // session) that all received the same Retry-After do not resume in lockstep
+    // and re-stampede the provider the instant the window opens.
+    match extract_retry_after_ms(error) {
+        Some(retry_after_ms) => retry_after_ms.saturating_add(retry_after_jitter_ms()),
+        None => base_retry_backoff_ms(retry_config, attempt),
+    }
 }
 
-/// Exponential backoff base shared by the error-retry and empty-completion
-/// retry paths (no `retry-after` hint available on the latter).
+/// Equal-jitter exponential backoff base shared by the error-retry and
+/// empty-completion retry paths (no `retry-after` hint available on the latter).
+///
+/// AWS "equal jitter": `wait = ceil/2 + rand(0, ceil/2)`, where
+/// `ceil = backoff_ms * 2^min(attempt, 4)`. Keeping the lower half fixed avoids
+/// the near-zero waits that pure "full jitter" can produce, while randomizing
+/// the upper half desynchronizes retries across concurrent same-key processes
+/// (avoids the thundering herd that the old zero-jitter `ceil` produced).
 fn base_retry_backoff_ms(retry_config: &LlmRetryConfig, attempt: usize) -> u64 {
-    retry_config.backoff_ms.saturating_mul(1 << attempt.min(4))
+    let ceil = retry_config.backoff_ms.saturating_mul(1 << attempt.min(4));
+    equal_jitter_ms(ceil, &mut rand::rng())
+}
+
+/// Pure equal-jitter computation, seamed on an injectable RNG so tests can
+/// assert the `[ceil/2, ceil]` bounds and desynchronization deterministically.
+fn equal_jitter_ms<R: rand::RngExt>(ceil: u64, rng: &mut R) -> u64 {
+    let half = ceil / 2;
+    if half == 0 {
+        return ceil;
+    }
+    // `ceil/2` fixed lower half + `rand(0, ceil/2)` upper half → `[ceil/2, ceil]`.
+    half + rand_range_inclusive(half, rng)
+}
+
+/// Small additive jitter (0..=backoff base) layered on top of a provider
+/// Retry-After so identical Retry-After values do not resume in lockstep.
+fn retry_after_jitter_ms() -> u64 {
+    rand_range_inclusive(DEFAULT_LLM_CALL_BACKOFF_MS, &mut rand::rng())
+}
+
+/// `rand(0, max)` inclusive, seamed on an injectable RNG. Centralizes the
+/// half-open-to-inclusive conversion (`random_range` is exclusive of its end).
+fn rand_range_inclusive<R: rand::RngExt>(max: u64, rng: &mut R) -> u64 {
+    rng.random_range(0..max.saturating_add(1))
 }
 
 // ---------------------------------------------------------------------------
@@ -1118,6 +1179,12 @@ pub(crate) async fn observed_llm_call(
         .unwrap_or_else(|| crate::llm_config::default_tool_format(&opts.model, &opts.provider));
     let mut attempt = 0usize;
     loop {
+        // Network-only circuit breaker: if this route has seen sustained
+        // NetworkError/Timeout failures, fail fast instead of burning the retry
+        // budget against a dead link (laptop disconnect / DNS failure). 429s do
+        // NOT trip this — they are handled by the rate-limiter cooldown below.
+        super::rate_limit::check_network_breaker_for_llm_call(opts)?;
+
         let rate_limit_permit = super::rate_limit::acquire_permit_for_llm_call(opts).await?;
 
         let call_id = next_call_id();
@@ -1373,6 +1440,9 @@ pub(crate) async fn observed_llm_call(
                     duration_ms,
                     iteration: iteration.unwrap_or(0),
                 });
+                // A reachable, answering provider closes the network breaker
+                // (and resets any half-open probe).
+                super::rate_limit::observe_network_outcome_for_llm_call(opts, false);
                 return Ok(result);
             }
             Err(error) => {
@@ -1384,6 +1454,13 @@ pub(crate) async fn observed_llm_call(
                         super::rate_limit::observe_retry_after_for_llm_call(opts, retry_after_ms);
                     }
                 }
+                // Feed ONLY transport-level network failures (connection/DNS/
+                // timeout) to the breaker — never 429 (rate limit) or 5xx
+                // (server error on a reachable link).
+                super::rate_limit::observe_network_outcome_for_llm_call(
+                    opts,
+                    is_network_failure_llm_error(&error),
+                );
                 let retryable = is_retryable_llm_error(&error);
                 // A *thrown* unproductive completion (zero-token empty, or the
                 // billed-noncommittal contract violation whose tool call went
@@ -1780,6 +1857,96 @@ mod retry_tests {
             llm_retry_backoff_ms(&thrown("HTTP 503"), &config, 1, "mock"),
             0
         );
+    }
+
+    #[test]
+    fn equal_jitter_stays_within_ceil_half_to_ceil_bounds() {
+        use rand::{rngs::StdRng, SeedableRng};
+        // Sweep many seeds across the exponential ceil ladder and assert every
+        // draw lands in `[ceil/2, ceil]` — never near-zero (the win over full
+        // jitter), never above the exponential ceiling.
+        for attempt in 0..8usize {
+            let ceil = 250u64.saturating_mul(1 << attempt.min(4));
+            let half = ceil / 2;
+            for seed in 0..256u64 {
+                let mut rng = StdRng::seed_from_u64(seed);
+                let wait = equal_jitter_ms(ceil, &mut rng);
+                assert!(
+                    wait >= half && wait <= ceil,
+                    "attempt={attempt} ceil={ceil} seed={seed} wait={wait} out of [{half}, {ceil}]"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn equal_jitter_desynchronizes_concurrent_callers() {
+        use rand::{rngs::StdRng, SeedableRng};
+        // Two callers drawing from distinct entropy must not resume in lockstep:
+        // at least one differing pair proves the herd is broken (the old
+        // zero-jitter path returned the identical `ceil` for every caller).
+        let ceil = 4000u64;
+        let mut any_differ = false;
+        for seed in 0..64u64 {
+            let a = equal_jitter_ms(ceil, &mut StdRng::seed_from_u64(seed));
+            let b = equal_jitter_ms(ceil, &mut StdRng::seed_from_u64(seed + 10_000));
+            if a != b {
+                any_differ = true;
+                break;
+            }
+        }
+        assert!(any_differ, "equal jitter failed to desynchronize any pair");
+    }
+
+    #[test]
+    fn equal_jitter_tiny_ceil_floors_at_ceil() {
+        use rand::{rngs::StdRng, SeedableRng};
+        // ceil/2 == 0 (e.g. ceil < 2) cannot host a range; return the ceil.
+        let mut rng = StdRng::seed_from_u64(1);
+        assert_eq!(equal_jitter_ms(0, &mut rng), 0);
+        assert_eq!(equal_jitter_ms(1, &mut rng), 1);
+    }
+
+    #[test]
+    fn retry_after_path_adds_bounded_jitter() {
+        // A provider Retry-After is honored as a floor; the layered jitter never
+        // exceeds `retry_after + backoff_base`, so the wait stays in a tight band
+        // around the requested cooldown while desynchronizing siblings.
+        let config = LlmRetryConfig {
+            retries: 3,
+            backoff_ms: DEFAULT_LLM_CALL_BACKOFF_MS,
+        };
+        let err = thrown("HTTP 429 rate_limited retry-after: 5");
+        let base = extract_retry_after_ms(&err).expect("retry-after parsed");
+        for _ in 0..256 {
+            let wait = llm_retry_backoff_ms(&err, &config, 1, "openai");
+            assert!(
+                wait >= base && wait <= base + DEFAULT_LLM_CALL_BACKOFF_MS,
+                "retry-after jitter {wait} out of [{base}, {}]",
+                base + DEFAULT_LLM_CALL_BACKOFF_MS
+            );
+        }
+    }
+
+    #[test]
+    fn base_backoff_real_provider_respects_exponential_ceiling() {
+        // The live (un-seamed) path must still land in the equal-jitter band for
+        // the configured base, exercising `rand::rng()` rather than the test RNG.
+        let config = LlmRetryConfig {
+            retries: 5,
+            backoff_ms: DEFAULT_LLM_CALL_BACKOFF_MS,
+        };
+        for attempt in 1..=6usize {
+            let ceil = DEFAULT_LLM_CALL_BACKOFF_MS.saturating_mul(1 << attempt.min(4));
+            for _ in 0..64 {
+                let wait = base_retry_backoff_ms(&config, attempt);
+                assert!(
+                    wait >= ceil / 2 && wait <= ceil,
+                    "attempt={attempt} wait={wait} out of [{}, {ceil}]",
+                    ceil / 2
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -498,11 +498,10 @@ async fn vm_call_llm_api_with_body_inner(
         unreachable!("streaming LLM attempt loop exhausted without returning");
     }
 
-    let response = req.send().await.map_err(|e| {
-        VmError::Thrown(VmValue::String(std::sync::Arc::from(format!(
-            "{provider} API error: {e}"
-        ))))
-    })?;
+    let response = req
+        .send()
+        .await
+        .map_err(|e| non_stream_send_error(provider, e))?;
 
     // Check HTTP status BEFORE parsing the body as LLM response, or error
     // responses (e.g. vLLM "prompt too long" 400) silently become malformed
@@ -636,24 +635,49 @@ async fn send_stream_request_with_ollama_warmup(
 }
 
 fn stream_send_error(provider: &str, error: reqwest::Error) -> VmError {
-    let kind = if error.is_timeout() {
-        "timeout"
+    reqwest_send_error(provider, "stream", error)
+}
+
+/// Classify a non-streaming `req.send()` transport failure with the *same*
+/// reqwest-kind classifier the streaming path uses, so timeouts and connection
+/// failures are typed (`ErrorCategory::Timeout` / `TransientNetwork`) at the
+/// source instead of being reclassified downstream by fragile substring
+/// matching of a bare `"{provider} API error: {e}"` string.
+fn non_stream_send_error(provider: &str, error: reqwest::Error) -> VmError {
+    reqwest_send_error(provider, "request", error)
+}
+
+/// Shared reqwest-`Error`-kind classifier for both the streaming and
+/// non-streaming send paths. Maps the reqwest kind to an explicit
+/// [`crate::value::ErrorCategory`] (carried on a `CategorizedError`) so the
+/// retry/observability layer reads a typed category rather than re-deriving it
+/// from the message text. `phase` ("stream" / "request") only flavors the
+/// human-readable message; the typed category drives retry decisions.
+fn reqwest_send_error(provider: &str, phase: &str, error: reqwest::Error) -> VmError {
+    use crate::value::ErrorCategory;
+    let (kind, category) = if error.is_timeout() {
+        ("timeout", Some(ErrorCategory::Timeout))
     } else if error.is_connect() {
-        "connect"
+        ("connect", Some(ErrorCategory::TransientNetwork))
     } else if error.is_request() {
-        "request_build"
+        // A malformed request build is the caller's fault, not a transient
+        // network blip — leave it uncategorized so it is not blindly retried.
+        ("request_build", None)
     } else if error.is_body() {
-        "body"
+        ("body", Some(ErrorCategory::TransientNetwork))
     } else {
-        "unknown"
+        ("unknown", None)
     };
     // "unknown" uses Debug repr to surface the inner cause.
-    let detail = if kind == "unknown" {
-        format!("{provider} stream error ({kind}): {error:?}")
+    let message = if kind == "unknown" {
+        format!("{provider} {phase} error ({kind}): {error:?}")
     } else {
-        format!("{provider} stream error ({kind}): {error}")
+        format!("{provider} {phase} error ({kind}): {error}")
     };
-    VmError::Thrown(VmValue::String(std::sync::Arc::from(detail)))
+    match category {
+        Some(category) => VmError::CategorizedError { message, category },
+        None => VmError::Thrown(VmValue::String(std::sync::Arc::from(message))),
+    }
 }
 
 /// Canonical wire id for a streamed tool call.
@@ -1571,10 +1595,78 @@ fn is_ollama_empty_content_parser_bug(err: &VmError) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        append_ollama_tool_calls, consume_ollama_ndjson_lines, parse_ollama_tool_arguments,
-        should_request_stream_usage, telemetry_source,
+        append_ollama_tool_calls, consume_ollama_ndjson_lines, non_stream_send_error,
+        parse_ollama_tool_arguments, reqwest_send_error, should_request_stream_usage,
+        telemetry_source,
     };
+    use crate::value::{error_to_category, ErrorCategory, VmError};
     use std::time::Duration;
+
+    /// Drive a real `reqwest::Error` of the requested kind so the classifier is
+    /// exercised against genuine reqwest internals (its `is_*` predicates), not a
+    /// hand-rolled stand-in. `192.0.2.1` is reserved TEST-NET-1 (RFC 5737) and is
+    /// guaranteed unroutable, producing a connect/timeout failure deterministically.
+    async fn real_send_error(timeout: Duration) -> reqwest::Error {
+        let client = reqwest::Client::builder()
+            .timeout(timeout)
+            .connect_timeout(timeout)
+            .build()
+            .expect("client builds");
+        client
+            .get("http://192.0.2.1:9/never")
+            .send()
+            .await
+            .expect_err("send to unroutable TEST-NET-1 address must fail")
+    }
+
+    #[tokio::test]
+    async fn non_stream_send_error_is_typed_network_not_substring() {
+        // Connect/timeout failures must arrive as a typed CategorizedError whose
+        // category is transient — NOT a bare Thrown string reclassified by
+        // substring downstream.
+        let raw = real_send_error(Duration::from_millis(150)).await;
+        let typed = non_stream_send_error("openai", raw);
+        match &typed {
+            VmError::CategorizedError { category, .. } => {
+                assert!(
+                    matches!(
+                        category,
+                        ErrorCategory::Timeout | ErrorCategory::TransientNetwork
+                    ),
+                    "expected Timeout/TransientNetwork, got {category:?}"
+                );
+                assert!(
+                    category.is_transient(),
+                    "network send error must be transient"
+                );
+            }
+            other => panic!("expected typed CategorizedError, got {other:?}"),
+        }
+        // And the canonical category extractor reads the explicit category
+        // (proving no substring re-derivation is needed).
+        assert!(error_to_category(&typed).is_transient());
+    }
+
+    #[tokio::test]
+    async fn stream_and_non_stream_send_paths_share_one_classifier() {
+        // DRY check: both phases route through `reqwest_send_error` and yield the
+        // same typed category for the same underlying reqwest failure.
+        let stream_err = reqwest_send_error(
+            "anthropic",
+            "stream",
+            real_send_error(Duration::from_millis(150)).await,
+        );
+        let request_err = reqwest_send_error(
+            "anthropic",
+            "request",
+            real_send_error(Duration::from_millis(150)).await,
+        );
+        assert_eq!(
+            error_to_category(&stream_err).is_transient(),
+            error_to_category(&request_err).is_transient(),
+            "stream and non-stream send errors must classify identically"
+        );
+    }
 
     #[test]
     fn stream_usage_requested_for_openai_compatible_endpoints() {

--- a/crates/harn-vm/src/llm/rate_limit.rs
+++ b/crates/harn-vm/src/llm/rate_limit.rs
@@ -28,6 +28,15 @@ const WINDOW_SECS: u64 = 60;
 const RATE_LIMIT_ENV_FIELD_SUFFIXES: [&str; 5] =
     ["_RPM", "_TPM", "_INPUT_TPM", "_OUTPUT_TPM", "_CONCURRENCY"];
 
+/// Consecutive NetworkError/Timeout failures on one route that trip the
+/// network-only circuit breaker open. Distinct from 429 handling, which uses
+/// `cooldown_until_ms` + provider Retry-After and never feeds the breaker.
+const NETWORK_BREAKER_FAILURE_THRESHOLD: u32 = 4;
+/// How long the breaker stays open (fail-fast) before allowing a half-open probe.
+/// Short on purpose: a laptop reconnect or DNS recovery should be retried soon,
+/// we only want to stop burning the per-call retry budget while the link is down.
+const NETWORK_BREAKER_OPEN_MS: u64 = 5_000;
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct RateLimitRequest {
     input_tokens: u64,
@@ -193,6 +202,78 @@ impl SlidingWindow {
     }
 }
 
+/// Per-process, network-only circuit breaker for one route.
+///
+/// Opens ONLY on sustained `NetworkError`/`Timeout` (laptop disconnect, DNS
+/// failure, dropped link) — never on 429, which the rate limiter already handles
+/// via `cooldown_until_ms` + provider Retry-After. While open it fails fast so a
+/// call does not burn its whole retry budget against a dead link; after a short
+/// window it half-opens to admit a single probe, then closes on success or
+/// re-opens on another network failure.
+///
+/// Network reachability is a property of THIS process, so the breaker is
+/// per-process state (not shared via the durable rate-limit DB). It is distinct
+/// from the opt-in routing-policy breaker; this one is always-on and only ever
+/// reacts to transport-level network failures.
+#[derive(Debug, Default, PartialEq, Eq)]
+enum BreakerState {
+    #[default]
+    Closed,
+    /// Failing fast until `until_ms`, after which one half-open probe is admitted.
+    Open { until_ms: u128 },
+    /// A single probe is in flight; further calls fail fast until it resolves.
+    HalfOpen,
+}
+
+#[derive(Debug, Default)]
+struct NetworkBreaker {
+    state: BreakerState,
+    consecutive_network_failures: u32,
+}
+
+impl NetworkBreaker {
+    /// Whether a call should be admitted now, transitioning Open→HalfOpen when
+    /// the open window has elapsed. Returns `None` to admit (Closed/HalfOpen
+    /// probe), or `Some(remaining)` to fail fast while open.
+    fn admit(&mut self, now_ms: u128) -> Option<Duration> {
+        match self.state {
+            BreakerState::Closed => None,
+            BreakerState::HalfOpen => {
+                // A probe is already in flight; do not admit a second.
+                Some(Duration::from_millis(0))
+            }
+            BreakerState::Open { until_ms } => {
+                if now_ms >= until_ms {
+                    self.state = BreakerState::HalfOpen;
+                    None
+                } else {
+                    Some(Duration::from_millis(
+                        until_ms.saturating_sub(now_ms).min(u128::from(u64::MAX)) as u64,
+                    ))
+                }
+            }
+        }
+    }
+
+    fn record_network_failure(&mut self, now_ms: u128) {
+        self.consecutive_network_failures = self.consecutive_network_failures.saturating_add(1);
+        // A failed half-open probe (or crossing the threshold while closed)
+        // (re)opens the breaker for a fresh window.
+        if matches!(self.state, BreakerState::HalfOpen)
+            || self.consecutive_network_failures >= NETWORK_BREAKER_FAILURE_THRESHOLD
+        {
+            self.state = BreakerState::Open {
+                until_ms: now_ms.saturating_add(u128::from(NETWORK_BREAKER_OPEN_MS)),
+            };
+        }
+    }
+
+    fn record_success(&mut self) {
+        self.consecutive_network_failures = 0;
+        self.state = BreakerState::Closed;
+    }
+}
+
 struct RouteLimiter {
     request_window: Option<SlidingWindow>,
     total_token_window: Option<SlidingWindow>,
@@ -200,6 +281,7 @@ struct RouteLimiter {
     output_token_window: Option<SlidingWindow>,
     concurrency: Option<Arc<Semaphore>>,
     cooldown_until_ms: Option<u128>,
+    breaker: NetworkBreaker,
     limits: EffectiveRateLimits,
 }
 
@@ -214,6 +296,7 @@ impl RouteLimiter {
                 .concurrency
                 .map(|limit| Arc::new(Semaphore::new(limit.max(1) as usize))),
             cooldown_until_ms: None,
+            breaker: NetworkBreaker::default(),
             limits,
         }
     }
@@ -264,6 +347,19 @@ impl RouteLimiter {
         }
         let until_ms = now_ms.saturating_add(u128::from(retry_after_ms));
         self.cooldown_until_ms = Some(self.cooldown_until_ms.unwrap_or(0).max(until_ms));
+    }
+
+    /// Fail-fast wait if the network breaker is open; `None` admits the call.
+    fn breaker_block(&mut self, now_ms: u128) -> Option<Duration> {
+        self.breaker.admit(now_ms)
+    }
+
+    fn observe_network_failure(&mut self, now_ms: u128) {
+        self.breaker.record_network_failure(now_ms);
+    }
+
+    fn observe_success(&mut self) {
+        self.breaker.record_success();
     }
 }
 
@@ -799,6 +895,83 @@ pub(crate) fn observe_retry_after_for_llm_call(
     }
 }
 
+/// Fail-fast error returned when the network breaker is open for a route.
+fn breaker_open_error(provider: &str, model: &str, remaining: Duration) -> crate::value::VmError {
+    let route = if model.trim().is_empty() {
+        provider.to_string()
+    } else {
+        format!(
+            "{provider}/{}",
+            crate::llm_config::normalize_model_id(model)
+        )
+    };
+    crate::value::VmError::CategorizedError {
+        message: format!(
+            "network circuit breaker open for '{route}': sustained network failures; \
+             failing fast for {}ms (a half-open probe will follow)",
+            remaining.as_millis()
+        ),
+        category: crate::value::ErrorCategory::TransientNetwork,
+    }
+}
+
+/// Fail-fast if the per-route network breaker is open. Returns `Ok(())` to admit
+/// the call (Closed, or an admitted half-open probe), or a typed transient error
+/// to short-circuit the retry loop while the link is down.
+///
+/// Separate from `acquire_permit_for_llm_call` so the breaker decision is taken
+/// once per call attempt at the same seam that observes the outcome, rather than
+/// being entangled with the (durable) rate-limit wait loop.
+pub(crate) fn check_network_breaker_for_llm_call(
+    opts: &super::api::LlmCallOptions,
+) -> Result<(), crate::value::VmError> {
+    ensure_initialized_from_config();
+    let keys = limiter_keys(&opts.provider, &opts.model);
+    let now_ms = crate::clock_mock::instant_now().as_millis();
+    let mut registry = registry().lock().expect("rate limiter mutex poisoned");
+    // Use the max remaining-open across the route's keys: if any key is open, the
+    // call fails fast. `breaker_block` also performs the Open→HalfOpen
+    // transition, so probe admission is consistent across sibling callers.
+    let mut blocked: Option<Duration> = None;
+    for key in &keys {
+        let limiter = limiter_for_key(&mut registry.limiters, key);
+        if let Some(remaining) = limiter.breaker_block(now_ms) {
+            blocked = Some(match blocked {
+                Some(prev) => prev.max(remaining),
+                None => remaining,
+            });
+        }
+    }
+    drop(registry);
+    match blocked {
+        Some(remaining) => Err(breaker_open_error(&opts.provider, &opts.model, remaining)),
+        None => Ok(()),
+    }
+}
+
+/// Feed a completed LLM-call outcome to the route's network breaker.
+///
+/// `network_failure == true` ONLY for transport-level `NetworkError`/`Timeout`
+/// (never 429 — that is rate limiting, not unreachability). A success closes the
+/// breaker; a network failure increments toward / re-opens it.
+pub(crate) fn observe_network_outcome_for_llm_call(
+    opts: &super::api::LlmCallOptions,
+    network_failure: bool,
+) {
+    ensure_initialized_from_config();
+    let keys = limiter_keys(&opts.provider, &opts.model);
+    let now_ms = crate::clock_mock::instant_now().as_millis();
+    let mut registry = registry().lock().expect("rate limiter mutex poisoned");
+    for key in keys {
+        let limiter = limiter_for_key(&mut registry.limiters, &key);
+        if network_failure {
+            limiter.observe_network_failure(now_ms);
+        } else {
+            limiter.observe_success();
+        }
+    }
+}
+
 /// Wait until the provider rate limit allows an opaque request, then record it.
 /// Returns immediately if no limit is configured or the window has capacity.
 pub(crate) async fn acquire_permit(
@@ -1308,5 +1481,145 @@ mod tests {
         drop(registry);
 
         reset_test_rate_limit_state();
+    }
+
+    // ---- network circuit breaker (pure state-machine tests) ----------------
+
+    #[test]
+    fn breaker_opens_after_threshold_consecutive_network_failures() {
+        let mut b = NetworkBreaker::default();
+        // Below threshold: still closed, calls admitted.
+        for i in 1..NETWORK_BREAKER_FAILURE_THRESHOLD {
+            b.record_network_failure(u128::from(i));
+            assert!(
+                b.admit(u128::from(i)).is_none(),
+                "must stay closed below threshold ({i} failures)"
+            );
+        }
+        // Crossing the threshold opens it.
+        b.record_network_failure(100);
+        let blocked = b.admit(100).expect("breaker must be open at threshold");
+        assert!(
+            blocked.as_millis() > 0 && blocked.as_millis() <= u128::from(NETWORK_BREAKER_OPEN_MS),
+            "open window remaining {}ms out of (0, {NETWORK_BREAKER_OPEN_MS}]",
+            blocked.as_millis()
+        );
+    }
+
+    #[test]
+    fn breaker_fails_fast_while_open_then_half_opens_then_closes_on_probe_success() {
+        let mut b = NetworkBreaker::default();
+        let open_at = 1_000u128;
+        for _ in 0..NETWORK_BREAKER_FAILURE_THRESHOLD {
+            b.record_network_failure(open_at);
+        }
+        // Fail fast inside the open window.
+        assert!(
+            b.admit(open_at + 1).is_some(),
+            "must fail fast while open window is active"
+        );
+        // After the window elapses, exactly one half-open probe is admitted...
+        let after = open_at + u128::from(NETWORK_BREAKER_OPEN_MS) + 1;
+        assert!(
+            b.admit(after).is_none(),
+            "half-open probe must be admitted once the window elapses"
+        );
+        // ...and a concurrent caller while the probe is in flight is blocked.
+        assert!(
+            b.admit(after).is_some(),
+            "second concurrent call must not get a second half-open probe"
+        );
+        // A successful probe closes the breaker and clears the failure count.
+        b.record_success();
+        assert!(
+            b.admit(after).is_none(),
+            "breaker must close after probe success"
+        );
+        assert_eq!(b.consecutive_network_failures, 0);
+    }
+
+    #[test]
+    fn breaker_reopens_when_half_open_probe_fails() {
+        let mut b = NetworkBreaker::default();
+        let open_at = 0u128;
+        for _ in 0..NETWORK_BREAKER_FAILURE_THRESHOLD {
+            b.record_network_failure(open_at);
+        }
+        let after = u128::from(NETWORK_BREAKER_OPEN_MS) + 1;
+        assert!(b.admit(after).is_none(), "half-open probe admitted");
+        // The probe fails (still no network): the breaker re-opens immediately,
+        // even though the *count* logic alone is irrelevant in half-open state.
+        b.record_network_failure(after);
+        assert!(
+            b.admit(after + 1).is_some(),
+            "a failed half-open probe must re-open the breaker"
+        );
+    }
+
+    #[test]
+    fn breaker_success_resets_failure_streak() {
+        let mut b = NetworkBreaker::default();
+        b.record_network_failure(0);
+        b.record_network_failure(0);
+        b.record_success();
+        assert_eq!(b.consecutive_network_failures, 0);
+        // One post-success failure must not be enough to re-open (streak reset).
+        b.record_network_failure(0);
+        assert!(
+            b.admit(0).is_none(),
+            "single failure after reset must stay closed"
+        );
+    }
+
+    #[test]
+    fn breaker_does_not_open_on_rate_limit_or_server_errors() {
+        // 429 / 5xx must NOT feed the breaker. Drive the same number of NON-network
+        // outcomes well past the threshold and assert it never opens. (The wiring
+        // in agent_observe only calls `observe_network_failure` for true network
+        // failures; here we assert the classifier that gates that call.)
+        use super::super::agent_observe::is_network_failure_llm_error;
+        use crate::value::{ErrorCategory, VmError, VmValue};
+
+        let rate_limited = VmError::CategorizedError {
+            message: "429 too many requests".to_string(),
+            category: ErrorCategory::RateLimit,
+        };
+        let server_error = VmError::CategorizedError {
+            message: "503 service unavailable".to_string(),
+            category: ErrorCategory::ServerError,
+        };
+        let thrown_429 = VmError::Thrown(VmValue::String(std::sync::Arc::from(
+            "[rate_limited] too many requests",
+        )));
+        assert!(
+            !is_network_failure_llm_error(&rate_limited),
+            "429 is not a network failure"
+        );
+        assert!(
+            !is_network_failure_llm_error(&server_error),
+            "5xx is not a network failure"
+        );
+        assert!(
+            !is_network_failure_llm_error(&thrown_429),
+            "thrown 429 is not a network failure"
+        );
+
+        // A genuine network/timeout failure IS one.
+        let connect = VmError::CategorizedError {
+            message: "openai request error (connect): connection refused".to_string(),
+            category: ErrorCategory::TransientNetwork,
+        };
+        let timeout = VmError::CategorizedError {
+            message: "openai request error (timeout): operation timed out".to_string(),
+            category: ErrorCategory::Timeout,
+        };
+        assert!(
+            is_network_failure_llm_error(&connect),
+            "connect failure is a network failure"
+        );
+        assert!(
+            is_network_failure_llm_error(&timeout),
+            "timeout is a network failure"
+        );
     }
 }


### PR DESCRIPTION
Three deterministic robustness improvements to the outbound-LLM retry/throttle layer (from a SOTA audit). Pure wins: deterministic and unit-tested, no meter/eval needed. Each seam was traced to bytes before editing.

## Cut 1 — equal-jitter backoff (highest value)
`agent_observe.rs::base_retry_backoff_ms` computed `base * 2^min(attempt,4)` = 250/500/1000/2000/4000ms with **zero jitter**, so concurrent same-key callers (`eval --concurrency K` plus a coexisting session) retried in lockstep → thundering herd. Now AWS **equal jitter**: `wait = ceil/2 + rand(0, ceil/2)`, `ceil = 250 * 2^min(attempt,4)` — desynchronizes retries while avoiding the near-zero waits of full jitter. A small additive jitter is also layered on top of an honored provider `Retry-After`. RNG is seamed (`equal_jitter_ms<R: RngExt>`) for deterministic bounds testing.

## Cut 2 — typed non-streaming send errors
Streaming `req.send()` failures already got rich reqwest-kind classification; non-streaming `req.send()` failures became a bare `"{provider} API error: {e}"` string reclassified downstream by substring. Both paths now share one reqwest-kind classifier (`reqwest_send_error`) that emits a typed `ErrorCategory::Timeout` / `TransientNetwork` at the source. DRY: `stream_send_error` and `non_stream_send_error` are thin wrappers over the shared classifier.

## Cut 3 — network-only circuit breaker
A per-route, **per-process** breaker (`NetworkBreaker`, stored next to `cooldown_until_ms` in `RouteLimiter`) opens only on sustained `NetworkError`/`Timeout` (laptop disconnect / DNS failure / dropped link), fails fast for a short window, admits a single half-open probe, then closes on success / re-opens on probe failure. It deliberately does **not** react to 429 (handled by the existing rate-limiter cooldown + `Retry-After`) or 5xx — so it only stops the retry budget from burning against a truly dead link. Distinct from the opt-in routing-policy breaker.

## Verification
- `cargo nextest run` on the three touched modules: **91 passed, 0 failed**. New tests cover: equal-jitter `[ceil/2, ceil]` bounds + desynchronization + tiny-ceil floor + Retry-After jitter band; non-stream timeout/connect errors classified as typed Timeout/TransientNetwork (driven by a **real** reqwest error to RFC-5737 TEST-NET-1, not a stand-in) + stream/non-stream parity; breaker opens after K consecutive network failures, fails fast while open, half-opens + closes on probe success, re-opens on probe failure, and **does NOT open on 429/5xx**.
- `cargo clippy` + `cargo fmt` clean.
- No generated artifacts touched.

Files: `crates/harn-vm/src/llm/agent_observe.rs`, `crates/harn-vm/src/llm/api/transport.rs`, `crates/harn-vm/src/llm/rate_limit.rs` (+ a `changelog.d/` fragment). Disjoint from the concurrent code_index dependency-roots work (#3352); rebased onto it cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)