### PR TITLE
fix(sqlite): WAL mode on LLM cache + durable rate limiter for multi-session safety

### DIFF
--- a/changelog.d/3379-sqlite-wal-multisession.fixed.md
+++ b/changelog.d/3379-sqlite-wal-multisession.fixed.md
@@ -1,0 +1,4 @@
+Enable SQLite WAL mode (with `busy_timeout` + `synchronous=NORMAL`) on the LLM read cache
+(`llm.sqlite`) and the durable rate limiter (`llm-rate-limits.sqlite`) so multiple concurrent
+Harn sessions on one machine no longer hit `SQLITE_BUSY` (silently dropped usage rows / blocked
+LLM calls). Matches the WAL pattern already used by `events.sqlite`.

--- a/crates/harn-vm/src/durable_rate_limit.rs
+++ b/crates/harn-vm/src/durable_rate_limit.rs
@@ -257,7 +257,17 @@ fn try_reserve_once(
     }
 
     let mut conn = Connection::open(path).map_err(sql_error)?;
+    // Set busy_timeout BEFORE the WAL pragma so the WAL-mode promotion waits
+    // out a transient SQLITE_BUSY from another session's writer instead of
+    // failing fast. WAL lets concurrent sessions sharing this project's
+    // rate-limit DB serialize on the write lock for at most busy_timeout
+    // rather than throwing "database is locked" up into the agent loop.
+    // Matches the proven event-log setup (crates/harn-vm/src/event_log/sqlite.rs).
     conn.busy_timeout(Duration::from_millis(DEFAULT_BUSY_TIMEOUT_MS))
+        .map_err(sql_error)?;
+    conn.pragma_update(None, "journal_mode", "WAL")
+        .map_err(sql_error)?;
+    conn.pragma_update(None, "synchronous", "NORMAL")
         .map_err(sql_error)?;
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS durable_rate_limit_entries (

--- a/crates/harn-vm/src/durable_rate_limit.rs
+++ b/crates/harn-vm/src/durable_rate_limit.rs
@@ -2,9 +2,9 @@ use crate::value::VmDictExt;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use rusqlite::{params, Connection, TransactionBehavior};
+use rusqlite::{params, Connection, ErrorCode, TransactionBehavior};
 
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
 use crate::stdlib::options::{non_negative_millis_from_value, ErrorKind};
@@ -14,6 +14,8 @@ use crate::vm::Vm;
 
 const DEFAULT_WINDOW_MS: u64 = 60_000;
 const DEFAULT_BUSY_TIMEOUT_MS: u64 = 5_000;
+const SQLITE_BUSY_RETRY_INITIAL_MS: u64 = 2;
+const SQLITE_BUSY_RETRY_MAX_MS: u64 = 50;
 const MAX_SLEEP_MS: u64 = 60_000;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -244,6 +246,86 @@ fn try_reserve_once(
     buckets: &[RateBucket],
     now_ms: i64,
 ) -> Result<ReserveAttempt, VmError> {
+    try_reserve_once_with_options(
+        path,
+        buckets,
+        now_ms,
+        DEFAULT_BUSY_TIMEOUT_MS,
+        DEFAULT_BUSY_TIMEOUT_MS,
+        || {},
+    )
+}
+
+fn try_reserve_once_with_options<F>(
+    path: &Path,
+    buckets: &[RateBucket],
+    now_ms: i64,
+    sqlite_busy_timeout_ms: u64,
+    retry_timeout_ms: u64,
+    mut on_busy: F,
+) -> Result<ReserveAttempt, VmError>
+where
+    F: FnMut(),
+{
+    let started = Instant::now();
+    let mut backoff = Duration::from_millis(SQLITE_BUSY_RETRY_INITIAL_MS);
+    let retry_timeout = Duration::from_millis(retry_timeout_ms);
+    loop {
+        match try_reserve_once_inner(path, buckets, now_ms, sqlite_busy_timeout_ms) {
+            Ok(attempt) => return Ok(attempt),
+            Err(error) if error.is_sqlite_busy_or_locked() && started.elapsed() < retry_timeout => {
+                on_busy();
+                std::thread::sleep(backoff);
+                backoff = (backoff * 2).min(Duration::from_millis(SQLITE_BUSY_RETRY_MAX_MS));
+            }
+            Err(error) => return Err(error.into_vm_error()),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ReserveOnceError {
+    Vm(VmError),
+    Sqlite(rusqlite::Error),
+}
+
+impl ReserveOnceError {
+    fn is_sqlite_busy_or_locked(&self) -> bool {
+        let Self::Sqlite(rusqlite::Error::SqliteFailure(error, _)) = self else {
+            return false;
+        };
+        matches!(
+            error.code,
+            ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked
+        )
+    }
+
+    fn into_vm_error(self) -> VmError {
+        match self {
+            Self::Vm(error) => error,
+            Self::Sqlite(error) => sql_error(error),
+        }
+    }
+}
+
+impl From<rusqlite::Error> for ReserveOnceError {
+    fn from(error: rusqlite::Error) -> Self {
+        Self::Sqlite(error)
+    }
+}
+
+impl From<VmError> for ReserveOnceError {
+    fn from(error: VmError) -> Self {
+        Self::Vm(error)
+    }
+}
+
+fn try_reserve_once_inner(
+    path: &Path,
+    buckets: &[RateBucket],
+    now_ms: i64,
+    sqlite_busy_timeout_ms: u64,
+) -> Result<ReserveAttempt, ReserveOnceError> {
     if let Some(parent) = path
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
@@ -256,19 +338,17 @@ fn try_reserve_once(
         })?;
     }
 
-    let mut conn = Connection::open(path).map_err(sql_error)?;
+    let mut conn = Connection::open(path)?;
     // Set busy_timeout BEFORE the WAL pragma so the WAL-mode promotion waits
     // out a transient SQLITE_BUSY from another session's writer instead of
     // failing fast. WAL lets concurrent sessions sharing this project's
     // rate-limit DB serialize on the write lock for at most busy_timeout
     // rather than throwing "database is locked" up into the agent loop.
     // Matches the proven event-log setup (crates/harn-vm/src/event_log/sqlite.rs).
-    conn.busy_timeout(Duration::from_millis(DEFAULT_BUSY_TIMEOUT_MS))
-        .map_err(sql_error)?;
-    conn.pragma_update(None, "journal_mode", "WAL")
-        .map_err(sql_error)?;
-    conn.pragma_update(None, "synchronous", "NORMAL")
-        .map_err(sql_error)?;
+    conn.busy_timeout(Duration::from_millis(sqlite_busy_timeout_ms))
+        .map_err(ReserveOnceError::Sqlite)?;
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+    conn.pragma_update(None, "synchronous", "NORMAL")?;
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS durable_rate_limit_entries (
             bucket_key TEXT NOT NULL,
@@ -278,11 +358,9 @@ fn try_reserve_once(
          CREATE INDEX IF NOT EXISTS durable_rate_limit_entries_key_ts_idx
             ON durable_rate_limit_entries(bucket_key, ts_ms);",
     )
-    .map_err(sql_error)?;
+    .map_err(ReserveOnceError::Sqlite)?;
 
-    let tx = conn
-        .transaction_with_behavior(TransactionBehavior::Immediate)
-        .map_err(sql_error)?;
+    let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
     let mut retry_after_ms = 0_u64;
     for bucket in buckets {
         prune_bucket(&tx, bucket, now_ms)?;
@@ -295,7 +373,7 @@ fn try_reserve_once(
     }
 
     if retry_after_ms > 0 {
-        tx.commit().map_err(sql_error)?;
+        tx.commit()?;
         return Ok(ReserveAttempt {
             acquired: false,
             retry_after_ms,
@@ -315,9 +393,9 @@ fn try_reserve_once(
                 i64::try_from(bucket.charged_units).unwrap_or(i64::MAX)
             ],
         )
-        .map_err(sql_error)?;
+        .map_err(ReserveOnceError::Sqlite)?;
     }
-    tx.commit().map_err(sql_error)?;
+    tx.commit()?;
     Ok(ReserveAttempt {
         acquired: true,
         retry_after_ms: 0,
@@ -400,13 +478,13 @@ fn prune_bucket(
     tx: &rusqlite::Transaction<'_>,
     bucket: &RateBucket,
     now_ms: i64,
-) -> Result<(), VmError> {
+) -> Result<(), ReserveOnceError> {
     let cutoff_ms = now_ms.saturating_sub(u64_to_i64(bucket.window_ms));
     tx.execute(
         "DELETE FROM durable_rate_limit_entries WHERE bucket_key = ?1 AND ts_ms <= ?2",
         params![&bucket.key, cutoff_ms],
     )
-    .map_err(sql_error)?;
+    .map_err(ReserveOnceError::Sqlite)?;
     Ok(())
 }
 
@@ -414,16 +492,14 @@ fn bucket_wait_ms(
     tx: &rusqlite::Transaction<'_>,
     bucket: &RateBucket,
     now_ms: i64,
-) -> Result<Option<u64>, VmError> {
-    let usage: i64 = tx
-        .query_row(
-            "SELECT COALESCE(SUM(units), 0)
+) -> Result<Option<u64>, ReserveOnceError> {
+    let usage: i64 = tx.query_row(
+        "SELECT COALESCE(SUM(units), 0)
              FROM durable_rate_limit_entries
              WHERE bucket_key = ?1",
-            params![&bucket.key],
-            |row| row.get(0),
-        )
-        .map_err(sql_error)?;
+        params![&bucket.key],
+        |row| row.get(0),
+    )?;
     let usage = usage.max(0) as u64;
     if usage.saturating_add(bucket.charged_units) <= bucket.limit {
         return Ok(None);
@@ -432,19 +508,17 @@ fn bucket_wait_ms(
     let needed = usage
         .saturating_add(bucket.charged_units)
         .saturating_sub(bucket.limit);
-    let mut stmt = tx
-        .prepare(
-            "SELECT ts_ms, units
+    let mut stmt = tx.prepare(
+        "SELECT ts_ms, units
              FROM durable_rate_limit_entries
              WHERE bucket_key = ?1
              ORDER BY ts_ms ASC",
-        )
-        .map_err(sql_error)?;
-    let mut rows = stmt.query(params![&bucket.key]).map_err(sql_error)?;
+    )?;
+    let mut rows = stmt.query(params![&bucket.key])?;
     let mut freed = 0_u64;
-    while let Some(row) = rows.next().map_err(sql_error)? {
-        let ts_ms: i64 = row.get(0).map_err(sql_error)?;
-        let units: i64 = row.get(1).map_err(sql_error)?;
+    while let Some(row) = rows.next()? {
+        let ts_ms: i64 = row.get(0)?;
+        let units: i64 = row.get(1)?;
         freed = freed.saturating_add(units.max(0) as u64);
         if freed >= needed {
             let expiry_ms = ts_ms.saturating_add(u64_to_i64(bucket.window_ms));

--- a/crates/harn-vm/src/durable_rate_limit/tests.rs
+++ b/crates/harn-vm/src/durable_rate_limit/tests.rs
@@ -1,8 +1,12 @@
 use super::*;
 use crate::{compile_source, register_vm_stdlib, reset_thread_local_state, Vm};
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, TransactionBehavior};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Barrier};
+use std::sync::{mpsc, Arc, Barrier};
+use std::time::Duration;
+
+const TRANSIENT_LOCK_TEST_BUSY_TIMEOUT_MS: u64 = 25;
+const TRANSIENT_LOCK_SIGNAL_TIMEOUT: Duration = Duration::from_secs(2);
 
 async fn run_harn(base_dir: &std::path::Path, source: &str) -> Vec<String> {
     reset_thread_local_state();
@@ -150,6 +154,53 @@ fn concurrent_threads_do_not_over_reserve_shared_bucket() {
     assert_eq!(
         attempts.iter().filter(|attempt| !attempt.acquired).count(),
         7
+    );
+    assert_eq!(usage(&path, "provider:rpm"), 1);
+}
+
+#[test]
+fn transient_sqlite_write_lock_retries_instead_of_erroring() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("rate.sqlite");
+    let setup = vec![bucket("setup", 1, 0, 60_000)];
+    try_reserve_once(&path, &setup, 1_000).expect("create schema");
+
+    let mut locker = Connection::open(&path).expect("open sqlite");
+    locker
+        .busy_timeout(Duration::from_millis(DEFAULT_BUSY_TIMEOUT_MS))
+        .expect("busy timeout");
+    let tx = locker
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .expect("hold write lock");
+
+    let path_for_thread = path.clone();
+    let buckets = vec![bucket("provider:rpm", 1, 1, 60_000)];
+    let (busy_tx, busy_rx) = mpsc::channel();
+    let handle = std::thread::spawn(move || {
+        try_reserve_once_with_options(
+            &path_for_thread,
+            &buckets,
+            1_000,
+            TRANSIENT_LOCK_TEST_BUSY_TIMEOUT_MS,
+            DEFAULT_BUSY_TIMEOUT_MS,
+            move || {
+                let _ = busy_tx.send(());
+            },
+        )
+    });
+
+    busy_rx
+        .recv_timeout(TRANSIENT_LOCK_SIGNAL_TIMEOUT)
+        .expect("worker should observe the transient sqlite lock before retrying");
+    drop(tx);
+
+    let attempt = handle
+        .join()
+        .expect("thread")
+        .expect("reserve should retry the transient sqlite lock");
+    assert!(
+        attempt.acquired,
+        "reservation succeeds once the write lock clears"
     );
     assert_eq!(usage(&path, "provider:rpm"), 1);
 }

--- a/crates/harn-vm/src/durable_rate_limit/tests.rs
+++ b/crates/harn-vm/src/durable_rate_limit/tests.rs
@@ -61,6 +61,29 @@ fn reserve_blocks_until_window_expires() {
     );
 }
 
+// Multi-session hardening: the durable rate-limit DB must open in WAL mode so
+// several sessions sharing one project's limiter serialize on the write lock
+// (bounded by busy_timeout) instead of throwing "database is locked" into the
+// agent loop.
+#[test]
+fn rate_limit_db_uses_wal_journal_mode() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("rate.sqlite");
+    let buckets = vec![bucket("provider:rpm", 10, 1, 1_000)];
+    // Create the DB (and apply its pragmas) via the production reserve path.
+    try_reserve_once(&path, &buckets, 1_000).expect("reserve");
+
+    let conn = Connection::open(&path).expect("open sqlite");
+    let mode: String = conn
+        .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+        .expect("read journal_mode");
+    assert_eq!(
+        mode.to_lowercase(),
+        "wal",
+        "rate-limit sqlite must be WAL for cross-session concurrency"
+    );
+}
+
 #[test]
 fn multi_bucket_reservation_is_atomic_when_one_bucket_is_full() {
     let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/harn-vm/src/llm/cache.rs
+++ b/crates/harn-vm/src/llm/cache.rs
@@ -546,7 +546,18 @@ fn sqlite_connection(path: &Path) -> Result<Connection, VmError> {
         })?;
     }
     let conn = Connection::open(path).map_err(sqlite_error)?;
+    // Set busy_timeout BEFORE the WAL pragma so SQLite waits out a transient
+    // SQLITE_BUSY while another process/connection is mid-write rather than
+    // failing the WAL-mode promotion fast. WAL then lets one writer and many
+    // readers proceed concurrently, which is what makes the cache safe when
+    // two sessions in the same project run read-heavy roles (evaluator,
+    // enrichment, QC) at once. Matches the proven event-log setup
+    // (crates/harn-vm/src/event_log/sqlite.rs).
     conn.busy_timeout(Duration::from_secs(5))
+        .map_err(sqlite_error)?;
+    conn.pragma_update(None, "journal_mode", "WAL")
+        .map_err(sqlite_error)?;
+    conn.pragma_update(None, "synchronous", "NORMAL")
         .map_err(sqlite_error)?;
     conn.execute_batch(SQLITE_CREATE_TABLE)
         .map_err(sqlite_error)?;

--- a/crates/harn-vm/src/llm/cache_tests.rs
+++ b/crates/harn-vm/src/llm/cache_tests.rs
@@ -233,6 +233,28 @@ fn mem_cache_clear_resets_metrics_and_entries() {
     assert_eq!(metrics_snapshot(&options).misses, 0);
 }
 
+// Multi-session hardening: the sqlite cache must open in WAL mode so two
+// sessions in the same project can run read-heavy LLM roles concurrently
+// without a writer blocking readers into "database is locked".
+#[test]
+fn sqlite_cache_connection_uses_wal_journal_mode() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("cache.sqlite");
+    // Force the file (and its pragmas) to be created via the production path.
+    let options = sqlite_options(path.clone());
+    cache_put_at(&options, "a", serde_json::json!({"value": "a"}), 1_000).unwrap();
+
+    let conn = sqlite_connection(&path).expect("open cache connection");
+    let mode: String = conn
+        .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+        .expect("read journal_mode");
+    assert_eq!(
+        mode.to_lowercase(),
+        "wal",
+        "cache sqlite must be WAL for cross-session concurrency"
+    );
+}
+
 // Regression for the cache-key omission bug: tools, structured-output schema,
 // and stop sequences each change the model's output, so two calls differing
 // only in one of them must produce DIFFERENT cache keys (otherwise a wrong

--- a/scripts/lint_test_patterns.sh
+++ b/scripts/lint_test_patterns.sh
@@ -426,6 +426,10 @@ NON_TEST_WALL_CLOCK_ALLOWLIST=(
   "crates/harn-vm/src/a2a/mod.rs"
   "crates/harn-vm/src/agent_events/sinks.rs"
   "crates/harn-vm/src/agent_sessions.rs"
+  # Durable rate limiting retries real SQLite writer-lock contention and bounds
+  # wall-clock backoff with host monotonic time; VM clock injection would not
+  # model the blocking rusqlite calls it is defending.
+  "crates/harn-vm/src/durable_rate_limit.rs"
   "crates/harn-vm/src/connectors/a2a_push/mod.rs"
   "crates/harn-vm/src/connectors/harn_module.rs"
   "crates/harn-vm/src/connectors/shared.rs"


### PR DESCRIPTION
Forward-looking hardening for a user running **several Burin/Harn sessions on one machine**. Two SQLite stores under the project state root are shared across sessions in the same project, but both opened in default rollback-journal mode (`busy_timeout` only, no WAL):

| store | file | cross-session failure mode |
| --- | --- | --- |
| LLM read-cache | `crates/harn-vm/src/llm/cache.rs:548` | concurrent read-heavy roles (evaluator/enrichment/QC) in one project: one session's write txn blocks the other's reads into `database is locked` after `busy_timeout` |
| durable rate limiter | `crates/harn-vm/src/durable_rate_limit.rs:259` | N sessions hit `SQLITE_BUSY` on the `Immediate` write txn → error propagates through `acquire_durable_for_keys` and **fails the agent's LLM call** instead of degrading |

Both now set `journal_mode=WAL` + `synchronous=NORMAL` **after** the existing `busy_timeout` (so the WAL promotion waits out a transient lock), mirroring the proven `event_log/sqlite.rs:39-47` setup. WAL = one writer + many readers concurrently; busy_timeout absorbs writer-vs-writer overlap.

Deterministic tests assert each DB reports WAL after the production open path.

### Verified
- `cargo test -p harn-vm --lib -- wal_journal_mode` → 2 pass
- `cargo clippy -p harn-vm --lib` clean; `cargo fmt` applied

### Follow-ups (design, out of scope here)
- The durable limiter is scoped **per-project** (`rate_limit.rs:616`), so N projects each enforce the provider quota in isolation and can collectively exceed the account-global quota.
- A persistent `SQLITE_BUSY` still aborts the LLM call rather than failing open to the in-process sliding window.

Companion burin-code PR (burin-labs/burin-code#2425) hardens `~/.burin/usage.sqlite` the same way and adds the eval contention-metric policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)