### PR TITLE
feat(serve): declarative @policy(kinds:) route auth policy (#3323)

### DIFF
--- a/changelog.d/3323-policy-annotation.added.md
+++ b/changelog.d/3323-policy-annotation.added.md
@@ -1,0 +1,19 @@
+- **`@policy(kinds: "...")` — a declarative route auth policy for
+  `harn serve site`.** A routed `pub fn` can now declare the principal
+  kinds permitted to invoke it, composing with `@scopes` rather than
+  replacing it: `@policy(kinds: "operator platform_admin")` admits a
+  request only when the embedder-resolved principal `kind` (see
+  `harness.auth.kind()`) is in the allow-set. Enforcement runs at site
+  admission immediately after the scope check and **fails closed** — a
+  principal the embedder did not classify can never satisfy a non-empty
+  allow-set. Denials render the tenant-safe `forbidden_principal_kind`
+  403 envelope, which names the route's allowed kinds (route
+  configuration) but never echoes the caller's own kind. The parsed policy
+  is carried on the route's export entry (`ExportedFunction.policy`) so
+  audit tooling can see which routes declare a principal-kind guard. A
+  malformed argument (unknown key, positional, or non-string value) is
+  dropped with a `HARN-SRV-017` diagnostic and a typechecker warning,
+  leaving any host-side defense-in-depth check in place. Together with the
+  `harness.auth` handle this is the declarative half of the Harn-side route
+  auth policy (issue #3323); the imperative `require_policy(...)` helper for
+  method-specific / resource-match cases is a follow-up.

--- a/crates/harn-parser/src/typechecker/inference/statements/attributes.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements/attributes.rs
@@ -33,7 +33,7 @@ impl TypeChecker {
                 "deprecated" | "test" | "complexity" | "acp_tool" | "acp_skill" | "invariant"
                 | "deterministic" | "semantic" | "archivist" | "retroactive" | "persona"
                 | "step" | "trigger" | "handoff" | "budget" | "command" | "serial" | "heavy"
-                | "scopes" | "route" | "job" | "schedule" | "queue" | "retry" => {}
+                | "scopes" | "policy" | "route" | "job" | "schedule" | "queue" | "retry" => {}
                 other => {
                     self.warning_at(
                         Code::UnknownAttribute,
@@ -224,6 +224,7 @@ impl TypeChecker {
             "serial" => self.validate_serial_args(attr),
             "heavy" => self.validate_heavy_args(attr),
             "scopes" => self.validate_scopes_args(attr),
+            "policy" => self.validate_policy_args(attr),
             "job" => self.validate_job_args(attr),
             "schedule" => self.validate_schedule_args(attr),
             "queue" => self.validate_queue_args(attr),
@@ -236,6 +237,53 @@ impl TypeChecker {
                 );
             }
             _ => {}
+        }
+    }
+
+    /// `@policy(kinds: "operator team_admin")` — a declarative route auth
+    /// policy that composes with `@scopes`. Today the only key is `kinds`:
+    /// a whitespace-separated list of allowed principal kinds the dispatch
+    /// must match (see `harness.auth.kind()`). Empty or non-string values
+    /// warn; the route still mounts (the host keeps any defense-in-depth
+    /// check) but the declared guard is ignored for the bad argument.
+    pub(super) fn validate_policy_args(&mut self, attr: &Attribute) {
+        const KNOWN_KEYS: &[&str] = &["kinds"];
+        if attr.args.is_empty() {
+            self.warning_at(
+                Code::InvalidAttributeArgument,
+                "`@policy(...)` requires at least one argument, e.g. `@policy(kinds: \"operator\")`"
+                    .to_string(),
+                attr.span,
+            );
+            return;
+        }
+        for arg in &attr.args {
+            let Some(name) = self.require_named_arg("@policy", arg) else {
+                continue;
+            };
+            if !KNOWN_KEYS.contains(&name) {
+                self.warning_at(
+                    Code::InvalidAttributeArgument,
+                    format!("unknown `@policy` argument `{name}`; expected one of {KNOWN_KEYS:?}"),
+                    arg.span,
+                );
+                continue;
+            }
+            let Some(value) = symbol_like_value(&arg.value.node) else {
+                self.warning_at(
+                    Code::InvalidAttributeArgument,
+                    format!("`@policy({name}: ...)` must be a string literal"),
+                    arg.span,
+                );
+                continue;
+            };
+            if value.split_whitespace().next().is_none() {
+                self.warning_at(
+                    Code::InvalidAttributeArgument,
+                    format!("`@policy({name}: ...)` cannot be empty"),
+                    arg.span,
+                );
+            }
         }
     }
 

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -580,6 +580,55 @@ pipeline review_branch(task) {}
 }
 
 #[test]
+fn test_policy_attribute_is_recognized_and_validates_args() {
+    // A well-formed `@policy(kinds: ...)` is recognized (no unknown-attr
+    // warning) and clean.
+    let clean = warnings(
+        r#"
+@policy(kinds: "operator platform_admin")
+@route("POST", "/admin/x")
+fn admin_x(req) { return req }
+"#,
+    );
+    assert!(
+        clean
+            .iter()
+            .all(|w| !w.contains("unknown attribute") && !w.contains("@policy")),
+        "well-formed @policy should not warn: {clean:?}"
+    );
+
+    // An unknown key warns but the attribute is still recognized.
+    let bad_key = warnings(
+        r#"
+@policy(roles: "operator")
+@route("POST", "/admin/x")
+fn admin_x(req) { return req }
+"#,
+    );
+    assert!(
+        bad_key
+            .iter()
+            .any(|w| w.contains("unknown `@policy` argument `roles`")),
+        "expected unknown-arg warning, got {bad_key:?}"
+    );
+
+    // A non-string value warns.
+    let bad_value = warnings(
+        r#"
+@policy(kinds: 42)
+@route("POST", "/admin/x")
+fn admin_x(req) { return req }
+"#,
+    );
+    assert!(
+        bad_value
+            .iter()
+            .any(|w| w.contains("`@policy(kinds: ...)` must be a string literal")),
+        "expected non-string warning, got {bad_value:?}"
+    );
+}
+
+#[test]
 fn test_command_attribute_warns_on_function_decls() {
     let warns = warnings(
         r#"

--- a/crates/harn-serve/src/adapters/mcp.rs
+++ b/crates/harn-serve/src/adapters/mcp.rs
@@ -752,6 +752,13 @@ impl McpServer {
             Err(DispatchError::Forbidden { required, granted }) => {
                 forbidden_jsonrpc_error_response(job.request_id, &required, &granted)
             }
+            // `@policy(kinds:)` is a `harn serve site` admission gate; the
+            // MCP transport never raises it, but map it to the same
+            // authorization error code defensively, using its tenant-safe
+            // message.
+            Err(error @ DispatchError::ForbiddenPrincipalKind { .. }) => {
+                harn_vm::jsonrpc::error_response(job.request_id, -32001, &error.message())
+            }
             Err(DispatchError::MissingExport(message)) => {
                 harn_vm::jsonrpc::error_response(job.request_id, -32602, &message)
             }

--- a/crates/harn-serve/src/adapters/site.rs
+++ b/crates/harn-serve/src/adapters/site.rs
@@ -509,6 +509,12 @@ struct SiteRoute {
     /// HTTP method. Unioned onto `required_scopes` for the matching method;
     /// empty for the common uniform route. See [`SiteRoute::scopes_for`].
     method_scopes: BTreeMap<String, BTreeSet<String>>,
+    /// `@policy(...)` allowed principal kinds declared on the function.
+    /// When non-empty, admission additionally requires the hook-resolved
+    /// principal's `kind` to be in this set (checked after `@scopes`).
+    /// Empty for routes without a `@policy(kinds:)` guard. See
+    /// [`crate::exports::RoutePolicy`].
+    allowed_kinds: BTreeSet<String>,
     /// `@stream` marker: after admission, hand the request head to the
     /// [`SiteStreamProvider`] instead of dispatching into the VM. The
     /// request body is never read.
@@ -618,6 +624,11 @@ fn build_site_router(
             spec: spec.clone(),
             required_scopes: function.required_scopes.clone(),
             method_scopes: function.method_scopes.clone(),
+            allowed_kinds: function
+                .policy
+                .as_ref()
+                .map(|policy| policy.allowed_kinds.clone())
+                .unwrap_or_default(),
             stream: function.stream,
             raw: function.raw,
             ws: function.ws,
@@ -742,6 +753,26 @@ async fn site_dispatch(State(state): State<SiteState>, request: Request) -> Resp
                         DispatchError::Forbidden {
                             required: required_scopes.into_owned(),
                             granted: context.scopes,
+                        },
+                        &request_id,
+                    );
+                }
+                // `@policy(kinds: ...)` composes with `@scopes`: once the
+                // scope floor is met, a route that declares allowed
+                // principal kinds additionally requires the hook-resolved
+                // principal's `kind` to be one of them. A request whose
+                // principal carries no kind (the embedder did not classify
+                // it) can never satisfy a non-empty allow-set, so it is
+                // refused — fail-closed on the principal-class gate.
+                if !route.allowed_kinds.is_empty()
+                    && !context
+                        .kind
+                        .as_deref()
+                        .is_some_and(|kind| route.allowed_kinds.contains(kind))
+                {
+                    return axum_response_from_dispatch_error(
+                        DispatchError::ForbiddenPrincipalKind {
+                            allowed: route.allowed_kinds.clone(),
                         },
                         &request_id,
                     );

--- a/crates/harn-serve/src/error.rs
+++ b/crates/harn-serve/src/error.rs
@@ -14,6 +14,14 @@ pub enum DispatchError {
         required: BTreeSet<String>,
         granted: BTreeSet<String>,
     },
+    /// The caller authenticated and carries the required scopes, but their
+    /// principal `kind` is not in the route's `@policy(kinds: ...)`
+    /// allow-set. Adapters render this as HTTP 403. The body reports the
+    /// route's `allowed_kinds` (route configuration, not tenant data) but
+    /// never echoes the caller's own kind, keeping the denial tenant-safe.
+    ForbiddenPrincipalKind {
+        allowed: BTreeSet<String>,
+    },
     /// One of the route's declared rate-limit buckets (per-route /
     /// per-tenant / per-scope) or the backpressure watermark rejected
     /// this dispatch. Adapters render this as HTTP 429 with a
@@ -54,6 +62,7 @@ impl DispatchError {
             | Self::Io(message)
             | Self::Cache(message) => message.clone(),
             Self::Forbidden { required, granted } => forbidden_message(required, granted),
+            Self::ForbiddenPrincipalKind { allowed } => forbidden_principal_kind_message(allowed),
             Self::RateLimited {
                 scope,
                 retry_after_ms,
@@ -75,6 +84,22 @@ pub fn forbidden_message(required: &BTreeSet<String>, granted: &BTreeSet<String>
         "missing required scope".to_string()
     } else {
         format!("missing required scope(s): {}", missing.join(", "))
+    }
+}
+
+/// Render a stable, tenant-safe diagnostic for a `@policy(kinds: ...)`
+/// principal-kind denial. Names the route's allowed kinds (route config)
+/// but never the caller's own kind, so the text is safe to surface in
+/// logs, receipts, and the HTTP body without leaking identity detail.
+pub fn forbidden_principal_kind_message(allowed: &BTreeSet<String>) -> String {
+    if allowed.is_empty() {
+        "principal kind not permitted for this route".to_string()
+    } else {
+        let allowed: Vec<&str> = allowed.iter().map(String::as_str).collect();
+        format!(
+            "principal kind not permitted for this route; allowed: {}",
+            allowed.join(", ")
+        )
     }
 }
 

--- a/crates/harn-serve/src/exports.rs
+++ b/crates/harn-serve/src/exports.rs
@@ -22,6 +22,31 @@ pub enum ExportedCallableKind {
     Pipeline,
 }
 
+/// Declarative route auth policy declared via `@policy(...)`, composing
+/// with the `@scopes` requirement rather than replacing it. Today it
+/// carries the set of allowed principal kinds (matched against
+/// `harness.auth.kind()` at admission); a route with a non-empty
+/// `allowed_kinds` admits only a principal whose kind is in the set.
+/// Surfaced in the export catalog so audit tooling can see which routes
+/// declare a principal-kind guard, and enforced by the `harn serve site`
+/// admission layer after the scope check. The host keeps any
+/// defense-in-depth Rust check during migration (the issue's
+/// non-replacement rule).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RoutePolicy {
+    /// Principal kinds permitted to invoke the route (e.g. `"operator"`,
+    /// `"tenant"`). Empty means the policy imposes no kind restriction.
+    pub allowed_kinds: BTreeSet<String>,
+}
+
+impl RoutePolicy {
+    /// Whether the policy imposes no restriction at all — used to collapse
+    /// a `@policy` that parsed to nothing effective back to `None`.
+    pub fn is_empty(&self) -> bool {
+        self.allowed_kinds.is_empty()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ExportedFunction {
     pub name: String,
@@ -51,6 +76,13 @@ pub struct ExportedFunction {
     /// surface and use `required_scopes` alone. Empty for the common
     /// uniform case, keeping the per-method path zero-cost.
     pub method_scopes: BTreeMap<String, BTreeSet<String>>,
+    /// Declarative auth policy declared via `@policy(...)` — today, the set
+    /// of allowed principal kinds the dispatch must match, composing with
+    /// `required_scopes`. `None` when no `@policy` is present (or it parsed
+    /// to nothing effective). Consulted by the `harn serve site` admission
+    /// layer (after the scope check) and exposed for audit. See
+    /// [`RoutePolicy`].
+    pub policy: Option<RoutePolicy>,
     /// Rate / backpressure ceilings declared via `@limits(...)`. `None`
     /// when the route is unbounded — the dispatch path short-circuits
     /// cheaply when both `limits` and `budget` are absent.
@@ -272,6 +304,12 @@ pub const WS_WITHOUT_ROUTE: &str = "HARN-SRV-015";
 /// (`@ws` + `@stream` is *not* a conflict — it is the combined route that
 /// upgrades a genuine handshake and falls through to the stream otherwise.)
 pub const WS_CONFLICTS_WITH_STREAM_OR_RAW: &str = "HARN-SRV-016";
+/// `@policy(...)` carries an argument that is not the supported
+/// `kinds: "..."` string form (an unknown key, a positional argument, or a
+/// non-string value). The offending argument is dropped, leaving the
+/// route's principal-kind guard incomplete; any host-side defense-in-depth
+/// check still applies.
+pub const POLICY_BAD_ARGS: &str = "HARN-SRV-017";
 
 impl std::fmt::Display for ExportDiagnostic {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -331,6 +369,7 @@ impl ExportCatalog {
             }
 
             let scopes = scopes_from_attributes(attrs, name, &mut diagnostics);
+            let policy = policy_from_attributes(attrs, name, &mut diagnostics);
             let (limits, budget) = limits_and_budget_from_attributes(attrs);
             let route = route_from_attributes(attrs, name, &mut diagnostics);
             let stream = stream_from_attributes(attrs, name, route.as_ref(), &mut diagnostics);
@@ -349,6 +388,7 @@ impl ExportCatalog {
                         .and_then(harn_vm::json_schema_for_type_expr),
                     required_scopes: scopes.baseline,
                     method_scopes: scopes.per_method,
+                    policy,
                     limits,
                     budget,
                     route,
@@ -377,6 +417,7 @@ impl ExportCatalog {
                 continue;
             }
             let scopes = scopes_from_attributes(attrs, name, &mut diagnostics);
+            let policy = policy_from_attributes(attrs, name, &mut diagnostics);
             let (limits, budget) = limits_and_budget_from_attributes(attrs);
             // Pipelines never carry a route, so a `@stream` / `@raw` on
             // one is inert — diagnose it the same way as on an unrouted fn.
@@ -396,6 +437,7 @@ impl ExportCatalog {
                         .and_then(harn_vm::json_schema_for_type_expr),
                     required_scopes: scopes.baseline,
                     method_scopes: scopes.per_method,
+                    policy,
                     limits,
                     budget,
                     // Pipelines are dispatch-only; they never carry an
@@ -540,6 +582,49 @@ fn scopes_from_attributes(
         }
     }
     parsed
+}
+
+/// Parse `@policy(...)` declarations into a [`RoutePolicy`].
+///
+/// Today the only supported argument is `kinds: "operator team_admin"` — a
+/// whitespace-separated string of allowed principal kinds, unioned across
+/// repeated `@policy` attributes and repeated `kinds:` arguments. Any other
+/// argument shape (unknown key, positional, or non-string value) is dropped
+/// with a [`POLICY_BAD_ARGS`] diagnostic, leaving the route's principal-kind
+/// guard incomplete — mirroring how a dropped `@scopes` literal leaves the
+/// route less restricted. Returns `None` when no `@policy` is present, or
+/// when every declaration parsed to nothing effective (so the catalog's
+/// `policy` field means "has an effective policy").
+fn policy_from_attributes(
+    attrs: &[Attribute],
+    fn_name: &str,
+    diagnostics: &mut Vec<ExportDiagnostic>,
+) -> Option<RoutePolicy> {
+    let mut policy = RoutePolicy::default();
+    for attr in attrs {
+        if attr.name != "policy" {
+            continue;
+        }
+        for arg in &attr.args {
+            match (arg.name.as_deref(), &arg.value.node) {
+                (Some("kinds"), Node::StringLiteral(value) | Node::RawStringLiteral(value)) => {
+                    for kind in value.split_whitespace() {
+                        policy.allowed_kinds.insert(kind.to_string());
+                    }
+                }
+                _ => diagnostics.push(ExportDiagnostic {
+                    code: POLICY_BAD_ARGS,
+                    line: arg.span.line,
+                    message: format!(
+                        "`@policy` on `{fn_name}` accepts only `kinds: \"...\"` (a whitespace-separated \
+                         string of allowed principal kinds); dropping an unrecognized argument leaves \
+                         the route's principal-kind guard incomplete"
+                    ),
+                }),
+            }
+        }
+    }
+    (!policy.is_empty()).then_some(policy)
 }
 
 /// Split a `@scopes` literal into an optional `(METHOD, scope)` pair.
@@ -1560,6 +1645,72 @@ pub fn list_sessions() -> string { return "ok" }
             .find(|d| d.code == SCOPES_ARG_NOT_STRING)
             .expect("scopes diagnostic");
         assert!(diagnostic.message.contains("list_sessions"));
+    }
+
+    #[test]
+    fn policy_attribute_parses_allowed_kinds() {
+        let catalog = catalog_from_source(
+            r#"
+@scopes("admin:dlq:write")
+@policy(kinds: "operator platform_admin")
+@route("POST", "/admin/dlq/replay")
+pub fn replay_dlq(req: dict) -> dict { return req }
+"#,
+        );
+        assert!(
+            catalog.diagnostics().is_empty(),
+            "unexpected diagnostics: {:?}",
+            catalog.diagnostics()
+        );
+        let policy = catalog
+            .function("replay_dlq")
+            .expect("replay_dlq")
+            .policy
+            .as_ref()
+            .expect("policy present");
+        assert_eq!(
+            policy.allowed_kinds,
+            BTreeSet::from(["operator".to_string(), "platform_admin".to_string()])
+        );
+    }
+
+    #[test]
+    fn policy_without_attribute_leaves_policy_none() {
+        let catalog = catalog_from_source(
+            r#"
+@route("GET", "/open")
+pub fn open_route(req: dict) -> dict { return req }
+"#,
+        );
+        assert!(catalog
+            .function("open_route")
+            .expect("open_route")
+            .policy
+            .is_none());
+    }
+
+    #[test]
+    fn policy_with_unknown_arg_is_diagnosed_and_dropped() {
+        let catalog = catalog_from_source(
+            r#"
+@policy(roles: "operator")
+@route("POST", "/x")
+pub fn guarded(req: dict) -> dict { return req }
+"#,
+        );
+        // The unrecognized `roles:` key is dropped, leaving no effective
+        // policy — and a loud diagnostic is emitted.
+        assert!(catalog
+            .function("guarded")
+            .expect("guarded")
+            .policy
+            .is_none());
+        let diagnostic = catalog
+            .diagnostics()
+            .iter()
+            .find(|d| d.code == POLICY_BAD_ARGS)
+            .expect("policy diagnostic");
+        assert!(diagnostic.message.contains("guarded"));
     }
 
     #[test]

--- a/crates/harn-serve/src/http_codec.rs
+++ b/crates/harn-serve/src/http_codec.rs
@@ -514,6 +514,14 @@ pub fn dispatch_error_payload(error: DispatchError, request_id: &str) -> (Status
             let message = crate::error::forbidden_message(&required, &granted);
             (StatusCode::FORBIDDEN, "forbidden", message, payload)
         }
+        DispatchError::ForbiddenPrincipalKind { allowed } => {
+            let message = crate::error::forbidden_principal_kind_message(&allowed);
+            let details = json!({
+                "kind": "forbidden_principal_kind",
+                "allowed_kinds": allowed.iter().collect::<Vec<_>>(),
+            });
+            (StatusCode::FORBIDDEN, "forbidden", message, details)
+        }
         DispatchError::RateLimited {
             scope,
             retry_after_ms,

--- a/crates/harn-serve/tests/site_auth.rs
+++ b/crates/harn-serve/tests/site_auth.rs
@@ -66,6 +66,13 @@ pub fn whoami_route(harness: Harness, req: dict) -> dict {
     "scopes": harness.auth.scopes(),
   })
 }
+
+@scopes("personas:read")
+@policy(kinds: "operator")
+@route("POST", "/operator/action")
+pub fn operator_action(req: dict) -> dict {
+  return http_ok({ "ok": true })
+}
 "#;
 
 /// `SiteAuth` hook that always admits with a fixed identity.
@@ -505,4 +512,59 @@ pub fn whoami_route(harness: Harness, req: dict) -> dict {
     assert_eq!(body["authed"], false);
     assert_eq!(body["subject"], Value::Null);
     assert_eq!(body["scopes"].as_array().expect("scopes array").len(), 0);
+}
+
+/// `@policy(kinds: "operator")` composes with `@scopes`: a principal that
+/// carries the scope *and* the allowed kind is admitted.
+#[tokio::test]
+async fn policy_kinds_admits_matching_principal_kind() {
+    let hook = Arc::new(AllowAuth {
+        scopes: &["personas:read"],
+        kind: Some("operator"),
+        ..Default::default()
+    });
+    let (_dir, router) = site_router(Some(hook), None);
+    let (status, body) = read_json(request(router, "POST", "/operator/action").await).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["ok"], true);
+}
+
+/// A principal with the required scope but a *disallowed* kind is refused
+/// at admission with a tenant-safe `forbidden_principal_kind` envelope
+/// that names the allowed kinds but never the caller's own kind.
+#[tokio::test]
+async fn policy_kinds_denies_wrong_principal_kind() {
+    let hook = Arc::new(AllowAuth {
+        scopes: &["personas:read"],
+        kind: Some("tenant"),
+        ..Default::default()
+    });
+    let (_dir, router) = site_router(Some(hook), None);
+    let (status, body) = read_json(request(router, "POST", "/operator/action").await).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(body["code"], "forbidden");
+    assert_eq!(body["details"]["kind"], "forbidden_principal_kind");
+    assert_eq!(body["details"]["allowed_kinds"][0], "operator");
+    // Tenant-safe: the denial never echoes the caller's own kind.
+    let rendered = body.to_string();
+    assert!(
+        !rendered.contains("tenant"),
+        "denial leaked caller kind: {rendered}"
+    );
+    assert!(body["request_id"].as_str().is_some());
+}
+
+/// A principal the embedder did not classify (no `kind`) can never satisfy
+/// a non-empty `@policy(kinds:)` allow-set — the gate fails closed.
+#[tokio::test]
+async fn policy_kinds_denies_unclassified_principal() {
+    let hook = Arc::new(AllowAuth {
+        scopes: &["personas:read"],
+        // no `kind` set
+        ..Default::default()
+    });
+    let (_dir, router) = site_router(Some(hook), None);
+    let (status, body) = read_json(request(router, "POST", "/operator/action").await).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(body["details"]["kind"], "forbidden_principal_kind");
 }


### PR DESCRIPTION
## What

Adds a declarative **`@policy(kinds: "operator platform_admin")`** route attribute for `harn serve site` that gates admission on the embedder-resolved principal **kind**, composing with `@scopes` (not replacing it). This is the declarative half of the Harn-side route auth policy (#3323), built on the `harness.auth` principal handle.

> **Stacked on #3369** (`harness.auth`). Base will retarget to `main` once #3369 merges; review the [slice-2 commit](../commits/feat/harness-policy-annotation) for this PR's diff only.

## How it composes

```harn
@scopes("admin:dlq:write")          # caller must carry this scope …
@policy(kinds: "operator")          # … AND be an operator-kind principal
@route("POST", "/admin/dlq/replay")
pub fn replay_dlq(req) { ... }
```

Once the scope floor is met, a route with a non-empty allow-set additionally requires the principal's `kind` (`harness.auth.kind()`) to be in the set.

## Design

- **Parser** — `@policy` joins the known-attribute allowlist; `validate_policy_args` warns on unknown keys / non-string values at the typechecker layer. `harn check` accepts it.
- **Exports** — `policy_from_attributes` → `ExportedFunction.policy: Option<RoutePolicy>` (`allowed_kinds`), surfaced in the export catalog so audit tooling sees which routes declare a principal-kind guard. Malformed args drop with a `HARN-SRV-017` diagnostic (mirroring how a dropped `@scopes` literal is diagnosed) — the route still mounts and any host-side defense-in-depth check stays.
- **Admission** — enforced at the site adapter immediately after the scope check, and **fails closed**: a principal the embedder did not classify (no `kind`) can never satisfy a non-empty allow-set.
- **Denial** — new `DispatchError::ForbiddenPrincipalKind` → `403` `forbidden_principal_kind` envelope. **Tenant-safe**: it names the route's `allowed_kinds` (route configuration) but never echoes the caller's own kind.

## Why

Unblocks harn-cloud #823 migrating admin/operator routes off duplicated Rust dispatch guards onto a declarative, audited Harn-side policy. The imperative `require_policy(...)` helper (for method-specific / resource-match-against-body cases the annotation can't express) is the follow-up slice.

## Tests

- exports parsing: kinds parsed / absent → `None` / unknown-arg diagnosed + dropped.
- parser: `@policy` recognized (no unknown-attr warning); unknown key + non-string value warn.
- `site_auth` integration: admits a matching kind, denies a wrong kind with the tenant-safe envelope (asserts the caller's kind does not leak), denies an unclassified principal.
- `harn check` accepts `@policy`.

Full local validation: harn-parser 481 ✓, harn-serve lib 451 ✓ + all integration suites ✓, `cargo fmt --check` ✓, `cargo clippy` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)