### PR TITLE
Add no-dispatch equivalent failover opt-in

### DIFF
--- a/changelog.d/no-dispatch-equivalent-failover.added.md
+++ b/changelog.d/no-dispatch-equivalent-failover.added.md
@@ -1,0 +1,4 @@
+- **Equivalent LLM failover can now opt into no-dispatch upstream contract violations.**
+  `equivalent_failover: {on_no_dispatch: true}` lets same-logical-model
+  fallback routes advance after the normal empty-completion retry is exhausted
+  for billed no-dispatch provider responses.

--- a/crates/harn-vm/src/llm/helpers/options/routing.rs
+++ b/crates/harn-vm/src/llm/helpers/options/routing.rs
@@ -192,6 +192,7 @@ pub(super) fn parse_equivalent_failover_option(
 
     let mut enabled = true;
     let mut max_routes = DEFAULT_EQUIVALENT_FAILOVER_MAX_ROUTES;
+    let mut on_no_dispatch = false;
     match raw {
         VmValue::Nil | VmValue::Bool(false) => return Ok(None),
         VmValue::Bool(true) => {}
@@ -204,6 +205,20 @@ pub(super) fn parse_equivalent_failover_option(
                         return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
                             format!(
                                 "equivalent_failover.enabled: expected bool, got {}",
+                                other.type_name()
+                            ),
+                        ))));
+                    }
+                };
+            }
+            if let Some(value) = dict.get("on_no_dispatch") {
+                on_no_dispatch = match value {
+                    VmValue::Nil => false,
+                    VmValue::Bool(value) => *value,
+                    other => {
+                        return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
+                            format!(
+                                "equivalent_failover.on_no_dispatch: expected bool, got {}",
                                 other.type_name()
                             ),
                         ))));
@@ -244,7 +259,10 @@ pub(super) fn parse_equivalent_failover_option(
     }
 
     Ok(crate::llm::routing::build_equivalent_failover_policy(
-        provider, model, max_routes,
+        provider,
+        model,
+        max_routes,
+        on_no_dispatch,
     ))
 }
 

--- a/crates/harn-vm/src/llm/helpers/options/routing_tests.rs
+++ b/crates/harn-vm/src/llm/helpers/options/routing_tests.rs
@@ -521,6 +521,72 @@ fn equivalent_failover_builds_catalog_backed_routing_policy() {
         .iter()
         .all(|link| link.model != "same-provider-model"));
     assert_eq!(policy.failover.max_attempts, Some(2));
+    assert!(!policy.failover.on_no_dispatch);
+
+    crate::llm_config::clear_user_overrides();
+    super::super::reset_provider_key_cache();
+}
+
+#[test]
+fn equivalent_failover_enables_no_dispatch_failover_when_requested() {
+    install_equivalent_routes();
+    let mut failover = crate::value::DictMap::new();
+    failover.insert("max_routes".to_string(), VmValue::Int(2));
+    failover.insert("on_no_dispatch".to_string(), VmValue::Bool(true));
+    let opts = extract_with_options(crate::value::DictMap::from_iter([
+        (
+            "provider".to_string(),
+            VmValue::String(std::sync::Arc::from("primary")),
+        ),
+        (
+            "model".to_string(),
+            VmValue::String(std::sync::Arc::from("primary-model")),
+        ),
+        ("equivalent_failover".to_string(), VmValue::dict(failover)),
+    ]))
+    .expect("options");
+
+    let policy = opts.routing_policy.expect("equivalent routing policy");
+    assert_eq!(policy.failover.max_attempts, Some(2));
+    assert!(policy.failover.on_no_dispatch);
+
+    crate::llm_config::clear_user_overrides();
+    super::super::reset_provider_key_cache();
+}
+
+#[test]
+fn equivalent_failover_rejects_non_bool_no_dispatch_option() {
+    install_equivalent_routes();
+    let mut failover = crate::value::DictMap::new();
+    failover.insert(
+        "on_no_dispatch".to_string(),
+        VmValue::String(std::sync::Arc::from("yes")),
+    );
+
+    let err = match extract_with_options(crate::value::DictMap::from_iter([
+        (
+            "provider".to_string(),
+            VmValue::String(std::sync::Arc::from("primary")),
+        ),
+        (
+            "model".to_string(),
+            VmValue::String(std::sync::Arc::from("primary-model")),
+        ),
+        ("equivalent_failover".to_string(), VmValue::dict(failover)),
+    ])) {
+        Ok(_) => panic!("non-bool on_no_dispatch should fail"),
+        Err(err) => err,
+    };
+
+    match err {
+        VmError::Thrown(VmValue::String(message)) => {
+            assert!(
+                message.contains("equivalent_failover.on_no_dispatch"),
+                "{message}"
+            );
+        }
+        other => panic!("expected thrown on_no_dispatch error, got {other:?}"),
+    }
 
     crate::llm_config::clear_user_overrides();
     super::super::reset_provider_key_cache();

--- a/crates/harn-vm/src/llm/routing.rs
+++ b/crates/harn-vm/src/llm/routing.rs
@@ -46,6 +46,7 @@ pub(crate) fn build_equivalent_failover_policy(
     provider: &str,
     model: &str,
     max_routes: usize,
+    on_no_dispatch: bool,
 ) -> Option<Arc<RoutingPolicyConfig>> {
     if max_routes < 2 {
         return None;
@@ -92,6 +93,7 @@ pub(crate) fn build_equivalent_failover_policy(
     Some(Arc::new(RoutingPolicyConfig {
         failover: FailoverRules {
             max_attempts: Some(chain.len()),
+            on_no_dispatch,
             ..FailoverRules::default()
         },
         latency: LatencyRules::default(),
@@ -167,6 +169,10 @@ pub(crate) struct FailoverRules {
     pub on_status: Vec<u16>,
     pub on_timeout_ms: Option<u64>,
     pub on_error_kinds: Vec<String>,
+    /// Opt-in for billed no-dispatch upstream contract violations. Kept out
+    /// of default failover because these errors are already retried once by
+    /// `observed_llm_call` before routing sees the exhausted error.
+    pub on_no_dispatch: bool,
     pub max_attempts: Option<usize>,
 }
 
@@ -486,6 +492,7 @@ fn parse_failover(value: Option<&VmValue>) -> Result<FailoverRules, VmError> {
         on_status: parse_status_list(&dict, "on_status")?,
         on_timeout_ms: parse_pos_u64(&dict, "on_timeout_ms")?,
         on_error_kinds: parse_string_list(&dict, "on_error_kinds")?,
+        on_no_dispatch: false,
         max_attempts: parse_pos_usize(&dict, "max_attempts")?,
     })
 }
@@ -700,6 +707,9 @@ fn failover_value(failover: &FailoverRules) -> VmValue {
     if let Some(ms) = failover.on_timeout_ms {
         dict.insert("on_timeout_ms".to_string(), VmValue::Int(ms as i64));
     }
+    if failover.on_no_dispatch {
+        dict.insert("on_no_dispatch".to_string(), VmValue::Bool(true));
+    }
     if let Some(max) = failover.max_attempts {
         dict.insert("max_attempts".to_string(), VmValue::Int(max as i64));
     }
@@ -906,6 +916,10 @@ fn matches_failover(rules: &FailoverRules, error: &VmError) -> (bool, RoutingErr
         status,
     };
 
+    if rules.on_no_dispatch && is_no_dispatch_contract_violation(&snapshot.message) {
+        return (true, snapshot);
+    }
+
     if let Some(code) = status {
         if rules.on_status.contains(&code) {
             return (true, snapshot);
@@ -972,6 +986,14 @@ fn matches_failover(rules: &FailoverRules, error: &VmError) -> (bool, RoutingErr
     }
 
     (false, snapshot)
+}
+
+fn is_no_dispatch_contract_violation(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    lower.contains("returned billed output")
+        && lower.contains("completion_tokens=")
+        && lower.contains("no dispatchable tool call or answer")
+        && lower.contains("upstream contract violation")
 }
 
 fn extract_status_code(error: &VmError) -> Option<u16> {
@@ -2112,6 +2134,62 @@ mod tests {
         };
         let (eligible, _) = matches_failover(&rules, &err);
         assert!(eligible);
+    }
+
+    #[test]
+    fn no_dispatch_contract_violation_does_not_failover_by_default() {
+        let rules = FailoverRules::default();
+        let err = VmError::Runtime(
+            "provider openrouter model qwen/qwen3.6-35b-a3b returned billed output \
+             (completion_tokens=342) with no dispatchable tool call or answer \
+             (upstream contract violation): the model finished cleanly"
+                .to_string(),
+        );
+
+        let (eligible, _) = matches_failover(&rules, &err);
+
+        assert!(!eligible);
+    }
+
+    #[test]
+    fn no_dispatch_contract_violation_can_opt_into_failover() {
+        let rules = FailoverRules {
+            on_no_dispatch: true,
+            ..Default::default()
+        };
+        let err = VmError::Runtime(
+            "provider openrouter model qwen/qwen3.6-35b-a3b returned billed output \
+             (completion_tokens=342) with no dispatchable tool call or answer \
+             (upstream contract violation): the model finished cleanly"
+                .to_string(),
+        );
+
+        let (eligible, snap) = matches_failover(&rules, &err);
+
+        assert!(eligible);
+        assert!(snap.message.contains("upstream contract violation"));
+    }
+
+    #[test]
+    fn no_dispatch_matcher_requires_billed_completion_token_contract_shape() {
+        let rules = FailoverRules {
+            on_no_dispatch: true,
+            ..Default::default()
+        };
+        let cases = [
+            "returned billed output with no dispatchable tool call or answer \
+             (upstream contract violation)",
+            "returned billed output (completion_tokens=12) with no answer \
+             (upstream contract violation)",
+            "returned billed output (completion_tokens=12) with no dispatchable tool call or answer",
+            "completion_tokens=12 with no dispatchable tool call or answer \
+             (upstream contract violation)",
+        ];
+
+        for message in cases {
+            let (eligible, _) = matches_failover(&rules, &VmError::Runtime(message.to_string()));
+            assert!(!eligible, "message should not be eligible: {message}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `equivalent_failover.on_no_dispatch` as an opt-in flag for same-logical-model failover.
- Matches only billed no-dispatch upstream contract violations after the existing empty-completion retry path has exhausted.
- Adds focused parser and routing matcher tests plus a changelog fragment.

## Validation

- `cargo fmt --check && cargo test -p harn-vm no_dispatch --lib`
- `cargo test -p harn-vm equivalent_failover --lib`
- pre-commit hook: markdownlint, Rust formatting, clippy on changed `harn-vm` package
- pre-push hook: markdownlint and targeted local checks

## Caveats

- No Burin live evals, provider calls, or local model loops were run.
- The checkout had unrelated local edits before this branch; this PR commit intentionally excludes them.
