### PR TITLE
[codex] Track provenance for seeded sessions

### DIFF
--- a/changelog.d/3419.added.md
+++ b/changelog.d/3419.added.md
@@ -1,0 +1,3 @@
+- Add provenance and compaction recommendation options to
+  `agent_session_seed_from_jsonl` for explicit external coding-agent transcript
+  imports.

--- a/conformance/tests/agents/agent_session_seed_from_jsonl.expected
+++ b/conformance/tests/agents/agent_session_seed_from_jsonl.expected
@@ -2,6 +2,13 @@ true
 3
 message_events
 false
+external_agent_session
+codex
+codex-session-1
+true
+Codex import
+harn
+true
 true
 native
 3

--- a/conformance/tests/agents/agent_session_seed_from_jsonl.harn
+++ b/conformance/tests/agents/agent_session_seed_from_jsonl.harn
@@ -42,13 +42,26 @@ pipeline main() {
       truncate_to_last: 3,
       provider: "mock",
       model: "mock",
+      source_agent: "codex",
+      source_session_id: "codex-session-1",
+      source_label: "Codex import",
+      source_provenance: {workspace: "harn"},
+      recommend_compaction: true,
     },
   )
   __io_println(seeded.ok)
   __io_println(seeded.turns_loaded)
   __io_println(seeded.source_format)
   __io_println(seeded.partial)
+  __io_println(seeded.source.kind)
+  __io_println(seeded.source.agent)
+  __io_println(seeded.source.session_id)
+  __io_println(seeded.recommend_compaction)
   let snap = agent_session_snapshot(seeded.session_id)
+  let seeded_meta = snap.metadata.seeded_from_jsonl
+  __io_println(seeded_meta.source.label)
+  __io_println(seeded_meta.source.provenance.workspace)
+  __io_println(seeded_meta.recommend_compaction)
   __io_println(agent_session_system_prompt(seeded.session_id) != nil)
   __io_println(agent_session_tool_format(seeded.session_id))
   __io_println(len(snap.messages))

--- a/crates/harn-vm/src/stdlib/agent_sessions.rs
+++ b/crates/harn-vm/src/stdlib/agent_sessions.rs
@@ -179,6 +179,22 @@ fn opt_json(opts: &crate::value::DictMap, arg_name: &str) -> serde_json::Value {
         .unwrap_or(serde_json::Value::Null)
 }
 
+fn opt_dict_json(
+    opts: &crate::value::DictMap,
+    fn_name: &str,
+    arg_name: &str,
+) -> Result<serde_json::Value, VmError> {
+    match opts.get(arg_name) {
+        None | Some(VmValue::Nil) => Ok(serde_json::Value::Null),
+        Some(VmValue::Dict(_)) => Ok(crate::llm::helpers::vm_value_to_json(
+            opts.get(arg_name).expect("checked above"),
+        )),
+        _ => Err(err(format!(
+            "{fn_name}: `{arg_name}` must be a dict or nil"
+        ))),
+    }
+}
+
 fn opts_dict_arg(
     args: &[VmValue],
     idx: usize,
@@ -1203,6 +1219,12 @@ const SEED_FROM_JSONL_OPT_KEYS: &[&str] = &[
     "validate",
     "provider",
     "model",
+    "source_agent",
+    "source_session_id",
+    "source_kind",
+    "source_label",
+    "source_provenance",
+    "recommend_compaction",
 ];
 
 #[harn_builtin(
@@ -1238,6 +1260,19 @@ fn agent_session_seed_from_jsonl_builtin(
         target_model: opt_string(&opts, "agent_session_seed_from_jsonl", "model")?,
     };
     let rename_session = opt_string(&opts, "agent_session_seed_from_jsonl", "rename_session")?;
+    let source_agent = opt_string(&opts, "agent_session_seed_from_jsonl", "source_agent")?;
+    let source_session_id =
+        opt_string(&opts, "agent_session_seed_from_jsonl", "source_session_id")?;
+    let source_kind = opt_string(&opts, "agent_session_seed_from_jsonl", "source_kind")?;
+    let source_label = opt_string(&opts, "agent_session_seed_from_jsonl", "source_label")?;
+    let source_provenance =
+        opt_dict_json(&opts, "agent_session_seed_from_jsonl", "source_provenance")?;
+    let recommend_compaction = arg_bool_opt(
+        &opts,
+        "agent_session_seed_from_jsonl",
+        "recommend_compaction",
+        false,
+    )?;
     let path_buf = PathBuf::from(&path);
     let seeded = match crate::llm::transcript_seed::load_seeded_transcript_from_jsonl(
         &path_buf,
@@ -1246,10 +1281,18 @@ fn agent_session_seed_from_jsonl_builtin(
         Ok(seeded) => seeded,
         Err(message) => return Ok(seed_result_error(message)),
     };
+    let source = seed_source_metadata(
+        source_kind,
+        source_agent,
+        source_session_id,
+        source_label,
+        source_provenance,
+    );
 
     let metadata = serde_json::json!({
         "seeded_from_jsonl": {
             "path": path,
+            "source": source,
             "source_records": seeded.record_count,
             "source_format": seeded.source_format.as_str(),
             "partial": seeded.partial,
@@ -1257,6 +1300,7 @@ fn agent_session_seed_from_jsonl_builtin(
             "provider": seeded.provider,
             "model": seeded.model,
             "tool_format": seeded.tool_format,
+            "recommend_compaction": recommend_compaction,
         }
     });
     let session_id = match agent_sessions::seed_from_messages(
@@ -1281,8 +1325,43 @@ fn agent_session_seed_from_jsonl_builtin(
         "provider": seeded.provider,
         "model": seeded.model,
         "tool_format": seeded.tool_format,
+        "source": source,
+        "recommend_compaction": recommend_compaction,
         "error": serde_json::Value::Null,
     })))
+}
+
+fn seed_source_metadata(
+    source_kind: Option<String>,
+    source_agent: Option<String>,
+    source_session_id: Option<String>,
+    source_label: Option<String>,
+    source_provenance: serde_json::Value,
+) -> serde_json::Value {
+    let has_external_identity = source_agent.is_some()
+        || source_session_id.is_some()
+        || source_label.is_some()
+        || source_provenance
+            .as_object()
+            .map(|map| !map.is_empty())
+            .unwrap_or(false);
+    serde_json::json!({
+        "schema": "harn.session_seed_source.v1",
+        "kind": source_kind.unwrap_or_else(|| {
+            if has_external_identity {
+                "external_agent_session".to_string()
+            } else {
+                "harn_jsonl".to_string()
+            }
+        }),
+        "agent": source_agent,
+        "session_id": source_session_id,
+        "label": source_label,
+        "provenance": match source_provenance {
+            serde_json::Value::Null => serde_json::Value::Object(serde_json::Map::new()),
+            value => value,
+        },
+    })
 }
 
 const REANCHOR_OPT_KEYS: &[&str] = &["carry_transcript", "compact", "reason"];

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -2564,7 +2564,8 @@ Lifecycle builtins (all hard-error on unknown ids except `exists`, `open`,
 - `agent_session_seed_from_jsonl(path, opts?)` creates a new session from a
   replayable `llm_transcript.jsonl` sidecar. Useful opts:
   `truncate_to_last`, `drop_tool_calls`, `rename_session`, `validate`,
-  `provider`, `model`.
+  `provider`, `model`, `source_agent`, `source_session_id`, `source_kind`,
+  `source_label`, `source_provenance`, `recommend_compaction`.
 - `agent_session_compact(id, opts)` — supports LLM/truncate/observation-mask/custom
   compaction, accepts the same compaction policy fields as
   `transcript_auto_compact`, and errors on unknown option keys.

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -2989,7 +2989,7 @@ See the [Sessions](./sessions.md) chapter for the full model.
 | `agent_session_trim(id, keep_last)` | id, keep_last: int | int | Retain last `keep_last` messages; returns kept count |
 | `agent_session_compact(id, opts)` | id, opts: dict | int | Runs the LLM/truncate/observation-mask/custom compactor; custom strategies use `custom_compactor`, `mask_callback`, or `compress_callback` closures |
 | `agent_session_inject(id, message)` | id, message: dict | nil | Appends `{role, content, …}`; missing `role` errors |
-| `agent_session_seed_from_jsonl(jsonl_path, opts?)` | jsonl_path: string, opts: dict | dict | Create a new session from a replayable `llm_transcript.jsonl` sidecar. Options: `truncate_to_last`, `drop_tool_calls`, `rename_session`, `validate`, `provider`, `model` |
+| `agent_session_seed_from_jsonl(jsonl_path, opts?)` | jsonl_path: string, opts: dict | dict | Create a new session from a replayable `llm_transcript.jsonl` sidecar. Options: `truncate_to_last`, `drop_tool_calls`, `rename_session`, `validate`, `provider`, `model`, `source_agent`, `source_session_id`, `source_kind`, `source_label`, `source_provenance`, `recommend_compaction` |
 | `agent_session_close(id, status?)` | id, optional status string/dict | nil | Evicts immediately regardless of LRU cap and records an `agent_session_closed` event with the close reason |
 
 Pair with `agent_loop(..., {session_id: id, ...})`: prior messages load

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -1658,7 +1658,10 @@ replayable LLM transcript sidecar. Exact replay uses prompt-visible `message`
 events or full request snapshots; provider-response-only sidecars are
 assistant-response best effort and require `validate: false`. Options include
 `truncate_to_last`, `drop_tool_calls`, `rename_session`, `validate`, `provider`,
-and `model`.
+`model`, `source_agent`, `source_session_id`, `source_kind`, `source_label`,
+`source_provenance`, and `recommend_compaction`. Source metadata is recorded
+under `metadata.seeded_from_jsonl.source` so hosts can explain externally
+imported sessions before resuming or compacting them.
 
 Delegated workers accept `carry.transcript_mode` to define continuation
 semantics across `send_input(...)`, retriggered workers, and resumed snapshots.

--- a/docs/src/llm/agent_loop.md
+++ b/docs/src/llm/agent_loop.md
@@ -985,8 +985,11 @@ the loop picks which skill(s) to activate:
   imports exact prompt-visible `message` events or older full request
   snapshots, optionally checks `provider` / `model`, and supports
   `truncate_to_last` plus `drop_tool_calls` for oversized histories.
-  Provider-response-only sidecars require `validate: false` because
-  they lack user and tool-result turns.
+  Hosts can also attach external-session provenance with
+  `source_agent`, `source_session_id`, `source_label`,
+  `source_provenance`, and `recommend_compaction`. Provider-response-only
+  sidecars require `validate: false` because they lack user and
+  tool-result turns.
 
 ### Scoped tools
 

--- a/docs/src/sessions.md
+++ b/docs/src/sessions.md
@@ -145,10 +145,19 @@ messages:
 ```harn
 let seeded = agent_session_seed_from_jsonl(
   ".harn-runs/audit/agent-llm/llm_transcript.jsonl",
-  {truncate_to_last: 40, rename_session: "audit-recovery"},
+  {
+    truncate_to_last: 40,
+    rename_session: "audit-recovery",
+    source_agent: "codex",
+    source_session_id: "7f9f9a2e",
+    recommend_compaction: true,
+  },
 )
 
 if seeded.ok {
+  if seeded.recommend_compaction {
+    agent_session_compact(seeded.session_id, {compact_strategy: "llm"})
+  }
   agent_loop("Continue from the failed release step.", nil, {
     session_id: seeded.session_id,
     provider: seeded.provider,
@@ -168,13 +177,30 @@ Options:
   turns cannot be reconstructed from them.
 - `provider` / `model` (string): optional guardrails. When set, validation
   checks the transcript's recorded request provider/model before seeding.
+- `source_agent` / `source_session_id` / `source_label` (string): optional
+  provenance for external coding-agent imports. Use stable agent slugs such as
+  `codex`, `claude-code`, or `cursor` when a host imports user-selected chats.
+- `source_kind` (string, default `external_agent_session` when source identity
+  is present, otherwise `harn_jsonl`): classifies the source without changing
+  replay behavior.
+- `source_provenance` (dict): adapter-specific, non-secret metadata that helps
+  a UI explain where the transcript came from.
+- `recommend_compaction` (bool, default `false`): records that a host should
+  offer or run compaction before resuming. This is useful for outside sessions
+  produced by a different model, tool schema, or transcript format.
 
 The result shape is `{ok, session_id?, turns_loaded?, messages_loaded?,
 source_records?, source_format?, partial?, truncated?, provider?, model?,
-tool_format?, error?}`. `source_format` is `message_events`,
-`request_snapshots`, or `provider_responses_only`; the last is available only
-with `validate: false` and is assistant-response best effort, not prefix-cache
-equivalent replay.
+tool_format?, source?, recommend_compaction?, error?}`. `source` has schema
+`harn.session_seed_source.v1` and is also stored under
+`agent_session_snapshot(session_id).metadata.seeded_from_jsonl.source`.
+`source_format` is `message_events`, `request_snapshots`, or
+`provider_responses_only`; the last is available only with `validate: false`
+and is assistant-response best effort, not prefix-cache equivalent replay.
+
+For third-party coding-agent chats, keep discovery and user consent in the host
+or product layer. Harn only needs the explicit JSONL file and provenance
+metadata; it should not crawl private agent state directories by itself.
 
 ## Portable session bundles
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -1656,7 +1656,10 @@ replayable LLM transcript sidecar. Exact replay uses prompt-visible `message`
 events or full request snapshots; provider-response-only sidecars are
 assistant-response best effort and require `validate: false`. Options include
 `truncate_to_last`, `drop_tool_calls`, `rename_session`, `validate`, `provider`,
-and `model`.
+`model`, `source_agent`, `source_session_id`, `source_kind`, `source_label`,
+`source_provenance`, and `recommend_compaction`. Source metadata is recorded
+under `metadata.seeded_from_jsonl.source` so hosts can explain externally
+imported sessions before resuming or compacting them.
 
 Delegated workers accept `carry.transcript_mode` to define continuation
 semantics across `send_input(...)`, retriggered workers, and resumed snapshots.


### PR DESCRIPTION
## Summary

Adds explicit provenance metadata for JSONL-seeded Harn sessions so host products can safely import or contextualize user-selected external coding-agent chats without making Harn responsible for crawling private agent state directories.

## What changed

- Extended `agent_session_seed_from_jsonl` with source provenance options: `source_agent`, `source_session_id`, `source_kind`, `source_label`, `source_provenance`, and `recommend_compaction`.
- Persists the provenance envelope under `metadata.seeded_from_jsonl.source` with schema `harn.session_seed_source.v1`.
- Returns the same `source` and `recommend_compaction` fields from the builtin result.
- Updated conformance coverage and session/builtin/spec docs, including generated language-spec sync.

## Product impact

This gives Burin/Harn a clean boundary for future Codex/Claude/Cursor imports: Burin or another trusted host handles opt-in local discovery and UI consent; Harn receives an explicit transcript plus provenance and can recommend compaction before resuming foreign-model context.

## Verification

- `make sync-language-spec`
- `cargo fmt --all --check`
- `cargo run --quiet --bin harn -- fmt --check conformance/tests/agents/agent_session_seed_from_jsonl.harn`
- `cargo run --quiet --bin harn -- check conformance/tests/agents/agent_session_seed_from_jsonl.harn`
- `cargo run --quiet --bin harn -- test conformance --filter agent_session_seed_from_jsonl`
- `cargo test -p harn-vm transcript_seed`
- pre-commit hook: markdown, Harn fmt/lint, Rust fmt, clippy on `harn-vm`, generated highlight/language-spec checks
- pre-push hook: markdown, targeted Rust checks, affected Harn fmt/lint, language-spec mirror, generated highlight checks
- `git diff --check`