### PR TITLE
[codex] Recognize stream route attribute in checker

### DIFF
--- a/changelog.d/3403.fixed.md
+++ b/changelog.d/3403.fixed.md
@@ -1,0 +1,3 @@
+- **`harn check` now recognizes `@stream` route attributes (#3403).** Stream
+  routes no longer emit an `unknown attribute @stream` warning during static
+  checking.

--- a/crates/harn-parser/src/typechecker/inference/statements/attributes.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements/attributes.rs
@@ -33,7 +33,8 @@ impl TypeChecker {
                 "deprecated" | "test" | "complexity" | "acp_tool" | "acp_skill" | "invariant"
                 | "deterministic" | "semantic" | "archivist" | "retroactive" | "persona"
                 | "step" | "trigger" | "handoff" | "budget" | "command" | "serial" | "heavy"
-                | "scopes" | "policy" | "route" | "job" | "schedule" | "queue" | "retry" => {}
+                | "scopes" | "policy" | "route" | "stream" | "job" | "schedule" | "queue"
+                | "retry" => {}
                 other => {
                     self.warning_at(
                         Code::UnknownAttribute,

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -629,6 +629,23 @@ fn admin_x(req) { return req }
 }
 
 #[test]
+fn test_stream_route_attribute_is_recognized() {
+    let warns = warnings(
+        r#"
+@stream
+@route("GET", "/events")
+fn events(req) { return req }
+"#,
+    );
+    assert!(
+        warns
+            .iter()
+            .all(|w| !w.contains("unknown attribute") && !w.contains("@stream")),
+        "stream route attribute should not warn as unknown: {warns:?}"
+    );
+}
+
+#[test]
 fn test_command_attribute_warns_on_function_decls() {
     let warns = warnings(
         r#"


### PR DESCRIPTION
## Summary
- teach the parser/typechecker attribute allowlist that `@stream` is a known route marker
- add a regression test so `harn check` no longer emits `unknown attribute @stream` for routed stream functions

## Validation
- `git diff --check origin/main..HEAD`
- `cargo fmt --all -- --check`
- `cargo test -p harn-parser test_stream_route_attribute_is_recognized`
- worker also ran `cargo test -p harn-serve stream_attribute_marks_routed_functions_only` and direct `harn check` verification

No release in this PR.