### PR TITLE
refactor(mcp): overlayable TOML preset catalog + identity-probe schema (#3348)

### DIFF
--- a/changelog.d/3348.added.md
+++ b/changelog.d/3348.added.md
@@ -1,0 +1,10 @@
+- **MCP server presets are now overlayable data, not Rust constants (#3348).**
+  The well-known preset catalog (Notion, Linear, GitHub, Filesystem) moved from
+  a compiled-in table to bundled TOML (`mcp_presets.toml`) that can be overridden
+  or extended at runtime without a recompile — point `HARN_MCP_PRESETS_CONFIG` at
+  a file or drop one at `~/.config/harn/mcp_presets.toml`; overlays merge
+  last-writer-wins by preset `id`, then append new presets. The catalog also
+  gains an optional, inert `identity` descriptor schema (`IdentityProbeDescriptor`)
+  describing how to fetch a human-readable "logged in as …" string per server;
+  the probe runner that consumes it ships separately (#3349). The serialized JSON
+  catalog contract is unchanged.

--- a/crates/harn-cli/src/commands/mcp/presets.rs
+++ b/crates/harn-cli/src/commands/mcp/presets.rs
@@ -68,15 +68,15 @@ fn write_preset(out: &mut String, preset: &McpPreset) {
     if preset.transport == mcp_presets::PresetTransport::Http {
         writeln!(out, "  url:       {}", preset.url).ok();
     } else {
-        let argv = std::iter::once(preset.command)
-            .chain(preset.args.iter().copied())
+        let argv = std::iter::once(preset.command.as_str())
+            .chain(preset.args.iter().map(String::as_str))
             .collect::<Vec<_>>()
             .join(" ");
         writeln!(out, "  command:   {argv}").ok();
     }
     let auth = match preset.auth_kind {
         mcp_presets::PresetAuthKind::None => "none".to_string(),
-        mcp_presets::PresetAuthKind::Oauth => match preset.oauth_scopes {
+        mcp_presets::PresetAuthKind::Oauth => match &preset.oauth_scopes {
             Some(scopes) => format!("oauth (scopes: {scopes})"),
             None => "oauth".to_string(),
         },
@@ -133,7 +133,7 @@ mod tests {
         let text = render_text();
         for preset in mcp_presets::presets() {
             assert!(
-                text.contains(preset.name),
+                text.contains(&preset.name),
                 "text catalog missing preset {}",
                 preset.id
             );

--- a/crates/harn-vm/src/mcp_presets.rs
+++ b/crates/harn-vm/src/mcp_presets.rs
@@ -3,29 +3,45 @@
 //! Thin clients (the burin-code TUI and the macOS GUI) used to each carry
 //! their own hardcoded list of "one-click" MCP servers — Notion, Linear,
 //! GitHub, a local filesystem server, etc. Those lists drifted from each
-//! other. This module is the single harn-owned source of truth: it ships a
-//! static table of presets that any client renders identically.
+//! other. This module is the single harn-owned source of truth.
+//!
+//! **Data, not code (harn#3348).** The catalog ships as bundled TOML
+//! (`mcp_presets.toml`, compiled in via `include_str!`) and is overlayable at
+//! runtime without a recompile: set `HARN_MCP_PRESETS_CONFIG` to a TOML file,
+//! or drop one at `~/.config/harn/mcp_presets.toml`. Overlays merge
+//! last-writer-wins by `id`, then append new presets — mirroring how
+//! `llm_config` layers `providers.toml`. On-disk fields are snake_case; the
+//! serialized JSON contract (see [`PresetCatalog`]) stays camelCase so existing
+//! consumers are byte-for-byte unaffected.
 //!
 //! The catalog is **descriptive metadata only** — it never connects to a
-//! server or fabricates credentials. A preset is a template a client fills
-//! in (allowed roots for filesystem, an OAuth login for Notion) before
-//! handing the resolved spec to the MCP registry. Required substitutions are
-//! declared as [`PresetPlaceholder`]s so a client can prompt for them.
+//! server or fabricates credentials. A preset is a template a client fills in
+//! (allowed roots for filesystem, an OAuth login for Notion) before handing the
+//! resolved spec to the MCP registry. Required substitutions are declared as
+//! [`PresetPlaceholder`]s so a client can prompt for them.
 //!
-//! The serialized JSON shape (see [`PresetCatalog`]) is a stable contract
-//! surface consumed by downstream tooling. Bumping the shape requires
-//! bumping [`PRESET_CATALOG_SCHEMA_VERSION`] and coordinating consumers.
+//! Bumping the serialized shape requires bumping [`PRESET_CATALOG_SCHEMA_VERSION`]
+//! and coordinating consumers.
 
-use serde::Serialize;
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
 
 /// JSON schema version for the preset catalog. Increment on any breaking
-/// shape change to [`PresetCatalog`] / [`McpPreset`].
+/// shape change to [`PresetCatalog`] / [`McpPreset`]. The optional
+/// [`McpPreset::identity`] field added in harn#3348 is omitted when absent, so
+/// the shipped output is unchanged and the version holds at 1 until a vetted
+/// identity descriptor actually ships in the catalog.
 pub const PRESET_CATALOG_SCHEMA_VERSION: u32 = 1;
+
+/// Bundled default catalog. Editable here; overlayable at runtime.
+const BUILTIN_TOML: &str = include_str!("mcp_presets.toml");
 
 /// Transport a preset's server speaks. Mirrors the `transport` field of
 /// [`crate::mcp::McpServerSpec`] so a resolved preset drops straight into a
 /// server spec.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PresetTransport {
     /// Local subprocess speaking MCP over stdio.
@@ -36,7 +52,7 @@ pub enum PresetTransport {
 
 /// Hint about how a client authenticates to the server, so the UI can route
 /// to the right setup affordance. Purely advisory — harn does not enforce it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PresetAuthKind {
     /// No credential needed (e.g. a local filesystem server).
@@ -48,7 +64,7 @@ pub enum PresetAuthKind {
 }
 
 /// Loose grouping for client-side organization. Advisory; clients may ignore.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PresetCategory {
     Productivity,
@@ -58,27 +74,27 @@ pub enum PresetCategory {
 
 /// One value a client must collect before the preset can connect. The
 /// `target` says where the resolved value goes (an env var, a CLI arg slot,
-/// or the URL), and `placeholder` is the literal token embedded in the
-/// template that the client replaces.
-#[derive(Debug, Clone, Copy, Serialize)]
-#[serde(rename_all = "camelCase")]
+/// or the URL), and `token` is the literal token embedded in the template that
+/// the client replaces.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
 pub struct PresetPlaceholder {
     /// Stable identifier for the value (e.g. `"allowed_root"`).
-    pub key: &'static str,
+    pub key: String,
     /// Human-readable label for a prompt (e.g. `"Allowed directory"`).
-    pub label: &'static str,
+    pub label: String,
     /// Where the resolved value belongs.
     pub target: PlaceholderTarget,
     /// The literal token in the template to substitute, if any. `None` means
     /// the value is appended (e.g. a filesystem allowed-root positional arg).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub token: Option<&'static str>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
     /// Whether the preset cannot connect without this value.
     pub required: bool,
 }
 
 /// Where a [`PresetPlaceholder`] value is substituted.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PlaceholderTarget {
     /// An environment variable named by the placeholder `key`.
@@ -89,39 +105,96 @@ pub enum PlaceholderTarget {
     Url,
 }
 
+/// Declarative recipe for fetching a human-readable "logged in as …" string
+/// for a server after auth (harn#3348 schema; the probe runner ships in
+/// harn#3349). MCP has no standard `whoami`, so each known server needs a
+/// vetted recipe. **Pure data** — defining it here changes no behavior until
+/// the runner exists.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
+pub struct IdentityProbeDescriptor {
+    /// Display template referencing captured field names in braces, e.g.
+    /// `"{name} <{email}> — {workspace}"`. The runner elides unresolved
+    /// `{field}` placeholders (and any bracketed segment left empty).
+    pub display_template: String,
+    /// Ordered probe sources; the runner tries each until one yields a
+    /// non-empty identity.
+    #[serde(default)]
+    pub sources: Vec<IdentityProbeSource>,
+}
+
+/// Where the identity runner looks. A flat struct (rather than a tagged enum)
+/// keeps the TOML simple and dodges internally-tagged-enum/TOML edge cases;
+/// the runner validates that the fields relevant to `kind` are present.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
+pub struct IdentityProbeSource {
+    /// Which kind of probe this is.
+    pub kind: IdentityProbeKind,
+    /// MCP tool to call when `kind = tool` (e.g. Notion's self/whoami tool).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool: Option<String>,
+    /// HTTP endpoint to GET (with the bearer) when `kind = http`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// capture-name → dotted JSON path into the source's JSON payload, e.g.
+    /// `name = "owner.user.name"`. Captures feed `display_template`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub fields: BTreeMap<String, String>,
+}
+
+/// The kind of identity probe a [`IdentityProbeSource`] performs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IdentityProbeKind {
+    /// Capture fields from the OAuth token-exchange JSON response (Notion, for
+    /// instance, returns `workspace_name` + `owner.user` inline).
+    TokenResponse,
+    /// Call a named MCP tool and capture fields from its JSON result.
+    Tool,
+    /// GET an authenticated HTTP endpoint and capture fields from its JSON.
+    Http,
+}
+
 /// A single well-known MCP server preset. Fields after `transport` are
-/// transport-specific: `command`/`args` populate a stdio spec, `url`
-/// populates an HTTP spec. Empty strings mean "not applicable for this
-/// transport".
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
+/// transport-specific: `command`/`args` populate a stdio spec, `url` populates
+/// an HTTP spec. Empty strings mean "not applicable for this transport".
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
 pub struct McpPreset {
     /// Stable lookup key (e.g. `"notion"`). Unique across the catalog.
-    pub id: &'static str,
+    pub id: String,
     /// Display name for the client UI (e.g. `"Notion"`).
-    pub name: &'static str,
+    pub name: String,
     /// One-line description of what the server exposes.
-    pub description: &'static str,
+    pub description: String,
     /// SF Symbols-style icon hint for the macOS GUI; clients without an icon
     /// model may ignore it.
-    pub icon: &'static str,
+    pub icon: String,
     /// Advisory category for grouping.
     pub category: PresetCategory,
     /// Transport the resolved server speaks.
     pub transport: PresetTransport,
     /// stdio command (empty for HTTP presets).
-    pub command: &'static str,
+    #[serde(default)]
+    pub command: String,
     /// stdio command arguments (empty for HTTP presets).
-    pub args: &'static [&'static str],
+    #[serde(default)]
+    pub args: Vec<String>,
     /// HTTP endpoint URL template (empty for stdio presets).
-    pub url: &'static str,
+    #[serde(default)]
+    pub url: String,
     /// How a client authenticates.
     pub auth_kind: PresetAuthKind,
     /// Suggested OAuth scope string, when `auth_kind` is `oauth`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub oauth_scopes: Option<&'static str>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oauth_scopes: Option<String>,
     /// Values the client must collect before connecting.
-    pub placeholders: &'static [PresetPlaceholder],
+    #[serde(default)]
+    pub placeholders: Vec<PresetPlaceholder>,
+    /// Optional recipe for displaying the authenticated identity (harn#3348).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<IdentityProbeDescriptor>,
 }
 
 /// The full catalog, ready to serialize as the stable JSON contract.
@@ -132,102 +205,92 @@ pub struct PresetCatalog {
     pub presets: Vec<McpPreset>,
 }
 
-const NOTION_PLACEHOLDERS: &[PresetPlaceholder] = &[];
+/// Deserialization envelope for a catalog TOML file (bundled or overlay).
+#[derive(Debug, Default, Deserialize)]
+struct PresetFile {
+    #[serde(default)]
+    presets: Vec<McpPreset>,
+}
 
-const LINEAR_PLACEHOLDERS: &[PresetPlaceholder] = &[];
+/// Lazily-built effective catalog (bundled base + runtime overlay).
+static CATALOG: OnceLock<PresetCatalog> = OnceLock::new();
 
-const GITHUB_PLACEHOLDERS: &[PresetPlaceholder] = &[PresetPlaceholder {
-    key: "GITHUB_PERSONAL_ACCESS_TOKEN",
-    label: "GitHub personal access token",
-    target: PlaceholderTarget::Env,
-    token: None,
-    required: true,
-}];
+fn load() -> &'static PresetCatalog {
+    CATALOG.get_or_init(build_catalog)
+}
 
-const FILESYSTEM_PLACEHOLDERS: &[PresetPlaceholder] = &[PresetPlaceholder {
-    key: "allowed_root",
-    label: "Allowed directory",
-    target: PlaceholderTarget::Arg,
-    token: None,
-    required: true,
-}];
+fn build_catalog() -> PresetCatalog {
+    let mut presets = parse_presets(BUILTIN_TOML)
+        .expect("embedded mcp_presets.toml must parse — invariant checked by tests");
+    if let Some(overlay) = load_overlay() {
+        merge_presets(&mut presets, overlay);
+    }
+    PresetCatalog {
+        schema_version: PRESET_CATALOG_SCHEMA_VERSION,
+        presets,
+    }
+}
 
-/// The canonical preset list. Order is the suggested display order.
-const PRESETS: &[McpPreset] = &[
-    McpPreset {
-        id: "notion",
-        name: "Notion",
-        description: "Pages, databases, and comments from your Notion workspace.",
-        icon: "doc.text.fill",
-        category: PresetCategory::Productivity,
-        transport: PresetTransport::Http,
-        command: "",
-        args: &[],
-        url: "https://mcp.notion.com/mcp",
-        auth_kind: PresetAuthKind::Oauth,
-        oauth_scopes: None,
-        placeholders: NOTION_PLACEHOLDERS,
-    },
-    McpPreset {
-        id: "linear",
-        name: "Linear",
-        description: "Issues, projects, and cycles from your Linear workspace.",
-        icon: "list.bullet.rectangle.fill",
-        category: PresetCategory::Productivity,
-        transport: PresetTransport::Http,
-        command: "",
-        args: &[],
-        url: "https://mcp.linear.app/mcp",
-        auth_kind: PresetAuthKind::Oauth,
-        oauth_scopes: Some("read write"),
-        placeholders: LINEAR_PLACEHOLDERS,
-    },
-    McpPreset {
-        id: "github",
-        name: "GitHub",
-        description: "Repositories, issues, and pull requests via the GitHub MCP server.",
-        icon: "chevron.left.forwardslash.chevron.right",
-        category: PresetCategory::Development,
-        transport: PresetTransport::Stdio,
-        command: "npx",
-        args: &["-y", "@modelcontextprotocol/server-github"],
-        url: "",
-        auth_kind: PresetAuthKind::ApiToken,
-        oauth_scopes: None,
-        placeholders: GITHUB_PLACEHOLDERS,
-    },
-    McpPreset {
-        id: "filesystem",
-        name: "Filesystem",
-        description: "Read and write files under one or more allowed local directories.",
-        icon: "folder.fill",
-        category: PresetCategory::Local,
-        transport: PresetTransport::Stdio,
-        command: "npx",
-        args: &["-y", "@modelcontextprotocol/server-filesystem"],
-        url: "",
-        auth_kind: PresetAuthKind::None,
-        oauth_scopes: None,
-        placeholders: FILESYSTEM_PLACEHOLDERS,
-    },
-];
+/// Parse a catalog TOML document into its preset list.
+fn parse_presets(src: &str) -> Result<Vec<McpPreset>, toml::de::Error> {
+    Ok(toml::from_str::<PresetFile>(src)?.presets)
+}
 
-/// Borrow the static preset list. The single source of truth.
+/// Resolve the runtime overlay, if any: the `HARN_MCP_PRESETS_CONFIG` path
+/// wins, else `~/.config/harn/mcp_presets.toml`. Skipped under `cfg(test)` so
+/// unit tests see only the bundled defaults plus explicit overlays.
+fn load_overlay() -> Option<Vec<McpPreset>> {
+    if let Ok(path) = std::env::var("HARN_MCP_PRESETS_CONFIG") {
+        return read_overlay(&path);
+    }
+    if should_load_home_overlay() {
+        let home = crate::user_dirs::home_dir()?;
+        let path = home.join(".config").join("harn").join("mcp_presets.toml");
+        return read_overlay(&path.to_string_lossy());
+    }
+    None
+}
+
+fn read_overlay(path: &str) -> Option<Vec<McpPreset>> {
+    let content = std::fs::read_to_string(path).ok()?;
+    match parse_presets(&content) {
+        Ok(presets) => Some(presets),
+        Err(error) => {
+            eprintln!("[mcp_presets] TOML parse error in {path}: {error}");
+            None
+        }
+    }
+}
+
+fn should_load_home_overlay() -> bool {
+    !cfg!(test)
+}
+
+/// Merge an overlay into the base list: replace presets sharing an `id`
+/// (last-writer-wins), append genuinely new ones in overlay order.
+fn merge_presets(base: &mut Vec<McpPreset>, overlay: Vec<McpPreset>) {
+    for preset in overlay {
+        if let Some(existing) = base.iter_mut().find(|existing| existing.id == preset.id) {
+            *existing = preset;
+        } else {
+            base.push(preset);
+        }
+    }
+}
+
+/// Borrow the effective preset list. The single source of truth.
 pub fn presets() -> &'static [McpPreset] {
-    PRESETS
+    load().presets.as_slice()
 }
 
 /// Look up one preset by its stable `id`.
 pub fn preset(id: &str) -> Option<&'static McpPreset> {
-    PRESETS.iter().find(|preset| preset.id == id)
+    load().presets.iter().find(|preset| preset.id == id)
 }
 
 /// Build the serializable catalog envelope.
 pub fn catalog() -> PresetCatalog {
-    PresetCatalog {
-        schema_version: PRESET_CATALOG_SCHEMA_VERSION,
-        presets: PRESETS.to_vec(),
-    }
+    load().clone()
 }
 
 #[cfg(test)]
@@ -235,17 +298,28 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
 
+    fn base_presets() -> Vec<McpPreset> {
+        parse_presets(BUILTIN_TOML).expect("bundled catalog parses")
+    }
+
+    #[test]
+    fn bundled_catalog_parses() {
+        let presets = base_presets();
+        assert_eq!(presets.len(), 4, "bundled catalog should ship 4 presets");
+    }
+
     #[test]
     fn catalog_carries_schema_version() {
         let catalog = catalog();
         assert_eq!(catalog.schema_version, PRESET_CATALOG_SCHEMA_VERSION);
-        assert_eq!(catalog.presets.len(), PRESETS.len());
+        assert_eq!(catalog.presets.len(), presets().len());
     }
 
     #[test]
     fn preset_ids_are_unique() {
-        let ids: HashSet<&str> = PRESETS.iter().map(|preset| preset.id).collect();
-        assert_eq!(ids.len(), PRESETS.len(), "preset ids must be unique");
+        let presets = base_presets();
+        let ids: HashSet<&str> = presets.iter().map(|preset| preset.id.as_str()).collect();
+        assert_eq!(ids.len(), presets.len(), "preset ids must be unique");
     }
 
     #[test]
@@ -257,7 +331,7 @@ mod tests {
 
     #[test]
     fn transport_specific_fields_are_coherent() {
-        for preset in PRESETS {
+        for preset in base_presets() {
             match preset.transport {
                 PresetTransport::Http => {
                     assert!(!preset.url.is_empty(), "{} http needs a url", preset.id);
@@ -285,7 +359,7 @@ mod tests {
 
     #[test]
     fn oauth_scopes_only_on_oauth_presets() {
-        for preset in PRESETS {
+        for preset in base_presets() {
             if preset.oauth_scopes.is_some() {
                 assert_eq!(
                     preset.auth_kind,
@@ -316,6 +390,121 @@ mod tests {
         assert!(
             notion.get("oauthScopes").is_none(),
             "Notion MCP does not currently expose configurable OAuth scopes"
+        );
+        assert!(
+            notion.get("identity").is_none(),
+            "no identity descriptor ships in the catalog yet (harn#3349 runner pending)"
+        );
+    }
+
+    #[test]
+    fn github_placeholder_round_trips_from_toml() {
+        let github = base_presets()
+            .into_iter()
+            .find(|preset| preset.id == "github")
+            .expect("github preset present");
+        assert_eq!(github.placeholders.len(), 1);
+        let placeholder = &github.placeholders[0];
+        assert_eq!(placeholder.key, "GITHUB_PERSONAL_ACCESS_TOKEN");
+        assert_eq!(placeholder.target, PlaceholderTarget::Env);
+        assert!(placeholder.required);
+        assert!(placeholder.token.is_none());
+    }
+
+    #[test]
+    fn overlay_overrides_by_id_and_appends_new() {
+        let mut base = base_presets();
+        let overlay = parse_presets(
+            r#"
+[[presets]]
+id = "notion"
+name = "Notion (corp)"
+description = "Corp Notion workspace."
+icon = "doc.text.fill"
+category = "productivity"
+transport = "http"
+url = "https://notion.corp.example/mcp"
+auth_kind = "oauth"
+
+[[presets]]
+id = "sentry"
+name = "Sentry"
+description = "Errors and issues from Sentry."
+icon = "exclamationmark.triangle.fill"
+category = "development"
+transport = "http"
+url = "https://mcp.sentry.dev/mcp"
+auth_kind = "oauth"
+"#,
+        )
+        .expect("overlay parses");
+        merge_presets(&mut base, overlay);
+
+        let notion = base.iter().find(|preset| preset.id == "notion").unwrap();
+        assert_eq!(notion.name, "Notion (corp)");
+        assert_eq!(notion.url, "https://notion.corp.example/mcp");
+        assert!(
+            base.iter().any(|preset| preset.id == "sentry"),
+            "new overlay preset should be appended"
+        );
+        assert_eq!(base.len(), 5, "4 base + 1 appended");
+    }
+
+    #[test]
+    fn identity_descriptor_parses_from_toml() {
+        let presets = parse_presets(
+            r#"
+[[presets]]
+id = "notion"
+name = "Notion"
+description = "Notion workspace."
+icon = "doc.text.fill"
+category = "productivity"
+transport = "http"
+url = "https://mcp.notion.com/mcp"
+auth_kind = "oauth"
+
+[presets.identity]
+display_template = "{name} <{email}> — {workspace}"
+
+[[presets.identity.sources]]
+kind = "token_response"
+[presets.identity.sources.fields]
+name = "owner.user.name"
+email = "owner.user.person.email"
+workspace = "workspace_name"
+
+[[presets.identity.sources]]
+kind = "tool"
+tool = "notion-get-self"
+[presets.identity.sources.fields]
+name = "name"
+email = "person.email"
+"#,
+        )
+        .expect("identity descriptor parses");
+        let identity = presets[0]
+            .identity
+            .as_ref()
+            .expect("notion has identity descriptor");
+        assert_eq!(identity.display_template, "{name} <{email}> — {workspace}");
+        assert_eq!(identity.sources.len(), 2);
+        assert_eq!(identity.sources[0].kind, IdentityProbeKind::TokenResponse);
+        assert_eq!(
+            identity.sources[0]
+                .fields
+                .get("workspace")
+                .map(String::as_str),
+            Some("workspace_name")
+        );
+        assert_eq!(identity.sources[1].kind, IdentityProbeKind::Tool);
+        assert_eq!(identity.sources[1].tool.as_deref(), Some("notion-get-self"));
+
+        // Round-trips to camelCase JSON for thin clients.
+        let json = serde_json::to_value(&presets[0]).expect("serialize");
+        assert_eq!(
+            json["identity"]["displayTemplate"],
+            serde_json::json!("{name} <{email}> — {workspace}")
         );
     }
 }

--- a/crates/harn-vm/src/mcp_presets.toml
+++ b/crates/harn-vm/src/mcp_presets.toml
@@ -1,0 +1,67 @@
+# Canonical catalog of well-known MCP server presets (harn#2650).
+#
+# This is the harn-owned source of truth for one-click MCP servers, rendered
+# identically by every client (the burin-code TUI and the macOS GUI). It is
+# **data, not code** (harn#3348): edit it here to change the shipped defaults,
+# or override/extend it at runtime without a recompile via
+# `~/.config/harn/mcp_presets.toml` (or the `HARN_MCP_PRESETS_CONFIG` env var).
+# Runtime overlays merge last-writer-wins by `id`, then append new presets.
+#
+# Field names are snake_case here; the stable JSON contract serializes them as
+# camelCase (see `mcp_presets.rs`). Transport-specific fields: `command`/`args`
+# populate a stdio spec, `url` populates an HTTP spec. Omit what does not apply.
+
+[[presets]]
+id = "notion"
+name = "Notion"
+description = "Pages, databases, and comments from your Notion workspace."
+icon = "doc.text.fill"
+category = "productivity"
+transport = "http"
+url = "https://mcp.notion.com/mcp"
+auth_kind = "oauth"
+
+[[presets]]
+id = "linear"
+name = "Linear"
+description = "Issues, projects, and cycles from your Linear workspace."
+icon = "list.bullet.rectangle.fill"
+category = "productivity"
+transport = "http"
+url = "https://mcp.linear.app/mcp"
+auth_kind = "oauth"
+oauth_scopes = "read write"
+
+[[presets]]
+id = "github"
+name = "GitHub"
+description = "Repositories, issues, and pull requests via the GitHub MCP server."
+icon = "chevron.left.forwardslash.chevron.right"
+category = "development"
+transport = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+auth_kind = "api_token"
+
+[[presets.placeholders]]
+key = "GITHUB_PERSONAL_ACCESS_TOKEN"
+label = "GitHub personal access token"
+target = "env"
+required = true
+
+[[presets]]
+id = "filesystem"
+name = "Filesystem"
+description = "Read and write files under one or more allowed local directories."
+icon = "folder.fill"
+category = "local"
+transport = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem"]
+auth_kind = "none"
+
+[[presets.placeholders]]
+key = "allowed_root"
+label = "Allowed directory"
+target = "arg"
+required = true

--- a/crates/harn-vm/src/stdlib/project.rs
+++ b/crates/harn-vm/src/stdlib/project.rs
@@ -1152,17 +1152,17 @@ fn missing_preset_credentials(id: &str, credentials: &BTreeSet<String>) -> Vec<S
         return Vec::new();
     };
     let mut missing = Vec::new();
-    for placeholder in preset.placeholders {
+    for placeholder in &preset.placeholders {
         if !placeholder.required {
             continue;
         }
         if placeholder.target != crate::mcp_presets::PlaceholderTarget::Env {
-            missing.push(placeholder.key.to_string());
+            missing.push(placeholder.key.clone());
             continue;
         }
-        let alias = credential_alias(placeholder.key);
+        let alias = credential_alias(&placeholder.key);
         if !credentials.contains(&alias) {
-            missing.push(placeholder.key.to_string());
+            missing.push(placeholder.key.clone());
         }
     }
     missing


### PR DESCRIPTION
Closes #3348. First PR of the Agent Identity & Provenance Epic F (#3331) and the data-not-code foundation the rest of that program + the bulk-OAuth program (#3354) build on.

## What
- Moves the well-known MCP preset catalog (Notion / Linear / GitHub / Filesystem) out of a Rust-const table into bundled TOML (`crates/harn-vm/src/mcp_presets.toml`, compiled in via `include_str!`).
- Adds a **runtime overlay**: `HARN_MCP_PRESETS_CONFIG` (path) wins, else `~/.config/harn/mcp_presets.toml`. Overlays merge **last-writer-wins by `id`**, then append new presets — same layering shape as `llm_config`/`providers.toml`. Edit/extend the catalog **without a recompile**.
- Adds an inert **`IdentityProbeDescriptor`** schema (per-preset `[identity]` table + `kind`-tagged sources: `token_response` / `tool` / `http`, plus a `display_template`). Pure data — the probe runner that consumes it ships in #3349.

## Invariants honored
- **Data, not code.** The catalog and identity recipes are overlayable data files, not constants.
- **Zero consumer impact.** On-disk fields are snake_case for human editing; the serialized JSON contract stays camelCase. Schema version held at **1** — the shipped catalog output is byte-for-byte unchanged (the optional `identity` field is omitted when absent, and none ships yet).
- Accessors `presets()`/`preset()`/`catalog()` keep their exact signatures via a `OnceLock`-backed effective catalog.

## Tests
- `mcp_presets`: 10 unit tests — bundled parse, schema/JSON-shape stability, overlay override-by-id + append, placeholder round-trip, identity-descriptor parse + camelCase round-trip.
- Consumers green: `harn-cli` `commands::mcp::presets` (2) and `harn-vm` `stdlib::project` (37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
