### PR TITLE
[codex] Add actor-chain lineage to TrustRecord

### DIFF
--- a/changelog.d/3335.added.md
+++ b/changelog.d/3335.added.md
@@ -1,0 +1,3 @@
+- Added OpenTrustGraph actor-chain lineage metadata on trust records and
+  verifier checks that nested actor chains stay aligned with `parent_record_id`
+  lineage.

--- a/conformance/tests/trust_graph/trust_graph_schema_v0_1_chain_export_unchanged.harn
+++ b/conformance/tests/trust_graph/trust_graph_schema_v0_1_chain_export_unchanged.harn
@@ -1,7 +1,7 @@
 import "std/triggers"
 
 /**
- * Verifies that the v0.1 schema bump (#1778) is additive at the record
+ * Verifies that the v0.1 schema bump is additive at the record
  * metadata layer only: the chain-export envelope discriminator stays
  * `opentrustgraph-chain/v0`, and a v0.1 record + chain still validates
  * end-to-end. Backwards compatibility of the prior `opentrustgraph/v0`

--- a/conformance/tests/trust_graph/trust_graph_schema_v0_1_effects_inheritance.expected
+++ b/conformance/tests/trust_graph/trust_graph_schema_v0_1_effects_inheritance.expected
@@ -6,3 +6,9 @@ true
 true
 true
 true
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/trust_graph/trust_graph_schema_v0_1_effects_inheritance.harn
+++ b/conformance/tests/trust_graph/trust_graph_schema_v0_1_effects_inheritance.harn
@@ -1,12 +1,11 @@
 import "std/triggers"
 
 /**
- * Verifies the v0.1 schema bump (#1778): a 3-agent chain
- * (parent → child → grandchild) round-trips `effects_grant`,
- * `effects_used`, and `parent_record_id` end-to-end through the
- * stdlib `trust_graph_record` / `trust_query` surface, and the
- * inheritance invariant `effects_used ⊆ child.effects_grant ⊆
- * parent.effects_grant` holds.
+ * Verifies v0.1 lineage metadata: a 3-agent chain
+ * (parent → child → grandchild) round-trips `actor_chain`,
+ * `effects_grant`, `effects_used`, and `parent_record_id` end-to-end
+ * through the stdlib `trust_graph_record` / `trust_query` surface, and
+ * the effect plus actor-chain inheritance invariants hold.
  */
 pipeline test(task) {
   let unique = to_string(to_int(harness.clock.timestamp())) + "-"
@@ -24,6 +23,13 @@ pipeline test(task) {
   let parent_agent = "trust-graph-v0-1-parent-" + unique
   let child_agent = "trust-graph-v0-1-child-" + unique
   let grandchild_agent = "trust-graph-v0-1-grandchild-" + unique
+  let actor_origin = "user:operator-" + unique
+  let parent_actor = "agent:" + parent_agent
+  let child_actor = "agent:" + child_agent
+  let grandchild_actor = "agent:" + grandchild_agent
+  let parent_actor_chain = {sub: actor_origin, act: {sub: parent_actor}}
+  let child_actor_chain = {sub: actor_origin, act: {sub: child_actor, act: {sub: parent_actor}}}
+  let grandchild_actor_chain = {sub: actor_origin, act: {sub: grandchild_actor, act: {sub: child_actor, act: {sub: parent_actor}}}}
   let parent_id: TrustEntryId = trust_graph_record(
     {
       agent: parent_agent,
@@ -32,7 +38,7 @@ pipeline test(task) {
       outcome: "success",
       trace_id: "trace-parent-" + unique,
       autonomy_tier: "act_auto",
-      metadata: {effects_grant: parent_grant},
+      metadata: {actor_chain: parent_actor_chain, effects_grant: parent_grant},
     },
   )
   let child_id: TrustEntryId = trust_graph_record(
@@ -43,7 +49,7 @@ pipeline test(task) {
       outcome: "success",
       trace_id: "trace-child-" + unique,
       autonomy_tier: "act_auto",
-      metadata: {effects_grant: child_grant, parent_record_id: parent_id},
+      metadata: {actor_chain: child_actor_chain, effects_grant: child_grant, parent_record_id: parent_id},
     },
   )
   let _grandchild_id: TrustEntryId = trust_graph_record(
@@ -54,7 +60,7 @@ pipeline test(task) {
       outcome: "success",
       trace_id: "trace-grandchild-" + unique,
       autonomy_tier: "act_auto",
-      metadata: {effects_used: grandchild_used, parent_record_id: child_id},
+      metadata: {actor_chain: grandchild_actor_chain, effects_used: grandchild_used, parent_record_id: child_id},
     },
   )
   let parent: list<TrustRecord> = trust_query({agent: parent_agent})
@@ -68,5 +74,11 @@ pipeline test(task) {
   __io_println(len(parent[0].metadata?.effects_grant) == 3)
   __io_println(len(child[0].metadata?.effects_grant) == 2)
   __io_println(len(grandchild[0].metadata?.effects_used) == 1)
+  __io_println(parent[0].metadata?.actor_chain?.sub == actor_origin)
+  __io_println(child[0].metadata?.actor_chain?.act?.sub == child_actor)
+  __io_println(child[0].metadata?.actor_chain?.act?.act?.sub == parent_actor)
+  __io_println(grandchild[0].metadata?.actor_chain?.act?.sub == grandchild_actor)
+  __io_println(grandchild[0].metadata?.actor_chain?.act?.act?.sub == child_actor)
+  __io_println(grandchild[0].metadata?.actor_chain?.act?.act?.act?.sub == parent_actor)
   __io_println(report.verified)
 }

--- a/conformance/tests/trust_graph/trust_graph_schema_v0_1_round_trip.harn
+++ b/conformance/tests/trust_graph/trust_graph_schema_v0_1_round_trip.harn
@@ -1,7 +1,7 @@
 import "std/triggers"
 
 /**
- * Verifies the v0.1 schema bump (#1778): newly-appended records carry
+ * Verifies the v0.1 schema bump: newly-appended records carry
  * the `opentrustgraph/v0.1` discriminator end-to-end, and the chain still
  * verifies cleanly.
  */

--- a/crates/harn-serve/src/core.rs
+++ b/crates/harn-serve/src/core.rs
@@ -714,9 +714,7 @@ impl DispatchCore {
             .metadata
             .insert("function".to_string(), serde_json::json!(request.function));
         if let Some(actor_chain) = request.actor_chain.as_ref() {
-            record
-                .metadata
-                .insert("actor_chain".to_string(), actor_chain.to_json_value());
+            record.set_actor_chain(Some(actor_chain.clone()));
         }
         if let Some(tenant) = request.tenant_id.as_ref() {
             record

--- a/crates/harn-vm/src/trust_graph.rs
+++ b/crates/harn-vm/src/trust_graph.rs
@@ -6,6 +6,7 @@ use sha2::{Digest, Sha256};
 use time::{Duration, OffsetDateTime};
 use uuid::Uuid;
 
+use crate::actor_chain::ActorChain;
 use crate::event_log::{
     active_event_log, sanitize_topic_component, AnyEventLog, EventId, EventLog, LogError, LogEvent,
     Topic,
@@ -13,10 +14,9 @@ use crate::event_log::{
 use crate::orchestration::{CapabilityPolicy, EffectRecord};
 
 pub const OPENTRUSTGRAPH_SCHEMA_V0: &str = "opentrustgraph/v0";
-/// OpenTrustGraph v0.1: additive metadata schema (#1778). Adds the
-/// `effects_grant`, `effects_used`, and `parent_record_id` reserved keys
-/// under `TrustRecord.metadata` so chain validators can prove that a
-/// child agent's `effects_used ⊆ parent.effects_grant` (E5.5).
+/// OpenTrustGraph v0.1: additive metadata schema. Reserves lineage keys under
+/// `TrustRecord.metadata` so chain validators can prove that child-agent
+/// effects and actors stay inside the parent chain.
 ///
 /// Backwards compatible: v0 records are still accepted (the new keys are
 /// optional). One patch release window after this bump, v0 will be
@@ -29,16 +29,19 @@ pub const OPENTRUSTGRAPH_ACCEPTED_SCHEMAS: &[&str] =
 pub const OPENTRUSTGRAPH_CHAIN_SCHEMA_V0: &str = "opentrustgraph-chain/v0";
 
 /// Reserved metadata key for the effect grant attached to a record by its
-/// spawning parent. v0.1 addition (#1778).
+/// spawning parent.
 pub const METADATA_KEY_EFFECTS_GRANT: &str = "effects_grant";
 /// Reserved metadata key for the effects the recorded action actually
-/// exercised. Must be a subset of the parent's `effects_grant`. v0.1
-/// addition (#1778).
+/// exercised. Must be a subset of the parent's `effects_grant`.
 pub const METADATA_KEY_EFFECTS_USED: &str = "effects_used";
 /// Reserved metadata key pointing at the parent record's `record_id`.
 /// Lets verifiers reconstruct the agent chain without scanning the whole
-/// stream. v0.1 addition (#1778).
+/// stream.
 pub const METADATA_KEY_PARENT_RECORD_ID: &str = "parent_record_id";
+/// Reserved metadata key carrying the RFC 8693 actor chain for the record.
+/// When paired with `parent_record_id`, the nested `act` chain must extend
+/// the parent's actor chain by exactly one hop.
+pub const METADATA_KEY_ACTOR_CHAIN: &str = "actor_chain";
 pub const TRUST_GRAPH_RECORDS_TOPIC: &str = "trust_graph.records";
 pub const TRUST_GRAPH_GLOBAL_TOPIC: &str = "trust_graph";
 pub const TRUST_GRAPH_LEGACY_GLOBAL_TOPIC: &str = "trust.graph";
@@ -189,9 +192,9 @@ impl TrustRecord {
         record
     }
 
-    /// Attach the typed effect grant a parent extended to this record. v0.1
-    /// (#1778). Empty grants are skipped so legacy `metadata` shape is
-    /// preserved when there is nothing to record.
+    /// Attach the typed effect grant a parent extended to this record.
+    /// Empty grants are skipped so records stay compact when there is
+    /// nothing to prove.
     pub fn with_effects_grant(mut self, effects: Vec<EffectRecord>) -> Self {
         self.set_effects_grant(effects);
         self
@@ -212,9 +215,9 @@ impl TrustRecord {
         decode_effect_list(self.metadata.get(METADATA_KEY_EFFECTS_GRANT))
     }
 
-    /// Attach the typed effect set the action actually exercised. v0.1
-    /// (#1778). Verifiers must check `effects_used ⊆ effects_grant` (and
-    /// transitively up the parent chain).
+    /// Attach the typed effect set the action actually exercised.
+    /// Verifiers must check `effects_used ⊆ effects_grant` through the
+    /// parent chain.
     pub fn with_effects_used(mut self, effects: Vec<EffectRecord>) -> Self {
         self.set_effects_used(effects);
         self
@@ -235,9 +238,9 @@ impl TrustRecord {
         decode_effect_list(self.metadata.get(METADATA_KEY_EFFECTS_USED))
     }
 
-    /// Point this record at its parent's `record_id`. v0.1 (#1778). The
-    /// existing release-record key (`parent_trust_record_id`) is retained
-    /// for the release flow; this is the generic spawn-lineage pointer.
+    /// Point this record at its parent's `record_id`. The existing
+    /// release-record key (`parent_trust_record_id`) is retained for the
+    /// release flow; this is the generic spawn-lineage pointer.
     pub fn with_parent_record_id(mut self, parent_record_id: impl Into<String>) -> Self {
         self.set_parent_record_id(Some(parent_record_id.into()));
         self
@@ -262,6 +265,43 @@ impl TrustRecord {
             .get(METADATA_KEY_PARENT_RECORD_ID)
             .and_then(|value| value.as_str())
             .map(str::to_string)
+    }
+
+    /// Attach the RFC 8693 actor chain for the principal that caused this
+    /// record.
+    pub fn with_actor_chain(mut self, actor_chain: ActorChain) -> Self {
+        self.set_actor_chain(Some(actor_chain));
+        self
+    }
+
+    /// Set or clear the reserved `actor_chain` metadata entry.
+    pub fn set_actor_chain(&mut self, actor_chain: Option<ActorChain>) {
+        match actor_chain {
+            Some(actor_chain) => {
+                self.metadata.insert(
+                    METADATA_KEY_ACTOR_CHAIN.to_string(),
+                    actor_chain.to_json_value(),
+                );
+            }
+            None => {
+                self.metadata.remove(METADATA_KEY_ACTOR_CHAIN);
+            }
+        }
+    }
+
+    /// Decode the reserved actor-chain metadata entry, dropping malformed
+    /// values for callers that only need best-effort display data.
+    pub fn actor_chain(&self) -> Option<ActorChain> {
+        self.try_actor_chain().ok().flatten()
+    }
+
+    /// Decode the reserved actor-chain metadata entry and report malformed
+    /// RFC 8693 claim shapes to strict validators.
+    pub fn try_actor_chain(&self) -> Result<Option<ActorChain>, crate::ActorChainError> {
+        self.metadata
+            .get(METADATA_KEY_ACTOR_CHAIN)
+            .map(ActorChain::from_json_value)
+            .transpose()
     }
 }
 
@@ -592,6 +632,15 @@ pub async fn verify_trust_chain(log: &Arc<AnyEventLog>) -> Result<TrustChainRepo
         }
         previous_hash = Some(record.entry_hash.clone());
     }
+    let lineage_errors = validate_lineage_invariants(
+        records
+            .iter()
+            .map(|(event_id, record)| (format!("event {event_id}"), Some(*event_id), record)),
+    );
+    if broken_at_event_id.is_none() {
+        broken_at_event_id = lineage_errors.iter().find_map(|error| error.event_id);
+    }
+    errors.extend(lineage_errors.into_iter().map(|error| error.message));
 
     Ok(TrustChainReport {
         topic: topic.as_str().to_string(),
@@ -631,6 +680,141 @@ pub fn compute_trust_record_hash(record: &TrustRecord) -> Result<String, LogErro
         .map_err(|error| LogError::Serde(format!("trust record canonicalize error: {error}")))?;
     let digest = Sha256::digest(canonical.as_bytes());
     Ok(format!("sha256:{}", hex::encode(digest)))
+}
+
+struct LineageInvariantError {
+    event_id: Option<EventId>,
+    message: String,
+}
+
+impl LineageInvariantError {
+    fn new(event_id: Option<EventId>, message: String) -> Self {
+        Self { event_id, message }
+    }
+}
+
+fn validate_lineage_invariants<'a, I>(records: I) -> Vec<LineageInvariantError>
+where
+    I: IntoIterator<Item = (String, Option<EventId>, &'a TrustRecord)>,
+{
+    let mut errors = Vec::new();
+    let mut by_id: HashMap<&'a str, &'a TrustRecord> = HashMap::new();
+
+    for (label, event_id, record) in records {
+        let actor_chain = match record.try_actor_chain() {
+            Ok(actor_chain) => actor_chain,
+            Err(error) => {
+                errors.push(LineageInvariantError::new(
+                    event_id,
+                    format!("{label}: actor_chain invalid: {error}"),
+                ));
+                None
+            }
+        };
+        let effects_used = record.effects_used();
+        if let Some(parent_id) = record.parent_record_id() {
+            let parent = by_id.get(parent_id.as_str()).copied();
+            if parent.is_none() && (!effects_used.is_empty() || actor_chain.is_some()) {
+                errors.push(LineageInvariantError::new(
+                    event_id,
+                    format!("{label}: parent_record_id {parent_id:?} not found in chain"),
+                ));
+            }
+            if let Some(parent) = parent {
+                validate_effect_lineage(
+                    &mut errors,
+                    &label,
+                    event_id,
+                    &parent_id,
+                    parent,
+                    &effects_used,
+                );
+                validate_actor_lineage(
+                    &mut errors,
+                    &label,
+                    event_id,
+                    &parent_id,
+                    parent,
+                    actor_chain,
+                );
+            }
+        }
+
+        if !record.record_id.is_empty() {
+            by_id.insert(record.record_id.as_str(), record);
+        }
+    }
+
+    errors
+}
+
+fn validate_effect_lineage(
+    errors: &mut Vec<LineageInvariantError>,
+    label: &str,
+    event_id: Option<EventId>,
+    parent_id: &str,
+    parent: &TrustRecord,
+    effects_used: &[EffectRecord],
+) {
+    if effects_used.is_empty() {
+        return;
+    }
+    let parent_grant = parent.effects_grant();
+    for effect in effects_used {
+        if !parent_grant.contains(effect) {
+            errors.push(LineageInvariantError::new(
+                event_id,
+                format!(
+                    "{label}: effects_used escaped grant from parent {parent_id:?}: {effect:?}"
+                ),
+            ));
+        }
+    }
+}
+
+fn validate_actor_lineage(
+    errors: &mut Vec<LineageInvariantError>,
+    label: &str,
+    event_id: Option<EventId>,
+    parent_id: &str,
+    parent: &TrustRecord,
+    actor_chain: Option<ActorChain>,
+) {
+    let Some(actor_chain) = actor_chain else {
+        return;
+    };
+    let parent_actor_chain = match parent.try_actor_chain() {
+        Ok(Some(parent_actor_chain)) => parent_actor_chain,
+        Ok(None) => {
+            errors.push(LineageInvariantError::new(
+                event_id,
+                format!("{label}: actor_chain parent {parent_id:?} missing actor_chain"),
+            ));
+            return;
+        }
+        Err(error) => {
+            errors.push(LineageInvariantError::new(
+                event_id,
+                format!("{label}: parent actor_chain invalid: {error}"),
+            ));
+            return;
+        }
+    };
+    if !actor_chain_extends_parent(&actor_chain, &parent_actor_chain) {
+        errors.push(LineageInvariantError::new(
+            event_id,
+            format!("{label}: actor_chain escaped parentage from parent {parent_id:?}"),
+        ));
+    }
+}
+
+fn actor_chain_extends_parent(child: &ActorChain, parent: &ActorChain) -> bool {
+    if child.origin() != parent.origin() {
+        return false;
+    }
+    let child_actors: Vec<&str> = child.actors().collect();
+    let parent_actors: Vec<&str> = parent.actors().collect();
+    child_actors.len() == parent_actors.len() + 1 && child_actors[1..] == parent_actors[..]
 }
 
 pub fn group_trust_records_by_trace(records: &[TrustRecord]) -> Vec<TrustTraceGroup> {
@@ -846,6 +1030,7 @@ async fn finalize_trust_record(
     log: &Arc<AnyEventLog>,
     mut record: TrustRecord,
 ) -> Result<TrustRecord, LogError> {
+    attach_current_actor_chain(&mut record);
     let latest = latest_chain_record(log).await?;
     record.chain_index = latest
         .as_ref()
@@ -861,6 +1046,15 @@ async fn finalize_trust_record(
     record.entry_hash.clear();
     record.entry_hash = compute_trust_record_hash(&record)?;
     Ok(record)
+}
+
+fn attach_current_actor_chain(record: &mut TrustRecord) {
+    if record.metadata.contains_key(METADATA_KEY_ACTOR_CHAIN) {
+        return;
+    }
+    if let Some(actor_chain) = crate::agent_sessions::current_actor_chain() {
+        record.set_actor_chain(Some(actor_chain));
+    }
 }
 
 async fn latest_chain_record(
@@ -1075,6 +1269,8 @@ mod tests {
         include_str!("trust_graph/fixtures/invalid/tampered-chain.json");
     const INVALID_MISSING_APPROVAL_JSON: &str =
         include_str!("trust_graph/fixtures/invalid/missing-approval.json");
+    const INVALID_ACTOR_CHAIN_PARENTAGE_JSON: &str =
+        include_str!("trust_graph/fixtures/invalid/actor-chain-parentage.json");
 
     #[derive(Debug, serde::Deserialize)]
     struct TrustChainFixture {
@@ -1127,6 +1323,10 @@ mod tests {
             (
                 "fixtures/invalid/missing-approval.json",
                 INVALID_MISSING_APPROVAL_JSON,
+            ),
+            (
+                "fixtures/invalid/actor-chain-parentage.json",
+                INVALID_ACTOR_CHAIN_PARENTAGE_JSON,
             ),
         ] {
             let source = std::fs::read_to_string(spec_dir.join(relative)).unwrap_or_else(|e| {
@@ -1485,6 +1685,15 @@ mod tests {
                 .any(|error| error.contains("approval required")),
             "missing-approval errors: {missing_errors:?}"
         );
+
+        let actor_parentage = parse_chain_fixture(INVALID_ACTOR_CHAIN_PARENTAGE_JSON);
+        let actor_errors = validate_chain_fixture(&actor_parentage);
+        assert!(
+            actor_errors
+                .iter()
+                .any(|error| error.contains("actor_chain escaped parentage")),
+            "actor-chain-parentage errors: {actor_errors:?}"
+        );
     }
 
     fn parse_chain_fixture(input: &str) -> TrustChainFixture {
@@ -1530,6 +1739,17 @@ mod tests {
             errors.extend(validate_fixture_record_contract(index, record));
         }
         errors.extend(validate_fixture_hash_chain(fixture));
+        errors.extend(
+            validate_lineage_invariants(
+                fixture
+                    .records
+                    .iter()
+                    .enumerate()
+                    .map(|(index, record)| (format!("record {index}"), None, record)),
+            )
+            .into_iter()
+            .map(|error| error.message),
+        );
 
         let expected_verified = errors.is_empty();
         if fixture.chain.verified != expected_verified {
@@ -1647,7 +1867,7 @@ mod tests {
             .unwrap_or(0)
     }
 
-    // ----- OpenTrustGraph v0.1 schema bump (#1778) -----
+    // ----- OpenTrustGraph v0.1 schema and lineage metadata -----
 
     use crate::orchestration::{EffectKind, EffectScope};
 
@@ -1688,10 +1908,11 @@ mod tests {
         assert!(decoded.effects_grant().is_empty());
         assert!(decoded.effects_used().is_empty());
         assert!(decoded.parent_record_id().is_none());
+        assert!(decoded.actor_chain().is_none());
     }
 
     #[test]
-    fn v0_1_effect_metadata_round_trips_through_json() {
+    fn v0_1_lineage_metadata_round_trips_through_json() {
         let grant = vec![
             EffectRecord::new(EffectKind::Net, EffectScope::Write)
                 .with_resource("https://api.example"),
@@ -1700,6 +1921,9 @@ mod tests {
         let used =
             vec![EffectRecord::new(EffectKind::Fs, EffectScope::Read)
                 .with_resource("/workspace/src")];
+        let actor_chain = ActorChain::new("user:kenneth")
+            .pushed("agent:parent")
+            .pushed("agent:child");
         let record = TrustRecord::new(
             "child-agent",
             "fs.read",
@@ -1710,7 +1934,8 @@ mod tests {
         )
         .with_effects_grant(grant.clone())
         .with_effects_used(used.clone())
-        .with_parent_record_id("parent-record-001");
+        .with_parent_record_id("parent-record-001")
+        .with_actor_chain(actor_chain.clone());
 
         let encoded = serde_json::to_string(&record).unwrap();
         let decoded: TrustRecord = serde_json::from_str(&encoded).unwrap();
@@ -1721,10 +1946,11 @@ mod tests {
             decoded.parent_record_id().as_deref(),
             Some("parent-record-001")
         );
+        assert_eq!(decoded.actor_chain(), Some(actor_chain));
     }
 
     #[test]
-    fn effect_helpers_remove_keys_on_empty_input() {
+    fn lineage_helpers_remove_keys_on_empty_input() {
         let mut record = TrustRecord::new(
             "agent",
             "noop",
@@ -1734,14 +1960,46 @@ mod tests {
             AutonomyTier::Suggest,
         )
         .with_effects_grant(vec![EffectRecord::new(EffectKind::Net, EffectScope::Write)])
-        .with_parent_record_id("parent-1");
+        .with_parent_record_id("parent-1")
+        .with_actor_chain(ActorChain::new("user:kenneth").pushed("agent:agent"));
         assert!(record.metadata.contains_key(METADATA_KEY_EFFECTS_GRANT));
         assert!(record.metadata.contains_key(METADATA_KEY_PARENT_RECORD_ID));
+        assert!(record.metadata.contains_key(METADATA_KEY_ACTOR_CHAIN));
 
         record.set_effects_grant(Vec::new());
         record.set_parent_record_id(None);
+        record.set_actor_chain(None);
         assert!(!record.metadata.contains_key(METADATA_KEY_EFFECTS_GRANT));
         assert!(!record.metadata.contains_key(METADATA_KEY_PARENT_RECORD_ID));
+        assert!(!record.metadata.contains_key(METADATA_KEY_ACTOR_CHAIN));
+    }
+
+    #[tokio::test]
+    async fn append_attaches_current_session_actor_chain() {
+        crate::reset_thread_local_state();
+        let log: Arc<AnyEventLog> = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(16)));
+        let actor_chain = ActorChain::new("user:kenneth").pushed("agent:reviewer");
+        let session_id = crate::agent_sessions::open_or_create_with_actor_chain(
+            Some("trust-actor-session".to_string()),
+            Some(actor_chain.clone()),
+        );
+        let _session = crate::agent_sessions::enter_current_session(session_id);
+
+        let appended = append_trust_record(
+            &log,
+            &TrustRecord::new(
+                "reviewer",
+                "fs.read",
+                None,
+                TrustOutcome::Success,
+                "trace-actor-session",
+                AutonomyTier::ActAuto,
+            ),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(appended.actor_chain(), Some(actor_chain));
     }
 
     #[tokio::test]
@@ -1764,7 +2022,8 @@ mod tests {
                 "trace-parent",
                 AutonomyTier::ActAuto,
             )
-            .with_effects_grant(parent_grant.clone()),
+            .with_effects_grant(parent_grant.clone())
+            .with_actor_chain(ActorChain::new("user:kenneth").pushed("agent:parent")),
         )
         .await
         .unwrap();
@@ -1785,7 +2044,12 @@ mod tests {
                 AutonomyTier::ActAuto,
             )
             .with_effects_grant(child_grant.clone())
-            .with_parent_record_id(parent.record_id.clone()),
+            .with_parent_record_id(parent.record_id.clone())
+            .with_actor_chain(
+                ActorChain::new("user:kenneth")
+                    .pushed("agent:parent")
+                    .pushed("agent:child"),
+            ),
         )
         .await
         .unwrap();
@@ -1804,7 +2068,13 @@ mod tests {
                 AutonomyTier::ActAuto,
             )
             .with_effects_used(grandchild_used.clone())
-            .with_parent_record_id(child.record_id.clone()),
+            .with_parent_record_id(child.record_id.clone())
+            .with_actor_chain(
+                ActorChain::new("user:kenneth")
+                    .pushed("agent:parent")
+                    .pushed("agent:child")
+                    .pushed("agent:grandchild"),
+            ),
         )
         .await
         .unwrap();
@@ -1838,5 +2108,51 @@ mod tests {
         let report = verify_trust_chain(&log).await.unwrap();
         assert!(report.verified, "verification errors: {:?}", report.errors);
         assert_eq!(report.total, 3);
+    }
+
+    #[tokio::test]
+    async fn verify_chain_rejects_actor_chain_that_escapes_parentage() {
+        let log: Arc<AnyEventLog> = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(16)));
+        let parent = append_trust_record(
+            &log,
+            &TrustRecord::new(
+                "parent",
+                "agent.spawn",
+                None,
+                TrustOutcome::Success,
+                "trace-parent",
+                AutonomyTier::ActAuto,
+            )
+            .with_actor_chain(ActorChain::new("user:kenneth").pushed("agent:parent")),
+        )
+        .await
+        .unwrap();
+
+        append_trust_record(
+            &log,
+            &TrustRecord::new(
+                "child",
+                "agent.spawn",
+                None,
+                TrustOutcome::Success,
+                "trace-child",
+                AutonomyTier::ActAuto,
+            )
+            .with_parent_record_id(parent.record_id)
+            .with_actor_chain(
+                ActorChain::new("user:kenneth")
+                    .pushed("agent:other-parent")
+                    .pushed("agent:child"),
+            ),
+        )
+        .await
+        .unwrap();
+
+        let report = verify_trust_chain(&log).await.unwrap();
+        assert!(!report.verified);
+        assert!(report
+            .errors
+            .iter()
+            .any(|error| error.contains("actor_chain escaped parentage")));
     }
 }

--- a/crates/harn-vm/src/trust_graph/fixtures/invalid/actor-chain-parentage.json
+++ b/crates/harn-vm/src/trust_graph/fixtures/invalid/actor-chain-parentage.json
@@ -1,14 +1,14 @@
 {
   "chain": {
-    "generated_at": "2026-04-19T20:33:00Z",
+    "generated_at": "2026-04-19T20:34:00Z",
     "producer": {
       "name": "harn",
       "version": "0.8.x"
     },
-    "root_hash": "sha256:39ff5a2c614a49c14059863afe5c3320343ff1198514b7d9060ef079aa23b6eb",
+    "root_hash": "sha256:3683b2872a27f01bfaa48f586644a35f193addef81a7d9c2ccd736e2ef9e152c",
     "topic": "trust_graph",
     "total": 3,
-    "verified": true
+    "verified": false
   },
   "records": [
     {
@@ -64,12 +64,12 @@
       "autonomy_tier": "act_auto",
       "chain_index": 2,
       "cost_usd": null,
-      "entry_hash": "sha256:ffcb9cb912d2a48b3400be9469e8f2601ca5ae8926fc8787d23597eb913d6701",
+      "entry_hash": "sha256:c615ab724f9662673f0af61da0e2c843c08c66b5ac10262ac1ff4cbc63351e30",
       "metadata": {
         "actor_chain": {
           "act": {
             "act": {
-              "sub": "agent:parent-orchestrator"
+              "sub": "agent:other-parent"
             },
             "sub": "agent:child-spawner"
           },
@@ -107,13 +107,13 @@
       "autonomy_tier": "act_auto",
       "chain_index": 3,
       "cost_usd": 0.001,
-      "entry_hash": "sha256:39ff5a2c614a49c14059863afe5c3320343ff1198514b7d9060ef079aa23b6eb",
+      "entry_hash": "sha256:3683b2872a27f01bfaa48f586644a35f193addef81a7d9c2ccd736e2ef9e152c",
       "metadata": {
         "actor_chain": {
           "act": {
             "act": {
               "act": {
-                "sub": "agent:parent-orchestrator"
+                "sub": "agent:other-parent"
               },
               "sub": "agent:child-spawner"
             },
@@ -133,7 +133,7 @@
         "parent_record_id": "01966f4c-3001-7002-a000-000000000002"
       },
       "outcome": "success",
-      "previous_hash": "sha256:ffcb9cb912d2a48b3400be9469e8f2601ca5ae8926fc8787d23597eb913d6701",
+      "previous_hash": "sha256:c615ab724f9662673f0af61da0e2c843c08c66b5ac10262ac1ff4cbc63351e30",
       "record_id": "01966f4c-3002-7003-a000-000000000003",
       "schema": "opentrustgraph/v0.1",
       "timestamp": "2026-04-19T20:32:00Z",

--- a/crates/harn-vm/src/trust_graph/fixtures/valid/effect-inheritance-chain.json
+++ b/crates/harn-vm/src/trust_graph/fixtures/valid/effect-inheritance-chain.json
@@ -5,7 +5,7 @@
       "name": "harn",
       "version": "0.8.x"
     },
-    "root_hash": "sha256:783dd6eb93fc13f2d42773f11693543a7f7cb2c28cef980b409c9f69830e5272",
+    "root_hash": "sha256:39ff5a2c614a49c14059863afe5c3320343ff1198514b7d9060ef079aa23b6eb",
     "topic": "trust_graph",
     "total": 3,
     "verified": true
@@ -18,8 +18,14 @@
       "autonomy_tier": "act_auto",
       "chain_index": 1,
       "cost_usd": null,
-      "entry_hash": "sha256:0345151a3326dac3e5126efe1d903a09be8105609c62f2e6ceed3bbf2b65028f",
+      "entry_hash": "sha256:4995c13f9e31cfd5d049254f00bb5748de8f4a3c84f8946606a688b4b7a112f0",
       "metadata": {
+        "actor_chain": {
+          "act": {
+            "sub": "agent:parent-orchestrator"
+          },
+          "sub": "user:operator"
+        },
         "effects_grant": [
           {
             "kind": {
@@ -58,8 +64,17 @@
       "autonomy_tier": "act_auto",
       "chain_index": 2,
       "cost_usd": null,
-      "entry_hash": "sha256:f26018404c747e059fae75d71a4c2ecf46673f14f63ee89e12f89295bb94c281",
+      "entry_hash": "sha256:ffcb9cb912d2a48b3400be9469e8f2601ca5ae8926fc8787d23597eb913d6701",
       "metadata": {
+        "actor_chain": {
+          "act": {
+            "act": {
+              "sub": "agent:parent-orchestrator"
+            },
+            "sub": "agent:child-spawner"
+          },
+          "sub": "user:operator"
+        },
         "effects_grant": [
           {
             "kind": {
@@ -79,7 +94,7 @@
         "parent_record_id": "01966f4c-3000-7001-a000-000000000001"
       },
       "outcome": "success",
-      "previous_hash": "sha256:0345151a3326dac3e5126efe1d903a09be8105609c62f2e6ceed3bbf2b65028f",
+      "previous_hash": "sha256:4995c13f9e31cfd5d049254f00bb5748de8f4a3c84f8946606a688b4b7a112f0",
       "record_id": "01966f4c-3001-7002-a000-000000000002",
       "schema": "opentrustgraph/v0.1",
       "timestamp": "2026-04-19T20:31:00Z",
@@ -92,8 +107,20 @@
       "autonomy_tier": "act_auto",
       "chain_index": 3,
       "cost_usd": 0.001,
-      "entry_hash": "sha256:783dd6eb93fc13f2d42773f11693543a7f7cb2c28cef980b409c9f69830e5272",
+      "entry_hash": "sha256:39ff5a2c614a49c14059863afe5c3320343ff1198514b7d9060ef079aa23b6eb",
       "metadata": {
+        "actor_chain": {
+          "act": {
+            "act": {
+              "act": {
+                "sub": "agent:parent-orchestrator"
+              },
+              "sub": "agent:child-spawner"
+            },
+            "sub": "agent:grandchild-worker"
+          },
+          "sub": "user:operator"
+        },
         "effects_used": [
           {
             "kind": {
@@ -106,7 +133,7 @@
         "parent_record_id": "01966f4c-3001-7002-a000-000000000002"
       },
       "outcome": "success",
-      "previous_hash": "sha256:f26018404c747e059fae75d71a4c2ecf46673f14f63ee89e12f89295bb94c281",
+      "previous_hash": "sha256:ffcb9cb912d2a48b3400be9469e8f2601ca5ae8926fc8787d23597eb913d6701",
       "record_id": "01966f4c-3002-7003-a000-000000000003",
       "schema": "opentrustgraph/v0.1",
       "timestamp": "2026-04-19T20:32:00Z",

--- a/crates/harn-vm/src/trust_graph/schemas/trust-record.v0.1.schema.json
+++ b/crates/harn-vm/src/trust_graph/schemas/trust-record.v0.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/opentrustgraph/v0.1/trust-record.schema.json",
   "title": "OpenTrustGraph TrustRecord v0.1",
-  "description": "One autonomy, approval, or control-plane event in an append-only OpenTrustGraph chain. v0.1 reserves three additional `metadata` keys (`effects_grant`, `effects_used`, `parent_record_id`) so chain validators can prove that a child agent's `effects_used ⊆ parent.effects_grant`. v0 records still validate against this schema for one patch release window (see CONFORMANCE.md §5).",
+  "description": "One autonomy, approval, or control-plane event in an append-only OpenTrustGraph chain. v0.1 reserves lineage metadata keys (`effects_grant`, `effects_used`, `parent_record_id`, `actor_chain`) so chain validators can prove that a child agent's effects and actors stayed inside the parent chain. v0 records still validate against this schema for one patch release window (see CONFORMANCE.md §5).",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -77,8 +77,12 @@
     },
     "metadata": {
       "type": "object",
-      "description": "Runtime-specific detail bag. Consumers must preserve unknown keys. v0.1 reserves the three keys below; older consumers MAY ignore them.",
+      "description": "Runtime-specific detail bag. Consumers must preserve unknown keys. v0.1 reserves the lineage keys below; older consumers MAY ignore them.",
       "properties": {
+        "actor_chain": {
+          "$ref": "#/$defs/actorChain",
+          "description": "RFC 8693 actor chain for the principal that caused this record. When `parent_record_id` is present, verifiers MUST check this chain extends the parent's `actor_chain` by exactly one nested `act` hop."
+        },
         "effects_grant": {
           "type": "array",
           "description": "Typed effect set the parent extended to this record. Empty/absent means no grant tracking. Items follow the EffectRecord shape (kind, scope, optional resource).",
@@ -152,6 +156,33 @@
             }
           }
         }
+      }
+    },
+    "actorChain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sub"],
+      "properties": {
+        "sub": { "type": "string", "minLength": 1 },
+        "act": { "$ref": "#/$defs/actorNode" },
+        "may_act": { "$ref": "#/$defs/principalClaim" }
+      }
+    },
+    "actorNode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sub"],
+      "properties": {
+        "sub": { "type": "string", "minLength": 1 },
+        "act": { "$ref": "#/$defs/actorNode" }
+      }
+    },
+    "principalClaim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sub"],
+      "properties": {
+        "sub": { "type": "string", "minLength": 1 }
       }
     },
     "effectRecord": {

--- a/docs/src/spec/open-trust-graph/v0.md
+++ b/docs/src/spec/open-trust-graph/v0.md
@@ -23,10 +23,10 @@ The full normative content lives in three places, each linked below:
   control-plane decision. Records carry `agent`, `action`, `approver`,
   `outcome`, `trace_id`, `autonomy_tier`, `timestamp`, `cost_usd`,
   `chain_index`, `previous_hash`, `entry_hash`, and an extensible
-  `metadata` bag. `v0.1` reserves three keys at the metadata layer —
-  `effects_grant`, `effects_used`, and `parent_record_id` — so chain
-  validators can prove that a child agent's `effects_used` stayed inside
-  the parent's `effects_grant`. `opentrustgraph/v0` records still validate
+  `metadata` bag. `v0.1` reserves lineage keys at the metadata layer —
+  `actor_chain`, `effects_grant`, `effects_used`, and `parent_record_id` —
+  so chain validators can prove that a child agent's effects and actors
+  stayed inside the parent chain. `opentrustgraph/v0` records still validate
   for one patch release window per
   [`opentrustgraph-spec/CONFORMANCE.md` §5](https://github.com/burin-labs/harn/blob/main/opentrustgraph-spec/CONFORMANCE.md#5-versioning).
 - **Chain export:** `opentrustgraph-chain/v0`. Wraps an ordered record
@@ -89,8 +89,10 @@ library, and it is exercised against every fixture in
 |-----------------------------------------|----------|----------------------------------------------------|
 | `fixtures/valid/decision-chain.json`    | accept   | Two-record chain with a control-plane promotion    |
 | `fixtures/valid/tier-transition.json`   | accept   | Three-record chain ending in an approved action    |
+| `fixtures/valid/effect-inheritance-chain.json` | accept | Effect inheritance plus actor-chain parentage |
 | `fixtures/invalid/tampered-chain.json`  | reject   | Self-consistent record but broken `previous_hash`  |
 | `fixtures/invalid/missing-approval.json`| reject   | `approval.required = true` with no approver        |
+| `fixtures/invalid/actor-chain-parentage.json` | reject | Child `actor_chain` does not extend its parent |
 
 These fixtures are normative test vectors. The Harn runtime parses them
 in `crates/harn-vm/src/trust_graph.rs::tests::opentrustgraph_*` so the

--- a/docs/src/trust-graph.md
+++ b/docs/src/trust-graph.md
@@ -27,9 +27,9 @@ Each record carries:
 - `chain_index`
 - `previous_hash`
 - `entry_hash`
-- `metadata` (v0.1 reserves `effects_grant`, `effects_used`, and
-  `parent_record_id` so chain validators can prove that a child agent's
-  `effects_used ⊆ parent.effects_grant`)
+- `metadata` (v0.1 reserves `actor_chain`, `effects_grant`, `effects_used`,
+  and `parent_record_id` so chain validators can prove that a child agent's
+  effects and actors stayed inside the parent chain)
 
 [otg-versioning]: https://github.com/burin-labs/harn/blob/main/opentrustgraph-spec/CONFORMANCE.md#5-versioning
 

--- a/opentrustgraph-spec/CONFORMANCE.md
+++ b/opentrustgraph-spec/CONFORMANCE.md
@@ -116,15 +116,15 @@ appending the same logical records.
 
 The fixtures under `fixtures/invalid/` are negative test vectors. A
 conformant verifier MUST reject them and SHOULD report an error that
-mentions either `previous_hash mismatch`, `entry_hash mismatch`, or
-`approval required` so operators can triage failures quickly.
+mentions `previous_hash mismatch`, `entry_hash mismatch`, `approval required`,
+or `actor_chain escaped parentage` so operators can triage failures quickly.
 
 ## 5. Versioning
 
 - The schema version moves with the on-disk shape. Adding a new optional
   property at the top level is backwards compatible. Reserving new
-  metadata keys (as `v0.1` does for `effects_grant`, `effects_used`, and
-  `parent_record_id`) is also additive and gets a minor bump.
+  metadata keys (as `v0.1` does for `effects_grant`, `effects_used`,
+  `parent_record_id`, and `actor_chain`) is also additive and gets a minor bump.
 - A minor bump (`v0.1`) MUST stay record-shape compatible with the prior
   minor version. Consumers MUST continue to accept the prior minor
   version's discriminator for one patch release window after the bump
@@ -138,16 +138,17 @@ mentions either `previous_hash mismatch`, `entry_hash mismatch`, or
 - Multiple major versions MAY coexist on the same stream; consumers
   dispatch on the `schema` discriminator.
 
-### 5.1 v0.1 reserved metadata keys (#1778)
+### 5.1 v0.1 Reserved Metadata Keys
 
-`v0.1` adds three reserved keys under `TrustRecord.metadata`. Producers
+`v0.1` adds four reserved lineage keys under `TrustRecord.metadata`. Producers
 MAY omit them; consumers MUST preserve them when re-emitting records.
 
-| Key                 | Type                          | Meaning                                                                              |
-| ------------------- | ----------------------------- | ------------------------------------------------------------------------------------ |
-| `effects_grant`     | array of `EffectRecord`       | Typed effect set the parent extended to this record at spawn time.                   |
-| `effects_used`      | array of `EffectRecord`       | Typed effect set the action actually exercised.                                      |
-| `parent_record_id`  | string (UUID) or null/absent  | Pointer at the parent record's `record_id`. `null`/absent for root records.          |
+| Key                 | Type                          | Meaning                                                                     |
+| ------------------- | ----------------------------- | --------------------------------------------------------------------------- |
+| `actor_chain`       | RFC 8693 actor chain object   | Subject plus nested `act` chain for the principal that caused this record.  |
+| `effects_grant`     | array of `EffectRecord`       | Typed effect set the parent extended to this record at spawn time.          |
+| `effects_used`      | array of `EffectRecord`       | Typed effect set the action actually exercised.                             |
+| `parent_record_id`  | string (UUID) or null/absent  | Pointer at the parent record's `record_id`. `null`/absent for root records. |
 
 `EffectRecord` follows the shape defined in
 `schemas/trust-record.v0.1.schema.json#/$defs/effectRecord`, which mirrors
@@ -166,3 +167,17 @@ Verifiers report failures with an error message containing the substring
 `effects_used escaped grant` so operators can triage them quickly. The
 subset check uses structural equality of the canonical `EffectRecord`
 shape (`kind`, `scope`, `resource`).
+
+When a record `r` carries both `actor_chain` and a `parent_record_id`
+referencing `p`, a v0.1-conformant chain verifier MUST check:
+
+```text
+r.actor_chain.act == current_actor + p.actor_chain.act
+r.actor_chain.sub == p.actor_chain.sub
+```
+
+In other words, dropping the current nested `act` hop from `r.actor_chain`
+must produce `p.actor_chain`; the top-level `sub` must be identical. The
+comparison intentionally ignores `may_act`, which is an authorization hint,
+not audit lineage. Verifiers report failures with an error message
+containing the substring `actor_chain escaped parentage`.

--- a/opentrustgraph-spec/README.md
+++ b/opentrustgraph-spec/README.md
@@ -22,12 +22,15 @@ inventing another envelope.
 - Chain export: `opentrustgraph-chain/v0` (unchanged in v0.1 — the bump
   is additive at the record metadata layer).
 
-`v0.1` reserves three additional keys under `TrustRecord.metadata`:
+`v0.1` reserves four lineage keys under `TrustRecord.metadata`:
+`actor_chain` (RFC 8693 subject/actor chain for who caused this record),
 `effects_grant` (typed effect list the parent extended to this record),
 `effects_used` (typed effect list the action actually exercised), and
 `parent_record_id` (pointer to the parent record's `record_id`).
 Verifiers MUST check that a child's `effects_used` is a subset of the
-parent's `effects_grant`.
+parent's `effects_grant`; when `actor_chain` is present with
+`parent_record_id`, verifiers MUST also check that the child's nested `act`
+chain extends the parent's `actor_chain` by exactly one hop.
 
 ## Contents
 
@@ -52,7 +55,9 @@ parent's `effects_grant`.
 - `fixtures/valid/effect-inheritance-chain.json`: a v0.1 three-agent chain
   (parent → child → grandchild) that demonstrates the effect-inheritance
   invariant `effects_used ⊆ child.effects_grant ⊆ parent.effects_grant`,
-  plus `parent_record_id` linkage.
+  plus `parent_record_id` and `actor_chain` linkage.
+- `fixtures/invalid/actor-chain-parentage.json`: a self-consistent v0.1 chain
+  whose `actor_chain` no longer extends the referenced parent record.
 - `fixtures/invalid/missing-approval.json`: a record that declares approval was
   required but omits the approver/signature evidence.
 - `examples/python/verify_chain.py`: reference, stdlib-only verifier in pure

--- a/opentrustgraph-spec/examples/python/README.md
+++ b/opentrustgraph-spec/examples/python/README.md
@@ -9,10 +9,12 @@ linkage contract is interoperable with non-Harn runtimes.
 # Verify a chain export.
 python3 verify_chain.py ../../fixtures/valid/decision-chain.json
 python3 verify_chain.py ../../fixtures/valid/tier-transition.json
+python3 verify_chain.py ../../fixtures/valid/effect-inheritance-chain.json
 
 # Reject tampered or missing-approval fixtures.
 python3 verify_chain.py ../../fixtures/invalid/tampered-chain.json
 python3 verify_chain.py ../../fixtures/invalid/missing-approval.json
+python3 verify_chain.py ../../fixtures/invalid/actor-chain-parentage.json
 
 # Read from stdin (for piping out of a producer):
 harn trust-graph export | python3 verify_chain.py

--- a/opentrustgraph-spec/examples/python/verify_chain.py
+++ b/opentrustgraph-spec/examples/python/verify_chain.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import hashlib
 import json
 import sys
-from typing import Any, Iterator, List
+from typing import Any, Iterator, List, Tuple
 
 CHAIN_SCHEMA = "opentrustgraph-chain/v0"
 # v0.1 is the current record discriminator. v0 is accepted for one patch
@@ -62,6 +62,39 @@ def canonical_record_bytes(record: dict[str, Any]) -> bytes:
 def compute_entry_hash(record: dict[str, Any]) -> str:
     digest = hashlib.sha256(canonical_record_bytes(record)).hexdigest()
     return f"sha256:{digest}"
+
+
+def actor_chain_parts(value: Any, path: str) -> Tuple[str, List[str]]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must be an object")
+    origin = value.get("sub")
+    if not isinstance(origin, str) or not origin:
+        raise ValueError(f"{path}.sub must be a string")
+    actors: List[str] = []
+    current = value.get("act")
+    current_path = f"{path}.act"
+    while current is not None:
+        if not isinstance(current, dict):
+            raise ValueError(f"{current_path} must be an object")
+        subject = current.get("sub")
+        if not isinstance(subject, str) or not subject:
+            raise ValueError(f"{current_path}.sub must be a string")
+        actors.append(subject)
+        current = current.get("act")
+        current_path = f"{current_path}.act"
+    return origin, actors
+
+
+def actor_chain_extends_parent(
+    child: Tuple[str, List[str]], parent: Tuple[str, List[str]]
+) -> bool:
+    child_origin, child_actors = child
+    parent_origin, parent_actors = parent
+    return (
+        child_origin == parent_origin
+        and len(child_actors) == len(parent_actors) + 1
+        and child_actors[1:] == parent_actors
+    )
 
 
 def verify_chain(envelope: dict[str, Any]) -> List[str]:
@@ -116,29 +149,58 @@ def verify_chain(envelope: dict[str, Any]) -> List[str]:
             if not signatures:
                 errors.append(f"{label}: approval required but signatures are empty")
 
-        # v0.1: when a record claims `effects_used` and points at a
-        # parent record via `parent_record_id`, the used set MUST be a
-        # subset of the parent's `effects_grant`. See CONFORMANCE.md §5.1.
+        # v0.1 lineage: when a record carries effects or actor-chain
+        # metadata and points at a parent record via `parent_record_id`,
+        # those child claims must stay inside the parent record's lineage.
         metadata = record.get("metadata") or {}
         parent_id = metadata.get("parent_record_id")
         effects_used = metadata.get("effects_used") or []
-        if parent_id and effects_used:
+        actor_chain = None
+        if metadata.get("actor_chain") is not None:
+            try:
+                actor_chain = actor_chain_parts(metadata["actor_chain"], f"{label}.actor_chain")
+            except ValueError as error:
+                errors.append(f"{label}: actor_chain invalid: {error}")
+        if parent_id and (effects_used or actor_chain is not None):
             parent_record = by_id.get(parent_id)
             if parent_record is None:
                 errors.append(
                     f"{label}: parent_record_id {parent_id!r} not found in chain"
                 )
             else:
-                parent_grant = (parent_record.get("metadata") or {}).get(
-                    "effects_grant"
-                ) or []
-                canonical_parent_grant = [_canonicalize(e) for e in parent_grant]
-                for effect in effects_used:
-                    if _canonicalize(effect) not in canonical_parent_grant:
+                parent_metadata = parent_record.get("metadata") or {}
+                if effects_used:
+                    parent_grant = parent_metadata.get("effects_grant") or []
+                    canonical_parent_grant = [_canonicalize(e) for e in parent_grant]
+                    for effect in effects_used:
+                        if _canonicalize(effect) not in canonical_parent_grant:
+                            errors.append(
+                                f"{label}: effects_used escaped grant from parent "
+                                f"{parent_id!r}: {effect!r}"
+                            )
+                if actor_chain is not None:
+                    parent_actor_raw = parent_metadata.get("actor_chain")
+                    if parent_actor_raw is None:
                         errors.append(
-                            f"{label}: effects_used escaped grant from parent "
-                            f"{parent_id!r}: {effect!r}"
+                            f"{label}: actor_chain parent {parent_id!r} missing actor_chain"
                         )
+                    else:
+                        try:
+                            parent_actor_chain = actor_chain_parts(
+                                parent_actor_raw,
+                                f"parent {parent_id!r}.actor_chain",
+                            )
+                            if not actor_chain_extends_parent(
+                                actor_chain, parent_actor_chain
+                            ):
+                                errors.append(
+                                    f"{label}: actor_chain escaped parentage from "
+                                    f"parent {parent_id!r}"
+                                )
+                        except ValueError as error:
+                            errors.append(
+                                f"{label}: parent actor_chain invalid: {error}"
+                            )
 
         record_id = record.get("record_id")
         if isinstance(record_id, str) and record_id:

--- a/opentrustgraph-spec/fixtures/invalid/actor-chain-parentage.json
+++ b/opentrustgraph-spec/fixtures/invalid/actor-chain-parentage.json
@@ -1,14 +1,14 @@
 {
   "chain": {
-    "generated_at": "2026-04-19T20:33:00Z",
+    "generated_at": "2026-04-19T20:34:00Z",
     "producer": {
       "name": "harn",
       "version": "0.8.x"
     },
-    "root_hash": "sha256:39ff5a2c614a49c14059863afe5c3320343ff1198514b7d9060ef079aa23b6eb",
+    "root_hash": "sha256:3683b2872a27f01bfaa48f586644a35f193addef81a7d9c2ccd736e2ef9e152c",
     "topic": "trust_graph",
     "total": 3,
-    "verified": true
+    "verified": false
   },
   "records": [
     {
@@ -64,12 +64,12 @@
       "autonomy_tier": "act_auto",
       "chain_index": 2,
       "cost_usd": null,
-      "entry_hash": "sha256:ffcb9cb912d2a48b3400be9469e8f2601ca5ae8926fc8787d23597eb913d6701",
+      "entry_hash": "sha256:c615ab724f9662673f0af61da0e2c843c08c66b5ac10262ac1ff4cbc63351e30",
       "metadata": {
         "actor_chain": {
           "act": {
             "act": {
-              "sub": "agent:parent-orchestrator"
+              "sub": "agent:other-parent"
             },
             "sub": "agent:child-spawner"
           },
@@ -107,13 +107,13 @@
       "autonomy_tier": "act_auto",
       "chain_index": 3,
       "cost_usd": 0.001,
-      "entry_hash": "sha256:39ff5a2c614a49c14059863afe5c3320343ff1198514b7d9060ef079aa23b6eb",
+      "entry_hash": "sha256:3683b2872a27f01bfaa48f586644a35f193addef81a7d9c2ccd736e2ef9e152c",
       "metadata": {
         "actor_chain": {
           "act": {
             "act": {
               "act": {
-                "sub": "agent:parent-orchestrator"
+                "sub": "agent:other-parent"
               },
               "sub": "agent:child-spawner"
             },
@@ -133,7 +133,7 @@
         "parent_record_id": "01966f4c-3001-7002-a000-000000000002"
       },
       "outcome": "success",
-      "previous_hash": "sha256:ffcb9cb912d2a48b3400be9469e8f2601ca5ae8926fc8787d23597eb913d6701",
+      "previous_hash": "sha256:c615ab724f9662673f0af61da0e2c843c08c66b5ac10262ac1ff4cbc63351e30",
       "record_id": "01966f4c-3002-7003-a000-000000000003",
       "schema": "opentrustgraph/v0.1",
       "timestamp": "2026-04-19T20:32:00Z",

--- a/opentrustgraph-spec/schemas/trust-record.v0.1.schema.json
+++ b/opentrustgraph-spec/schemas/trust-record.v0.1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://harnlang.com/schemas/opentrustgraph/v0.1/trust-record.schema.json",
   "title": "OpenTrustGraph TrustRecord v0.1",
-  "description": "One autonomy, approval, or control-plane event in an append-only OpenTrustGraph chain. v0.1 reserves three additional `metadata` keys (`effects_grant`, `effects_used`, `parent_record_id`) so chain validators can prove that a child agent's `effects_used ⊆ parent.effects_grant`. v0 records still validate against this schema for one patch release window (see CONFORMANCE.md §5).",
+  "description": "One autonomy, approval, or control-plane event in an append-only OpenTrustGraph chain. v0.1 reserves lineage metadata keys (`effects_grant`, `effects_used`, `parent_record_id`, `actor_chain`) so chain validators can prove that a child agent's effects and actors stayed inside the parent chain. v0 records still validate against this schema for one patch release window (see CONFORMANCE.md §5).",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -77,8 +77,12 @@
     },
     "metadata": {
       "type": "object",
-      "description": "Runtime-specific detail bag. Consumers must preserve unknown keys. v0.1 reserves the three keys below; older consumers MAY ignore them.",
+      "description": "Runtime-specific detail bag. Consumers must preserve unknown keys. v0.1 reserves the lineage keys below; older consumers MAY ignore them.",
       "properties": {
+        "actor_chain": {
+          "$ref": "#/$defs/actorChain",
+          "description": "RFC 8693 actor chain for the principal that caused this record. When `parent_record_id` is present, verifiers MUST check this chain extends the parent's `actor_chain` by exactly one nested `act` hop."
+        },
         "effects_grant": {
           "type": "array",
           "description": "Typed effect set the parent extended to this record. Empty/absent means no grant tracking. Items follow the EffectRecord shape (kind, scope, optional resource).",
@@ -152,6 +156,33 @@
             }
           }
         }
+      }
+    },
+    "actorChain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sub"],
+      "properties": {
+        "sub": { "type": "string", "minLength": 1 },
+        "act": { "$ref": "#/$defs/actorNode" },
+        "may_act": { "$ref": "#/$defs/principalClaim" }
+      }
+    },
+    "actorNode": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sub"],
+      "properties": {
+        "sub": { "type": "string", "minLength": 1 },
+        "act": { "$ref": "#/$defs/actorNode" }
+      }
+    },
+    "principalClaim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sub"],
+      "properties": {
+        "sub": { "type": "string", "minLength": 1 }
       }
     },
     "effectRecord": {

--- a/opentrustgraph-spec/schemas/trust-record.v0.proto
+++ b/opentrustgraph-spec/schemas/trust-record.v0.proto
@@ -47,7 +47,8 @@ enum AutonomyTier {
 // proto3 convention; the runtime validator enforces them and the JSON
 // Schema is the normative source of truth.
 message TrustRecord {
-  // Schema discriminator, always "opentrustgraph/v0".
+  // Schema discriminator, "opentrustgraph/v0.1" for current records.
+  // "opentrustgraph/v0" remains valid during the compatibility window.
   string schema = 1;
 
   // Globally unique record id. UUIDv7 is recommended.
@@ -89,6 +90,8 @@ message TrustRecord {
   string entry_hash = 14;
 
   // Runtime-specific metadata bag. Consumers MUST preserve unknown keys.
+  // v0.1 reserves actor_chain, effects_grant, effects_used, and
+  // parent_record_id as lineage metadata.
   google.protobuf.Struct metadata = 15;
 }
 

--- a/spec/opentrustgraph.md
+++ b/spec/opentrustgraph.md
@@ -19,10 +19,10 @@ Version markers:
 {"schema":"opentrustgraph-chain/v0"}
 ```
 
-`v0.1` is an additive bump over `v0`. It reserves three new keys under
-`TrustRecord.metadata` — `effects_grant`, `effects_used`, and
+`v0.1` is an additive bump over `v0`. It reserves four lineage keys under
+`TrustRecord.metadata` — `actor_chain`, `effects_grant`, `effects_used`, and
 `parent_record_id` — so chain validators can prove that a child agent's
-`effects_used ⊆ parent.effects_grant`. The chain hash inputs are
+effects and actors stayed inside the parent chain. The chain hash inputs are
 unchanged because metadata was already hash-covered. `v0` records still
 parse for one patch release window per
 [`opentrustgraph-spec/CONFORMANCE.md` §5](../opentrustgraph-spec/CONFORMANCE.md#5-versioning),
@@ -76,7 +76,11 @@ Fields:
 - `entry_hash`: SHA-256 hash over the canonical record with `entry_hash`
   removed. Harn stores it with the `sha256:` prefix.
 - `metadata`: extensible runtime-specific detail bag. `v0.1` reserves
-  three keys at this layer:
+  lineage keys at this layer:
+  - `actor_chain`: RFC 8693 `{sub, act}` actor chain for the principal
+    that caused the record. When `parent_record_id` is present, verifiers
+    MUST check that this chain extends the parent's `actor_chain` by
+    exactly one nested `act` hop.
   - `effects_grant`: typed `EffectRecord` list (`kind`, `scope`, optional
     `resource`) the parent extended to this record.
   - `effects_used`: typed `EffectRecord` list the action actually


### PR DESCRIPTION
## Summary
- Adds typed `TrustRecord` actor-chain metadata helpers and automatically attaches the current session `ActorChain` before hashing records.
- Verifies `actor_chain` lineage against `parent_record_id` alongside existing effect-lineage checks, including Rust, Harn conformance, and Python reference-verifier coverage.
- Updates OpenTrustGraph v0.1 schemas, spec docs, mirrored fixtures, and changelog fragment for the reserved `actor_chain` metadata key.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-3335 cargo test -p harn-vm trust_graph --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-3335 cargo test -p harn-serve dispatch_threads_actor_chain_into_agent_session --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-3335 cargo run --quiet --bin harn -- test conformance --filter trust_graph_schema_v0_1_effects_inheritance`
- `python3 -m py_compile opentrustgraph-spec/examples/python/verify_chain.py`
- Python reference verifier accepted 3 valid fixtures and rejected 3 invalid fixtures
- `cargo fmt --check`
- `make lint-test-patterns`
- pre-commit hook: passed
- pre-push hook: passed

Closes #3335