### PR TITLE
chore: speed up local dev setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/scripts/claude-dev-setup-once.sh",
+            "args": [],
+            "timeout": 600
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -1,0 +1,7 @@
+version = 1
+name = "harn"
+
+[setup]
+script = '''
+./scripts/dev_setup.sh
+'''

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ conformance/tests/**/.harn/test-timings.json
 
 # Shared Claude skill definitions are tracked; local Claude state is not.
 .claude/*
+!.claude/settings.json
 !.claude/commands/
 !.claude/skills/
 !.claude/skills/harn-scripting/
@@ -50,8 +51,12 @@ conformance/tests/**/.harn/test-timings.json
 # so it lives only in burin-code's local `.claude/commands/`.
 .claude/commands/merge-captain.md
 
-# Codex worktree environment files are per-worktree local state.
-.codex/environments/
+# Codex local environment config is reviewed repo setup; other generated
+# environment files remain local state.
+.codex/*
+!.codex/environments/
+.codex/environments/*
+!.codex/environments/environment.toml
 
 # JavaScript, portal, and website artifacts.
 node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,14 @@ local `harn` binary so it matches the version in use.
   tools, repo-local Node tooling when available, sccache config, per-worktree
   Cargo target config when `CODEX_WORKTREE_PATH` is set, and
   `cargo check --workspace`.
+- Setup phases are fingerprinted under `.codex/dev-setup/`, so repeated setup
+  is normally a fast no-op. Use `HARN_DEV_SETUP_FORCE=1 make setup` to refresh
+  every phase.
+- Codex app worktrees use `.codex/environments/environment.toml`, which calls
+  `make setup` through the same repo bootstrap path.
+- Claude Code project settings run `scripts/claude-dev-setup-once.sh` on
+  session startup. It delegates to the same setup path once per dependency
+  fingerprint and stores ignored logs under `.claude/dev-setup/`.
 - Use `make test` for workspace Rust tests. It uses `cargo nextest` when
   available and falls back to `cargo test --workspace`.
 - Use `make test-cargo` only when you need baseline Cargo behavior.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,18 @@ This script:
 - reuses the repo-root portal bootstrap path for `npm run portal:*` commands
 - runs `cargo check --workspace`
 
+Heavy setup phases are fingerprinted under `.codex/dev-setup/`, so rerunning
+the script in an already prepared checkout is normally a fast no-op. Set
+`HARN_DEV_SETUP_FORCE=1` to refresh every phase.
+
+Codex app-managed worktrees use the tracked local environment config at
+`.codex/environments/environment.toml`, which delegates to this same setup
+script.
+Claude Code uses the tracked project settings at `.claude/settings.json` to run
+`scripts/claude-dev-setup-once.sh` on new sessions. The hook delegates to this
+same setup script once per dependency fingerprint and writes logs under
+`.claude/dev-setup/`.
+
 ## Running checks
 
 Before submitting a PR, run the full check suite:

--- a/README.md
+++ b/README.md
@@ -438,8 +438,16 @@ installs repo-local Node tooling including the portal frontend, builds
 `crates/harn-cli/portal-dist`, enables the sccache rustc wrapper, and runs a
 workspace `cargo check`. When `CODEX_WORKTREE_PATH` is set, it also writes a
 per-worktree temp `target-dir` into `.cargo/config.toml` so parallel Codex
-worktrees do not fight over one shared Cargo target. `make portal` launches the
-built-in observability UI for persisted runs under `.harn-runs/`.
+worktrees do not fight over one shared Cargo target. Heavy setup phases are
+fingerprinted under `.codex/dev-setup/`, so rerunning the script in an already
+prepared checkout is normally a fast no-op; set `HARN_DEV_SETUP_FORCE=1` to
+refresh all phases. The tracked Codex local
+environment at `.codex/environments/environment.toml` calls the same script for
+new app-managed worktrees. Claude Code project settings use a `SessionStart`
+hook to run `scripts/claude-dev-setup-once.sh`, which delegates to this script
+once per dependency fingerprint and writes logs under `.claude/dev-setup/`.
+`make portal` launches the built-in observability UI
+for persisted runs under `.harn-runs/`.
 
 The repo-root portal scripts (`npm run portal:lint`, `portal:test`,
 `portal:build`, and `portal:dev`) self-bootstrap

--- a/scripts/claude-dev-setup-once.sh
+++ b/scripts/claude-dev-setup-once.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+input="$(cat)"
+hook_cwd="$(printf '%s' "$input" | python3 -c 'import json, sys; print(json.load(sys.stdin).get("cwd", ""))' 2>/dev/null || true)"
+root="${CLAUDE_PROJECT_DIR:-${hook_cwd:-$PWD}}"
+root="$(git -C "$root" rev-parse --show-toplevel 2>/dev/null || printf '%s\n' "$root")"
+cd "$root"
+
+if [[ ! -x scripts/dev_setup.sh ]]; then
+  exit 0
+fi
+
+persist_env() {
+  if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
+    printf 'export HARN_DEV_TARGET_WORKTREE_PATH=%q\n' "$root" >> "$CLAUDE_ENV_FILE"
+  fi
+}
+
+emit_context() {
+  local message="$1"
+  MESSAGE="$message" python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": os.environ["MESSAGE"],
+    }
+}))
+PY
+}
+
+fingerprint="$(
+  {
+    printf 'claude-dev-setup-once:v1\n'
+    for path in \
+      scripts/claude-dev-setup-once.sh \
+      scripts/dev_setup.sh \
+      Cargo.lock \
+      package-lock.json \
+      crates/harn-cli/portal/package-lock.json \
+      tree-sitter-harn/package-lock.json \
+      editors/vscode/package-lock.json \
+      website/package-lock.json
+    do
+      [[ -f "$path" ]] && shasum -a 256 "$path"
+    done
+    true
+  } | shasum -a 256 | awk '{print $1}'
+)"
+
+state_dir=".claude/dev-setup"
+stamp="${state_dir}/${fingerprint}.stamp"
+mkdir -p "$state_dir"
+
+persist_env
+if [[ -f "$stamp" && "${CLAUDE_DEV_SETUP_FORCE:-0}" != "1" ]]; then
+  exit 0
+fi
+
+log_path="${state_dir}/setup-$(date -u +%Y%m%dT%H%M%SZ).log"
+start_time="$(date +%s)"
+
+set +e
+HARN_DEV_TARGET_WORKTREE_PATH="${HARN_DEV_TARGET_WORKTREE_PATH:-$root}" \
+  ./scripts/dev_setup.sh >"$log_path" 2>&1
+status=$?
+set -e
+
+duration="$(( $(date +%s) - start_time ))"
+
+if [[ "$status" -eq 0 ]]; then
+  touch "$stamp"
+  ln -sf "$(basename "$log_path")" "${state_dir}/latest.log"
+  emit_context "Project dev setup completed in ${duration}s. Log: ${root}/${log_path}"
+else
+  emit_context "Project dev setup failed after ${duration}s with exit ${status}. Read ${root}/${log_path} before assuming dependencies are ready."
+fi
+
+exit 0

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+SETUP_STATE_DIR="${HARN_DEV_SETUP_STATE_DIR:-$ROOT_DIR/.codex/dev-setup}"
+
+log() {
+  printf '\n==> %s\n' "$*"
+}
+
 derive_target_dir() {
   local worktree_path="${HARN_DEV_TARGET_WORKTREE_PATH:-${CODEX_WORKTREE_PATH:-}}"
   if [[ -z "${worktree_path}" ]]; then
@@ -124,6 +130,72 @@ write_build_config() {
   mv "${tmp_path}" "${config_path}"
 }
 
+hash_setup_inputs() {
+  local name="$1"
+  shift
+
+  {
+    printf '%s\n' "${name}"
+    for path in "$@"; do
+      if [[ -f "${path}" ]]; then
+        shasum -a 256 "${path}"
+      elif [[ -d "${path}" ]]; then
+        find "${path}" \
+          \( -name node_modules -o -name target -o -name .git -o -name dist -o -name portal-dist \) -prune \
+          -o -type f -print0 \
+          | sort -z \
+          | xargs -0 shasum -a 256
+      fi
+    done
+    true
+  } | shasum -a 256 | awk '{print $1}'
+}
+
+cargo_setup_fingerprint() {
+  {
+    printf 'cargo-check:v1\n'
+    find . \
+      \( -name target -o -name '.target-*' -o -name .codex -o -name .claude -o -name node_modules -o -name .git \) -prune \
+      -o \( -name Cargo.toml -o -name Cargo.lock -o -name build.rs \) -type f -print0 \
+      | sort -z \
+      | xargs -0 shasum -a 256
+    true
+  } | shasum -a 256 | awk '{print $1}'
+}
+
+run_setup_step() {
+  local label="$1"
+  local stamp="$2"
+  shift 2
+
+  local required=()
+  while [[ "$#" -gt 0 && "$1" != "--" ]]; do
+    required+=("$1")
+    shift
+  done
+  shift
+
+  if [[ "${HARN_DEV_SETUP_FORCE:-0}" != "1" && -f "${stamp}" ]]; then
+    local ready=1
+    local required_path
+    for required_path in "${required[@]}"; do
+      if [[ ! -e "${required_path}" ]]; then
+        ready=0
+        break
+      fi
+    done
+
+    if [[ "${ready}" -eq 1 ]]; then
+      echo "${label} up to date."
+      return 0
+    fi
+  fi
+
+  log "${label}"
+  "$@"
+  touch "${stamp}"
+}
+
 echo "=== Harn dev setup ==="
 
 if ! command -v cargo >/dev/null 2>&1; then
@@ -138,10 +210,10 @@ echo "Configured git hooks path -> .githooks"
 # Install optional but recommended Cargo tools.
 for tool_spec in "cargo-nextest:cargo-nextest --locked" "sccache:sccache --locked"; do
   tool="${tool_spec%%:*}"
-  install_args="${tool_spec#*:}"
+  read -r -a install_args <<< "${tool_spec#*:}"
   if ! command -v "$tool" >/dev/null 2>&1; then
     echo "Installing $tool..."
-    cargo install $install_args || echo "warning: failed to install $tool (non-fatal)"
+    cargo install "${install_args[@]}" || echo "warning: failed to install $tool (non-fatal)"
   else
     echo "$tool already installed."
   fi
@@ -177,45 +249,93 @@ if [[ -n "${target_dir}" ]]; then
   echo "Configured Cargo target dir -> ${target_dir}"
 fi
 
+mkdir -p "${SETUP_STATE_DIR}"
+
 # Reclaim per-worktree target dirs left behind by worktrees that have since
 # been removed. Best-effort; never fail setup over housekeeping.
 if [[ -x ./scripts/prune_stale_targets.sh ]]; then
-  ./scripts/prune_stale_targets.sh || true
+  prune_stamp="${SETUP_STATE_DIR}/prune-stale-targets.stamp"
+  prune_interval="${HARN_DEV_SETUP_PRUNE_SECONDS:-86400}"
+  should_prune=1
+
+  if [[ "${HARN_DEV_SETUP_FORCE:-0}" != "1" && -f "${prune_stamp}" ]]; then
+    last_prune="$(stat -f %m "${prune_stamp}" 2>/dev/null || stat -c %Y "${prune_stamp}" 2>/dev/null || echo 0)"
+    now="$(date +%s)"
+    if (( now - last_prune < prune_interval )); then
+      should_prune=0
+    fi
+  fi
+
+  if [[ "${should_prune}" -eq 1 ]]; then
+    ./scripts/prune_stale_targets.sh && touch "${prune_stamp}" || true
+  else
+    echo "harn-target GC recently checked."
+  fi
 fi
 
 if command -v npm >/dev/null 2>&1; then
-  echo "Installing repo-local Node tooling..."
-  npm install
+  root_node_fp="$(hash_setup_inputs root-node package.json package-lock.json)"
+  run_setup_step \
+    "Installing repo-local Node tooling" \
+    "${SETUP_STATE_DIR}/root-node-${root_node_fp}.stamp" \
+    node_modules \
+    -- npm install --no-audit --fund=false
 
   if [[ -f crates/harn-cli/portal/package.json ]]; then
-    ./scripts/ensure_portal_deps.sh
+    portal_deps_fp="$(hash_setup_inputs portal-deps scripts/ensure_portal_deps.sh crates/harn-cli/portal/package.json crates/harn-cli/portal/package-lock.json)"
+    run_setup_step \
+      "Installing portal frontend dependencies" \
+      "${SETUP_STATE_DIR}/portal-deps-${portal_deps_fp}.stamp" \
+      crates/harn-cli/portal/node_modules \
+      -- ./scripts/ensure_portal_deps.sh
   fi
 
   if [[ -f tree-sitter-harn/package.json ]]; then
-    echo "Installing tree-sitter-harn dependencies..."
-    (cd tree-sitter-harn && npm install)
+    tree_sitter_fp="$(hash_setup_inputs tree-sitter-node tree-sitter-harn/package.json tree-sitter-harn/package-lock.json)"
+    run_setup_step \
+      "Installing tree-sitter-harn dependencies" \
+      "${SETUP_STATE_DIR}/tree-sitter-node-${tree_sitter_fp}.stamp" \
+      tree-sitter-harn/node_modules \
+      -- bash -c 'cd tree-sitter-harn && npm install --no-audit --fund=false'
   fi
 
   if [[ -f editors/vscode/package.json ]]; then
-    echo "Installing VS Code extension dependencies..."
-    (cd editors/vscode && npm install)
+    vscode_fp="$(hash_setup_inputs vscode-node editors/vscode/package.json editors/vscode/package-lock.json)"
+    run_setup_step \
+      "Installing VS Code extension dependencies" \
+      "${SETUP_STATE_DIR}/vscode-node-${vscode_fp}.stamp" \
+      editors/vscode/node_modules \
+      -- bash -c 'cd editors/vscode && npm install --no-audit --fund=false'
   fi
 
   if [[ -f crates/harn-cli/portal/package.json ]]; then
-    echo "Building portal frontend..."
-    npm run portal:build
+    portal_build_fp="$(hash_setup_inputs portal-build package.json package-lock.json scripts/ensure_portal_deps.sh crates/harn-cli/portal)"
+    run_setup_step \
+      "Building portal frontend" \
+      "${SETUP_STATE_DIR}/portal-build-${portal_build_fp}.stamp" \
+      crates/harn-cli/portal-dist/index.html \
+      -- npm run portal:build
   fi
 
   if [[ -f website/package.json ]]; then
-    echo "Installing harnlang.com site dependencies..."
-    (cd website && npm install)
+    website_fp="$(hash_setup_inputs website-node website/package.json website/package-lock.json)"
+    run_setup_step \
+      "Installing harnlang.com site dependencies" \
+      "${SETUP_STATE_DIR}/website-node-${website_fp}.stamp" \
+      website/node_modules \
+      -- bash -c 'cd website && npm install --no-audit --fund=false'
   fi
 else
   echo "warning: npm not found; skipping markdown, portal, tree-sitter, VS Code extension, and docs-site dependencies"
 fi
 
-echo "Running a quick workspace build check..."
-cargo check --workspace
+cargo_target_root="${target_dir:-$ROOT_DIR/target}"
+cargo_fp="$(cargo_setup_fingerprint)"
+run_setup_step \
+  "Running a quick workspace build check" \
+  "${SETUP_STATE_DIR}/cargo-check-${cargo_fp}.stamp" \
+  "${cargo_target_root}/debug" \
+  -- cargo check --workspace
 
 # macOS-only: sign any locally-built harn binaries with the team Developer
 # ID Application identity so Gatekeeper doesn't pop up "Verifying harn..."


### PR DESCRIPTION
## Summary
- fingerprint heavy local setup phases so repeated Codex/Claude setup runs are fast no-ops
- add tracked Codex and Claude project setup entrypoints that delegate to the same script
- document the setup cache behavior and force-refresh knob

## Validation
- bash -n scripts/dev_setup.sh scripts/claude-dev-setup-once.sh
- shellcheck scripts/dev_setup.sh scripts/claude-dev-setup-once.sh
- python3 -m json.tool .claude/settings.json
- Python tomllib parse of .codex/environments/environment.toml
- git diff --check
- pre-commit markdownlint
- pre-push markdownlint/targeted hooks