### PR TITLE
feat(stdlib): require_policy imperative route auth-policy guard (std/harness/policy)

### DIFF
--- a/changelog.d/require-policy-helper.added.md
+++ b/changelog.d/require-policy-helper.added.md
@@ -1,0 +1,13 @@
+- **`std/harness/policy.require_policy` — imperative route auth-policy guard.**
+  The second half of the route-policy toolkit (the declarative
+  `@policy(kinds: ...)` annotation is the first): a `.harn` handler can call
+  `require_policy({kinds: [...], scopes: [...]})` to enforce a principal-kind
+  / scope policy that depends on runtime data the annotation cannot see (a
+  path or body field, resource ownership). It composes the ambient
+  `harness.auth` principal and returns `nil` when the policy is satisfied, or
+  a ready-to-return tenant-safe HTTP 403 envelope (`http_error`) when it is
+  not — `let denial = require_policy({...}); if denial != nil { return denial }`.
+  Denials name the route's requirement (`allowed_kinds`, the missing scope)
+  but never echo the caller's own kind, matching the `@policy` denial, and
+  fail closed: an unauthenticated or unclassified principal never satisfies a
+  non-empty `kinds` allow-set.

--- a/conformance/tests/scenarios/require_policy_guard.expected
+++ b/conformance/tests/scenarios/require_policy_guard.expected
@@ -1,0 +1,3 @@
+[harn] kind deny ok
+[harn] scope deny ok
+[harn] noop allow ok

--- a/conformance/tests/scenarios/require_policy_guard.harn
+++ b/conformance/tests/scenarios/require_policy_guard.harn
@@ -1,0 +1,31 @@
+// std/harness/policy.require_policy: imperative auth-policy guard composing
+// the ambient `harness.auth` principal. In a plain test context no principal
+// is bound, so harness.auth is anonymous (kind() == nil, no scopes) and every
+// guard with a requirement must fail closed with a tenant-safe HTTP 403.
+import { require_policy } from "std/harness/policy"
+
+pipeline test(task) {
+  // kinds clause: an unclassified principal can never satisfy a non-empty
+  // allow-set, so it is denied.
+  let kind_denial = require_policy({kinds: ["operator", "platform_admin"]})
+  assert(kind_denial != nil, "unclassified principal must be denied")
+  assert_eq(kind_denial.status, 403)
+  assert_eq(kind_denial.body.code, "forbidden")
+  assert_eq(kind_denial.body.details.kind, "forbidden_principal_kind")
+  assert_eq(kind_denial.body.details.allowed_kinds, ["operator", "platform_admin"])
+  // Tenant-safe: the denial names the route's allow-set but never echoes the
+  // caller's own kind.
+  assert_eq(kind_denial.body.details["caller_kind"], nil)
+  log("kind deny ok")
+  // scopes clause: a scope the principal was not granted is denied.
+  let scope_denial = require_policy({scopes: ["secrets:write"]})
+  assert(scope_denial != nil, "missing scope must be denied")
+  assert_eq(scope_denial.status, 403)
+  assert_eq(scope_denial.body.details.kind, "forbidden")
+  assert_eq(scope_denial.body.details.missing_scope, "secrets:write")
+  log("scope deny ok")
+  // No clauses (or an empty allow-set) → nothing to enforce → allowed (nil).
+  assert_eq(require_policy({}), nil)
+  assert_eq(require_policy({kinds: []}), nil)
+  log("noop allow ok")
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -310,6 +310,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/llm/safe.harn"),
     },
     StdlibSource {
+        module: "harness/policy",
+        source: include_str!("stdlib/harness/policy.harn"),
+    },
+    StdlibSource {
         module: "llm/budget",
         source: include_str!("stdlib/llm/budget.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/harness/policy.harn
+++ b/crates/harn-stdlib/src/stdlib/harness/policy.harn
@@ -1,0 +1,70 @@
+/**
+ * @harn-entrypoint-category harness.stdlib
+ *
+ * std/harness/policy — imperative route auth-policy guards that compose the
+ * ambient `harness.auth` principal. Reach for these when an authorization
+ * decision depends on runtime data (a path or body field, resource
+ * ownership) that the declarative `@scopes(...)` / `@policy(kinds: ...)`
+ * route annotations cannot see; the annotations remain the right tool for
+ * static, request-independent gates.
+ *
+ * Each guard returns `nil` when the bound principal satisfies the policy, or
+ * a ready-to-return HTTP 403 envelope (built by `http_error`) when it does
+ * not — so a handler denies in one line:
+ *
+ *   let denial = require_policy({kinds: ["operator"], scopes: ["secrets:write"]})
+ *   if denial != nil { return denial }
+ *   // ...authorized work...
+ *
+ * Denials are tenant-safe: the body names the *route's* requirement
+ * (`allowed_kinds`, or the missing scope) but never echoes the caller's own
+ * principal kind, mirroring the declarative `@policy` denial. Guards fail
+ * closed — an unauthenticated or unclassified principal (kind `nil`) can
+ * never satisfy a non-empty `kinds` allow-set.
+ */
+fn __policy_list(value, label) {
+  if value == nil {
+    return []
+  }
+  if type_of(value) != "list" {
+    throw label + " must be a list of strings"
+  }
+  return value
+}
+
+/**
+ * Enforce a principal-kind and/or scope policy against the ambient
+ * `harness.auth` principal. `opts`:
+ *   {kinds?: [string], scopes?: [string]}
+ * `kinds` (when non-empty) requires the principal's embedder-assigned kind
+ * to be one of the listed values; `scopes` requires every listed scope to be
+ * granted. Returns `nil` when the principal satisfies every clause, otherwise
+ * an HTTP 403 envelope the caller should return verbatim.
+ *
+ * @effects: []
+ * @errors: []
+ */
+pub fn require_policy(opts) {
+  if opts != nil && type_of(opts) != "dict" {
+    throw "require_policy: opts must be a dict"
+  }
+  let kinds = __policy_list(opts?.kinds, "require_policy: kinds")
+  if len(kinds) > 0 {
+    let kind = harness.auth.kind()
+    if kind == nil || !kinds.contains(kind) {
+      // Tenant-safe: report the route's allow-set, never the caller's kind.
+      return http_error(
+        403,
+        "forbidden",
+        "principal kind not permitted for this route",
+        {kind: "forbidden_principal_kind", allowed_kinds: kinds},
+      )
+    }
+  }
+  for scope in __policy_list(opts?.scopes, "require_policy: scopes") {
+    if !harness.auth.has_scope(scope) {
+      return http_error(403, "forbidden", "missing required scope", {kind: "forbidden", missing_scope: scope})
+    }
+  }
+  return nil
+}


### PR DESCRIPTION
## What

Completes the **Hybrid** route-policy design. The declarative `@policy(kinds: ...)` annotation (shipped) covers static, request-independent principal-kind gates at admission. This adds the **imperative** half for policies that depend on runtime data the annotation cannot see — a path/body field, resource ownership.

```harn
import { require_policy } from "std/harness/policy"

@scopes("secrets:read")
@route("POST", "/tenants/{id}/secrets")
pub fn rotate(req) {
  let denial = require_policy({ kinds: ["operator"], scopes: ["secrets:write"] })
  if denial != nil { return denial }
  // ...authorized work...
}
```

`require_policy` composes the ambient `harness.auth` principal and returns `nil` when the policy is satisfied, or a ready-to-return tenant-safe HTTP 403 envelope (via `http_error`) when it is not.

## Design

- **Zero new Rust dispatch plumbing.** Pure stdlib `.harn` that reuses the existing `http_error` response path and the `harness.auth` handle. The return-the-denial shape deliberately sidesteps the fact that a handler `throw` renders **500**, not 403 — the handler returns the denial envelope, which the existing http_response machinery renders as a real 403.
- **Tenant-safe.** The body names the *route's* requirement (`allowed_kinds`, or the missing scope) but never echoes the caller's own kind — matching the `@policy` annotation's denial.
- **Fails closed.** An unauthenticated / unclassified principal (kind `nil`) can never satisfy a non-empty `kinds` allow-set.

## Verification

- harn-stdlib module-catalog tests pass (`require_policy` is auto-cataloged from source; entrypoint category declared).
- New conformance scenario `require_policy_guard.harn` exercises the fail-closed **kind** denial, the **scope** denial, the **tenant-safe body** (asserts no caller-kind leak), and the **no-clause allow** path. PASS.
- The envelope→HTTP-403 rendering is the existing, already-tested `http_response` / `@policy` machinery; `require_policy` only constructs a standard `http_error` envelope.

Pairs with the merged `harness.auth` handle (#3369) and `@policy(kinds:)` annotation (#3371).

🤖 Generated with [Claude Code](https://claude.com/claude-code)