### PR TITLE
feat(serve): expose authenticated principal to .harn as harness.auth (#3323)

### DIFF
--- a/changelog.d/3323-harness-auth-principal.added.md
+++ b/changelog.d/3323-harness-auth-principal.added.md
@@ -1,0 +1,21 @@
+- **`harness.auth` — a read-only authenticated-principal handle for `.harn`
+  routes.** A `harn-serve` dispatch now threads the principal it
+  authenticated at admission — subject, scheme, granted scopes, and an
+  optional embedder-assigned principal `kind` — to the `.harn` callee as the
+  ambient `harness.auth` sub-handle, alongside the existing `harness.tenant`.
+  Routes can read identity and compose their own authorization without a
+  host-side dispatch guard: `harness.auth.is_authenticated()`,
+  `harness.auth.subject()` / `try_subject()`, `harness.auth.scheme()` /
+  `try_scheme()`, `harness.auth.kind()`, `harness.auth.scopes()`, and
+  `harness.auth.has_scope(scope)`. `subject()`/`scheme()` raise a typed
+  `Auth` error when no principal is bound (mirroring `harness.tenant.id()`);
+  the `try_*`/`kind` getters return `nil` and `scopes()`/`has_scope()`/
+  `is_authenticated()` degrade to empty/false so an unauthenticated route can
+  branch without try/catch. The handle is identity-only: it carries no
+  credentials or secrets, never the tenant (that stays the single-sourced
+  `harness.tenant` ambient), and never the opaque embedder auth context (that
+  stays the host-call-bridge channel). The synthetic anonymous principal
+  harn-serve admits under allow-all binds nothing, so `is_authenticated()` is
+  `false` when no credential authenticated the request. Foundation for
+  Harn-side route auth policies (issue #3323); unblocks harn-cloud's adoption
+  of declarative route policies in place of duplicated Rust dispatch guards.

--- a/crates/harn-parser/src/harness_methods.rs
+++ b/crates/harn-parser/src/harness_methods.rs
@@ -134,6 +134,20 @@ pub fn harness_tenant_ambient(method: &str) -> Option<&'static str> {
     }
 }
 
+pub fn harness_auth_ambient(method: &str) -> Option<&'static str> {
+    match method {
+        "is_authenticated" => Some("harness_auth_is_authenticated"),
+        "subject" => Some("harness_auth_subject"),
+        "try_subject" => Some("harness_auth_try_subject"),
+        "scheme" => Some("harness_auth_scheme"),
+        "try_scheme" => Some("harness_auth_try_scheme"),
+        "kind" => Some("harness_auth_kind"),
+        "scopes" => Some("harness_auth_scopes"),
+        "has_scope" => Some("harness_auth_has_scope"),
+        _ => None,
+    }
+}
+
 pub fn harness_obs_ambient(method: &str) -> Option<&'static str> {
     match method {
         "span" | "start_span" => Some("__obs_start_span"),
@@ -161,6 +175,7 @@ pub fn harness_sub_handle_ambient(sub_handle: &str, method: &str) -> Option<&'st
         "system" => harness_system_ambient(method),
         "llm" => harness_llm_ambient(method),
         "tenant" => harness_tenant_ambient(method),
+        "auth" => harness_auth_ambient(method),
         "obs" => harness_obs_ambient(method),
         _ => None,
     }
@@ -180,6 +195,7 @@ pub fn harness_type_sub_handle(type_name: &str) -> Option<&'static str> {
         "HarnessSystem" => Some("system"),
         "HarnessLlm" => Some("llm"),
         "HarnessTenant" => Some("tenant"),
+        "HarnessAuth" => Some("auth"),
         "HarnessObs" => Some("obs"),
         _ => None,
     }

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -1166,6 +1166,7 @@ impl TypeChecker {
                 "system" => Some(TypeExpr::Named("HarnessSystem".into())),
                 "llm" => Some(TypeExpr::Named("HarnessLlm".into())),
                 "tenant" => Some(TypeExpr::Named("HarnessTenant".into())),
+                "auth" => Some(TypeExpr::Named("HarnessAuth".into())),
                 "obs" => Some(TypeExpr::Named("HarnessObs".into())),
                 _ if optional => Some(TypeExpr::Named("nil".into())),
                 _ => None,

--- a/crates/harn-serve/src/adapter.rs
+++ b/crates/harn-serve/src/adapter.rs
@@ -129,6 +129,7 @@ mod tests {
             tenant_id: None,
             request_id: None,
             auth_context: None,
+            auth_principal: None,
         }
     }
 

--- a/crates/harn-serve/src/adapters/a2a/tasks.rs
+++ b/crates/harn-serve/src/adapters/a2a/tasks.rs
@@ -121,6 +121,7 @@ impl A2aServer {
                 tenant_id: None,
                 request_id: Some(task.id.clone()),
                 auth_context: None,
+                auth_principal: None,
             })
             .await;
 

--- a/crates/harn-serve/src/adapters/mcp/schema.rs
+++ b/crates/harn-serve/src/adapters/mcp/schema.rs
@@ -39,6 +39,7 @@ pub(super) fn build_call_request(
         tenant_id: None,
         request_id,
         auth_context: None,
+        auth_principal: None,
     })
 }
 

--- a/crates/harn-serve/src/adapters/site.rs
+++ b/crates/harn-serve/src/adapters/site.rs
@@ -213,11 +213,44 @@ pub struct SiteAuthContext {
     /// principal (via [`AuthRequest::granted_scopes`]) so the
     /// dispatch-level scope check agrees with the edge.
     pub scopes: BTreeSet<String>,
+    /// Stable identifier for the authenticated subject (e.g. the
+    /// embedder's API-key id or session subject). Surfaced read-only to
+    /// the `.harn` callee as `harness.auth.subject()` for attribution and
+    /// policy. `None` admits an anonymous/public request.
+    pub subject: Option<String>,
+    /// Auth scheme the embedder admitted the request under (e.g.
+    /// `"apikey"`, `"oauth"`, `"session"`). Surfaced as
+    /// `harness.auth.scheme()`. `None` when the embedder does not
+    /// classify the credential scheme.
+    pub scheme: Option<String>,
+    /// Optional principal classification the embedder assigned (e.g.
+    /// `"operator"` vs `"tenant"` vs `"worker"`). Surfaced as
+    /// `harness.auth.kind()` so a `.harn` route policy can gate on
+    /// allowed principal kinds. Generic — harn-serve never interprets it.
+    pub kind: Option<String>,
     /// Opaque embedder context (e.g. the API-key record or session
     /// claims). Never interpreted by harn-serve; surfaced to the
     /// embedder's [`harn_vm::HostCallBridge`] for the duration of the
     /// dispatch via [`crate::current_auth_context`].
     pub context: Option<Value>,
+}
+
+impl SiteAuthContext {
+    /// Project the embedder identity into the generic
+    /// [`harn_vm::AuthPrincipal`] threaded onto the dispatch as the
+    /// ambient `harness.auth` handle. Carries only identity facts —
+    /// subject, scheme, granted scopes, and principal kind — never the
+    /// opaque embedder `context` (that stays the host-call-bridge channel
+    /// via [`crate::current_auth_context`]) and never the tenant (that is
+    /// the single-sourced `harness.tenant` ambient).
+    pub(crate) fn principal(&self) -> harn_vm::AuthPrincipal {
+        harn_vm::AuthPrincipal {
+            subject: self.subject.clone().unwrap_or_default(),
+            scheme: self.scheme.clone().unwrap_or_default(),
+            scopes: self.scopes.clone(),
+            kind: self.kind.clone(),
+        }
+    }
 }
 
 impl SiteAuthOutcome {
@@ -891,6 +924,7 @@ async fn site_dispatch(State(state): State<SiteState>, request: Request) -> Resp
         auth_context: auth_context
             .as_ref()
             .and_then(|context| context.context.clone()),
+        auth_principal: auth_context.as_ref().map(SiteAuthContext::principal),
     };
 
     let response = match state.runtime.call(call).await {
@@ -1081,6 +1115,7 @@ async fn drive_ws_session(
             auth_context: auth_context
                 .as_ref()
                 .and_then(|context| context.context.clone()),
+            auth_principal: auth_context.as_ref().map(SiteAuthContext::principal),
         };
         match runtime.call(call).await {
             Ok(response) => {

--- a/crates/harn-serve/src/auth.rs
+++ b/crates/harn-serve/src/auth.rs
@@ -6,6 +6,19 @@ use harn_vm::{ProviderId, TenantId};
 use subtle::ConstantTimeEq;
 use time::{Duration, OffsetDateTime};
 
+/// Subject assigned to the synthetic principal harn-serve admits when a
+/// request carries no authenticated credential — no auth method
+/// configured (allow-all), or an allow-all MCP/agent handshake. Paired
+/// with [`ANONYMOUS_SCHEME`]; see [`AuthenticatedPrincipal::is_anonymous`].
+pub const ANONYMOUS_SUBJECT: &str = "anonymous";
+
+/// Scheme marking the [`ANONYMOUS_SUBJECT`] synthetic principal — the
+/// dispatch authenticated no identity. Real auth methods set a concrete
+/// scheme (`api_key`, `hmac`, `oauth21`), so this string never collides
+/// with a genuinely authenticated principal. The ambient `harness.auth`
+/// handle treats such a principal as unauthenticated and binds nothing.
+pub const ANONYMOUS_SCHEME: &str = "none";
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AuthenticatedPrincipal {
     pub subject: String,
@@ -20,6 +33,17 @@ pub struct AuthenticatedPrincipal {
     /// an admin/system bearer). Threaded through `DispatchCtx` into
     /// the `.harn` callee as `harness.tenant.id()`.
     pub tenant_id: Option<TenantId>,
+}
+
+impl AuthenticatedPrincipal {
+    /// Whether this is the synthetic [`ANONYMOUS_SUBJECT`] principal
+    /// harn-serve admits when no credential authenticated the request
+    /// (allow-all). The ambient `harness.auth` handle binds nothing for
+    /// an anonymous principal, so a `.harn` route sees
+    /// `harness.auth.is_authenticated() == false`.
+    pub fn is_anonymous(&self) -> bool {
+        self.scheme == ANONYMOUS_SCHEME
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -347,8 +371,8 @@ impl AuthPolicy {
     ) -> AuthorizationDecision {
         let mut principal = if self.methods.is_empty() {
             AuthenticatedPrincipal {
-                subject: "anonymous".to_string(),
-                scheme: "none".to_string(),
+                subject: ANONYMOUS_SUBJECT.to_string(),
+                scheme: ANONYMOUS_SCHEME.to_string(),
                 granted_scopes: BTreeSet::new(),
                 tenant_id: None,
             }
@@ -408,16 +432,16 @@ impl AuthPolicy {
     pub fn authorize_mcp(&self, server: &str, tool: Option<&str>) -> AuthorizationDecision {
         let Some(allowlist) = &self.mcp_allowlist else {
             return AuthorizationDecision::Authorized(AuthenticatedPrincipal {
-                subject: "anonymous".to_string(),
-                scheme: "none".to_string(),
+                subject: ANONYMOUS_SUBJECT.to_string(),
+                scheme: ANONYMOUS_SCHEME.to_string(),
                 granted_scopes: BTreeSet::new(),
                 tenant_id: None,
             });
         };
         match allowlist.check(server, tool) {
             AllowlistOutcome::Allow => AuthorizationDecision::Authorized(AuthenticatedPrincipal {
-                subject: "anonymous".to_string(),
-                scheme: "none".to_string(),
+                subject: ANONYMOUS_SUBJECT.to_string(),
+                scheme: ANONYMOUS_SCHEME.to_string(),
                 granted_scopes: BTreeSet::new(),
                 tenant_id: None,
             }),

--- a/crates/harn-serve/src/core.rs
+++ b/crates/harn-serve/src/core.rs
@@ -147,6 +147,16 @@ pub struct CallRequest {
     /// [`crate::current_auth_context`] for the duration of the
     /// dispatch. `None` (the default) installs nothing.
     pub auth_context: Option<serde_json::Value>,
+    /// Authenticated principal resolved at admission — subject, scheme,
+    /// granted scopes, and optional principal kind. Unlike
+    /// [`Self::auth_context`] (the opaque embedder blob surfaced only to
+    /// the host-call bridge), this is the generic identity harn-serve
+    /// itself vouches for; `invoke_*` installs it as the ambient
+    /// `harness.auth` handle (see [`harn_vm::enter_auth_principal`]) so a
+    /// `.harn` route can read scopes/subject/kind and compose its own
+    /// authorization policy. `None` (the default) leaves the dispatch
+    /// unauthenticated (`harness.auth.is_authenticated()` is `false`).
+    pub auth_principal: Option<harn_vm::AuthPrincipal>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -264,7 +274,24 @@ impl DispatchCore {
                 // span attributes consistent with the value the .harn
                 // callee actually sees.
                 if request.tenant_id.is_none() {
-                    request.tenant_id = principal.tenant_id;
+                    request.tenant_id = principal.tenant_id.clone();
+                }
+                // Surface the same authenticated identity to the `.harn`
+                // callee as the ambient `harness.auth` handle. An adapter
+                // that already resolved the principal (e.g. the site
+                // adapter's `SiteAuth` hook) wins; otherwise project the
+                // policy-resolved principal. The synthetic anonymous
+                // principal (allow-all, no credential) binds nothing, so a
+                // `.harn` route reads `harness.auth.is_authenticated() ==
+                // false`. The AuthPolicy path carries no embedder-assigned
+                // `kind`, so it stays `None`.
+                if request.auth_principal.is_none() && !principal.is_anonymous() {
+                    request.auth_principal = Some(harn_vm::AuthPrincipal {
+                        subject: principal.subject.clone(),
+                        scheme: principal.scheme.clone(),
+                        scopes: principal.granted_scopes,
+                        kind: None,
+                    });
                 }
             }
             AuthorizationDecision::Rejected(message) => {
@@ -499,6 +526,7 @@ impl DispatchCore {
         let budget = function.budget.clone();
         let request_id = request.request_id.clone();
         let auth_context = request.auth_context.clone();
+        let auth_principal = request.auth_principal.clone();
         let local = LocalSet::new();
         local
             .run_until(harn_vm::mcp_progress::scope_context(progress, async move {
@@ -511,6 +539,7 @@ impl DispatchCore {
                 let _budget_guard = budget.as_ref().and_then(BudgetSpec::install);
                 let _request_id_guard = request_id.map(harn_vm::enter_request_id);
                 let _auth_context_guard = auth_context.map(crate::enter_auth_context);
+                let _auth_principal_guard = auth_principal.map(harn_vm::enter_auth_principal);
 
                 let mut vm = Vm::new();
                 harn_vm::register_vm_stdlib(&mut vm);
@@ -580,6 +609,7 @@ impl DispatchCore {
         let budget = function.budget.clone();
         let request_id = request.request_id.clone();
         let auth_context = request.auth_context.clone();
+        let auth_principal = request.auth_principal.clone();
         let local = LocalSet::new();
         local
             .run_until(harn_vm::mcp_progress::scope_context(progress, async move {
@@ -592,6 +622,7 @@ impl DispatchCore {
                 let _budget_guard = budget.as_ref().and_then(BudgetSpec::install);
                 let _request_id_guard = request_id.map(harn_vm::enter_request_id);
                 let _auth_context_guard = auth_context.map(crate::enter_auth_context);
+                let _auth_principal_guard = auth_principal.map(harn_vm::enter_auth_principal);
 
                 let mut vm = Vm::new();
                 harn_vm::register_vm_stdlib(&mut vm);
@@ -852,6 +883,7 @@ pub fn greet(name: string) -> string {
                 tenant_id: None,
                 request_id: None,
                 auth_context: None,
+                auth_principal: None,
             })
             .await
             .expect("dispatch");
@@ -895,6 +927,7 @@ pipeline default(task) {
                 tenant_id: None,
                 request_id: None,
                 auth_context: None,
+                auth_principal: None,
             })
             .await
             .expect("dispatch");
@@ -955,6 +988,7 @@ pub fn greet(name: string) -> string {
                 tenant_id: None,
                 request_id: None,
                 auth_context: None,
+                auth_principal: None,
             })
             .await
             .expect("dispatch");
@@ -994,6 +1028,7 @@ pub fn inspect(upload: string) -> string {
             tenant_id: None,
             request_id: None,
             auth_context: None,
+            auth_principal: None,
         };
 
         let first = core
@@ -1048,6 +1083,7 @@ pub fn greet(name: string) -> string {
                 tenant_id: None,
                 request_id: None,
                 auth_context: None,
+                auth_principal: None,
             })
             .await
             .expect("dispatch");
@@ -1099,6 +1135,7 @@ pub fn spin() -> string {
                 tenant_id: None,
                 request_id: None,
                 auth_context: None,
+                auth_principal: None,
             })
             .await
             .expect("dispatch");
@@ -1161,6 +1198,7 @@ pub fn whoami(harness: Harness) -> string {
                 tenant_id: None,
                 request_id: None,
                 auth_context: None,
+                auth_principal: None,
             })
             .await
             .expect("dispatch");
@@ -1211,6 +1249,7 @@ pub fn whoami(harness: Harness) -> string {
                 tenant_id: None,
                 request_id: None,
                 auth_context: None,
+                auth_principal: None,
             })
             .await
             .expect_err("missing tenant should error");
@@ -1275,6 +1314,7 @@ pub fn whoami(harness: Harness) -> string {
                 tenant_id: Some(harn_vm::TenantId::new("override-tenant")),
                 request_id: None,
                 auth_context: None,
+                auth_principal: None,
             })
             .await
             .expect("dispatch");

--- a/crates/harn-serve/src/http_codec.rs
+++ b/crates/harn-serve/src/http_codec.rs
@@ -854,6 +854,7 @@ mod tests {
             tenant_id: None,
             request_id: None,
             auth_context: None,
+            auth_principal: None,
         };
         core.dispatch(request).await.map(|response| response.value)
     }
@@ -1153,6 +1154,7 @@ pub fn handler() -> dict {
             tenant_id: None,
             request_id,
             auth_context: None,
+            auth_principal: None,
         };
         core.dispatch(request).await.map(|response| response.value)
     }

--- a/crates/harn-serve/tests/limits_loadgen.rs
+++ b/crates/harn-serve/tests/limits_loadgen.rs
@@ -45,6 +45,7 @@ fn synth_request(function: &str) -> CallRequest {
         tenant_id: None,
         request_id: None,
         auth_context: None,
+        auth_principal: None,
     }
 }
 

--- a/crates/harn-serve/tests/site_auth.rs
+++ b/crates/harn-serve/tests/site_auth.rs
@@ -53,12 +53,28 @@ pub fn ctx_route(req: dict) -> dict {
 pub fn per_method_route(req: dict) -> dict {
   return http_ok({ "ok": true })
 }
+
+@scopes("personas:read")
+@route("GET", "/whoami")
+pub fn whoami_route(harness: Harness, req: dict) -> dict {
+  return http_ok({
+    "authed": harness.auth.is_authenticated(),
+    "subject": harness.auth.try_subject(),
+    "kind": harness.auth.kind(),
+    "has_read": harness.auth.has_scope("personas:read"),
+    "has_admin": harness.auth.has_scope("admin:write"),
+    "scopes": harness.auth.scopes(),
+  })
+}
 "#;
 
 /// `SiteAuth` hook that always admits with a fixed identity.
+#[derive(Default)]
 struct AllowAuth {
     tenant: Option<&'static str>,
     scopes: &'static [&'static str],
+    subject: Option<&'static str>,
+    kind: Option<&'static str>,
     context: Option<Value>,
 }
 
@@ -68,6 +84,9 @@ impl SiteAuth for AllowAuth {
         SiteAuthOutcome::Allow(SiteAuthContext {
             tenant_id: self.tenant.map(TenantId::new),
             scopes: self.scopes.iter().map(|scope| scope.to_string()).collect(),
+            subject: self.subject.map(str::to_string),
+            scheme: Some("apikey".to_string()),
+            kind: self.kind.map(str::to_string),
             context: self.context.clone(),
         })
     }
@@ -112,6 +131,7 @@ impl SiteAuth for HeaderAuth {
             tenant_id: None,
             scopes: ["personas:read".to_string()].into(),
             context: Some(json!({ "route": route.path, "method": route.method })),
+            ..Default::default()
         })
     }
 }
@@ -227,6 +247,7 @@ async fn allow_with_tenant_and_scopes_reaches_scoped_route() {
         tenant: Some("acme"),
         scopes: &["personas:read", "sessions:write"],
         context: None,
+        ..Default::default()
     });
     let (_dir, router) = site_router(Some(hook), None);
     let (status, body) = read_json(get(router, "/scoped").await).await;
@@ -242,6 +263,7 @@ async fn allow_with_missing_scopes_yields_canonical_403() {
         tenant: Some("acme"),
         scopes: &["sessions:read"],
         context: None,
+        ..Default::default()
     });
     let (_dir, router) = site_router(Some(hook), None);
     let (status, body) = read_json(get(router, "/scoped").await).await;
@@ -273,6 +295,7 @@ async fn public_route_admits_tenantless_scopeless_allow() {
         tenant: None,
         scopes: &[],
         context: None,
+        ..Default::default()
     });
     let (_dir, router) = site_router(Some(hook), None);
     let (status, body) = read_json(get(router, "/public").await).await;
@@ -289,6 +312,7 @@ async fn auth_context_is_visible_to_the_host_call_bridge() {
         tenant: None,
         scopes: &[],
         context: Some(json!({ "key_id": "k_123", "session": "s_9" })),
+        ..Default::default()
     });
     let (_dir, router) = site_router(Some(hook), Some(Arc::new(BridgeConfigurator)));
     let (status, body) = read_json(get(router, "/ctx").await).await;
@@ -306,6 +330,7 @@ async fn absent_auth_context_is_absent_at_the_bridge() {
         tenant: None,
         scopes: &[],
         context: None,
+        ..Default::default()
     });
     let (_dir, router) = site_router(Some(hook), Some(Arc::new(BridgeConfigurator)));
     let (status, body) = read_json(get(router, "/ctx").await).await;
@@ -356,6 +381,7 @@ async fn per_method_get_requires_only_the_baseline_scope() {
         tenant: None,
         scopes: &["base:read"],
         context: None,
+        ..Default::default()
     });
     let (_dir, router) = site_router(Some(hook), None);
     let (status, body) = read_json(request(router, "GET", "/per_method").await).await;
@@ -373,6 +399,7 @@ async fn per_method_put_demands_the_method_scoped_extra() {
         tenant: None,
         scopes: &["base:read"],
         context: None,
+        ..Default::default()
     });
     let (_dir, router) = site_router(Some(hook), None);
     let (status, body) = read_json(request(router, "PUT", "/per_method").await).await;
@@ -391,6 +418,7 @@ async fn per_method_put_admits_with_baseline_plus_extra() {
         tenant: None,
         scopes: &["base:read", "personas:write"],
         context: None,
+        ..Default::default()
     });
     let (_dir, router) = site_router(Some(hook), None);
     let (status, body) = read_json(request(router, "PUT", "/per_method").await).await;
@@ -406,9 +434,75 @@ async fn per_method_unlisted_method_falls_back_to_baseline() {
         tenant: None,
         scopes: &["base:read"],
         context: None,
+        ..Default::default()
     });
     let (_dir, router) = site_router(Some(hook), None);
     let (status, body) = read_json(request(router, "DELETE", "/per_method").await).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["ok"], true);
+}
+
+/// The hook-resolved identity is threaded to the `.harn` route as the
+/// ambient `harness.auth` handle: a route can read the subject, the
+/// embedder-assigned principal kind, and test/enumerate the granted
+/// scopes — the foundation a `.harn`-side auth policy composes (issue
+/// burin-labs/harn#3323; unblocks harn-cloud route-policy adoption).
+#[tokio::test]
+async fn harness_auth_exposes_bound_principal_to_route() {
+    let hook = Arc::new(AllowAuth {
+        tenant: Some("acme"),
+        scopes: &["personas:read", "sessions:write"],
+        subject: Some("k_operator"),
+        kind: Some("operator"),
+        ..Default::default()
+    });
+    let (_dir, router) = site_router(Some(hook), None);
+    let (status, body) = read_json(get(router, "/whoami").await).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["authed"], true);
+    assert_eq!(body["subject"], "k_operator");
+    assert_eq!(body["kind"], "operator");
+    assert_eq!(body["has_read"], true);
+    assert_eq!(body["has_admin"], false);
+    // `scopes()` returns the granted set as a sorted list.
+    let scopes: Vec<&str> = body["scopes"]
+        .as_array()
+        .expect("scopes array")
+        .iter()
+        .map(|scope| scope.as_str().expect("scope string"))
+        .collect();
+    assert_eq!(scopes, vec!["personas:read", "sessions:write"]);
+}
+
+/// Without an embedder hook the dispatch is unauthenticated end to end:
+/// `harness.auth.is_authenticated()` is `false` and `scopes()` is empty.
+/// (The `/whoami` route's own `@scopes` is dropped here so the request
+/// reaches the handler under the allow-all default — proving the
+/// `harness.auth` view, not the admission gate.)
+#[tokio::test]
+async fn harness_auth_reports_anonymous_without_hook() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("anon.harn");
+    std::fs::write(
+        &path,
+        r#"
+@route("GET", "/whoami")
+pub fn whoami_route(harness: Harness, req: dict) -> dict {
+  return http_ok({
+    "authed": harness.auth.is_authenticated(),
+    "subject": harness.auth.try_subject(),
+    "scopes": harness.auth.scopes(),
+  })
+}
+"#,
+    )
+    .expect("write script");
+    let config = SiteServerConfig::new(build_core(&path, None));
+    let router = SiteServer::new(config).router().expect("site router");
+
+    let (status, body) = read_json(get(router, "/whoami").await).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["authed"], false);
+    assert_eq!(body["subject"], Value::Null);
+    assert_eq!(body["scopes"].as_array().expect("scopes array").len(), 0);
 }

--- a/crates/harn-serve/tests/site_raw_bodies.rs
+++ b/crates/harn-serve/tests/site_raw_bodies.rs
@@ -152,6 +152,7 @@ impl SiteAuth for AllowAuth {
             tenant_id: Some(TenantId::new("acme")),
             scopes: self.scopes.iter().map(|scope| scope.to_string()).collect(),
             context: None,
+            ..Default::default()
         })
     }
 }

--- a/crates/harn-serve/tests/site_streaming.rs
+++ b/crates/harn-serve/tests/site_streaming.rs
@@ -101,6 +101,7 @@ impl SiteAuth for AllowAuth {
             tenant_id: self.tenant.map(TenantId::new),
             scopes: self.scopes.iter().map(|scope| scope.to_string()).collect(),
             context: None,
+            ..Default::default()
         })
     }
 }

--- a/crates/harn-serve/tests/site_websocket.rs
+++ b/crates/harn-serve/tests/site_websocket.rs
@@ -209,6 +209,7 @@ impl SiteAuth for AllowAuth {
             tenant_id: self.tenant.map(TenantId::new),
             scopes: self.scopes.iter().map(|s| s.to_string()).collect(),
             context: None,
+            ..Default::default()
         })
     }
 }

--- a/crates/harn-vm/src/harness.rs
+++ b/crates/harn-vm/src/harness.rs
@@ -48,6 +48,11 @@ pub enum HarnessKind {
     /// the dispatching host bound to this call. See
     /// [`crate::harness_tenant`].
     Tenant,
+    /// Auth sub-handle exposing the ambient authenticated principal (if
+    /// any) — subject, scheme, granted scopes, and optional principal
+    /// kind — that the dispatching host bound to this call. See
+    /// [`crate::harness_auth`].
+    Auth,
     /// Observability sub-handle: spans, counter/histogram/gauge
     /// instruments, structured logs, and the ambient request_id
     /// surfaced by the dispatching host. See
@@ -75,6 +80,7 @@ impl HarnessKind {
             HarnessKind::System => "HarnessSystem",
             HarnessKind::Llm => "HarnessLlm",
             HarnessKind::Tenant => "HarnessTenant",
+            HarnessKind::Auth => "HarnessAuth",
             HarnessKind::Obs => "HarnessObs",
         }
     }
@@ -96,6 +102,7 @@ impl HarnessKind {
             HarnessKind::System => Some("system"),
             HarnessKind::Llm => Some("llm"),
             HarnessKind::Tenant => Some("tenant"),
+            HarnessKind::Auth => Some("auth"),
             HarnessKind::Obs => Some("obs"),
         }
     }
@@ -115,6 +122,7 @@ impl HarnessKind {
             "system" => Some(HarnessKind::System),
             "llm" => Some(HarnessKind::Llm),
             "tenant" => Some(HarnessKind::Tenant),
+            "auth" => Some(HarnessKind::Auth),
             "obs" => Some(HarnessKind::Obs),
             _ => None,
         }
@@ -134,6 +142,7 @@ impl HarnessKind {
         HarnessKind::System,
         HarnessKind::Llm,
         HarnessKind::Tenant,
+        HarnessKind::Auth,
         HarnessKind::Obs,
     ];
 
@@ -152,6 +161,7 @@ impl HarnessKind {
         HarnessKind::System,
         HarnessKind::Llm,
         HarnessKind::Tenant,
+        HarnessKind::Auth,
         HarnessKind::Obs,
     ];
 }
@@ -679,6 +689,13 @@ impl Harness {
         }
     }
 
+    /// Field access for `harness.auth`.
+    pub fn auth(&self) -> HarnessAuth {
+        HarnessAuth {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
     /// Field access for `harness.obs`.
     pub fn obs(&self) -> HarnessObs {
         HarnessObs {
@@ -800,6 +817,18 @@ pub struct HarnessTenant {
     inner: Arc<HarnessInner>,
 }
 
+/// auth sub-handle: `is_authenticated`, `subject` / `try_subject`,
+/// `scheme` / `try_scheme`, `kind`, `scopes`, `has_scope`. Surfaces the
+/// ambient authenticated principal bound by the dispatching host (see
+/// [`crate::harness_auth`]). Like [`HarnessTenant`] it holds no host
+/// state — the methods consult a thread-local stack — but rides the
+/// shared `Arc<HarnessInner>` so null/mock-mode gating in
+/// [`crate::vm::methods::harness`] applies uniformly.
+#[derive(Debug, Clone)]
+pub struct HarnessAuth {
+    inner: Arc<HarnessInner>,
+}
+
 /// obs sub-handle: `span` / `start_span` / `end_span` / `counter` /
 /// `histogram` / `gauge` / `log` / `request_id`. Wraps the existing
 /// `__obs_*` builtins and the request_id ambient pushed by the
@@ -838,6 +867,7 @@ sub_handle_inner!(
     HarnessSystem,
     HarnessLlm,
     HarnessTenant,
+    HarnessAuth,
     HarnessObs,
 );
 
@@ -1044,6 +1074,7 @@ mod tests {
             r"fn main(harness: Harness) { harness.system.cpu() }",
             r"fn main(harness: Harness) { harness.llm.catalog() }",
             r"fn main(harness: Harness) { harness.tenant.id() }",
+            r"fn main(harness: Harness) { harness.auth.subject() }",
             r#"fn main(harness: Harness) { harness.obs.log("blocked", "info", {}) }"#,
         ] {
             let error = run_harness_source(source, harness.clone()).expect_err("call denied");
@@ -1073,11 +1104,65 @@ mod tests {
                 (HarnessKind::System, "cpu"),
                 (HarnessKind::Llm, "catalog"),
                 (HarnessKind::Tenant, "id"),
+                (HarnessKind::Auth, "subject"),
                 (HarnessKind::Obs, "log"),
             ]
         );
         assert_eq!(events[0].args, vec!["blocked"]);
         assert_eq!(events[3].args, vec!["/x"]);
+    }
+
+    #[test]
+    fn auth_sub_handle_reads_bound_principal() {
+        use crate::harness_auth::{enter_auth_principal, AuthPrincipal};
+        let _principal = enter_auth_principal(AuthPrincipal {
+            subject: "k_123".to_string(),
+            scheme: "apikey".to_string(),
+            scopes: ["admin:dlq:write", "read:events"]
+                .iter()
+                .map(|scope| scope.to_string())
+                .collect(),
+            kind: Some("operator".to_string()),
+        });
+        let source = r#"
+fn main(harness: Harness) {
+  __io_println(harness.auth.is_authenticated())
+  __io_println(harness.auth.subject())
+  __io_println(harness.auth.scheme())
+  __io_println(harness.auth.kind())
+  __io_println(harness.auth.has_scope("admin:dlq:write"))
+  __io_println(harness.auth.has_scope("missing:scope"))
+  __io_println(len(harness.auth.scopes()))
+}
+"#;
+        let output = run_harness_source(source, Harness::real()).expect("dispatch succeeds");
+        assert_eq!(output, "true\nk_123\napikey\noperator\ntrue\nfalse\n2\n");
+    }
+
+    #[test]
+    fn auth_sub_handle_without_principal_reports_anonymous() {
+        // No `enter_auth_principal` guard — the dispatch is unauthenticated,
+        // so the presence/scope getters degrade rather than error and
+        // `subject()` raises the canonical Auth error.
+        let source = r#"
+fn main(harness: Harness) {
+  if harness.auth.is_authenticated() { __io_println("auth") } else { __io_println("anon") }
+  __io_println(harness.auth.has_scope("x"))
+  __io_println(len(harness.auth.scopes()))
+}
+"#;
+        let output = run_harness_source(source, Harness::real()).expect("dispatch succeeds");
+        assert_eq!(output, "anon\nfalse\n0\n");
+
+        let error = run_harness_source(
+            r"fn main(harness: Harness) { harness.auth.subject() }",
+            Harness::real(),
+        )
+        .expect_err("subject() requires a bound principal");
+        assert!(
+            error.contains("no principal bound"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/harness_auth.rs
+++ b/crates/harn-vm/src/harness_auth.rs
@@ -1,0 +1,150 @@
+//! Ambient authenticated-principal scope threaded into `.harn` callees by
+//! hosts that authenticate a request before dispatch (today: `harn-serve`,
+//! which resolves an [`crate::auth`-style] principal — subject, scheme,
+//! granted scopes, and an optional embedder-assigned `kind` — at admission).
+//!
+//! Exposed to scripts as the `harness.auth` sub-handle:
+//!
+//! ```harn
+//! if !harness.auth.has_scope("admin:dlq:write") { return forbidden(req) }
+//! let actor = harness.auth.subject()
+//! ```
+//!
+//! The handle is **read-only identity** — it carries only the generic
+//! principal facts harn-serve itself authenticated (subject, scheme,
+//! granted scopes, an optional principal `kind`). It deliberately does NOT
+//! expose the tenant (that stays the single-sourced [`harness.tenant`]
+//! ambient, see [`crate::harness_tenant`]) and never carries credentials,
+//! secrets, or product-specific authorization concepts: a `.harn` policy
+//! helper composes these facts with `harness.tenant` and the route context
+//! to decide admission, so the language core stays about principals and
+//! scopes, not products.
+//!
+//! Method semantics:
+//! - `is_authenticated()` — whether the host bound a principal at all.
+//! - `subject()` / `scheme()` — the authenticated subject and auth scheme;
+//!   raise a typed [`ErrorCategory::Auth`] error when no principal is bound
+//!   (mirroring `harness.tenant.id()`). `try_subject()` / `try_scheme()`
+//!   return `nil` instead so callers can branch without try/catch.
+//! - `kind()` — the optional principal classification the host assigned
+//!   (e.g. `"operator"`, `"tenant"`, `"worker"`); `nil` when unset, even for
+//!   an authenticated principal, so it is inherently a `try`-shaped getter.
+//! - `scopes()` — the granted scope set as a sorted list (empty when no
+//!   principal is bound — an unauthenticated caller has granted nothing).
+//! - `has_scope(scope)` — membership test against `scopes()`; `false` when
+//!   no principal is bound.
+//!
+//! The scope is stack-shaped (push/pop via [`enter_auth_principal`]) so
+//! nested dispatches (a callee that re-enters the dispatcher under a
+//! different principal) restore the outer principal on return, exactly like
+//! [`crate::harness_tenant`] and [`crate::observability::request_id`].
+
+use std::cell::RefCell;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+/// The authenticated principal a host bound for the duration of a
+/// dispatch. Carries only generic identity facts harn-serve authenticated;
+/// never secrets, tenant (see [`crate::harness_tenant`]), or product
+/// authorization concepts.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct AuthPrincipal {
+    /// Stable identifier for the authenticated subject (e.g. an API-key id,
+    /// OAuth `sub`, or worker token id). Empty string is treated as "no
+    /// subject" by the getters but a bound principal should always set it.
+    pub subject: String,
+    /// Auth scheme that admitted the request (e.g. `"apikey"`, `"oauth"`,
+    /// `"hmac"`). Lets a policy gate on credential class.
+    pub scheme: String,
+    /// Scopes the credential carries — the same set harn-serve checked the
+    /// route's `@scopes` against. Sorted/deduped via `BTreeSet`.
+    pub scopes: BTreeSet<String>,
+    /// Optional principal classification the host assigned (e.g.
+    /// `"operator"` vs `"tenant"` vs `"worker"`). Generic — harn-serve does
+    /// not interpret it; policies match against it for "allowed principal
+    /// kinds". `None` when the host did not classify the principal.
+    pub kind: Option<String>,
+}
+
+thread_local! {
+    static ACTIVE_PRINCIPAL_STACK: RefCell<Vec<Arc<AuthPrincipal>>> =
+        const { RefCell::new(Vec::new()) };
+}
+
+/// RAII guard returned by [`enter_auth_principal`]. Popping the stack on
+/// drop keeps the ambient scope balanced even when the dispatched callable
+/// panics or returns an error.
+#[must_use = "dropping the guard immediately pops the auth-principal scope"]
+pub struct AuthPrincipalScopeGuard {
+    _private: (),
+}
+
+impl Drop for AuthPrincipalScopeGuard {
+    fn drop(&mut self) {
+        ACTIVE_PRINCIPAL_STACK.with(|stack| {
+            stack.borrow_mut().pop();
+        });
+    }
+}
+
+/// Push `principal` onto the ambient stack for the lifetime of the
+/// returned guard. The innermost entry wins for [`current_auth_principal`].
+pub fn enter_auth_principal(principal: AuthPrincipal) -> AuthPrincipalScopeGuard {
+    ACTIVE_PRINCIPAL_STACK.with(|stack| stack.borrow_mut().push(Arc::new(principal)));
+    AuthPrincipalScopeGuard { _private: () }
+}
+
+/// Currently-active authenticated principal, or `None` when the host
+/// dispatched without authenticating one. The innermost
+/// [`enter_auth_principal`] scope wins.
+pub fn current_auth_principal() -> Option<Arc<AuthPrincipal>> {
+    ACTIVE_PRINCIPAL_STACK.with(|stack| stack.borrow().last().cloned())
+}
+
+/// Standard message raised by `harness.auth.subject()` /
+/// `harness.auth.scheme()` when no principal is bound. Lives here (and not
+/// inline at the call site) so adapters and tests can assert against one
+/// canonical string.
+pub const MISSING_PRINCIPAL_MESSAGE: &str =
+    "harness.auth: no principal bound to this dispatch — the host did not authenticate the request";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn principal(subject: &str, scopes: &[&str]) -> AuthPrincipal {
+        AuthPrincipal {
+            subject: subject.to_string(),
+            scheme: "apikey".to_string(),
+            scopes: scopes.iter().map(|s| s.to_string()).collect(),
+            kind: Some("operator".to_string()),
+        }
+    }
+
+    #[test]
+    fn current_returns_none_when_nothing_pushed() {
+        assert!(current_auth_principal().is_none());
+    }
+
+    #[test]
+    fn guard_pops_on_drop_and_inner_scope_shadows_outer() {
+        let outer = enter_auth_principal(principal("outer", &["read:a"]));
+        assert_eq!(
+            current_auth_principal().map(|p| p.subject.clone()),
+            Some("outer".to_string())
+        );
+        {
+            let _inner = enter_auth_principal(principal("inner", &["read:b"]));
+            assert_eq!(
+                current_auth_principal().map(|p| p.subject.clone()),
+                Some("inner".to_string())
+            );
+        }
+        assert_eq!(
+            current_auth_principal().map(|p| p.subject.clone()),
+            Some("outer".to_string())
+        );
+        drop(outer);
+        assert!(current_auth_principal().is_none());
+    }
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -32,6 +32,7 @@ pub mod events;
 pub mod external_agent;
 pub mod flow;
 pub mod harness;
+pub mod harness_auth;
 pub(crate) mod harness_crypto;
 pub mod harness_net;
 pub mod harness_system;
@@ -166,6 +167,10 @@ pub use harness::{
     DenyEvent, Harness, HarnessCall, HarnessClock, HarnessCrypto, HarnessEnv, HarnessFs,
     HarnessKind, HarnessLlm, HarnessNet, HarnessObs, HarnessProcess, HarnessRandom, HarnessStdio,
     HarnessSystem, HarnessTenant, HarnessTerm, MockAwareClock, MockHarnessBuilder, VmHarness,
+};
+pub use harness_auth::{
+    current_auth_principal, enter_auth_principal, AuthPrincipal, AuthPrincipalScopeGuard,
+    MISSING_PRINCIPAL_MESSAGE,
 };
 pub use harness_net::{
     bypass_enabled as net_policy_bypass_enabled, NetMatcher, NetPolicy, NetPolicyAudit,

--- a/crates/harn-vm/src/vm/methods/harness.rs
+++ b/crates/harn-vm/src/vm/methods/harness.rs
@@ -93,6 +93,7 @@ impl crate::vm::Vm {
             HarnessKind::Crypto => self.call_harness_crypto_method(handle, method, args),
             HarnessKind::Llm => self.call_harness_llm_method(handle, method, args).await,
             HarnessKind::Tenant => self.call_harness_tenant_method(handle, method, args),
+            HarnessKind::Auth => self.call_harness_auth_method(handle, method, args),
             HarnessKind::Obs => self.call_harness_obs_method(handle, method, args).await,
         }
     }
@@ -124,6 +125,7 @@ impl crate::vm::Vm {
             HarnessKind::Random => Self::call_harness_random_method_sync_fast(method, args),
             HarnessKind::Crypto => Self::call_harness_crypto_method_sync_fast(method, args),
             HarnessKind::Tenant => Self::call_harness_tenant_method_sync_fast(method, args),
+            HarnessKind::Auth => Self::call_harness_auth_method_sync_fast(method, args),
             HarnessKind::Root
             | HarnessKind::Fs
             | HarnessKind::Net
@@ -494,6 +496,7 @@ impl crate::vm::Vm {
                 Some(Ok(crate::stdlib::json_to_vm_value(&json)))
             }
             HarnessKind::Tenant => Self::call_harness_tenant_method_sync_fast(method, args),
+            HarnessKind::Auth => Self::call_harness_auth_method_sync_fast(method, args),
             HarnessKind::Root
             | HarnessKind::Fs
             | HarnessKind::Net
@@ -711,6 +714,104 @@ impl crate::vm::Vm {
     ) -> Result<VmValue, VmError> {
         Self::call_harness_tenant_method_sync_fast(method, args)
             .unwrap_or_else(|| Err(method_unsupported(handle, method)))
+    }
+
+    fn call_harness_auth_method(
+        &mut self,
+        handle: &VmHarness,
+        method: &str,
+        args: &[VmValue],
+    ) -> Result<VmValue, VmError> {
+        Self::call_harness_auth_method_sync_fast(method, args)
+            .unwrap_or_else(|| Err(method_unsupported(handle, method)))
+    }
+
+    /// Read-only getters over the ambient authenticated principal (see
+    /// [`crate::harness_auth`]). Pure thread-local reads — no host state —
+    /// so the whole surface rides the sync-fast path. `subject`/`scheme`
+    /// raise a typed [`ErrorCategory::Auth`] error when no principal is
+    /// bound (mirroring `harness.tenant.id()`); the `try_*` and `kind`
+    /// getters return `nil`, and `scopes`/`has_scope`/`is_authenticated`
+    /// degrade to empty/false so an unauthenticated route can branch
+    /// without try/catch.
+    fn call_harness_auth_method_sync_fast(
+        method: &str,
+        args: &[VmValue],
+    ) -> Option<Result<VmValue, VmError>> {
+        use crate::harness_auth::{current_auth_principal, MISSING_PRINCIPAL_MESSAGE};
+
+        // `has_scope` is the one arity-1 method; everything else is nullary.
+        if method == "has_scope" {
+            let scope = match args {
+                [VmValue::String(scope)] => scope.to_string(),
+                [other] => {
+                    return Some(Err(VmError::TypeError(format!(
+                        "HarnessAuth.has_scope expects a string scope, got {}",
+                        other.type_name()
+                    ))));
+                }
+                _ => {
+                    return Some(Err(VmError::TypeError(
+                        "HarnessAuth.has_scope expects exactly one string argument".to_string(),
+                    )));
+                }
+            };
+            let granted = current_auth_principal()
+                .map(|principal| principal.scopes.contains(&scope))
+                .unwrap_or(false);
+            return Some(Ok(VmValue::Bool(granted)));
+        }
+
+        if !args.is_empty() {
+            return Some(Err(VmError::TypeError(format!(
+                "HarnessAuth.{method} takes no arguments"
+            ))));
+        }
+        let principal = current_auth_principal();
+        let auth_error = || VmError::CategorizedError {
+            message: MISSING_PRINCIPAL_MESSAGE.to_string(),
+            category: ErrorCategory::Auth,
+        };
+        match method {
+            "is_authenticated" => Some(Ok(VmValue::Bool(principal.is_some()))),
+            "scopes" => {
+                let scopes = principal
+                    .map(|principal| {
+                        principal
+                            .scopes
+                            .iter()
+                            .map(|scope| vm_string(scope.clone()))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                Some(Ok(VmValue::List(std::sync::Arc::new(scopes))))
+            }
+            "subject" => Some(match principal {
+                Some(principal) if !principal.subject.is_empty() => {
+                    Ok(vm_string(principal.subject.clone()))
+                }
+                _ => Err(auth_error()),
+            }),
+            "try_subject" => Some(Ok(principal
+                .filter(|principal| !principal.subject.is_empty())
+                .map(|principal| vm_string(principal.subject.clone()))
+                .unwrap_or(VmValue::Nil))),
+            "scheme" => Some(match principal {
+                Some(principal) if !principal.scheme.is_empty() => {
+                    Ok(vm_string(principal.scheme.clone()))
+                }
+                _ => Err(auth_error()),
+            }),
+            "try_scheme" => Some(Ok(principal
+                .filter(|principal| !principal.scheme.is_empty())
+                .map(|principal| vm_string(principal.scheme.clone()))
+                .unwrap_or(VmValue::Nil))),
+            "kind" => Some(Ok(principal
+                .and_then(|principal| principal.kind.clone())
+                .map(vm_string)
+                .unwrap_or(VmValue::Nil))),
+            _ => None,
+        }
     }
 
     async fn call_harness_obs_method(
@@ -1094,7 +1195,8 @@ impl crate::vm::Vm {
             | HarnessKind::Random
             | HarnessKind::Crypto
             | HarnessKind::System
-            | HarnessKind::Tenant => Err(method_unsupported(handle, method)),
+            | HarnessKind::Tenant
+            | HarnessKind::Auth => Err(method_unsupported(handle, method)),
             HarnessKind::Fs => match method {
                 "read_file" | "read" => {
                     let path = string_arg(args, 0, "HarnessFs.read_file")?;

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -521,6 +521,17 @@ impl super::super::Vm {
             ),
             crate::harness::HarnessKind::Crypto => matches!(method, "sha256"),
             crate::harness::HarnessKind::Tenant => matches!(method, "id" | "try_id"),
+            crate::harness::HarnessKind::Auth => matches!(
+                method,
+                "is_authenticated"
+                    | "subject"
+                    | "try_subject"
+                    | "scheme"
+                    | "try_scheme"
+                    | "kind"
+                    | "scopes"
+                    | "has_scope"
+            ),
             crate::harness::HarnessKind::Root
             | crate::harness::HarnessKind::Fs
             | crate::harness::HarnessKind::Net

--- a/crates/harn-vm/thread_local_audit.toml
+++ b/crates/harn-vm/thread_local_audit.toml
@@ -75,6 +75,12 @@ category = "runtime_registry"
 plan = "arc_registry_scope"
 
 [[thread_local]]
+path = "src/harness_auth.rs"
+statics = ["ACTIVE_PRINCIPAL_STACK"]
+category = "logical_task"
+plan = "task_local_or_explicit"
+
+[[thread_local]]
 path = "src/harness_tenant.rs"
 statics = ["ACTIVE_TENANT_STACK"]
 category = "logical_task"


### PR DESCRIPTION
## What

Adds **`harness.auth`** — a read-only authenticated-principal handle for `.harn` routes — the foundation for Harn-side route auth policies (#3323).

A `harn-serve` dispatch already authenticates a principal at admission but only surfaces the *opaque embedder context* (to the host-call bridge) and the *tenant* (`harness.tenant`). This threads the **generic identity** — subject, scheme, granted scopes, and an optional embedder-assigned principal `kind` — to the `.harn` callee as the ambient `harness.auth` sub-handle, mirroring `harness.tenant`. A route can now read identity and compose its own authorization (required scopes, allowed principal kinds, resource/tenant match) instead of relying on a duplicated host-side dispatch guard.

## Surface (read-only)

| method | returns | notes |
|---|---|---|
| `is_authenticated()` | `Bool` | a principal was bound |
| `subject()` / `try_subject()` | `String` / `String?` | `subject()` raises `Auth` when unbound (mirrors `tenant.id()`) |
| `scheme()` / `try_scheme()` | `String` / `String?` | credential scheme (`apikey`/`oauth`/…) |
| `kind()` | `String?` | embedder-assigned classification (`operator`/`tenant`/…) |
| `scopes()` | `[String]` | granted set (empty when unbound) |
| `has_scope(scope)` | `Bool` | membership test |

## Design

- **Identity-only / secure-by-construction.** No credentials or secrets cross the boundary; the tenant stays the single-sourced `harness.tenant` ambient (no duplication); the opaque embedder auth context stays the host-call-bridge channel (`current_auth_context`). Constant-heavy / product concepts never enter the language core — `kind` is an opaque generic string harn-serve never interprets.
- **Anonymous binds nothing.** The synthetic allow-all principal (`subject:"anonymous", scheme:"none"`) is treated as unauthenticated — `is_authenticated()` is `false` when no credential authenticated the request. Encapsulated as `AuthenticatedPrincipal::is_anonymous()` over named `ANONYMOUS_SUBJECT`/`ANONYMOUS_SCHEME` sentinels (replacing three inline literals).
- **Mechanics.** New `harn_vm::harness_auth` ambient (RAII stack, mirrors `harness_tenant`) + a `HarnessKind::Auth` handle on the sync-fast dispatch path. `harn-serve` installs it from `CallRequest::auth_principal` in `invoke_function`/`invoke_pipeline`, populated by the site adapter (`SiteAuthContext` gains optional `subject`/`scheme`/`kind`) and the AuthPolicy dispatch path.

## Why

Unblocks harn-cloud (#823) replacing duplicated Rust dispatch guards on admin/operator/attach routes with declarative `.harn`-side policy. This PR is the read-identity foundation; the policy-composition helper + route-export policy metadata are follow-ups.

## Tests

- `harness_auth` ambient unit tests (stack push/pop/shadow).
- VM tests: bound principal (subject/scheme/kind/scopes/has_scope) and anonymous degradation; `subject()` raises when unbound.
- `null_harness_records_deny_events_for_every_sub_handle` extended to cover `auth`.
- `site_auth` integration: a `.harn` route reads the hook-resolved identity end-to-end; reports anonymous without a hook.
- `harn check` accepts all new methods (static type gate).

Full local validation: harn-vm 3749 ✓, harn-parser 480 ✓, harn-serve lib 448 ✓, all `site_*` suites ✓, `cargo fmt --check` ✓, `cargo clippy` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)