### PR TITLE
fix(stdlib): terminate signature paren scan on every bracket kind

### DIFF
--- a/changelog.d/matching-paren-closer-symmetry.fixed.md
+++ b/changelog.d/matching-paren-closer-symmetry.fixed.md
@@ -1,0 +1,4 @@
+Fix `matching_paren_len` (stdlib public-function signature parser) so a top-level `]` or `}`
+terminates the scan when bracket depth returns to zero, matching its symmetric opener arm and the
+sibling `split_top_level_params`. Previously only `)` triggered the return, so a mismatched closing
+bracket made the scan run to the end and yield `None`.

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -1207,13 +1207,12 @@ fn matching_paren_len(input: &str) -> Option<usize> {
     for (offset, ch) in input.char_indices() {
         match ch {
             '(' | '[' | '{' => depth += 1,
-            ')' => {
+            ')' | ']' | '}' => {
                 depth = depth.saturating_sub(1);
                 if depth == 0 {
                     return Some(offset);
                 }
             }
-            ']' | '}' => depth = depth.saturating_sub(1),
             _ => {}
         }
     }
@@ -1245,7 +1244,8 @@ mod tests {
 
     use super::{
         entrypoint_modules, find_cli_script, get_stdlib_prompt_asset, get_stdlib_source,
-        public_functions_for_module, STDLIB_CLI_SCRIPTS, STDLIB_PROMPT_ASSETS, STDLIB_SOURCES,
+        matching_paren_len, parse_public_function_line, public_functions_for_module,
+        STDLIB_CLI_SCRIPTS, STDLIB_PROMPT_ASSETS, STDLIB_SOURCES,
     };
 
     #[test]
@@ -1582,5 +1582,30 @@ mod tests {
         ] {
             assert!(entries.contains(&entry), "{entry:?} should be declared");
         }
+    }
+
+    #[test]
+    fn matching_paren_len_closes_on_every_bracket_kind() {
+        // Each closer kind must terminate the scan once depth returns to zero,
+        // mirroring the symmetric opener arm and `split_top_level_params`.
+        assert_eq!(matching_paren_len("a, b)"), Some(4));
+        assert_eq!(matching_paren_len("x: [int])"), Some(8));
+        assert_eq!(matching_paren_len("x: {a: int})"), Some(11));
+        // A top-level `]`/`}` is the matching close for the consumed opener and
+        // must return rather than scanning to the end and yielding `None`.
+        assert_eq!(matching_paren_len("x]"), Some(1));
+        assert_eq!(matching_paren_len("x}"), Some(1));
+        assert_eq!(matching_paren_len("unterminated"), None);
+    }
+
+    #[test]
+    fn parse_public_function_line_handles_record_typed_params() {
+        let parsed =
+            parse_public_function_line("pub fn configure(opts: {retries: int}) -> bool", None)
+                .expect("signature with a record-typed parameter should parse");
+        assert_eq!(parsed.name, "configure");
+        assert_eq!(parsed.signature, "configure(opts: {retries: int}) -> bool");
+        assert_eq!(parsed.total_params, 1);
+        assert_eq!(parsed.required_params, 1);
     }
 }


### PR DESCRIPTION
## What

`matching_paren_len` in `crates/harn-stdlib/src/lib.rs` scans a stdlib `pub fn`
parameter list to find the close paren matching the consumed `(`, tracking
nested bracket depth so brackets inside parameter types don't confuse the scan.

Its **opener** arm already groups all three bracket kinds:

```rust
'(' | '[' | '{' => depth += 1,
```

…but the **closer** handling was asymmetric — only `)` checked `depth == 0` and
returned; `]`/`}` decremented depth without ever terminating the scan:

```rust
')' => { depth = depth.saturating_sub(1); if depth == 0 { return Some(offset); } }
']' | '}' => depth = depth.saturating_sub(1),   // never returns
```

So a top-level `]`/`}` (the matching close for the consumed opener) ran the scan
to the end of the input and yielded `None` instead of its offset. The sibling
helper `split_top_level_params` in the same file already treats all three
closers identically (`')' | ']' | '}' => depth -= 1`), which pins down the
intended behaviour.

## Fix

Group the three closers into a single arm that returns when depth hits zero —
mirroring the opener arm and the sibling helper, removing the asymmetry, and
tightening the code (one arm instead of two). Behaviour is **unchanged for all
balanced inputs**; only mismatched/top-level closers are now handled correctly.

## Tests

- `matching_paren_len_closes_on_every_bracket_kind` — direct coverage of each
  closer kind plus the unterminated case.
- `parse_public_function_line_handles_record_typed_params` — end-to-end parse of
  a record-typed parameter signature.

`cargo test -p harn-stdlib --lib` → 20 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)