### PR TITLE
Allow disabling agent await-resumption tool

### DIFF
--- a/changelog.d/3413.added.md
+++ b/changelog.d/3413.added.md
@@ -1,0 +1,5 @@
+- **Agent lifecycle tools can now skip the self-suspend surface (#3413).**
+  `agent_lifecycle_tools` and `agent_loop` accept
+  `agent_await_resumption_enabled: false` to avoid exposing
+  `agent_await_resumption` when a host does not want model-initiated
+  suspension in the active tool schema.

--- a/crates/harn-stdlib/src/stdlib/agent/workers.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/workers.harn
@@ -256,6 +256,17 @@ fn __agent_lifecycle_has_subagent_capability(registry, opts) {
     || __agent_tool_registry_has(registry, "spawn_agent")
 }
 
+fn __agent_lifecycle_await_enabled(opts) {
+  let value = opts?.agent_await_resumption_enabled
+  if value == nil {
+    return true
+  }
+  if type_of(value) != "bool" {
+    throw "agent_lifecycle_tools: agent_await_resumption_enabled must be bool or nil"
+  }
+  return value
+}
+
 fn __agent_lifecycle_add_await_tool(registry) {
   if __agent_tool_registry_has(registry, "agent_await_resumption") {
     return registry
@@ -346,9 +357,10 @@ fn __agent_lifecycle_add_subagent_tools(registry) {
 /**
  * agent_lifecycle_tools adds model-facing suspend/resume lifecycle tools.
  *
- * Every returned registry includes `agent_await_resumption`. Parent-side
- * `subagent_pause`, `subagent_resume`, and `subagent_stop` are added only
- * when the caller opts into subagent lifecycle control with `{subagents: true}` or
+ * Every returned registry includes `agent_await_resumption` unless the caller
+ * passes `{agent_await_resumption_enabled: false}`. Parent-side
+ * `subagent_pause`, `subagent_resume`, and `subagent_stop` are added only when
+ * the caller opts into subagent lifecycle control with `{subagents: true}` or
  * `{subagent_tools: true}`, or when the supplied registry already exposes a
  * `sub_agent_run` / `spawn_agent` tool.
  *
@@ -359,7 +371,11 @@ fn __agent_lifecycle_add_subagent_tools(registry) {
 pub fn agent_lifecycle_tools(registry = nil, options = nil) {
   let opts = __worker_options(options, "agent_lifecycle_tools")
   let base = registry ?? tool_registry()
-  var tools = __agent_lifecycle_add_await_tool(base)
+  var tools = if __agent_lifecycle_await_enabled(opts) {
+    __agent_lifecycle_add_await_tool(base)
+  } else {
+    base
+  }
   if __agent_lifecycle_has_subagent_capability(base, opts) {
     tools = __agent_lifecycle_add_subagent_tools(tools)
   }

--- a/tests/agent/lifecycle_tools_test.harn
+++ b/tests/agent/lifecycle_tools_test.harn
@@ -1,0 +1,32 @@
+// Run: harn test tests/agent/lifecycle_tools_test.harn
+//
+// Unit tests for agent lifecycle tool injection. These stay at the registry
+// seam so they do not need a mock model or a full agent_loop run.
+import { agent_lifecycle_tools } from "std/agent/workers"
+
+fn _has_tool(registry, name) {
+  for entry in registry?.tools ?? [] {
+    if entry?.name == name {
+      return true
+    }
+  }
+  return false
+}
+
+pipeline test_agent_await_resumption_injected_by_default(task) {
+  let tools = agent_lifecycle_tools(tool_registry(), {})
+  assert(_has_tool(tools, "agent_await_resumption"))
+}
+
+pipeline test_agent_await_resumption_can_be_disabled(task) {
+  let tools = agent_lifecycle_tools(tool_registry(), {agent_await_resumption_enabled: false})
+  assert(!_has_tool(tools, "agent_await_resumption"))
+}
+
+pipeline test_agent_await_resumption_opt_out_keeps_parent_subagent_tools(task) {
+  let tools = agent_lifecycle_tools(tool_registry(), {agent_await_resumption_enabled: false, subagents: true})
+  assert(!_has_tool(tools, "agent_await_resumption"))
+  assert(_has_tool(tools, "subagent_pause"))
+  assert(_has_tool(tools, "subagent_resume"))
+  assert(_has_tool(tools, "subagent_stop"))
+}


### PR DESCRIPTION
## Summary
- Add `agent_await_resumption_enabled: false` to skip automatic model-facing `agent_await_resumption` injection.
- Preserve the default behavior and parent subagent lifecycle tools.
- Add registry-level lifecycle-tool tests.

## Verification
- `HARN_LLM_CALLS_DISABLED=1 CARGO_TARGET_DIR=/tmp/harn-2122-target cargo run --quiet --bin harn -- test tests/agent/lifecycle_tools_test.harn --timing`
- `CARGO_TARGET_DIR=/tmp/harn-2122-target cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/agent/workers.harn tests/agent/lifecycle_tools_test.harn`
- `HARN_LLM_CALLS_DISABLED=1 CARGO_TARGET_DIR=/tmp/harn-2122-target cargo run --quiet --bin harn -- test tests/agent/ --timing`
- pre-commit/pre-push targeted checks

Burin-side follow-up for burin-code#2122 will pass this option from its compact cheap-tier tool-schema pack.