### PR TITLE
feat(llm): serving_precision capability for provider trust verdicts

### DIFF
--- a/changelog.d/serving-precision-capability.added.md
+++ b/changelog.d/serving-precision-capability.added.md
@@ -1,0 +1,7 @@
+Added a `serving_precision` provider capability field (`trusted` / `degraded` /
+`throttled` / `unverified`) so the capability matrix can label routes that serve
+a model at degraded quality or unusable timing. Seeded the known gpt-oss-120b
+verdicts (Fireworks + OpenRouter = trusted, SambaNova = degraded/quantized,
+Cerebras = throttled) and exposed the field on `harn check --provider-matrix
+--json`, giving the Burin meter precision canary a data-driven signal instead of
+trusting provider liveness alone.

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -479,6 +479,21 @@ pub struct ProviderRule {
     /// [`crate::llm::capability_audit`].
     #[serde(default)]
     pub openrouter_provider_order: Option<Vec<String>>,
+    /// Serving-quality / precision trust verdict for this `(provider, model)`
+    /// route. A provider can be live and fast yet still serve a model at
+    /// DEGRADED quality (e.g. an undocumented quantization) or reject otherwise
+    /// valid requests, silently contaminating any eval/meter that trusts its
+    /// numbers. This is the data-driven sibling of [`Self::provider_route_denylist`]
+    /// / [`Self::openrouter_provider_order`]: instead of routing *around* a bad
+    /// upstream, it labels the route's measured precision so tooling (the Burin
+    /// meter precision canary) can refuse to trust a `degraded` route and flag a
+    /// `throttled` one. Known values are `trusted` (full-precision verified
+    /// against a reference), `degraded` (proven to serve at reduced quality),
+    /// `throttled` (full-precision but rate-limited to unusable timing), and
+    /// `unverified` (no verdict — treated the same as unset). Unset means
+    /// `unverified`.
+    #[serde(default)]
+    pub serving_precision: Option<String>,
 }
 
 /// Resolved capabilities for a `(provider, model)` pair. Unset rule
@@ -564,6 +579,9 @@ pub struct Capabilities {
     /// preference order. See [`ProviderRule::openrouter_provider_order`]. Empty
     /// means "no pin" (free OpenRouter routing).
     pub openrouter_provider_order: Vec<String>,
+    /// Serving-quality / precision trust verdict for this route. See
+    /// [`ProviderRule::serving_precision`]. `"unverified"` when unset.
+    pub serving_precision: String,
 }
 
 impl Default for Capabilities {
@@ -634,6 +652,7 @@ impl Default for Capabilities {
             auto_reasoning_overrides: BTreeMap::new(),
             provider_route_denylist: Vec::new(),
             openrouter_provider_order: Vec::new(),
+            serving_precision: "unverified".to_string(),
         }
     }
 }
@@ -670,6 +689,9 @@ pub struct ProviderCapabilityMatrixRow {
     pub tool_mode_parity: String,
     pub tools: bool,
     pub cache: bool,
+    /// Serving-quality / precision trust verdict for this route. See
+    /// [`ProviderRule::serving_precision`]. `"unverified"` when unset.
+    pub serving_precision: String,
     pub source: String,
 }
 
@@ -1089,6 +1111,10 @@ fn rule_to_matrix_row(
         tools: rule.native_tools.unwrap_or(false)
             || rule.text_tool_wire_format_supported.unwrap_or(true),
         cache: rule.prompt_caching.unwrap_or(false),
+        serving_precision: rule
+            .serving_precision
+            .clone()
+            .unwrap_or_else(|| "unverified".to_string()),
         source: source.to_string(),
     }
 }
@@ -1287,6 +1313,7 @@ fn defaults_to_caps(defaults: &ProviderDefaults) -> Capabilities {
         auto_reasoning_overrides: None,
         provider_route_denylist: None,
         openrouter_provider_order: None,
+        serving_precision: None,
     };
     let mut caps = rule_to_caps(&empty, defaults);
     caps.preferred_tool_format = None;
@@ -1406,6 +1433,10 @@ fn rule_to_caps(rule: &ProviderRule, defaults: &ProviderDefaults) -> Capabilitie
         auto_reasoning_overrides: rule.auto_reasoning_overrides.clone().unwrap_or_default(),
         provider_route_denylist: rule.provider_route_denylist.clone().unwrap_or_default(),
         openrouter_provider_order: rule.openrouter_provider_order.clone().unwrap_or_default(),
+        serving_precision: rule
+            .serving_precision
+            .clone()
+            .unwrap_or_else(|| "unverified".to_string()),
     }
 }
 
@@ -1655,6 +1686,41 @@ preferred_tool_format = "native"
         reset();
         let caps = lookup("anthropic", "claude-opus-4-7");
         assert!(caps.provider_route_denylist.is_empty());
+    }
+
+    #[test]
+    fn serving_precision_seeds_known_gpt_oss_verdicts() {
+        reset();
+        // Full-precision routes verified during the 2026-06 meter effort.
+        assert_eq!(
+            lookup("fireworks", "accounts/fireworks/models/gpt-oss-120b").serving_precision,
+            "trusted"
+        );
+        assert_eq!(
+            lookup("openrouter", "openai/gpt-oss-120b").serving_precision,
+            "trusted"
+        );
+        // SambaNova serves gpt-oss quantized (proven 0/5 vs reference 3/3).
+        assert_eq!(
+            lookup("sambanova", "gpt-oss-120b").serving_precision,
+            "degraded"
+        );
+        // Cerebras is full precision but rate-throttled to unusable timing.
+        assert_eq!(
+            lookup("cerebras", "gpt-oss-120b").serving_precision,
+            "throttled"
+        );
+    }
+
+    #[test]
+    fn serving_precision_defaults_unverified_for_unmarked_rows() {
+        reset();
+        // A route with no serving_precision verdict resolves to "unverified",
+        // never an empty string, so callers can branch on a stable enum.
+        assert_eq!(
+            lookup("anthropic", "claude-opus-4-7").serving_precision,
+            "unverified"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -158,6 +158,21 @@
 #                     pinned to ["Cerebras","Groq"]). When both a pin and a
 #                     denylist are set the pin wins (a closed allowlist already
 #                     excludes everything else).
+#   serving_precision:
+#                     serving-quality / precision trust verdict for the route.
+#                     A provider can be live and fast yet serve a model at
+#                     DEGRADED quality (undocumented quantization) or reject
+#                     valid requests, silently contaminating any eval/meter that
+#                     trusts its numbers. This is the data-driven sibling of the
+#                     route-around fields above: instead of routing AROUND a bad
+#                     upstream it LABELS the measured precision so tooling (the
+#                     Burin meter precision canary) can refuse to trust a
+#                     `degraded` route. Known values: `trusted` (full precision,
+#                     reference-verified), `degraded` (proven reduced quality —
+#                     e.g. SambaNova gpt-oss quantized: 0/5 vs OpenRouter 3/3),
+#                     `throttled` (full precision but rate-limited to unusable
+#                     timing — e.g. Cerebras gpt-oss), `unverified` (no verdict;
+#                     same as unset). Defaults to `unverified`.
 #
 # OPINIONATED PROVIDER/MODEL/CONFIG POLICY (enforced by the footgun gate in
 # crate::llm::capability_audit, wired into `providers build-capabilities
@@ -1568,6 +1583,10 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "reasoning_summary"
+# Fireworks serves gpt-oss-120b at FULL precision (verified against the
+# OpenRouter full-precision reference during the 2026-06 meter-convergence
+# effort, once the harn #3319 reasoning-echo HTTP400 was fixed). Trusted.
+serving_precision = "trusted"
 
 [[provider.fireworks]]
 model_match = "*qwen3.6*"
@@ -2294,6 +2313,12 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "reasoning_summary"
+# SambaNova serves gpt-oss at DEGRADED quality (quantized). PROVEN during the
+# 2026-06 meter-convergence effort: c-feat 0/5 and cpp-storage 0/5 on SambaNova
+# vs 3/3 and 1/1 on the OpenRouter full-precision reference. The numbers looked
+# like a capability collapse but were provider contamination. The precision
+# canary MUST refuse to ledger a meter baseline on this route.
+serving_precision = "degraded"
 
 [[provider.sambanova]]
 model_match = "*"
@@ -3099,6 +3124,12 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "reasoning_summary"
+# Cerebras serves gpt-oss-120b at FULL precision, but request-rate throttling
+# (~57K tok/req capping to ~4.4 req/min during the 2026-06 effort) makes the
+# *timing* unusable for a durable N>=5 meter baseline even though the OUTPUTS
+# are trustworthy. The precision canary should not reject this route on quality
+# grounds, but the meter must budget for the throughput ceiling.
+serving_precision = "throttled"
 
 # Cerebras GLM 4.7 is a public preview model with native tools, native
 # structured output, and top-level `reasoning_effort`; `none` is the documented
@@ -3607,6 +3638,11 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "reasoning_summary"
+# Full-precision route: the Cerebras/Groq upstream allowlist above only ever
+# lands on full-precision upstreams, so OpenRouter openai/gpt-oss-120b is the
+# trusted-precision REFERENCE the meter precision canary pairs candidates
+# against. Verified clean across the 2026-06-13 live probes documented above.
+serving_precision = "trusted"
 
 [[provider.openrouter]]
 model_match = "stepfun/step-3.7-flash"

--- a/crates/harn-vm/src/llm/capability_sources/00-base.toml
+++ b/crates/harn-vm/src/llm/capability_sources/00-base.toml
@@ -154,6 +154,21 @@
 #                     pinned to ["Cerebras","Groq"]). When both a pin and a
 #                     denylist are set the pin wins (a closed allowlist already
 #                     excludes everything else).
+#   serving_precision:
+#                     serving-quality / precision trust verdict for the route.
+#                     A provider can be live and fast yet serve a model at
+#                     DEGRADED quality (undocumented quantization) or reject
+#                     valid requests, silently contaminating any eval/meter that
+#                     trusts its numbers. This is the data-driven sibling of the
+#                     route-around fields above: instead of routing AROUND a bad
+#                     upstream it LABELS the measured precision so tooling (the
+#                     Burin meter precision canary) can refuse to trust a
+#                     `degraded` route. Known values: `trusted` (full precision,
+#                     reference-verified), `degraded` (proven reduced quality —
+#                     e.g. SambaNova gpt-oss quantized: 0/5 vs OpenRouter 3/3),
+#                     `throttled` (full precision but rate-limited to unusable
+#                     timing — e.g. Cerebras gpt-oss), `unverified` (no verdict;
+#                     same as unset). Defaults to `unverified`.
 #
 # OPINIONATED PROVIDER/MODEL/CONFIG POLICY (enforced by the footgun gate in
 # crate::llm::capability_audit, wired into `providers build-capabilities

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/30-qwen-routed.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/30-qwen-routed.toml
@@ -75,6 +75,10 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "reasoning_summary"
+# Fireworks serves gpt-oss-120b at FULL precision (verified against the
+# OpenRouter full-precision reference during the 2026-06 meter-convergence
+# effort, once the harn #3319 reasoning-echo HTTP400 was fixed). Trusted.
+serving_precision = "trusted"
 
 [[provider.fireworks]]
 model_match = "*qwen3.6*"

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/37-sambanova.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/37-sambanova.toml
@@ -60,6 +60,12 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "reasoning_summary"
+# SambaNova serves gpt-oss at DEGRADED quality (quantized). PROVEN during the
+# 2026-06 meter-convergence effort: c-feat 0/5 and cpp-storage 0/5 on SambaNova
+# vs 3/3 and 1/1 on the OpenRouter full-precision reference. The numbers looked
+# like a capability collapse but were provider contamination. The precision
+# canary MUST refuse to ledger a meter baseline on this route.
+serving_precision = "degraded"
 
 [[provider.sambanova]]
 model_match = "*"

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/80-cerebras.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/80-cerebras.toml
@@ -43,6 +43,12 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "reasoning_summary"
+# Cerebras serves gpt-oss-120b at FULL precision, but request-rate throttling
+# (~57K tok/req capping to ~4.4 req/min during the 2026-06 effort) makes the
+# *timing* unusable for a durable N>=5 meter baseline even though the OUTPUTS
+# are trustworthy. The precision canary should not reject this route on quality
+# grounds, but the meter must budget for the throughput ceiling.
+serving_precision = "throttled"
 
 # Cerebras GLM 4.7 is a public preview model with native tools, native
 # structured output, and top-level `reasoning_effort`; `none` is the documented

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/99-openrouter-new-families.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/99-openrouter-new-families.toml
@@ -113,6 +113,11 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "reasoning_summary"
+# Full-precision route: the Cerebras/Groq upstream allowlist above only ever
+# lands on full-precision upstreams, so OpenRouter openai/gpt-oss-120b is the
+# trusted-precision REFERENCE the meter precision canary pairs candidates
+# against. Verified clean across the 2026-06-13 live probes documented above.
+serving_precision = "trusted"
 
 [[provider.openrouter]]
 model_match = "stepfun/step-3.7-flash"


### PR DESCRIPTION
## What

Adds a data-driven `serving_precision` field on the provider/model capability rows — the **labeling** sibling of the existing `provider_route_denylist` / `openrouter_provider_order` **route-around** fields. Where those route *around* a bad upstream, this **labels** a route's measured serving quality so downstream tooling (the Burin meter precision canary) can refuse to trust a degraded route instead of silently ledgering contaminated numbers.

Values: `trusted` | `degraded` | `throttled` | `unverified` (default/unset = `unverified`).

## Why (the footgun class)

Over the 2026-06 meter-convergence effort, every candidate provider for `gpt-oss-120b` had a distinct *trust* failure that liveness/throughput checks could not catch:
- **SambaNova** served gpt-oss at DEGRADED quality via quantization — PROVEN: c-feat 0/5 & cpp-storage 0/5 vs OpenRouter full-precision 3/3 & 1/1. Looked like a capability collapse, was provider contamination.
- **Cerebras** full precision but request-rate throttled to unusable timing.
- **Fireworks** rejected requests (HTTP400) until harn #3319.

A meter must VERIFY serving quality, not just liveness. This field is the data-driven anchor for that.

## Changes

- `serving_precision: Option<String>` on `ProviderRule`; resolved `serving_precision: String` on `Capabilities` (`"unverified"` when unset) and on `ProviderCapabilityMatrixRow` (so `harn check --provider-matrix --json` exposes it).
- Seeded verdicts on the gpt-oss-120b rows: Fireworks = `trusted`, OpenRouter `openai/gpt-oss-*` = `trusted` (the reference, pinned to Cerebras/Groq upstreams), SambaNova = `degraded`, Cerebras = `throttled`.
- Schema doc in `00-base.toml`; regenerated `capabilities.toml` snapshot (`providers build-capabilities`).
- Two resolution tests; changelog fragment.

## Tests

- `cargo test -p harn-vm --lib llm::capabilities` → 61 passed (incl. 2 new: `serving_precision_seeds_known_gpt_oss_verdicts`, `serving_precision_defaults_unverified_for_unmarked_rows`).
- `cargo test -p harn-vm --lib llm::capability_audit` → 8 passed (footgun gate clean).
- `harn providers build-capabilities --check` → snapshot up to date.

## Cross-repo

This is the **producer** half. The **consumer** is a Burin meter precision canary (separate burin-code PR) that reads this field via `harn check --provider-matrix --json` and pairs unverified candidates against a trusted reference before ledgering. That Burin PR carries its own fallback verdicts so it does not hard-block on this field landing; it consumes the richer signal once this lands → harn release → burin repin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)