### PR TITLE
Add disclosure stdlib helper

### DIFF
--- a/changelog.d/3337.added.md
+++ b/changelog.d/3337.added.md
@@ -1,0 +1,2 @@
+- Added `std/disclosure` for rendering Git trailers, Slack bylines, and GitHub
+  author choices from ActorChain values with layered TOML configuration.

--- a/conformance/tests/stdlib/disclosure_env_overlay.harn
+++ b/conformance/tests/stdlib/disclosure_env_overlay.harn
@@ -1,0 +1,6 @@
+import { render } from "std/disclosure"
+
+fn main(harness: Harness) {
+  let chain = {sub: "user:kenneth", act: {sub: "agent:merge-captain"}}
+  harness.stdio.println(render(chain, "slack", {project: false}))
+}

--- a/conformance/tests/stdlib/disclosure_env_overlay.harness.json
+++ b/conformance/tests/stdlib/disclosure_env_overlay.harness.json
@@ -1,0 +1,11 @@
+{
+  "mode": "mock",
+  "env": {
+    "HARN_DISCLOSURE_CONFIG": "[disclosure.surfaces.slack]\nkind = \"text\"\ntemplate = \"Env {{ current.name }} for {{ origin.name }}\"\n\n[disclosure.identities.\"agent:merge-captain\"]\nname = \"Env Bot\"\n\n[disclosure.identities.\"user:kenneth\"]\nname = \"Env Human\"\n"
+  },
+  "expect_calls": [
+    {"sub_handle": "env", "method": "get", "args": ["HARN_DISCLOSURE_CONFIG_PATH"]},
+    {"sub_handle": "env", "method": "get", "args": ["HARN_DISCLOSURE_CONFIG"]},
+    {"sub_handle": "stdio", "method": "println", "args": ["Env Env Bot for Env Human"]}
+  ]
+}

--- a/conformance/tests/stdlib/disclosure_project_overlay.expected
+++ b/conformance/tests/stdlib/disclosure_project_overlay.expected
@@ -1,0 +1,2 @@
+Project Project Bot for Project Human
+AI-assisted by Config Bot for Config Human.

--- a/conformance/tests/stdlib/disclosure_project_overlay.harn
+++ b/conformance/tests/stdlib/disclosure_project_overlay.harn
@@ -1,0 +1,39 @@
+import { render } from "std/disclosure"
+
+pipeline default() {
+  let root = path_join(harness.fs.temp_dir(), "harn-disclosure-project-" + uuid())
+  harness.fs.mkdir(root)
+  harness.fs
+    .write_text(
+    path_join(root, "harn.toml"),
+    "[disclosure.surfaces.slack]\n"
+      + "kind = \"text\"\n"
+      + "template = \"Project {{ current.name }} for {{ origin.name }}\"\n\n"
+      + "[disclosure.identities.\"agent:merge-captain\"]\n"
+      + "name = \"Project Bot\"\n\n"
+      + "[disclosure.identities.\"user:kenneth\"]\n"
+      + "name = \"Project Human\"\n",
+  )
+  let chain = {sub: "user:kenneth", act: {sub: "agent:merge-captain"}}
+  __io_println(render(chain, "slack", {project_root: root, env: false}))
+  let unrelated_root = path_join(harness.fs.temp_dir(), "harn-disclosure-unrelated-" + uuid())
+  harness.fs.mkdir(unrelated_root)
+  harness.fs
+    .write_text(
+    path_join(unrelated_root, "harn.toml"),
+    "[surfaces.slack]\n"
+      + "kind = \"text\"\n"
+      + "template = \"Wrong {{ current.name }} for {{ origin.name }}\"\n",
+  )
+  __io_println(
+    render(
+      chain,
+      "slack",
+      {
+        project_root: unrelated_root,
+        env: false,
+        config: {identities: {"agent:merge-captain": {name: "Config Bot"}, "user:kenneth": {name: "Config Human"}}},
+      },
+    ),
+  )
+}

--- a/conformance/tests/stdlib/disclosure_render.expected
+++ b/conformance/tests/stdlib/disclosure_render.expected
@@ -1,0 +1,9 @@
+Co-Authored-By: Merge Captain <merge-captain@bots.example>
+Assisted-by: Burin <burin@bots.example>
+AI-assisted by Merge Captain for Kenneth Sinder.
+github_author_choice
+human_author_agent_coauthor
+user:kenneth
+kennethsinder
+agent:merge-captain
+merge-captain-bot

--- a/conformance/tests/stdlib/disclosure_render.harn
+++ b/conformance/tests/stdlib/disclosure_render.harn
@@ -1,0 +1,22 @@
+import { render } from "std/disclosure"
+
+pipeline default() {
+  let chain = {sub: "user:kenneth", act: {sub: "agent:merge-captain", act: {sub: "agent:burin"}}}
+  let config = {
+    identities: {
+      "user:kenneth": {name: "Kenneth Sinder", email: "kenneth@example.com", github: "kennethsinder"},
+      "agent:merge-captain": {name: "Merge Captain", email: "merge-captain@bots.example", github: "merge-captain-bot"},
+      "agent:burin": {name: "Burin", email: "burin@bots.example", github: "burin-bot"},
+    },
+  }
+  let options = {project: false, env: false, config: config}
+  __io_println(render(chain, "git", options))
+  __io_println(render(chain, "slack", options))
+  let github = render(chain, "github", options)
+  __io_println(github.kind)
+  __io_println(github.mode)
+  __io_println(github.author.subject)
+  __io_println(github.author.github)
+  __io_println(github.co_author.subject)
+  __io_println(github.co_author.github)
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -146,6 +146,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/stdlib_schema.harn"),
     },
     StdlibSource {
+        module: "disclosure",
+        source: include_str!("stdlib/stdlib_disclosure.harn"),
+    },
+    StdlibSource {
         module: "testing",
         source: include_str!("stdlib/stdlib_testing.harn"),
     },
@@ -1320,6 +1324,7 @@ mod tests {
             "eval/stats",
             "eval/agreement",
             "edit",
+            "disclosure",
             "artifact/web",
             "command",
             "waitpoint",
@@ -1403,6 +1408,18 @@ mod tests {
         ] {
             assert!(exports.contains(name), "std/command should export {name}");
         }
+    }
+
+    #[test]
+    fn disclosure_stdlib_module_exports_render_helpers() {
+        let exports = public_functions_for_module("disclosure")
+            .into_iter()
+            .map(|function| function.name)
+            .collect::<BTreeSet<_>>();
+        assert!(
+            exports.contains("render"),
+            "std/disclosure should export render"
+        );
     }
 
     #[test]

--- a/crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn
@@ -1,0 +1,309 @@
+// std/disclosure — render surface-native authorship disclosure from ActorChain.
+//
+// Import: import { render } from "std/disclosure"
+import { deep_merge } from "std/collections"
+
+type DisclosureRenderOptions = {project?: bool, project_root?: string, env?: bool, config?: dict}
+
+const __BUILTIN_DISCLOSURE_CONFIG = """
+[defaults]
+email_domain = "actors.harn.invalid"
+
+[surfaces.git]
+kind = "text"
+template = "{{ if delegated }}Co-Authored-By: {{ current.name }} <{{ current.email }}>{{ for actor in prior_actors }}\nAssisted-by: {{ actor.name }} <{{ actor.email }}>{{ end }}{{ else }}Co-Authored-By: {{ origin.name }} <{{ origin.email }}>{{ end }}"
+
+[surfaces.slack]
+kind = "text"
+template = "AI-assisted by {{ current.label }} for {{ origin.label }}."
+
+[surfaces.github]
+kind = "github_author_choice"
+mode = "human_author_agent_coauthor"
+author = "origin"
+co_author = "current"
+"""
+
+fn __dict(value) -> dict {
+  if type_of(value) == "dict" {
+    return value
+  }
+  return {}
+}
+
+fn __as_config(value) -> dict {
+  let dict = __dict(value)
+  if contains(dict.keys(), "disclosure") {
+    return __dict(dict.disclosure)
+  }
+  return dict
+}
+
+fn __as_project_config(value) -> dict {
+  let dict = __dict(value)
+  if contains(dict.keys(), "disclosure") {
+    return __dict(dict.disclosure)
+  }
+  return {}
+}
+
+fn __parse_config_toml(text: string, label: string, project: bool = false) -> dict {
+  let parsed = try {
+    toml_parse(text)
+  }
+  if is_ok(parsed) {
+    let data = unwrap(parsed)
+    if project {
+      return __as_project_config(data)
+    }
+    return __as_config(data)
+  }
+  throw "std/disclosure: invalid TOML in " + label
+}
+
+fn __read_config_file(path: string, project: bool = false) -> dict {
+  if path == "" || !harness.fs.exists(path) {
+    return {}
+  }
+  return __parse_config_toml(harness.fs.read_text(path), path, project)
+}
+
+fn __looks_like_toml(text: string) -> bool {
+  let trimmed = trim(text)
+  return contains(text, "\n") || starts_with(trimmed, "[")
+}
+
+fn __project_config(options: dict) -> dict {
+  if options?.project == false {
+    return {}
+  }
+  let root = options?.project_root ?? project_root()
+  if root == nil || root == "" {
+    return {}
+  }
+  return __read_config_file(path_join(root, "harn.toml"), true)
+}
+
+fn __env_config(options: dict) -> dict {
+  if options?.env == false {
+    return {}
+  }
+  var config = {}
+  let path = harness.env.get("HARN_DISCLOSURE_CONFIG_PATH")
+  if path != nil && path != "" {
+    config = deep_merge(config, __read_config_file(to_string(path)))
+  }
+  let raw = harness.env.get("HARN_DISCLOSURE_CONFIG")
+  if raw == nil || raw == "" {
+    return config
+  }
+  let text = to_string(raw)
+  if __looks_like_toml(text) {
+    return deep_merge(config, __parse_config_toml(text, "HARN_DISCLOSURE_CONFIG"))
+  }
+  if harness.fs.exists(text) {
+    return deep_merge(config, __read_config_file(text))
+  }
+  return deep_merge(config, __parse_config_toml(text, "HARN_DISCLOSURE_CONFIG"))
+}
+
+fn __config(options) -> dict {
+  let opts = __dict(options)
+  var config = __parse_config_toml(__BUILTIN_DISCLOSURE_CONFIG, "built-in disclosure config")
+  config = deep_merge(config, __project_config(opts))
+  config = deep_merge(config, __env_config(opts))
+  config = deep_merge(config, __as_config(opts?.config))
+  return config
+}
+
+fn __chain_subjects(chain) -> list<string> {
+  require type_of(chain) == "dict", "std/disclosure: chain must be an ActorChain dict"
+  require chain?.sub != nil && chain.sub != "", "std/disclosure: chain.sub is required"
+  var subjects = []
+  var node = chain?.act
+  while node != nil {
+    require type_of(node) == "dict", "std/disclosure: chain.act entries must be dicts"
+    require node?.sub != nil && node.sub != "", "std/disclosure: chain.act.sub is required"
+    subjects = subjects + [to_string(node.sub)]
+    node = node?.act
+  }
+  return subjects + [to_string(chain.sub)]
+}
+
+fn __subject_parts(subject: string) -> dict {
+  let split_at = subject.index_of(":")
+  if split_at < 0 {
+    return {kind: "principal", id: subject}
+  }
+  return {kind: substring(subject, 0, split_at), id: substring(subject, split_at + 1)}
+}
+
+fn __slug(value: string) -> string {
+  let lowered = lowercase(trim(value))
+  let cleaned = regex_replace("[^a-z0-9._+-]+", "-", lowered)
+  let stripped = regex_replace("(^-+|-+$)", "", cleaned)
+  if stripped == "" {
+    return "actor"
+  }
+  return stripped
+}
+
+fn __profile_for(subject: string, config: dict) -> dict {
+  let identities = __dict(config?.identities)
+  if contains(identities.keys(), subject) {
+    return __dict(identities[subject])
+  }
+  return {}
+}
+
+fn __principal(subject: string, config: dict, role: string, position: int) -> dict {
+  let profile = __profile_for(subject, config)
+  let parts = __subject_parts(subject)
+  let name = to_string(profile?.name ?? profile?.display_name ?? profile?.label ?? parts.id ?? subject)
+  let label = to_string(profile?.label ?? profile?.slack_label ?? profile?.display_name ?? name)
+  let email_domain = to_string(config?.defaults?.email_domain ?? "actors.harn.invalid")
+  let email = to_string(profile?.email ?? (__slug(parts.kind + "+" + parts.id) + "@" + email_domain))
+  var principal = {
+    subject: subject,
+    kind: parts.kind,
+    id: parts.id,
+    role: role,
+    position: position,
+    name: name,
+    label: label,
+    email: email,
+  }
+  if profile?.github != nil {
+    principal = principal + {github: to_string(profile.github)}
+  }
+  if profile?.github_login != nil {
+    principal = principal + {github: to_string(profile.github_login)}
+  }
+  if profile?.login != nil {
+    principal = principal + {github: to_string(profile.login)}
+  }
+  if profile?.slack != nil {
+    principal = principal + {slack: to_string(profile.slack)}
+  }
+  if profile?.slack_id != nil {
+    principal = principal + {slack: to_string(profile.slack_id)}
+  }
+  return principal
+}
+
+fn __context(chain, config: dict) -> dict {
+  let subjects = __chain_subjects(chain)
+  let origin_index = len(subjects) - 1
+  var principals = []
+  for {index, value} in subjects.enumerate() {
+    let role = if index == 0 {
+      "current"
+    } else if index == origin_index {
+      "origin"
+    } else {
+      "actor"
+    }
+    principals = principals + [__principal(value, config, role, index)]
+  }
+  let origin = principals[origin_index]
+  let actors = if len(principals) > 1 {
+    principals.slice(0, origin_index)
+  } else {
+    []
+  }
+  let current = principals[0]
+  let prior_actors = if len(actors) > 1 {
+    actors.slice(1, len(actors))
+  } else {
+    []
+  }
+  return {
+    chain: chain,
+    principals: principals,
+    subjects: subjects,
+    current: current,
+    origin: origin,
+    actors: actors,
+    prior_actors: prior_actors,
+    delegated: len(actors) > 0,
+  }
+}
+
+fn __surface_config(config: dict, surface: string) -> dict {
+  let surfaces = __dict(config?.surfaces)
+  if !contains(surfaces.keys(), surface) {
+    throw "std/disclosure: unknown disclosure surface `" + surface + "`"
+  }
+  let surface_config = __dict(surfaces[surface])
+  if len(surface_config.keys()) == 0 {
+    throw "std/disclosure: disclosure surface `" + surface + "` must be a table"
+  }
+  return surface_config
+}
+
+fn __select_principal(ctx: dict, selector) {
+  let name = to_string(selector ?? "")
+  if name == "origin" {
+    return ctx.origin
+  }
+  if name == "current" {
+    return ctx.current
+  }
+  if name == "none" || name == "" {
+    return nil
+  }
+  for principal in ctx.principals {
+    if principal.subject == name || principal.role == name {
+      return principal
+    }
+  }
+  throw "std/disclosure: unknown principal selector `" + name + "`"
+}
+
+fn __render_text(surface_config: dict, ctx: dict) -> string {
+  let template = surface_config?.template
+  require template != nil && template != "", "std/disclosure: text disclosure surfaces require a template"
+  return render_string(to_string(template), ctx)
+}
+
+fn __render_github(surface_config: dict, ctx: dict) -> dict {
+  let author = __select_principal(ctx, surface_config?.author ?? "origin")
+  var co_author = __select_principal(ctx, surface_config?.co_author ?? "current")
+  if author != nil && co_author != nil && author.subject == co_author.subject {
+    co_author = nil
+  }
+  return {
+    surface: "github",
+    kind: "github_author_choice",
+    mode: to_string(surface_config?.mode ?? "human_author_agent_coauthor"),
+    author: author,
+    co_author: co_author,
+    principals: ctx.principals,
+    actor_chain: ctx.chain,
+  }
+}
+
+/**
+ * Render a surface-native authorship disclosure artifact from an ActorChain.
+ *
+ * Built-in surface config is overlaid by `[disclosure]` in `harn.toml`, then
+ * `HARN_DISCLOSURE_CONFIG_PATH` / `HARN_DISCLOSURE_CONFIG`, then
+ * `options.config`. Supported built-in surfaces are `git`, `slack`, and
+ * `github`.
+ *
+ * @effects: [fs-read, env-read]
+ * @errors: [TypeError, ValueError]
+ */
+pub fn render(chain, surface: string, options: DisclosureRenderOptions = {}) -> any {
+  let config = __config(options)
+  let surface_config = __surface_config(config, surface)
+  let ctx = __context(chain, config)
+  let kind = to_string(surface_config?.kind ?? "text")
+  if kind == "text" {
+    return __render_text(surface_config, ctx)
+  }
+  if kind == "github_author_choice" {
+    return __render_github(surface_config, ctx)
+  }
+  throw "std/disclosure: unsupported disclosure surface kind `" + kind + "`"
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -97,6 +97,7 @@
 - [Diff stdlib](./stdlib/diff.md)
 - [OAuth storage stdlib](./stdlib/oauth-storage.md)
 - [Prompt library stdlib](./stdlib/prompt-library.md)
+- [Disclosure stdlib](./stdlib/disclosure.md)
 - [Human in the loop](./hitl.md)
 - [Trust graph](./trust-graph.md)
   - [Autonomy tiers](./autonomy.md)

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -80,7 +80,7 @@ code or inside any pipeline.
 `import "std/..."` is only needed for the Harn-written helper modules
 described below (`std/text`, `std/json`, `std/math`, `std/collections`,
 `std/ansi`, `std/table`, `std/diff`, `std/path`, `std/fs`, `std/os`,
-`std/edit`, `std/artifact/web`, `std/ui_resource`, `std/cache`,
+`std/edit`, `std/disclosure`, `std/artifact/web`, `std/ui_resource`, `std/cache`,
 `std/llm/handlers`, `std/llm/budget`, `std/llm/prompts`, `std/vision`,
 `std/context`, `std/agent_state`, `std/agents`, `std/agent/user`,
 `std/agent/fact`, `std/agent/probe`, `std/agent/scratchpad`,
@@ -110,6 +110,7 @@ import "std/cache"
 import "std/collections"
 import "std/connectors/shared"
 import "std/context"
+import "std/disclosure"
 import "std/edit"
 import "std/artifact/web"
 import "std/ui_resource"

--- a/docs/src/stdlib/disclosure.md
+++ b/docs/src/stdlib/disclosure.md
@@ -1,0 +1,79 @@
+# Disclosure stdlib
+
+`std/disclosure` renders authorship disclosure artifacts from an
+RFC 8693-style `ActorChain` value. Use it when a host or connector needs the
+same actor chain represented in a surface-native form such as Git trailers,
+a Slack byline, or a GitHub author-mode decision.
+
+```harn
+import { render } from "std/disclosure"
+
+pipeline default() {
+  let chain = {
+    sub: "user:kenneth",
+    act: {sub: "agent:merge-captain", act: {sub: "agent:burin"}},
+  }
+
+  let trailers = render(chain, "git")
+  let byline = render(chain, "slack")
+  let github = render(chain, "github")
+}
+```
+
+Built-in surfaces:
+
+| Surface | Return value |
+|---|---|
+| `git` | Trailer block string |
+| `slack` | Byline string |
+| `github` | `{kind: "github_author_choice", mode, author, co_author, principals, actor_chain}` |
+
+## Configuration
+
+Disclosure config is layered in this order:
+
+1. Built-in defaults.
+2. `[disclosure]` in the project `harn.toml`.
+3. `HARN_DISCLOSURE_CONFIG_PATH`, then `HARN_DISCLOSURE_CONFIG`.
+4. `options.config` passed to `render`.
+
+Each overlay is TOML-shaped data. Later layers recursively override earlier
+layers. Project manifests read only the nested `[disclosure]` table; standalone
+environment/config files may use either `[disclosure.*]` tables or direct
+`[surfaces.*]` / `[identities.*]` tables.
+
+```toml
+[disclosure.defaults]
+email_domain = "example.invalid"
+
+[disclosure.identities."user:kenneth"]
+name = "Kenneth Sinder"
+email = "kenneth@example.com"
+github = "kennethsinder"
+
+[disclosure.identities."agent:merge-captain"]
+name = "Merge Captain"
+email = "merge-captain@bots.example"
+github = "merge-captain-bot"
+
+[disclosure.surfaces.slack]
+kind = "text"
+template = "AI-assisted by {{ current.label }} for {{ origin.label }}."
+```
+
+Text surfaces use the regular Harn prompt-template renderer with these
+bindings:
+
+| Binding | Description |
+|---|---|
+| `current` | Current actor principal, or the origin when the chain has no actors |
+| `origin` | Top-level `sub` principal |
+| `actors` | Actor principals, current first, excluding `origin` |
+| `prior_actors` | Actor principals after `current` |
+| `principals` | All principals, current actor through origin |
+| `subjects` | Raw subject strings in the same order as `principals` |
+| `delegated` | `true` when the chain has one or more acting agents |
+
+`HARN_DISCLOSURE_CONFIG` may contain inline TOML or a path to a TOML file.
+Pass `{project: false}` or `{env: false}` to disable those layers for a
+specific render call.


### PR DESCRIPTION
## Summary
- Add `std/disclosure::render` for ActorChain-backed Git trailer, Slack byline, and GitHub author-choice artifacts
- Layer disclosure config as built-in defaults < project `[disclosure]` < env TOML/path < explicit options
- Document the module and add conformance coverage for built-in surfaces plus project/env overlays

Fixes #3337.

## Verification
- `/Users/ksinder/projects/harn/target/debug/harn fmt --check crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn conformance/tests/stdlib/disclosure_render.harn conformance/tests/stdlib/disclosure_project_overlay.harn conformance/tests/stdlib/disclosure_env_overlay.harn`
- `/Users/ksinder/projects/harn/target/debug/harn check crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn`
- `/Users/ksinder/projects/harn/target/debug/harn lint crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-3337 cargo run --quiet --bin harn -- test conformance --filter disclosure_`
- `CARGO_TARGET_DIR=/tmp/harn-target-3337 make lint-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-3337 make fmt-harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-3337 make check-docs-snippets`
- `CARGO_TARGET_DIR=/tmp/harn-target-3337 cargo test -p harn-stdlib`
- pre-commit hook
- pre-push hook