### PR TITLE
feat(llm): llm_cost returns an exact decimal sourced from authored catalog rates

### DIFF
--- a/changelog.d/llm-cost-decimal.changed.md
+++ b/changelog.d/llm-cost-decimal.changed.md
@@ -1,0 +1,14 @@
+- **`llm_cost` returns an exact `decimal` instead of a binary `float`.** The
+  per-call cost is money, so it is now computed and returned as a `decimal`:
+  summing many calls no longer drifts, and the value compares exactly. Each
+  catalog rate is recovered to its *authored* decimal value (the short literal
+  in `providers.toml`, e.g. `0.15`) via shortest-round-trip recovery, so the
+  result is genuinely exact rather than `float`-rounding laundered into
+  false precision. `llm_format_usd` now accepts a `decimal` amount (alongside
+  `float`/`int`), so `llm_format_usd(llm_cost(...))` keeps working. This is a
+  breaking type change for scripts that compared `llm_cost(...)` against a
+  `float` literal — `decimal` is a clean island and never compares
+  equal/ordered with `float`, so compare against `decimal("…")` instead. The
+  `@budget` enforcement accumulator and `llm_session_cost`/`llm_pricing`/
+  `llm_compare_costs` continue to report `float` for now; migrating that
+  family to `decimal` is tracked separately.

--- a/conformance/tests/scenarios/llm_cost.harn
+++ b/conformance/tests/scenarios/llm_cost.harn
@@ -1,16 +1,22 @@
 pipeline test(task) {
-  // Test llm_cost builtin with known model pricing
+  // Test llm_cost builtin with known model pricing. `llm_cost` returns an
+  // exact `decimal` (money), so it is compared against decimal literals —
+  // decimals form a clean island and never compare equal/ordered against
+  // binary floats.
   let cost = llm_cost("gpt-4o-mini", 1000, 500)
   // gpt-4o-mini: $0.15/M input, $0.60/M output
   // 1000 * 0.15 / 1000000 = 0.00015
   // 500 * 0.60 / 1000000 = 0.0003
-  // total = 0.00045
-  assert(cost > 0.0004, "cost should be > 0.0004")
-  assert(cost < 0.0005, "cost should be < 0.0005")
+  // total = 0.00045 — exact, no float drift
+  assert_eq(cost, decimal("0.00045"))
+  assert(cost > decimal("0.0004"), "cost should be > 0.0004")
+  assert(cost < decimal("0.0005"), "cost should be < 0.0005")
+  // Formatting accepts the decimal amount directly.
+  assert_eq(llm_format_usd(cost), "$0.000450")
   log("cost ok")
-  // Unknown model returns 0
+  // Unknown model returns an exact zero decimal
   let unknown_cost = llm_cost("unknown-model", 1000, 500)
-  assert_eq(unknown_cost, 0.0)
+  assert_eq(unknown_cost, decimal("0"))
   log("unknown ok")
   // Budget builtins
   llm_budget(10.0)

--- a/crates/harn-builtin-meta/src/lib.rs
+++ b/crates/harn-builtin-meta/src/lib.rs
@@ -363,6 +363,7 @@ pub const TY_ANY: Ty = Ty::Any;
 pub const TY_BOOL: Ty = Ty::Named("bool");
 pub const TY_BYTES: Ty = Ty::Named("bytes");
 pub const TY_CLOSURE: Ty = Ty::Named("closure");
+pub const TY_DECIMAL: Ty = Ty::Named("decimal");
 pub const TY_DICT: Ty = Ty::Named("dict");
 pub const TY_DURATION: Ty = Ty::Named("duration");
 pub const TY_FLOAT: Ty = Ty::Named("float");

--- a/crates/harn-parser/src/builtin_signatures/signatures/agents.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/agents.rs
@@ -5,8 +5,8 @@ use super::shapes::{
     SUB_AGENT_OPTIONS, SUB_AGENT_RESULT, TRANSCRIPT, WORKER_SUMMARY,
 };
 use super::{
-    BuiltinSignature, Param, Ty, TY_ANY, TY_BOOL, TY_CLOSURE, TY_DICT, TY_DICT_OR_NIL, TY_FLOAT,
-    TY_INT, TY_LIST, TY_NIL, TY_STRING, TY_STRING_OR_NIL,
+    BuiltinSignature, Param, Ty, TY_ANY, TY_BOOL, TY_CLOSURE, TY_DECIMAL, TY_DICT, TY_DICT_OR_NIL,
+    TY_FLOAT, TY_INT, TY_LIST, TY_NIL, TY_STRING, TY_STRING_OR_NIL,
 };
 
 /// `list | dict | Transcript | SessionSnapshot` — used for
@@ -357,12 +357,13 @@ pub(crate) const SIGNATURES: &[BuiltinSignature] = &[
             Param::new("input_tokens", TY_INT),
             Param::new("output_tokens", TY_INT),
         ],
-        TY_FLOAT,
+        // Exact money: `llm_cost` returns a `decimal`, not a binary `float`.
+        TY_DECIMAL,
     ),
     BuiltinSignature::simple(
         "llm_format_usd",
         &[
-            Param::new("amount", Ty::Union(&[TY_FLOAT, TY_INT])),
+            Param::new("amount", Ty::Union(&[TY_DECIMAL, TY_FLOAT, TY_INT])),
             Param::optional("options", TY_DICT),
         ],
         TY_STRING,

--- a/crates/harn-parser/src/builtin_signatures/signatures/mod.rs
+++ b/crates/harn-parser/src/builtin_signatures/signatures/mod.rs
@@ -15,9 +15,9 @@ mod stdlib;
 mod workflow;
 
 pub(crate) use super::types::{
-    BuiltinSignature, Param, Ty, TY_ANY, TY_BOOL, TY_BYTES, TY_BYTES_OR_NIL, TY_CLOSURE, TY_DICT,
-    TY_DICT_OR_NIL, TY_DURATION, TY_FLOAT, TY_INT, TY_LIST, TY_NEVER, TY_NIL, TY_NUMBER, TY_STRING,
-    TY_STRING_OR_NIL,
+    BuiltinSignature, Param, Ty, TY_ANY, TY_BOOL, TY_BYTES, TY_BYTES_OR_NIL, TY_CLOSURE,
+    TY_DECIMAL, TY_DICT, TY_DICT_OR_NIL, TY_DURATION, TY_FLOAT, TY_INT, TY_LIST, TY_NEVER, TY_NIL,
+    TY_NUMBER, TY_STRING, TY_STRING_OR_NIL,
 };
 
 pub(crate) fn groups() -> [&'static [BuiltinSignature]; 6] {

--- a/crates/harn-parser/src/builtin_signatures/types.rs
+++ b/crates/harn-parser/src/builtin_signatures/types.rs
@@ -11,8 +11,8 @@ use crate::ast::{ShapeField, TypeExpr};
 
 pub use harn_builtin_meta::{
     BuiltinMetadata, BuiltinSignature, Param, ShapeFieldDescriptor, Ty, TY_ANY, TY_BOOL, TY_BYTES,
-    TY_BYTES_OR_NIL, TY_CLOSURE, TY_DICT, TY_DICT_OR_NIL, TY_DURATION, TY_FLOAT, TY_INT,
-    TY_INT_OR_NIL, TY_LIST, TY_NEVER, TY_NIL, TY_NUMBER, TY_STRING, TY_STRING_OR_NIL,
+    TY_BYTES_OR_NIL, TY_CLOSURE, TY_DECIMAL, TY_DICT, TY_DICT_OR_NIL, TY_DURATION, TY_FLOAT,
+    TY_INT, TY_INT_OR_NIL, TY_LIST, TY_NEVER, TY_NIL, TY_NUMBER, TY_STRING, TY_STRING_OR_NIL,
 };
 
 /// Convert a const-IR [`Ty`] into the parser's owned [`TypeExpr`]. Generic

--- a/crates/harn-vm/src/llm/cost.rs
+++ b/crates/harn-vm/src/llm/cost.rs
@@ -1,6 +1,8 @@
 use crate::value::VmDictExt;
+use rust_decimal::Decimal;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::str::FromStr;
 
 use crate::value::{categorized_error, ErrorCategory, VmError, VmValue};
 use crate::vm::{Vm, VmBuiltinArity, VmBuiltinMetadata};
@@ -530,18 +532,39 @@ pub(crate) fn latency_p50_ms_for(provider: &str) -> Option<u64> {
     latency
 }
 
-/// Calculate cost for a given model and token counts using the exact-id
-/// catalog pricing entry. Returns 0.0 when the model has no catalog entry,
-/// even if the inferred provider has provider-level economics — callers that
-/// know the provider should use `calculate_cost_for_provider` instead so
-/// they pick up provider economics, and `pricing_detail_for` when they need
-/// to surface unknown pricing explicitly.
-pub fn calculate_cost(model: &str, input_tokens: i64, output_tokens: i64) -> f64 {
+/// Recover the *authored* decimal value of a catalog rate that was parsed
+/// from a TOML float literal. The pricing catalog
+/// (`crates/harn-vm/src/llm/providers.toml`) writes short, human-authored
+/// decimals like `input_per_mtok = 0.15`; TOML deserializes them to `f64`,
+/// which cannot store `0.15` exactly. Rust's `{}` float formatter emits the
+/// *shortest* decimal string that round-trips to the same `f64` — for these
+/// short literals that is exactly the digits the author wrote (`"0.15"`,
+/// not `0.150000000000000008…`). Parsing that string straight into a
+/// `Decimal` therefore reconstructs the intended exact value without ever
+/// laundering the float's binary rounding error into false precision (which
+/// `Decimal::from_f64_retain` would). The `from_f64_retain` fallback only
+/// fires for non-finite inputs, which the catalog never contains.
+fn authored_rate_decimal(rate: f64) -> Decimal {
+    Decimal::from_str(&format!("{rate}"))
+        .ok()
+        .or_else(|| Decimal::from_f64_retain(rate))
+        .unwrap_or(Decimal::ZERO)
+}
+
+/// Compute the per-call USD cost for a model and token counts as an exact
+/// `Decimal`. Sources each rate directly from the per-MTok catalog literal
+/// via [`authored_rate_decimal`] (never through the derived per-1k rate,
+/// which would round-trip the value through an extra `f64` multiply) and
+/// does all arithmetic in `Decimal`. Division by 1,000,000 is an exact
+/// base-10 rescale, so the result carries no representational error.
+/// Returns `Decimal::ZERO` when the model has no catalog entry.
+pub fn calculate_cost_decimal(model: &str, input_tokens: i64, output_tokens: i64) -> Decimal {
     let Some(pricing) = crate::llm_config::model_pricing_per_mtok(model) else {
-        return 0.0;
+        return Decimal::ZERO;
     };
-    (input_tokens as f64 * pricing.input_per_mtok + output_tokens as f64 * pricing.output_per_mtok)
-        / 1_000_000.0
+    let gross = Decimal::from(input_tokens) * authored_rate_decimal(pricing.input_per_mtok)
+        + Decimal::from(output_tokens) * authored_rate_decimal(pricing.output_per_mtok);
+    gross / Decimal::from(1_000_000i64)
 }
 
 /// Calculate cost using catalog model pricing first, then provider catalog
@@ -672,8 +695,12 @@ pub(crate) fn register_cost_builtins(vm: &mut Vm) {
         let model = args.first().map(|a| a.display()).unwrap_or_default();
         let input_tokens = args.get(1).and_then(|a| a.as_int()).unwrap_or(0);
         let output_tokens = args.get(2).and_then(|a| a.as_int()).unwrap_or(0);
-        let cost = calculate_cost(&model, input_tokens, output_tokens);
-        Ok(VmValue::Float(cost))
+        // Return the cost as an exact `decimal` (not a binary `float`): the
+        // value names money, summing it should not drift, and the catalog
+        // rates are recovered exactly. Callers that want a formatted string
+        // pass the result to `llm_format_usd`, which accepts decimals.
+        let cost = calculate_cost_decimal(&model, input_tokens, output_tokens);
+        Ok(VmValue::Decimal(cost))
     });
 
     vm.register_builtin_with_metadata(
@@ -864,6 +891,14 @@ fn llm_format_usd_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue
     let amount = match args.first() {
         Some(VmValue::Float(value)) => *value,
         Some(VmValue::Int(value)) => *value as f64,
+        // Accept exact `decimal` amounts (e.g. the result of `llm_cost`).
+        // Formatting rounds to a fixed number of display decimals anyway, so
+        // converting to `f64` for the digit layout is lossless at that
+        // precision; the exact value never feeds back into money math here.
+        Some(VmValue::Decimal(value)) => {
+            use rust_decimal::prelude::ToPrimitive;
+            value.to_f64().unwrap_or(0.0)
+        }
         Some(VmValue::Nil) | None => 0.0,
         Some(other) => {
             return Err(VmError::Runtime(format!(
@@ -1133,8 +1168,11 @@ mod tests {
         );
         crate::llm_config::set_user_overrides(Some(overlay));
 
-        let cost = calculate_cost("gpt-4o-mini", 1000, 1000);
-        assert!((cost - 0.03).abs() < f64::EPSILON);
+        // 1000*10 + 1000*20 = 30000; /1e6 = 0.03, exactly.
+        assert_eq!(
+            calculate_cost_decimal("gpt-4o-mini", 1000, 1000),
+            Decimal::from_str("0.03").unwrap()
+        );
 
         crate::llm_config::clear_user_overrides();
     }
@@ -1144,9 +1182,93 @@ mod tests {
         let _guard = crate::llm::env_guard();
         crate::llm_config::clear_user_overrides();
         assert_eq!(
-            calculate_cost("definitely-unpriced-model", 1_000, 1_000),
-            0.0
+            calculate_cost_decimal("definitely-unpriced-model", 1_000, 1_000),
+            Decimal::ZERO
         );
+    }
+
+    #[test]
+    fn authored_rate_decimal_recovers_the_written_literal_not_float_noise() {
+        // Catalog rates are short literals parsed from TOML into f64; many
+        // (0.15, 0.8, 0.08) are not exactly representable in binary. The
+        // recovery must reconstruct the *authored* decimal, never the f64's
+        // binary-rounding tail that `from_f64_retain` would expose.
+        for (raw, written) in [
+            (0.15_f64, "0.15"),
+            (0.8, "0.8"),
+            (0.08, "0.08"),
+            (4.0, "4"),
+            (0.0, "0"),
+            (3.75, "3.75"),
+        ] {
+            let recovered = authored_rate_decimal(raw);
+            assert_eq!(
+                recovered,
+                Decimal::from_str(written).unwrap(),
+                "rate {raw} should recover as {written}"
+            );
+        }
+        // Guard the whole point of the helper: it must NOT equal the lossy
+        // `from_f64_retain` decimal for an inexact literal.
+        assert_ne!(
+            authored_rate_decimal(0.1),
+            Decimal::from_f64_retain(0.1).unwrap()
+        );
+    }
+
+    #[test]
+    fn calculate_cost_decimal_is_exact_for_inexact_catalog_rates() {
+        let _guard = crate::llm::env_guard();
+        let mut overlay = crate::llm_config::ProvidersConfig::default();
+        overlay.models.insert(
+            "gpt-4o-mini".to_string(),
+            crate::llm_config::ModelDef {
+                name: "Test GPT-4o Mini".to_string(),
+                provider: "openai".to_string(),
+                context_window: 128_000,
+                logical_model: None,
+                equivalence_group: None,
+                served_variant: None,
+                wire_model: None,
+                api_dialect: None,
+                rate_limits: None,
+                architecture: None,
+                local_memory: None,
+                runtime_context_window: None,
+                stream_timeout: None,
+                capabilities: Vec::new(),
+                // Inexact-in-binary rates, like the real catalog.
+                pricing: Some(crate::llm_config::ModelPricing {
+                    input_per_mtok: 0.15,
+                    output_per_mtok: 0.60,
+                    cache_read_per_mtok: None,
+                    cache_write_per_mtok: None,
+                }),
+                deprecated: false,
+                deprecation_note: None,
+                superseded_by: None,
+                fast_mode: None,
+                quality_tags: Vec::new(),
+                availability: crate::llm_config::ModelAvailability::default(),
+                tier: None,
+                open_weight: None,
+                strengths: Vec::new(),
+                benchmarks: std::collections::BTreeMap::new(),
+                family: None,
+                lineage: None,
+                complementary_with: Vec::new(),
+                avoid_as_reviewer_for: Vec::new(),
+            },
+        );
+        crate::llm_config::set_user_overrides(Some(overlay));
+
+        // 1000 * 0.15 + 500 * 0.60 = 150 + 300 = 450; /1e6 = 0.00045 exactly.
+        assert_eq!(
+            calculate_cost_decimal("gpt-4o-mini", 1000, 500),
+            Decimal::from_str("0.00045").unwrap()
+        );
+
+        crate::llm_config::clear_user_overrides();
     }
 
     #[test]

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1819,7 +1819,7 @@ See [LLM calls and agent loops](llm-and-agents.md) for full documentation.
 | `llm_catalog()` | — | list | Free-builtin alias for `harness.llm.catalog()`, available to scripts that do not receive a `Harness` parameter |
 | `llm_catalog_refresh(options?)` | `options?: dict\|nil` | dict | Free-builtin alias for `harness.llm.catalog_refresh(options?)`, available to scripts that do not receive a `Harness` parameter |
 | `llm_config(provider?)` | provider: string | dict | Get provider config (base_url, auth_style, etc.) |
-| `llm_cost(model, input_tokens, output_tokens)` | model: string, input_tokens: int, output_tokens: int | float | Estimate USD cost from catalog pricing, falling back to embedded pricing |
+| `llm_cost(model, input_tokens, output_tokens)` | model: string, input_tokens: int, output_tokens: int | decimal | Estimate USD cost (exact `decimal`) from catalog pricing, falling back to embedded pricing |
 | `llm_session_cost()` | — | dict | Session totals: `{total_cost, input_tokens, output_tokens, call_count}` |
 | `llm_budget(max_cost)` | max_cost: float | nil | Set session budget in USD. LLM calls pre-flight and throw if projected cost would exceed it |
 | `llm_budget_remaining()` | — | float or nil | Remaining budget (nil if no budget set) |


### PR DESCRIPTION
## What

`llm_cost` — the builtin literally named for `cost_usd` — returned a binary `float` computed from `float` catalog rates. Money that drifts when summed and never compares exactly. This makes it return an **exact `decimal`**.

### The core trick (honest exactness, not laundered precision)

The pricing catalog (`providers.toml`) writes short human-authored decimals like `input_per_mtok = 0.15`. TOML parses them to `f64`, which can't store `0.15` exactly. But Rust's `{}` float formatter emits the **shortest** decimal string that round-trips the f64 — for these short literals that is exactly the digits the author wrote. So `authored_rate_decimal` does `Decimal::from_str(&format!("{rate}"))` and recovers `0.15`, **not** the `from_f64_retain` tail `0.150000000000000008…`. This is genuine exactness; a naive `f64→Decimal` would just launder the float's rounding error into long, exact-*looking* false precision.

`calculate_cost_decimal` then computes entirely in `Decimal`, sourcing each rate straight from the per-MTok catalog literal (not the derived per-1k rate, which would add an extra f64 multiply) and dividing by 1,000,000 (an exact base-10 rescale).

## Changes

- `llm_cost` → returns `decimal`; `llm_format_usd` now accepts a `decimal` amount (alongside float/int) so `llm_format_usd(llm_cost(...))` keeps working.
- Parser: new `TY_DECIMAL`; `llm_cost` typed `-> decimal`, `llm_format_usd` amount accepts `decimal | float | int`.
- Removed the superseded f64 `calculate_cost` (only its own tests used it; the `@budget` accumulator does its own inline math).
- Doc table + conformance updated; new changelog fragment.

## Scope / what stays float (deliberate)

The `@budget` enforcement accumulator and the `llm_pricing` / `llm_session_cost` / `llm_compare_costs` reporting family stay `float` for now — that family is a larger, separately-tracked migration (it would force an `economics.harn` rewrite and touches the security-sensitive budget engine). `llm_cost` has **no other consumers** (harn-cloud doesn't call it; stdlib `economics` reimplements the math), so this return-type change is fully self-contained — no harn-cloud bump required.

⚠️ **Breaking** for scripts that compared `llm_cost(...)` against a `float` literal — `decimal` is a clean island and never compares equal/ordered with `float`. Compare against `decimal("…")`.

## Verification

- harn-vm cost unit tests, incl. round-trip recovery proof (`0.15`/`0.8`/`0.08` recover exactly; `0.1` ≠ `from_f64_retain(0.1)`) and exactness (`1000@0.15 + 500@0.60 → exactly 0.00045`).
- `cargo clippy` clean on touched crates.
- **All 104 `llm` conformance scenarios pass** — `llm_cost` yields exact `0.00045` and `$0.000450`; the untouched economics family is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)