### PR TITLE
fix(code_index): read_range reads raw path when the primary index is unbuilt

### DIFF
--- a/changelog.d/read-range-unbuilt-index.fixed.md
+++ b/changelog.d/read-range-unbuilt-index.fixed.md
@@ -1,0 +1,9 @@
+- **`read_range` reads a raw path again when the code index is unbuilt.** The
+  read-only secondary-roots work (#3352) routed `read_range` through a resolver
+  that returned no path when the primary index slot was `None` (never rebuilt),
+  so reads erred with "path must stay within the indexed workspace root". This
+  broke callers that read a file before any rebuild — `agent_run` scanning a
+  process-output temp file to surface buried test-failure lines, and eval/verify
+  reads over arbitrary shell output. Restored the pre-#3352 fallback: with an
+  unbuilt primary index, resolve the raw path so the read still succeeds (a
+  genuinely missing path still fails with "file not found").

--- a/crates/harn-hostlib/src/code_index/readonly.rs
+++ b/crates/harn-hostlib/src/code_index/readonly.rs
@@ -125,9 +125,12 @@ pub(super) fn resolve_read_path(
     // not-yet-existing paths (it is shared with write paths), so the
     // existence filter is what lets a dependency-only path win over the
     // phantom project path it would otherwise resolve to.
-    let primary_resolved = {
+    let (primary_resolved, primary_built) = {
         let guard = primary.lock().expect("code_index mutex poisoned");
-        guard.as_ref().and_then(|state| state.absolute_path(path))
+        (
+            guard.as_ref().and_then(|state| state.absolute_path(path)),
+            guard.is_some(),
+        )
     };
     if let Some(abs) = primary_resolved.as_ref().filter(|p| p.exists()) {
         return Some(abs.clone());
@@ -140,6 +143,20 @@ pub(super) fn resolve_read_path(
         {
             return Some(abs);
         }
+    }
+    // When the primary index has never been built, there is no workspace
+    // root to confine `path` against, so `absolute_path` yields `None` and
+    // both lookups above miss. Pre-#3352 `read_range` handled this by
+    // reading the raw path straight off the filesystem (the old
+    // `None => PathBuf::from(&path)` arm). Restore that fallback so callers
+    // that read a path before any rebuild — e.g. `agent_run` scanning a
+    // process-output temp file to surface buried test-failure lines, and
+    // eval/verify reads over arbitrary shell output — still resolve instead
+    // of erroring "path must stay within the indexed workspace root". The
+    // read step still returns a genuine "file not found" for a missing
+    // path, so the contract is unchanged.
+    if !primary_built {
+        return Some(PathBuf::from(path));
     }
     primary_resolved
 }

--- a/crates/harn-hostlib/tests/code_index.rs
+++ b/crates/harn-hostlib/tests/code_index.rs
@@ -766,3 +766,33 @@ fn add_readonly_roots_is_idempotent() {
         "idempotent re-add must not duplicate hits, got {hits:?}"
     );
 }
+
+#[test]
+fn read_range_reads_raw_path_when_primary_index_is_unbuilt() {
+    // Regression for the read-range fallback dropped by the read-only
+    // secondary-roots work (#3352): before any `rebuild`, the primary index
+    // slot is `None`, so there is no workspace root to confine the path
+    // against. `read_range` must still read the file straight off disk (the
+    // pre-#3352 `None => PathBuf::from(&path)` behavior) instead of
+    // rejecting it as out-of-scope. This is the path `agent_run` and
+    // eval/verify take when scanning a process-output temp file to surface
+    // buried test-failure lines.
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("run-output.txt");
+    fs::write(&file, "=== RUN\n--- FAIL: TestX\nfoo_test.go:42: boom\n").unwrap();
+
+    let (registry, _cap) = build_registry(); // no rebuild — primary slot is None
+    let read = call(
+        &registry,
+        "hostlib_code_index_read_range",
+        dict(&[(
+            "path",
+            VmValue::String(Arc::from(file.to_string_lossy().as_ref())),
+        )]),
+    );
+    let content = extract_str(extract_dict(&read).get("content").unwrap());
+    assert!(
+        content.contains("foo_test.go:42: boom"),
+        "unbuilt-index read_range must return raw file contents, got {content:?}"
+    );
+}


### PR DESCRIPTION
## Regression

burin-code's `test_output_failure_first.harn` (`agent_run({intent:"test"})` surfacing buried `--- FAIL`/`file:line` assertions) **passed on v0.8.109 and fails on v0.8.110**. Bisected to **#3352** (`feat(code_index): additive read-only secondary roots for dependency symbols`).

## Mechanism

`read_range` reads the full process-output temp file back through `hostlib_code_index_read_range`. #3352 replaced the registered builtin with `run_read_range_merged(index, Some(readonly), ..)` → `resolve_read_path`. When the **primary index slot is `None`** (no `rebuild` has run — exactly the case when reading an arbitrary temp file), `resolve_read_path` returned `None`, so `read_range` erred *"path must stay within the indexed workspace root"*. The pipeline swallowed that to `""`, the failure scan found nothing, and the buried assertion vanished from the summary.

Pre-#3352, the builtin's `None` arm read the raw path off disk (`None => PathBuf::from(&path)`). That fallback was lost for the `Some(readonly)` path.

Affects every caller that reads a path before any rebuild: `agent_run` output scanning **and eval/verify reads over arbitrary shell output**.

## Fix

In `resolve_read_path`, when the primary index is unbuilt, resolve the raw path (mirroring the old `None` arm). A genuinely missing path still fails at the read step with "file not found", so the contract is unchanged.

## Verification

- New regression unit test `read_range_reads_raw_path_when_primary_index_is_unbuilt` (reads a temp file through `read_range` with no rebuild) — passes
- `cargo test -p harn-hostlib --lib` — 326 pass
- burin-code `test_output_failure_first.harn` on origin/main + this fix: **14/14 pass** (was 12/14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)