### PR TITLE
Resume MCP calls after interactive OAuth

### DIFF
--- a/changelog.d/2271.fixed.md
+++ b/changelog.d/2271.fixed.md
@@ -1,0 +1,3 @@
+- Resume interactive HTTP MCP tool calls after a mid-loop OAuth 401 once the host
+  completes authorization, while headless runs now fail with a clear auth error
+  instead of hanging.

--- a/crates/harn-vm/src/mcp/tests.rs
+++ b/crates/harn-vm/src/mcp/tests.rs
@@ -2,12 +2,41 @@ use super::*;
 use crate::http::framing::{http_content_length_from_headers, TEST_HTTP_MAX_BODY_BYTES};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 #[derive(Debug)]
 struct RecordedHttpRequest {
     headers: BTreeMap<String, String>,
     body: serde_json::Value,
+}
+
+struct CapturingAgentEventSink(Arc<std::sync::Mutex<Vec<crate::agent_events::AgentEvent>>>);
+
+impl crate::agent_events::AgentEventSink for CapturingAgentEventSink {
+    fn handle_event(&self, event: &crate::agent_events::AgentEvent) {
+        self.0.lock().unwrap().push(event.clone());
+    }
+}
+
+struct CurrentHostBridgeGuard;
+
+impl CurrentHostBridgeGuard {
+    fn install() -> Self {
+        let bridge = crate::bridge::HostBridge::from_parts_with_writer(
+            Arc::new(Mutex::new(std::collections::HashMap::new())),
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            Arc::new(|_| Ok(())),
+            1,
+        );
+        crate::llm::install_current_host_bridge(Arc::new(bridge));
+        Self
+    }
+}
+
+impl Drop for CurrentHostBridgeGuard {
+    fn drop(&mut self) {
+        crate::llm::clear_current_host_bridge();
+    }
 }
 
 // The loopback HTTP tests start background GET streams against in-process
@@ -348,6 +377,119 @@ async fn modern_input_required_result_dispatches_and_retries() {
         .await;
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn modern_http_401_auth_required_waits_for_oauth_and_retries_tool_call() {
+    let _guard = http_mcp_test_guard().await;
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (base_url, mut requests, auth_challenged) =
+                spawn_auth_required_modern_http_mcp_server().await;
+            let handle = modern_http_handle(&base_url).await;
+            let server_url = format!("{base_url}/mcp");
+            let resource = crate::mcp_auth::canonical_resource_indicator(&server_url).unwrap();
+            let session_id =
+                crate::agent_sessions::open_or_create(Some("mcp-auth-retry".to_string()));
+            let _session_guard = crate::agent_sessions::enter_current_session(session_id.clone());
+            let _bridge_guard = CurrentHostBridgeGuard::install();
+            let captured_events = install_capturing_agent_sink(&session_id);
+
+            let notifier = tokio::spawn({
+                let resource = resource.clone();
+                async move {
+                    auth_challenged
+                        .await
+                        .expect("mock server should issue an auth challenge");
+                    let token = test_stored_mcp_token(&resource, "fresh-token");
+                    crate::mcp_oauth::notify_authorization_completed(&token);
+                }
+            });
+
+            let result = call_mcp_tool(
+                &handle,
+                "execute_sql",
+                serde_json::json!({"region": "us-west1", "query": "select 1"}),
+            )
+            .await
+            .unwrap();
+            notifier.await.expect("auth notifier task should complete");
+            assert_eq!(result, serde_json::json!("ok"));
+
+            let discover = recv_recorded_request(&mut requests).await;
+            assert_modern_http_request(&discover, "server/discover", None);
+            let first_call = recv_recorded_request(&mut requests).await;
+            assert_modern_http_request(&first_call, "tools/call", Some("execute_sql"));
+            assert!(!first_call.headers.contains_key("authorization"));
+            let retry_call = recv_recorded_request(&mut requests).await;
+            assert_modern_http_request(&retry_call, "tools/call", Some("execute_sql"));
+            assert_eq!(
+                retry_call.headers.get("authorization").map(String::as_str),
+                Some("Bearer fresh-token")
+            );
+
+            let events = captured_events.lock().unwrap().clone();
+            assert!(
+                events.iter().any(|event| matches!(
+                    event,
+                    crate::agent_events::AgentEvent::McpAuthRequired {
+                        session_id: event_session_id,
+                        server,
+                        resource: event_resource,
+                        scope: Some(scope),
+                    } if event_session_id == &session_id
+                        && server == "modern-http"
+                        && event_resource == &resource
+                        && scope == "repo"
+                )),
+                "expected McpAuthRequired event, got {events:?}"
+            );
+            crate::agent_events::clear_session_sinks(&session_id);
+            handle.disconnect().await.unwrap();
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn modern_http_401_without_interactive_host_returns_auth_error() {
+    let _guard = http_mcp_test_guard().await;
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            crate::llm::clear_current_host_bridge();
+            let (base_url, mut requests, _auth_challenged) =
+                spawn_auth_required_modern_http_mcp_server().await;
+            let handle = modern_http_handle(&base_url).await;
+            let session_id =
+                crate::agent_sessions::open_or_create(Some("mcp-auth-headless".to_string()));
+            let _session_guard = crate::agent_sessions::enter_current_session(session_id);
+            let error = call_mcp_tool(
+                &handle,
+                "execute_sql",
+                serde_json::json!({"region": "us-west1", "query": "select 1"}),
+            )
+            .await
+            .expect_err("headless MCP auth challenge should fail clearly");
+
+            match error {
+                VmError::CategorizedError { category, message } => {
+                    assert_eq!(category, crate::value::ErrorCategory::Auth);
+                    assert!(message.contains("modern-http"), "{message}");
+                    assert!(message.contains("no interactive host"), "{message}");
+                }
+                other => panic!("expected categorized auth error, got {other:?}"),
+            }
+
+            let discover = recv_recorded_request(&mut requests).await;
+            assert_modern_http_request(&discover, "server/discover", None);
+            let first_call = recv_recorded_request(&mut requests).await;
+            assert_modern_http_request(&first_call, "tools/call", Some("execute_sql"));
+            assert!(
+                matches!(requests.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+                "headless path should not retry"
+            );
+            handle.disconnect().await.unwrap();
+        })
+        .await;
+}
+
 #[test]
 fn x_mcp_header_validation_filters_invalid_tools_and_encodes_values() {
     let tools = vec![
@@ -500,6 +642,95 @@ async fn spawn_modern_http_mcp_server() -> (String, mpsc::UnboundedReceiver<Reco
     });
 
     (format!("http://{addr}"), request_rx)
+}
+
+async fn spawn_auth_required_modern_http_mcp_server() -> (
+    String,
+    mpsc::UnboundedReceiver<RecordedHttpRequest>,
+    oneshot::Receiver<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (request_tx, request_rx) = mpsc::unbounded_channel();
+    let (auth_challenged_tx, auth_challenged_rx) = oneshot::channel();
+
+    tokio::spawn(async move {
+        let mut challenged = false;
+        let mut auth_challenged_tx = Some(auth_challenged_tx);
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            let Ok((_request_line, headers, body)) = read_http_request(&mut stream).await else {
+                continue;
+            };
+            let Ok(request) = serde_json::from_slice::<serde_json::Value>(&body) else {
+                continue;
+            };
+            let _ = request_tx.send(RecordedHttpRequest {
+                headers: headers.clone(),
+                body: request.clone(),
+            });
+            let method = request.get("method").and_then(|value| value.as_str());
+            if method == Some("tools/call") && !challenged {
+                challenged = true;
+                if let Some(sender) = auth_challenged_tx.take() {
+                    let _ = sender.send(());
+                }
+                let _ = write_http_json(
+                    &mut stream,
+                    "401 Unauthorized",
+                    &[("WWW-Authenticate", r#"Bearer scope="repo""#)],
+                    serde_json::json!({"error": "authorization required"}),
+                )
+                .await;
+                continue;
+            }
+            if method == Some("tools/call")
+                && headers.get("authorization").map(String::as_str) != Some("Bearer fresh-token")
+            {
+                let _ = write_http_json(
+                    &mut stream,
+                    "401 Unauthorized",
+                    &[("WWW-Authenticate", r#"Bearer scope="repo""#)],
+                    serde_json::json!({"error": "authorization required"}),
+                )
+                .await;
+                continue;
+            }
+            let response = modern_http_response(&request, method);
+            let _ = write_http_json(&mut stream, "200 OK", &[], response).await;
+        }
+    });
+
+    (format!("http://{addr}"), request_rx, auth_challenged_rx)
+}
+
+fn install_capturing_agent_sink(
+    session_id: &str,
+) -> Arc<std::sync::Mutex<Vec<crate::agent_events::AgentEvent>>> {
+    let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+    crate::agent_events::register_sink(
+        session_id.to_string(),
+        Arc::new(CapturingAgentEventSink(events.clone())),
+    );
+    events
+}
+
+fn test_stored_mcp_token(resource: &str, access_token: &str) -> crate::mcp_oauth::StoredMcpToken {
+    crate::mcp_oauth::StoredMcpToken {
+        access_token: access_token.to_string(),
+        refresh_token: None,
+        expires_at_unix: None,
+        token_endpoint: "https://auth.example/token".to_string(),
+        client_id: "test-client".to_string(),
+        client_secret: None,
+        token_endpoint_auth_method: "none".to_string(),
+        issuer: "https://auth.example".to_string(),
+        resource: resource.to_string(),
+        scopes: Some("repo".to_string()),
+        token_response_extra: None,
+    }
 }
 
 async fn spawn_legacy_http_fallback_server(

--- a/crates/harn-vm/src/mcp/transport.rs
+++ b/crates/harn-vm/src/mcp/transport.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+const MCP_AUTH_COMPLETION_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(10);
+
 pub(crate) async fn stdio_call_raw(
     inner: &mut StdioMcpClientInner,
     server_name: &str,
@@ -208,7 +210,11 @@ pub(crate) async fn send_http_request(
     params: serde_json::Value,
     id: Option<u64>,
 ) -> Result<serde_json::Value, VmError> {
-    for attempt in 0..2 {
+    let mut legacy_session_retry_used = false;
+    let mut auth_retry_used = false;
+    let mut protocol_version_retry_used = false;
+    loop {
+        let auth_completion_rx = crate::mcp_oauth::subscribe_authorization_completions();
         let response = send_http_request_once(inner, method, params.clone(), id).await?;
 
         let status = response.status().as_u16();
@@ -229,8 +235,9 @@ pub(crate) async fn send_http_request(
             && status == 404
             && inner.session_id.is_some()
             && method != "initialize"
-            && attempt == 0
+            && !legacy_session_retry_used
         {
+            legacy_session_retry_used = true;
             inner.session_id = None;
             inner.abort_get_stream();
             reinitialize_http_client(inner).await?;
@@ -239,9 +246,16 @@ pub(crate) async fn send_http_request(
 
         if status == 401 {
             emit_mcp_auth_required_event(server_name, &inner.url, &headers);
-            return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
-                "MCP authorization required",
-            ))));
+            if auth_retry_used {
+                return Err(mcp_auth_required_error(
+                    server_name,
+                    &inner.url,
+                    "server still returned 401 after authorization completed",
+                ));
+            }
+            auth_retry_used = true;
+            wait_for_http_mcp_authorization(inner, server_name, auth_completion_rx).await?;
+            continue;
         }
 
         let body = response
@@ -279,8 +293,9 @@ pub(crate) async fn send_http_request(
         };
 
         if maybe_retry_unsupported_protocol(inner.protocol_mode, &mut inner.protocol_version, &msg)
-            && attempt == 0
+            && !protocol_version_retry_used
         {
+            protocol_version_retry_used = true;
             continue;
         }
 
@@ -290,8 +305,49 @@ pub(crate) async fn send_http_request(
         }
         return Ok(msg);
     }
+}
 
-    Err(VmError::Runtime("MCP HTTP request failed".into()))
+async fn wait_for_http_mcp_authorization(
+    inner: &mut HttpMcpClientInner,
+    server_name: &str,
+    auth_completion_rx: tokio::sync::broadcast::Receiver<crate::mcp_oauth::StoredMcpToken>,
+) -> Result<(), VmError> {
+    if crate::llm::current_agent_session_id().is_none() {
+        return Err(mcp_auth_required_error(
+            server_name,
+            &inner.url,
+            "no active agent session is available to surface an authorization prompt",
+        ));
+    }
+    if crate::llm::current_host_bridge().is_none() {
+        return Err(mcp_auth_required_error(
+            server_name,
+            &inner.url,
+            "no interactive host is available to complete OAuth",
+        ));
+    }
+
+    let resource = crate::mcp_auth::canonical_resource_indicator(&inner.url)
+        .unwrap_or_else(|_| inner.url.clone());
+    let token = crate::mcp_oauth::wait_for_authorization_completion(
+        &resource,
+        MCP_AUTH_COMPLETION_TIMEOUT,
+        auth_completion_rx,
+    )
+    .await
+    .map_err(|error| mcp_auth_required_error(server_name, &inner.url, &error))?;
+    inner.auth_token = Some(token.access_token);
+    inner.abort_get_stream();
+    Ok(())
+}
+
+fn mcp_auth_required_error(server_name: &str, server_url: &str, reason: &str) -> VmError {
+    let resource = crate::mcp_auth::canonical_resource_indicator(server_url)
+        .unwrap_or_else(|_| server_url.to_string());
+    VmError::CategorizedError {
+        category: crate::value::ErrorCategory::Auth,
+        message: format!("MCP authorization required for {server_name} ({resource}): {reason}"),
+    }
 }
 
 pub(crate) async fn send_http_request_once(

--- a/crates/harn-vm/src/mcp_oauth.rs
+++ b/crates/harn-vm/src/mcp_oauth.rs
@@ -36,7 +36,7 @@ use base64::Engine;
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::{broadcast, Mutex as AsyncMutex};
 
 use crate::mcp_auth::{
     authorization_code_token_form, build_oauth_authorization_url, canonical_resource_indicator,
@@ -66,6 +66,8 @@ const TOKEN_REFRESH_SKEW_SECS: i64 = 60;
 /// Upper bound on concurrently pending (begun-but-not-completed) authorizations.
 /// Caps memory from abandoned flows in a long-lived server.
 const MAX_PENDING_FLOWS: usize = 32;
+
+const AUTH_COMPLETION_CHANNEL_CAPACITY: usize = 64;
 
 /// A persisted MCP OAuth token plus everything needed to refresh it without
 /// re-running discovery. Keyed in the keyring by `(resource, issuer, client_id)`.
@@ -324,6 +326,7 @@ pub async fn complete_authorization(
         token_response_extra: token_response_extra(token.extra),
     };
     save_stored_token(&stored).await?;
+    notify_authorization_completed(&stored);
     Ok(stored)
 }
 
@@ -356,7 +359,44 @@ pub async fn import_stored_token(request: ImportStoredToken) -> Result<StoredMcp
     let discovery = discover(&request.server_url).await?;
     let stored = stored_token_for_import(&request, &discovery)?;
     save_stored_token(&stored).await?;
+    notify_authorization_completed(&stored);
     Ok(stored)
+}
+
+fn auth_completion_sender() -> &'static broadcast::Sender<StoredMcpToken> {
+    static SENDER: OnceLock<broadcast::Sender<StoredMcpToken>> = OnceLock::new();
+    SENDER.get_or_init(|| {
+        let (sender, _) = broadcast::channel(AUTH_COMPLETION_CHANNEL_CAPACITY);
+        sender
+    })
+}
+
+pub(crate) fn subscribe_authorization_completions() -> broadcast::Receiver<StoredMcpToken> {
+    auth_completion_sender().subscribe()
+}
+
+pub(crate) fn notify_authorization_completed(token: &StoredMcpToken) {
+    let _ = auth_completion_sender().send(token.clone());
+}
+
+pub(crate) async fn wait_for_authorization_completion(
+    resource: &str,
+    timeout: std::time::Duration,
+    mut receiver: broadcast::Receiver<StoredMcpToken>,
+) -> Result<StoredMcpToken, String> {
+    tokio::time::timeout(timeout, async {
+        loop {
+            match receiver.recv().await {
+                Ok(token) if token.resource == resource => return Ok(token),
+                Ok(_) | Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => {
+                    return Err("MCP authorization completion channel closed".to_string());
+                }
+            }
+        }
+    })
+    .await
+    .map_err(|_| format!("timed out waiting for MCP authorization for {resource}"))?
 }
 
 /// Discover the OAuth authorization server protecting an MCP server URL.


### PR DESCRIPTION
## Summary
- broadcast completed/imported MCP OAuth tokens inside harn-vm
- wait and retry HTTP MCP requests once after an interactive 401 auth prompt completes
- return a typed auth error for headless/no-host sessions instead of hanging or throwing a string

Fixes burin-labs/burin-code#2271.

## Verification
- cargo test -p harn-vm modern_http_401 -- --nocapture
- cargo test -p harn-vm mcp::tests:: -- --test-threads=1
- cargo test -p harn-vm mcp_oauth::tests:: -- --test-threads=1
- cargo test -p harn-vm --lib
- cargo test -p harn-vm --quiet
- cargo fmt -p harn-vm -- --check
- git diff --check
- pre-commit hook: markdown, Rust fmt, rust prompt prose ratchet, clippy on harn-vm
- pre-push hook: markdown and targeted local checks
