### PR TITLE
feat(mcp): authenticated-identity resolution + display_identity in status/ACP (#3349, #3350)

### DIFF
--- a/changelog.d/3349.added.md
+++ b/changelog.d/3349.added.md
@@ -1,0 +1,8 @@
+- **MCP authenticated-identity resolution (#3349).** New `harn_vm::mcp_identity`
+  turns the per-server identity recipes from the preset catalog into a
+  human-readable "logged in as …" string. The OAuth engine now captures the
+  non-credential extras a token endpoint returns (Notion, for one, inlines the
+  workspace + authorizing user) onto the stored token, so the headline
+  `token_response` source resolves with no extra network call. The bundled
+  Notion preset ships the first vetted descriptor; the preset-catalog schema is
+  now version 2.

--- a/changelog.d/3350.added.md
+++ b/changelog.d/3350.added.md
@@ -1,0 +1,6 @@
+- **`harn mcp status` now shows who you're logged in as (#3350).** The status
+  report carries a `display_identity` field — "Jane Doe <jane@acme.com> — Acme",
+  for example — for connected servers with a vetted identity recipe and a
+  captured token payload (the `mcp status --json` schema is now version 3, and
+  the human output appends `as=…`). The ACP `mcp/oauth_callback` response gains a
+  `displayIdentity` so an embedding GUI can show it the moment a server connects.

--- a/crates/harn-cli/src/commands/mcp/mod.rs
+++ b/crates/harn-cli/src/commands/mcp/mod.rs
@@ -140,6 +140,11 @@ pub(crate) async fn handle_mcp_command(command: &McpCommand) {
                     println!("Client ID: {}", token.client_id);
                     println!("Token auth method: {}", token.token_endpoint_auth_method);
                     println!("Issuer: {}", token.issuer);
+                    if let Some(identity) =
+                        harn_vm::mcp_identity::display_identity(&server.url, &token)
+                    {
+                        println!("Identity: {identity}");
+                    }
                 }
                 Ok(None) => {
                     if server_ref.json {
@@ -178,8 +183,9 @@ pub(crate) async fn handle_mcp_command(command: &McpCommand) {
 }
 
 /// Schema version for `harn mcp status --json`. Bump when the
-/// `McpStatusReport` shape changes in a way agents must detect.
-pub(crate) const MCP_STATUS_SCHEMA_VERSION: u32 = 2;
+/// `McpStatusReport` shape changes in a way agents must detect. Bumped to 3 in
+/// harn#3350 with the `display_identity` field.
+pub(crate) const MCP_STATUS_SCHEMA_VERSION: u32 = 3;
 
 /// Aggregate readiness report for every MCP server declared in the
 /// nearest `harn.toml`. Mirrors the `connect status` report shape: a
@@ -224,6 +230,10 @@ pub(crate) struct McpServerStatus {
     pub token_client_id: Option<String>,
     /// OAuth issuer bound to the stored token when known.
     pub token_issuer: Option<String>,
+    /// Human-readable "logged in as …" identity for the authorized account,
+    /// when the server has a vetted identity recipe and a captured token
+    /// payload (harn#3350). `None` otherwise.
+    pub display_identity: Option<String>,
 }
 
 /// Build and print the all-servers MCP status report.
@@ -247,6 +257,9 @@ async fn run_mcp_status_report(json: bool) -> Result<(), String> {
                 "{}\t{}\t{}\t{}",
                 server.name, server.transport, server.state, counts
             );
+            if let Some(identity) = &server.display_identity {
+                line.push_str(&format!("\tas={identity}"));
+            }
             if let Some(error) = &server.last_error {
                 line.push_str(&format!("\terror={error}"));
             }
@@ -316,6 +329,15 @@ async fn derive_server_status(server: &McpServerConfig) -> McpServerStatus {
         "disconnected".to_string()
     };
 
+    // Resolve a "logged in as …" string for connected servers that have a
+    // vetted identity recipe (harn#3350). Cheap-guarded so only descriptor-
+    // bearing servers (e.g. Notion) pay for a token load.
+    let display_identity = if state == "connected" {
+        server_display_identity(server).await
+    } else {
+        None
+    };
+
     McpServerStatus {
         name: server.name.clone(),
         transport,
@@ -331,7 +353,23 @@ async fn derive_server_status(server: &McpServerConfig) -> McpServerStatus {
         token_expires_at_unix: None,
         token_client_id: None,
         token_issuer: None,
+        display_identity,
     }
+}
+
+/// Resolve the authenticated-identity display string for a server, if it has a
+/// catalog identity recipe and a stored OAuth token carrying the captured
+/// token-response payload. Returns `None` (never errors) so status reporting
+/// degrades gracefully.
+async fn server_display_identity(server: &McpServerConfig) -> Option<String> {
+    // Only descriptor-bearing servers pay for a token load.
+    harn_vm::mcp_identity::descriptor_for(&server.url)?;
+    let discovery = mcp_oauth::discover(&server.url).await.ok()?;
+    let resource = canonical_server_resource(&server.url).ok()?;
+    let token = mcp_oauth::load_token(&resource, &discovery.authorization_server_issuer, None)
+        .await
+        .ok()??;
+    harn_vm::mcp_identity::display_identity(&server.url, &token)
 }
 
 fn print_focused_status_report(
@@ -356,6 +394,8 @@ fn print_focused_status_report(
             token_expires_at_unix: token.and_then(|token| token.expires_at_unix),
             token_client_id: token.map(|token| token.client_id.clone()),
             token_issuer: token.map(|token| token.issuer.clone()),
+            display_identity: token
+                .and_then(|token| harn_vm::mcp_identity::display_identity(&server.url, token)),
         }],
     };
     println!(
@@ -801,10 +841,11 @@ mod tests {
                 token_expires_at_unix: None,
                 token_client_id: None,
                 token_issuer: None,
+                display_identity: None,
             }],
         };
         let value: serde_json::Value = serde_json::to_value(&report).expect("serialize");
-        assert_eq!(value["schema_version"], 2);
+        assert_eq!(value["schema_version"], 3);
         assert_eq!(value["manifest"], "/repo/harn.toml");
         assert_eq!(value["servers"][0]["name"], "fs");
         assert_eq!(value["servers"][0]["transport"], "stdio");
@@ -813,5 +854,6 @@ mod tests {
         assert!(value["servers"][0]["tools"].is_null());
         assert!(value["servers"][0]["last_error"].is_null());
         assert!(value["servers"][0]["token_expires_at_unix"].is_null());
+        assert!(value["servers"][0]["display_identity"].is_null());
     }
 }

--- a/crates/harn-serve/src/adapters/acp/integrations.rs
+++ b/crates/harn-serve/src/adapters/acp/integrations.rs
@@ -165,15 +165,22 @@ impl AcpServer {
             }
         };
         match harn_vm::mcp_oauth::complete_authorization(&state, &code, issuer.as_deref()).await {
-            Ok(token) => self.send_response(
-                id,
-                serde_json::json!({
-                    "ok": true,
-                    "resource": token.resource,
-                    "issuer": token.issuer,
-                    "expiresAt": token.expires_at_unix,
-                }),
-            ),
+            Ok(token) => {
+                // Surface the "logged in as …" identity (harn#3350) so an
+                // embedding GUI can show it immediately on a successful connect.
+                let display_identity =
+                    harn_vm::mcp_identity::display_identity(&token.resource, &token);
+                self.send_response(
+                    id,
+                    serde_json::json!({
+                        "ok": true,
+                        "resource": token.resource,
+                        "issuer": token.issuer,
+                        "expiresAt": token.expires_at_unix,
+                        "displayIdentity": display_identity,
+                    }),
+                );
+            }
             Err(error) => self.send_error(id, -32000, &error),
         }
     }

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -49,6 +49,7 @@ pub mod mcp_card;
 pub mod mcp_elicit;
 pub mod mcp_file_upload;
 pub mod mcp_host;
+pub mod mcp_identity;
 pub mod mcp_oauth;
 pub mod mcp_presets;
 pub mod mcp_progress;

--- a/crates/harn-vm/src/mcp_bulk_auth.rs
+++ b/crates/harn-vm/src/mcp_bulk_auth.rs
@@ -615,6 +615,7 @@ mod tests {
                 issuer: "https://auth.example".to_string(),
                 resource: "https://mcp.example/mcp".to_string(),
                 scopes: None,
+                token_response_extra: None,
             })
         }
     }

--- a/crates/harn-vm/src/mcp_identity.rs
+++ b/crates/harn-vm/src/mcp_identity.rs
@@ -1,0 +1,267 @@
+//! MCP authenticated-identity resolution (harn#3349).
+//!
+//! MCP has no standard "who am I logged in as" call, so a connected server
+//! can't tell a user *which* account/workspace they authorized. This module
+//! turns the per-server [`IdentityProbeDescriptor`] recipes from the preset
+//! catalog (harn#3348) into a human-readable "logged in as …" string.
+//!
+//! The headline source — `token_response` — needs no network: many providers
+//! (Notion, for one) return workspace/owner fields right in the OAuth token
+//! response, which the engine now captures onto
+//! [`StoredMcpToken::token_response_extra`]. Resolving identity from that is a
+//! pure, synchronous render — cheap enough to fold into `mcp status`. The
+//! `tool` / `http` live-probe sources are recognized but resolved by a future
+//! follow-up; this module returns `None` for them rather than guessing.
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use crate::mcp_oauth::StoredMcpToken;
+use crate::mcp_presets::{self, IdentityProbeDescriptor, IdentityProbeKind};
+
+/// The identity descriptor for a server URL, from the preset catalog (including
+/// any runtime overlay). `None` when the server isn't a known preset or the
+/// preset declares no identity recipe.
+pub fn descriptor_for(server_url: &str) -> Option<&'static IdentityProbeDescriptor> {
+    mcp_presets::presets()
+        .iter()
+        .find(|preset| preset.url == server_url)?
+        .identity
+        .as_ref()
+}
+
+/// Resolve a display-identity string for a connected server from data already
+/// on hand — the token-response payload captured at authorization. Sync, no
+/// network. Returns `None` when there's no descriptor, no captured payload, or
+/// nothing renders (e.g. the only sources are live `tool`/`http` probes).
+pub fn display_identity(server_url: &str, token: &StoredMcpToken) -> Option<String> {
+    let descriptor = descriptor_for(server_url)?;
+    render_identity(descriptor, token.token_response_extra.as_ref())
+}
+
+/// Render a descriptor against an optional captured token-response payload.
+/// Tries each `token_response` source in order; returns the first non-empty
+/// render. Pure — the unit of behavior the tests exercise.
+pub fn render_identity(
+    descriptor: &IdentityProbeDescriptor,
+    token_response: Option<&Value>,
+) -> Option<String> {
+    for source in &descriptor.sources {
+        if source.kind != IdentityProbeKind::TokenResponse {
+            // `tool` / `http` need a live session; resolved by a follow-up.
+            continue;
+        }
+        let Some(payload) = token_response else {
+            continue;
+        };
+        let captures = capture(payload, &source.fields);
+        if let Some(rendered) = render(&descriptor.display_template, &captures) {
+            return Some(rendered);
+        }
+    }
+    None
+}
+
+/// Capture each declared field (`name -> dotted.json.path`) from a payload.
+/// Missing paths and non-scalar / empty values are simply absent from the map.
+fn capture(payload: &Value, fields: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    for (name, path) in fields {
+        if let Some(text) = lookup(payload, path).and_then(scalar_to_string) {
+            if !text.is_empty() {
+                out.insert(name.clone(), text);
+            }
+        }
+    }
+    out
+}
+
+/// Dotted-path lookup into a JSON value, e.g. `owner.user.person.email`.
+fn lookup<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+    let mut current = value;
+    for segment in path.split('.') {
+        current = current.get(segment)?;
+    }
+    Some(current)
+}
+
+fn scalar_to_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => Some(text.clone()),
+        Value::Number(number) => Some(number.to_string()),
+        Value::Bool(flag) => Some(flag.to_string()),
+        _ => None,
+    }
+}
+
+/// Render `display_template` (e.g. `"{name} <{email}> — {workspace}"`) from the
+/// captured fields. Present `{field}`s substitute; absent ones drop out, then
+/// the result is tidied (empty `<>`/`()` removed, whitespace collapsed, dangling
+/// separators trimmed). Returns `None` when no field resolved at all.
+fn render(template: &str, captures: &BTreeMap<String, String>) -> Option<String> {
+    let mut out = String::new();
+    let mut any = false;
+    for (index, part) in template.split('{').enumerate() {
+        if index == 0 {
+            out.push_str(part);
+            continue;
+        }
+        match part.split_once('}') {
+            Some((key, rest)) => {
+                if let Some(value) = captures.get(key) {
+                    out.push_str(value);
+                    any = true;
+                }
+                out.push_str(rest);
+            }
+            // Unbalanced brace — treat literally.
+            None => {
+                out.push('{');
+                out.push_str(part);
+            }
+        }
+    }
+    if !any {
+        return None;
+    }
+    let tidied = tidy(&out);
+    (!tidied.is_empty()).then_some(tidied)
+}
+
+/// Clean up a partially-substituted template: drop now-empty `<>`/`()` pairs,
+/// collapse internal whitespace, and trim dangling separators left by missing
+/// fields (but never trim `<`/`>` so a real `<email>` survives).
+fn tidy(text: &str) -> String {
+    let without_empty = text.replace("<>", "").replace("()", "");
+    let collapsed = without_empty
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    collapsed
+        .trim_matches(|c: char| c.is_whitespace() || matches!(c, '—' | '-' | '|' | ',' | ':'))
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp_presets::{IdentityProbeKind, IdentityProbeSource};
+    use serde_json::json;
+
+    fn notion_descriptor() -> IdentityProbeDescriptor {
+        IdentityProbeDescriptor {
+            display_template: "{name} <{email}> — {workspace}".to_string(),
+            sources: vec![IdentityProbeSource {
+                kind: IdentityProbeKind::TokenResponse,
+                tool: None,
+                url: None,
+                fields: BTreeMap::from([
+                    ("name".to_string(), "owner.user.name".to_string()),
+                    ("email".to_string(), "owner.user.person.email".to_string()),
+                    ("workspace".to_string(), "workspace_name".to_string()),
+                ]),
+            }],
+        }
+    }
+
+    #[test]
+    fn lookup_walks_dotted_paths() {
+        let payload = json!({"owner": {"user": {"name": "Jane"}}});
+        assert_eq!(
+            lookup(&payload, "owner.user.name").and_then(scalar_to_string),
+            Some("Jane".to_string())
+        );
+        assert!(lookup(&payload, "owner.user.missing").is_none());
+        assert!(lookup(&payload, "nope").is_none());
+    }
+
+    #[test]
+    fn renders_full_identity() {
+        let payload = json!({
+            "workspace_name": "Acme",
+            "owner": {"user": {"name": "Jane Doe", "person": {"email": "jane@acme.com"}}}
+        });
+        let rendered = render_identity(&notion_descriptor(), Some(&payload));
+        assert_eq!(rendered.as_deref(), Some("Jane Doe <jane@acme.com> — Acme"));
+    }
+
+    #[test]
+    fn elides_missing_trailing_field() {
+        // No workspace_name → the " — {workspace}" tail drops cleanly.
+        let payload = json!({
+            "owner": {"user": {"name": "Jane Doe", "person": {"email": "jane@acme.com"}}}
+        });
+        let rendered = render_identity(&notion_descriptor(), Some(&payload));
+        assert_eq!(rendered.as_deref(), Some("Jane Doe <jane@acme.com>"));
+    }
+
+    #[test]
+    fn elides_missing_email_brackets() {
+        // No email → the empty "<>" is removed, name + workspace remain.
+        let payload = json!({"workspace_name": "Acme", "owner": {"user": {"name": "Jane"}}});
+        let rendered = render_identity(&notion_descriptor(), Some(&payload));
+        assert_eq!(rendered.as_deref(), Some("Jane — Acme"));
+    }
+
+    #[test]
+    fn renders_only_workspace() {
+        let payload = json!({"workspace_name": "Acme"});
+        let rendered = render_identity(&notion_descriptor(), Some(&payload));
+        assert_eq!(rendered.as_deref(), Some("Acme"));
+    }
+
+    #[test]
+    fn none_when_no_fields_resolve() {
+        let payload = json!({"unrelated": "x"});
+        assert!(render_identity(&notion_descriptor(), Some(&payload)).is_none());
+        assert!(render_identity(&notion_descriptor(), None).is_none());
+    }
+
+    #[test]
+    fn skips_live_probe_only_sources() {
+        let descriptor = IdentityProbeDescriptor {
+            display_template: "{name}".to_string(),
+            sources: vec![IdentityProbeSource {
+                kind: IdentityProbeKind::Tool,
+                tool: Some("whoami".to_string()),
+                url: None,
+                fields: BTreeMap::from([("name".to_string(), "name".to_string())]),
+            }],
+        };
+        // Tool source isn't resolved synchronously yet → None even with payload.
+        let payload = json!({"name": "Jane"});
+        assert!(render_identity(&descriptor, Some(&payload)).is_none());
+    }
+
+    #[test]
+    fn display_identity_uses_catalog_descriptor_for_notion() {
+        // Exercises the catalog wiring end-to-end: the bundled Notion preset
+        // ships a token_response descriptor (harn#3349), so a stored token whose
+        // captured payload carries Notion's shape renders an identity.
+        let token = StoredMcpToken {
+            access_token: "a".into(),
+            refresh_token: None,
+            expires_at_unix: None,
+            token_endpoint: "https://auth/token".into(),
+            client_id: "c".into(),
+            client_secret: None,
+            token_endpoint_auth_method: "none".into(),
+            issuer: "https://auth".into(),
+            resource: "https://mcp.notion.com/mcp".into(),
+            scopes: None,
+            token_response_extra: Some(json!({
+                "workspace_name": "Acme",
+                "owner": {"user": {"name": "Jane Doe", "person": {"email": "jane@acme.com"}}}
+            })),
+        };
+        assert_eq!(
+            display_identity("https://mcp.notion.com/mcp", &token).as_deref(),
+            Some("Jane Doe <jane@acme.com> — Acme")
+        );
+        // A server with no catalog descriptor yields nothing.
+        let mut other = token;
+        other.resource = "https://unknown.example/mcp".into();
+        assert!(display_identity("https://unknown.example/mcp", &other).is_none());
+    }
+}

--- a/crates/harn-vm/src/mcp_oauth.rs
+++ b/crates/harn-vm/src/mcp_oauth.rs
@@ -85,9 +85,18 @@ pub struct StoredMcpToken {
     pub resource: String,
     #[serde(default)]
     pub scopes: Option<String>,
+    /// Non-credential extras the token endpoint returned alongside the tokens
+    /// (everything except `access_token`/`refresh_token`/`expires_in`). Notion,
+    /// for example, returns `workspace_name` + `owner.user` here. Captured so an
+    /// identity probe (harn#3349) can render a "logged in as …" string without a
+    /// follow-up network call. `None` for tokens stored before this existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_response_extra: Option<serde_json::Value>,
 }
 
-/// The raw token-endpoint response shape (a subset; unknown fields ignored).
+/// The raw token-endpoint response shape. The named fields are the credential
+/// material; `extra` flat-captures every other field (workspace/identity hints
+/// some providers inline) without it touching the stored credentials.
 #[derive(Clone, Debug, Deserialize)]
 struct TokenResponse {
     access_token: String,
@@ -95,6 +104,15 @@ struct TokenResponse {
     refresh_token: Option<String>,
     #[serde(default)]
     expires_in: Option<i64>,
+    #[serde(flatten)]
+    extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Wrap non-empty token-response extras as a JSON object for persistence.
+fn token_response_extra(
+    extra: serde_json::Map<String, serde_json::Value>,
+) -> Option<serde_json::Value> {
+    (!extra.is_empty()).then_some(serde_json::Value::Object(extra))
 }
 
 /// Inputs to [`begin_authorization`]. The server is identified by its URL; the
@@ -303,6 +321,7 @@ pub async fn complete_authorization(
         issuer: flow.issuer,
         resource: flow.resource,
         scopes: flow.scopes,
+        token_response_extra: token_response_extra(token.extra),
     };
     save_stored_token(&stored).await?;
     Ok(stored)
@@ -529,6 +548,10 @@ async fn refresh_token(
         issuer: token.issuer.clone(),
         resource,
         scopes: token.scopes.clone(),
+        // Prefer fresh extras if the refresh carried any; otherwise keep the
+        // identity hints captured at first authorization.
+        token_response_extra: token_response_extra(refreshed.extra)
+            .or_else(|| token.token_response_extra.clone()),
     })
 }
 
@@ -1021,6 +1044,8 @@ fn stored_token_for_import(
             .map(str::trim)
             .filter(|scopes| !scopes.is_empty())
             .map(str::to_string),
+        // Imported legacy tokens carry no captured token-response payload.
+        token_response_extra: None,
     })
 }
 
@@ -1096,6 +1121,7 @@ mod tests {
             issuer: "https://auth".into(),
             resource: "https://mcp".into(),
             scopes: None,
+            token_response_extra: None,
         };
         assert!(!token_needs_refresh(&token));
         token.expires_at_unix = Some(current_unix_timestamp() + 3600);
@@ -1315,6 +1341,7 @@ mod tests {
             issuer: "https://auth.example".to_string(),
             resource: "https://mcp.example/mcp".to_string(),
             scopes: None,
+            token_response_extra: None,
         };
         store.save_token(&stale).await.unwrap();
 

--- a/crates/harn-vm/src/mcp_presets.rs
+++ b/crates/harn-vm/src/mcp_presets.rs
@@ -30,10 +30,10 @@ use serde::{Deserialize, Serialize};
 
 /// JSON schema version for the preset catalog. Increment on any breaking
 /// shape change to [`PresetCatalog`] / [`McpPreset`]. The optional
-/// [`McpPreset::identity`] field added in harn#3348 is omitted when absent, so
-/// the shipped output is unchanged and the version holds at 1 until a vetted
-/// identity descriptor actually ships in the catalog.
-pub const PRESET_CATALOG_SCHEMA_VERSION: u32 = 1;
+/// [`McpPreset::identity`] field. Bumped to 2 in harn#3349 when the first vetted
+/// identity descriptor (Notion) began shipping in the catalog, so consumers can
+/// detect that presets may now carry an `identity` recipe.
+pub const PRESET_CATALOG_SCHEMA_VERSION: u32 = 2;
 
 /// Bundled default catalog. Editable here; overlayable at runtime.
 const BUILTIN_TOML: &str = include_str!("mcp_presets.toml");
@@ -374,7 +374,7 @@ mod tests {
     #[test]
     fn json_shape_is_stable() {
         let json = serde_json::to_value(catalog()).expect("serialize catalog");
-        assert_eq!(json["schemaVersion"], serde_json::json!(1));
+        assert_eq!(json["schemaVersion"], serde_json::json!(2));
         let notion = json["presets"]
             .as_array()
             .expect("presets array")
@@ -391,9 +391,14 @@ mod tests {
             notion.get("oauthScopes").is_none(),
             "Notion MCP does not currently expose configurable OAuth scopes"
         );
-        assert!(
-            notion.get("identity").is_none(),
-            "no identity descriptor ships in the catalog yet (harn#3349 runner pending)"
+        // Notion now ships a token_response identity descriptor (harn#3349).
+        assert_eq!(
+            notion["identity"]["displayTemplate"],
+            serde_json::json!("{name} <{email}> — {workspace}")
+        );
+        assert_eq!(
+            notion["identity"]["sources"][0]["kind"],
+            serde_json::json!("token_response")
         );
     }
 

--- a/crates/harn-vm/src/mcp_presets.toml
+++ b/crates/harn-vm/src/mcp_presets.toml
@@ -21,6 +21,18 @@ transport = "http"
 url = "https://mcp.notion.com/mcp"
 auth_kind = "oauth"
 
+# Notion returns the authorizing user + workspace inline in its OAuth token
+# response, so the "logged in as …" string needs no extra call (harn#3349).
+[presets.identity]
+display_template = "{name} <{email}> — {workspace}"
+
+[[presets.identity.sources]]
+kind = "token_response"
+[presets.identity.sources.fields]
+name = "owner.user.name"
+email = "owner.user.person.email"
+workspace = "workspace_name"
+
 [[presets]]
 id = "linear"
 name = "Linear"


### PR DESCRIPTION
Closes #3349 and #3350. The identity-display bridge of Agent Identity Epic F (#3331) — and the "logged in as …" payoff that both the bulk-OAuth program (#3354) and the burin connections UI consume.

## Why
MCP has no standard "who am I logged in as", so a connected server can't tell a user *which* account/workspace they authorized. This resolves it from data the catalog already describes — no new round-trip for the common case.

## F2 — identity resolution (#3349)
- The OAuth engine captures the **non-credential** extras a token endpoint returns (Notion inlines `workspace_name` + `owner.user`) onto `StoredMcpToken.token_response_extra`. The `#[serde(flatten)]` split keeps it strictly separate from `access_token`/`refresh_token`.
- New `harn_vm::mcp_identity` renders the per-server `IdentityProbeDescriptor` (from #3348) against that payload: dotted-path capture + template render with graceful elision of missing fields (`{name} <{email}> — {workspace}` → `Jane Doe <jane@acme.com> — Acme`, and degrades cleanly when fields are absent).
- The bundled **Notion** preset ships the first vetted `token_response` descriptor; preset-catalog schema → 2. `tool`/`http` live-probe sources are recognized but resolved by a follow-up (no guand guessing).

## F3 — surfacing it (#3350)
- `McpServerStatus` gains `display_identity` (`mcp status --json` schema → 3; human output appends `as=…`, focused output prints an `Identity:` line), populated for connected descriptor-bearing servers.
- The ACP `mcp/oauth_callback` response gains `displayIdentity` so an embedding GUI shows "connected as …" the moment a server connects.

## Invariants
- **Data, not code.** Identity recipes are overlayable catalog data; the engine just preserves what the AS returned, the identity module (which knows the catalog) renders.
- **No credential leak.** Only non-token fields are captured/persisted.

## Tests
`mcp_identity` unit tests (full / partial / empty identities, dotted paths, catalog wiring); updated engine, presets, and CLI status tests. `--all-targets` clippy clean across harn-vm/cli/serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
