### PR TITLE
fix(agent-events): flush JSONL event sink per record

### DIFF
--- a/changelog.d/event-log-jsonl-flush.fixed.md
+++ b/changelog.d/event-log-jsonl-flush.fixed.md
@@ -1,0 +1,4 @@
+- **JSONL agent event logs are now line-durable during live runs.** The flat
+  `JsonlEventSink` flushes after each appended event so replay/eval consumers
+  can read terminal tail records such as `iteration_end`, `typed_checkpoint`,
+  and `judge_decision` before the sink is dropped.

--- a/crates/harn-vm/src/agent_events/sinks.rs
+++ b/crates/harn-vm/src/agent_events/sinks.rs
@@ -179,10 +179,16 @@ impl AgentEventSink for JsonlEventSink {
             // Errors here are swallowed on purpose; a failing write
             // must never crash the agent loop, and the run record
             // itself is a secondary artifact.
-            let _ = state.writer.write_all(line.as_bytes());
-            let _ = state.writer.write_all(b"\n");
-            state.bytes_written += line.len() as u64 + 1;
-            let _ = self.rotate_if_needed(&mut state);
+            if state
+                .writer
+                .write_all(line.as_bytes())
+                .and_then(|_| state.writer.write_all(b"\n"))
+                .is_ok()
+            {
+                state.bytes_written += line.len() as u64 + 1;
+                let _ = state.writer.flush();
+                let _ = self.rotate_if_needed(&mut state);
+            }
         }
     }
 }

--- a/crates/harn-vm/src/agent_events/tests.rs
+++ b/crates/harn-vm/src/agent_events/tests.rs
@@ -164,6 +164,57 @@ fn judge_decision_round_trips_through_jsonl_sink() {
 }
 
 #[test]
+fn jsonl_sink_lines_are_durable_without_drop_or_explicit_flush() {
+    let dir = std::env::temp_dir().join(format!("harn-durable-event-log-{}", uuid::Uuid::now_v7()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("event_log.jsonl");
+    let sink = JsonlEventSink::open(&path).unwrap();
+
+    sink.handle_event(&AgentEvent::IterationEnd {
+        session_id: "s".into(),
+        iteration: 7,
+        iteration_info: serde_json::json!({"reason": "verified"}),
+    });
+    sink.handle_event(&AgentEvent::TypedCheckpoint {
+        session_id: "s".into(),
+        checkpoint: serde_json::json!({"schema": "burin.completion.v1"}),
+    });
+    sink.handle_event(&AgentEvent::JudgeDecision {
+        session_id: "s".into(),
+        iteration: 7,
+        verdict: "done".into(),
+        reasoning: "verification passed".into(),
+        next_step: None,
+        judge_duration_ms: 11,
+        trigger: Some("completion_check".into()),
+    });
+
+    let text = std::fs::read_to_string(&path).unwrap();
+    let lines = text.lines().collect::<Vec<_>>();
+    assert_eq!(
+        lines.len(),
+        3,
+        "tail events must be readable before sink drop"
+    );
+    assert!(
+        text.contains("\"type\":\"iteration_end\""),
+        "iteration_end tail must be line-durable"
+    );
+    assert!(
+        text.contains("\"type\":\"typed_checkpoint\""),
+        "typed_checkpoint tail must be line-durable"
+    );
+    assert!(
+        text.contains("\"type\":\"judge_decision\""),
+        "judge_decision tail must be line-durable"
+    );
+
+    drop(sink);
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_dir(&dir);
+}
+
+#[test]
 fn structural_validator_decision_round_trips_through_jsonl_sink() {
     use std::io::{BufRead, BufReader};
     let dir = std::env::temp_dir().join(format!(


### PR DESCRIPTION
## Summary
- flush the canonical JSONL agent-event sink after each written record
- add a regression test that reads event_log.jsonl before sink drop or explicit flush
- add a changelog fragment for durable event-log tails

## Verification
- cargo fmt --package harn-vm --check
- CARGO_TARGET_DIR=/private/tmp/harn-event-log-flush-target RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo test -p harn-vm agent_events::tests::jsonl_sink_lines_are_durable_without_drop_or_explicit_flush -- --nocapture
- CARGO_TARGET_DIR=/private/tmp/harn-event-log-flush-target RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo test -p harn-vm agent_events::tests -- --nocapture
- CARGO_TARGET_DIR=/private/tmp/harn-event-log-flush-target RUSTC_WRAPPER= SCCACHE_DISABLE=1 CARGO_BUILD_JOBS=4 git push pre-push checks