### PR TITLE
Recognize raw route attribute in checker

### DIFF
--- a/changelog.d/3404.fixed.md
+++ b/changelog.d/3404.fixed.md
@@ -1,0 +1,3 @@
+- **Route attribute checking now recognizes `@raw` (#3404).** Static
+  typechecking no longer reports declaration-only raw HTTP routes as unknown
+  attributes.

--- a/crates/harn-parser/src/typechecker/inference/statements/attributes.rs
+++ b/crates/harn-parser/src/typechecker/inference/statements/attributes.rs
@@ -33,8 +33,8 @@ impl TypeChecker {
                 "deprecated" | "test" | "complexity" | "acp_tool" | "acp_skill" | "invariant"
                 | "deterministic" | "semantic" | "archivist" | "retroactive" | "persona"
                 | "step" | "trigger" | "handoff" | "budget" | "command" | "serial" | "heavy"
-                | "scopes" | "policy" | "route" | "stream" | "job" | "schedule" | "queue"
-                | "retry" => {}
+                | "scopes" | "policy" | "route" | "stream" | "raw" | "job" | "schedule"
+                | "queue" | "retry" => {}
                 other => {
                     self.warning_at(
                         Code::UnknownAttribute,

--- a/crates/harn-parser/src/typechecker/tests/typing.rs
+++ b/crates/harn-parser/src/typechecker/tests/typing.rs
@@ -646,6 +646,23 @@ fn events(req) { return req }
 }
 
 #[test]
+fn test_raw_route_attribute_is_recognized() {
+    let warns = warnings(
+        r#"
+@raw
+@route("POST", "/hooks")
+fn hooks(req) { return req }
+"#,
+    );
+    assert!(
+        warns
+            .iter()
+            .all(|w| !w.contains("unknown attribute") && !w.contains("@raw")),
+        "raw route attribute should not warn as unknown: {warns:?}"
+    );
+}
+
+#[test]
 fn test_command_attribute_warns_on_function_decls() {
     let warns = warnings(
         r#"


### PR DESCRIPTION
## Summary
- recognize @raw as a valid route attribute in the static checker
- add a parser/typechecker regression test alongside the route/stream coverage

## Validation
- CARGO_TARGET_DIR="/private/tmp/harn-raw-route-attribute/.target" cargo test --locked -p harn-parser test_raw_route_attribute_is_recognized
- CARGO_TARGET_DIR="/private/tmp/harn-raw-route-attribute/.target" cargo test --locked -p harn-parser route_attribute_is_recognized
- CARGO_TARGET_DIR="/private/tmp/harn-raw-route-attribute/.target" cargo fmt --all -- --check
- CARGO_TARGET_DIR="/private/tmp/harn-raw-route-attribute/.target" cargo check --locked -p harn-parser
- CARGO_TARGET_DIR="/private/tmp/harn-raw-route-attribute/.target" cargo test --locked -p harn-parser
- CARGO_TARGET_DIR="/private/tmp/harn-raw-route-attribute/.target" cargo clippy --locked -p harn-parser --all-targets -- -D warnings

No crate release is included.