### PR TITLE
[codex] Cover host-built HTTP reply cookies

### DIFF
--- a/crates/harn-serve/tests/site_hosting.rs
+++ b/crates/harn-serve/tests/site_hosting.rs
@@ -19,7 +19,11 @@ use axum::body::{to_bytes, Body};
 use axum::http::{header, Method, Request, StatusCode};
 use axum::response::Response;
 use axum::Router;
-use harn_serve::{DispatchCore, DispatchCoreConfig, NoReplayCache, SiteServer, SiteServerConfig};
+use harn_serve::{
+    DispatchCore, DispatchCoreConfig, DispatchError, NoReplayCache, SiteServer, SiteServerConfig,
+    VmConfigurator,
+};
+use harn_vm::{HostCallBridge, Vm, VmError, VmValue};
 use serde_json::Value;
 use tower::ServiceExt;
 
@@ -131,6 +135,57 @@ fn router_trusting(path: &Path, proxies: &[&str]) -> Router {
     SiteServer::new(SiteServerConfig::new(build_core(path)).with_trusted_proxies(proxies))
         .router()
         .expect("site router")
+}
+
+struct HostReplyBridge;
+
+impl HostCallBridge for HostReplyBridge {
+    fn dispatch(
+        &self,
+        capability: &str,
+        operation: &str,
+        _params: &harn_vm::value::DictMap,
+    ) -> Result<Option<VmValue>, VmError> {
+        if capability != "http_reply" || operation != "build" {
+            return Ok(None);
+        }
+
+        let cookies = VmValue::List(Arc::new(vec![
+            VmValue::String(Arc::from("sid=abc; Path=/; HttpOnly")),
+            VmValue::String(Arc::from("theme=dark; Path=/; SameSite=Lax")),
+        ]));
+        let headers = harn_vm::value::DictMap::from_iter([
+            (
+                "Content-Type".to_string(),
+                VmValue::String(Arc::from("application/octet-stream")),
+            ),
+            ("Set-Cookie".to_string(), cookies),
+            (
+                "X-Reply-Source".to_string(),
+                VmValue::String(Arc::from("host-call")),
+            ),
+        ]);
+        let response = harn_vm::value::DictMap::from_iter([
+            ("status".to_string(), VmValue::Int(200)),
+            ("body_kind".to_string(), VmValue::String(Arc::from("bytes"))),
+            (
+                "raw_body".to_string(),
+                VmValue::Bytes(Arc::new(vec![0x00, 0xff, 0xfe, 0x80])),
+            ),
+            ("headers".to_string(), VmValue::dict(headers)),
+        ]);
+
+        Ok(Some(VmValue::dict(response)))
+    }
+}
+
+struct HostReplyBridgeConfigurator;
+
+impl VmConfigurator for HostReplyBridgeConfigurator {
+    fn configure(&self, _vm: &mut Vm) -> Result<(), DispatchError> {
+        harn_vm::set_host_call_bridge(Arc::new(HostReplyBridge));
+        Ok(())
+    }
 }
 
 /// A `GET /whoami` request carrying the given transport peer (mirroring
@@ -382,6 +437,62 @@ async fn binary_response_from_harn_handler_round_trips_byte_exact() {
     assert_eq!(
         response.headers()[header::CONTENT_DISPOSITION],
         "attachment; filename=\"demo.harnpack\""
+    );
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(body.as_ref(), &[0x00, 0xff, 0xfe, 0x80]);
+}
+
+#[tokio::test]
+async fn host_call_http_reply_from_preserves_bytes_and_repeated_set_cookie() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("site.harn");
+    std::fs::write(
+        &path,
+        r#"
+@route("GET", "/host-reply")
+pub fn host_reply(req: dict) -> dict {
+  return http_reply_from(host_call("http_reply.build", {}))
+}
+"#,
+    )
+    .expect("write script");
+    let mut config = DispatchCoreConfig::for_script(&path);
+    config.replay_cache = Arc::new(NoReplayCache);
+    config.vm_configurator = Arc::new(HostReplyBridgeConfigurator);
+    let router = SiteServer::new(SiteServerConfig::new(
+        DispatchCore::new(config).expect("dispatch core"),
+    ))
+    .router()
+    .expect("site router");
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/host-reply")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers()[header::CONTENT_TYPE],
+        "application/octet-stream"
+    );
+    assert_eq!(response.headers()["x-reply-source"], "host-call");
+    let cookies = response
+        .headers()
+        .get_all(header::SET_COOKIE)
+        .iter()
+        .map(|value| value.to_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        cookies,
+        vec![
+            "sid=abc; Path=/; HttpOnly",
+            "theme=dark; Path=/; SameSite=Lax",
+        ]
     );
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     assert_eq!(body.as_ref(), &[0x00, 0xff, 0xfe, 0x80]);


### PR DESCRIPTION
## Summary
- add harn-serve site coverage for a `.harn` handler returning `http_reply_from(host_call(...))`
- cover raw byte response bodies and multi-value `Set-Cookie` headers end-to-end through the site router

## Why
This locks in existing host-built HTTP response behavior that harn-cloud relies on while moving more route logic out of native gateway handlers. It is test-only and does not add the gated token-safe direct-response primitive.

## Validation
- `CARGO_TARGET_DIR="$PWD/.target" cargo fmt --all -- --check`
- `CARGO_TARGET_DIR="$PWD/.target" cargo test -p harn-serve --test site_hosting --locked`
- pre-push targeted checks for `harn-serve`

No production API changed.
