### PR TITLE
Add actor-chain git trailer helpers

### DIFF
--- a/changelog.d/3338.added.md
+++ b/changelog.d/3338.added.md
@@ -1,0 +1,5 @@
+- **Disclosure stdlib Git trailer helpers (#3338).** `std/disclosure` now
+  exposes `git_trailers` and `append_git_trailers` so commit messages and PR
+  bodies can append actor-chain `Co-Authored-By` / `Assisted-by` attribution
+  from the configured disclosure templates while filtering non-human
+  `Signed-off-by` lines.

--- a/conformance/tests/stdlib/disclosure_git_trailers.expected
+++ b/conformance/tests/stdlib/disclosure_git_trailers.expected
@@ -1,0 +1,18 @@
+Co-Authored-By: Merge Captain <merge-captain@bots.example>
+Signed-off-by: Human Merge Captain <kenneth@example.com>
+Signed-off-by: Kenneth Sinder <kenneth@example.com>
+--- default ---
+Co-Authored-By: Merge Captain <merge-captain@bots.example>
+Assisted-by: Burin <burin@bots.example>
+--- assembled ---
+Fix identity trailers
+
+Use the actor chain.
+
+Co-Authored-By: Merge Captain <merge-captain@bots.example>
+Signed-off-by: Human Merge Captain <kenneth@example.com>
+Signed-off-by: Kenneth Sinder <kenneth@example.com>
+--- suppressed ---
+Fix identity trailers
+--- config suppressed ---
+Fix identity trailers

--- a/conformance/tests/stdlib/disclosure_git_trailers.harn
+++ b/conformance/tests/stdlib/disclosure_git_trailers.harn
@@ -1,0 +1,46 @@
+import { append_git_trailers, git_trailers } from "std/disclosure"
+
+pipeline default() {
+  let chain = {sub: "user:kenneth", act: {sub: "agent:merge-captain"}}
+  let nested_chain = {sub: "user:kenneth", act: {sub: "agent:merge-captain", act: {sub: "agent:burin"}}}
+  let config = {
+    identities: {
+      "user:kenneth": {name: "Kenneth Sinder", email: "kenneth@example.com"},
+      "agent:merge-captain": {name: "Merge Captain", email: "merge-captain@bots.example"},
+      "agent:burin": {name: "Burin", email: "burin@bots.example"},
+    },
+    surfaces: {
+      git: {
+        kind: "text",
+        template: "Co-Authored-By: {{ current.name }} <{{ current.email }}>\nSigned-off-by: Human Merge Captain <{{ origin.email }}>\nSigned-off-by: {{ current.name }} <{{ current.email }}>\nSigned-off-by: {{ origin.name }} <{{ origin.email }}>",
+      },
+    },
+  }
+  let options = {project: false, env: false, config: config}
+  let trailers = git_trailers(chain, options)
+  require !contains(trailers, "Signed-off-by: Merge Captain"), "agent actor must not receive DCO sign-off"
+  require contains(trailers, "Signed-off-by: Human Merge Captain"), "human sign-off must not be filtered by name substring"
+  let suppressed_message = "Fix identity trailers\n"
+  require append_git_trailers(suppressed_message, chain, options + {enabled: false}) == suppressed_message, "suppressed append must preserve the original message"
+  __io_println(trailers)
+  __io_println("--- default ---")
+  __io_println(
+    git_trailers(nested_chain, {project: false, env: false, config: {identities: config.identities}}),
+  )
+  __io_println("--- assembled ---")
+  __io_println(append_git_trailers("Fix identity trailers\n\nUse the actor chain.", chain, options))
+  __io_println("--- suppressed ---")
+  __io_println(append_git_trailers("Fix identity trailers", chain, options + {enabled: false}))
+  __io_println("--- config suppressed ---")
+  __io_println(
+    append_git_trailers(
+      "Fix identity trailers",
+      chain,
+      {
+        project: false,
+        env: false,
+        config: {identities: config.identities, surfaces: {git: {enabled: false}}},
+      },
+    ),
+  )
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -1420,6 +1420,14 @@ mod tests {
             exports.contains("render"),
             "std/disclosure should export render"
         );
+        assert!(
+            exports.contains("git_trailers"),
+            "std/disclosure should export git_trailers"
+        );
+        assert!(
+            exports.contains("append_git_trailers"),
+            "std/disclosure should export append_git_trailers"
+        );
     }
 
     #[test]

--- a/crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn
@@ -5,13 +5,22 @@ import { deep_merge } from "std/collections"
 
 type DisclosureRenderOptions = {project?: bool, project_root?: string, env?: bool, config?: dict}
 
+type DisclosureGitTrailerOptions = {
+  project?: bool,
+  project_root?: string,
+  env?: bool,
+  config?: dict,
+  enabled?: bool,
+  suppress?: bool,
+}
+
 const __BUILTIN_DISCLOSURE_CONFIG = """
 [defaults]
 email_domain = "actors.harn.invalid"
 
 [surfaces.git]
 kind = "text"
-template = "{{ if delegated }}Co-Authored-By: {{ current.name }} <{{ current.email }}>{{ for actor in prior_actors }}\nAssisted-by: {{ actor.name }} <{{ actor.email }}>{{ end }}{{ else }}Co-Authored-By: {{ origin.name }} <{{ origin.email }}>{{ end }}"
+template = "{{ if delegated }}Co-Authored-By: {{ current.name }} <{{ current.email }}>{{ for actor in prior_actors }}\nAssisted-by: {{ actor.name }} <{{ actor.email }}>{{ end }}{{ end }}"
 
 [surfaces.slack]
 kind = "text"
@@ -188,6 +197,12 @@ fn __principal(subject: string, config: dict, role: string, position: int) -> di
   if profile?.slack_id != nil {
     principal = principal + {slack: to_string(profile.slack_id)}
   }
+  if profile?.human != nil {
+    principal = principal + {human: profile.human}
+  }
+  if profile?.is_human != nil {
+    principal = principal + {human: profile.is_human}
+  }
   return principal
 }
 
@@ -283,6 +298,109 @@ fn __render_github(surface_config: dict, ctx: dict) -> dict {
   }
 }
 
+fn __git_trailers_switch_enabled(value: dict) -> bool {
+  return value?.enabled != false && value?.suppress != true
+}
+
+fn __principal_is_human(principal: dict) -> bool {
+  if principal?.human == true {
+    return true
+  }
+  if principal?.human == false {
+    return false
+  }
+  let kind = lowercase(trim(to_string(principal?.kind ?? "")))
+  return kind == "user" || kind == "human" || kind == "person"
+}
+
+fn __email_from_signature(signature: string) -> string {
+  let open = signature.index_of("<")
+  let close = signature.last_index_of(">")
+  if open < 0 || close <= open {
+    return ""
+  }
+  return lowercase(trim(signature.substring(open + 1, close)))
+}
+
+fn __principal_matches_signature(principal: dict, signature: string) -> bool {
+  let normalized = lowercase(trim(signature))
+  let signed_email = __email_from_signature(normalized)
+  let principal_email = lowercase(trim(to_string(principal?.email ?? "")))
+  if signed_email != "" && principal_email != "" {
+    return signed_email == principal_email
+  }
+  let name = lowercase(trim(to_string(principal?.name ?? "")))
+  if principal_email != "" && name != "" && normalized == name + " <" + principal_email + ">" {
+    return true
+  }
+  if signed_email == "" && name != "" && normalized == name {
+    return true
+  }
+  let subject = lowercase(trim(to_string(principal?.subject ?? "")))
+  return signed_email == "" && subject != "" && normalized == subject
+}
+
+fn __signed_off_by_targets_non_human(line: string, ctx: dict) -> bool {
+  let trimmed = trim(line)
+  if !starts_with(lowercase(trimmed), "signed-off-by:") {
+    return false
+  }
+  let signature = lowercase(trim(substring(trimmed, len("Signed-off-by:"))))
+  for principal in ctx.principals {
+    if __principal_is_human(principal) {
+      continue
+    }
+    if __principal_matches_signature(principal, signature) {
+      return true
+    }
+  }
+  return false
+}
+
+fn __safe_git_trailers(block: string, ctx: dict) -> string {
+  var lines = []
+  for line in split(trim(block), "\n") {
+    let cleaned = trim(line)
+    if cleaned == "" || __signed_off_by_targets_non_human(cleaned, ctx) {
+      continue
+    }
+    if !contains(lines, cleaned) {
+      lines = lines + [cleaned]
+    }
+  }
+  return join(lines, "\n")
+}
+
+fn __message_has_line(message: string, line: string) -> bool {
+  let want = trim(line)
+  for existing in split(message, "\n") {
+    if trim(existing) == want {
+      return true
+    }
+  }
+  return false
+}
+
+fn __append_trailer_block(message: string, block: string) -> string {
+  var lines = []
+  for line in split(trim(block), "\n") {
+    let cleaned = trim(line)
+    if cleaned == "" || __message_has_line(message, cleaned) || contains(lines, cleaned) {
+      continue
+    }
+    lines = lines + [cleaned]
+  }
+  if len(lines) == 0 {
+    return message
+  }
+  let body = message.trim_end()
+  let trailers = join(lines, "\n")
+  if body == "" {
+    return trailers
+  }
+  return body + "\n\n" + trailers
+}
+
 /**
  * Render a surface-native authorship disclosure artifact from an ActorChain.
  *
@@ -306,4 +424,40 @@ pub fn render(chain, surface: string, options: DisclosureRenderOptions = {}) -> 
     return __render_github(surface_config, ctx)
   }
   throw "std/disclosure: unsupported disclosure surface kind `" + kind + "`"
+}
+
+/**
+ * Render the configured Git attribution trailers for an ActorChain.
+ *
+ * The trailer text comes from the `git` disclosure surface. A `Signed-off-by`
+ * line targeting a non-human actor is omitted so DCO sign-off remains
+ * human-only even when callers override the template.
+ *
+ * @effects: [fs-read, env-read]
+ * @errors: [TypeError, ValueError]
+ */
+pub fn git_trailers(chain, options: DisclosureGitTrailerOptions = {}) -> string {
+  let opts = __dict(options)
+  if !__git_trailers_switch_enabled(opts) {
+    return ""
+  }
+  let config = __config(opts)
+  let ctx = __context(chain, config)
+  let surface_config = __surface_config(config, "git")
+  if !__git_trailers_switch_enabled(surface_config) {
+    return ""
+  }
+  return __safe_git_trailers(__render_text(surface_config, ctx), ctx)
+}
+
+/**
+ * Append actor-chain Git attribution trailers to a commit message or PR body.
+ *
+ * Pass `{enabled: false}` or `{suppress: true}` to leave the text unchanged.
+ *
+ * @effects: [fs-read, env-read]
+ * @errors: [TypeError, ValueError]
+ */
+pub fn append_git_trailers(message: string, chain, options: DisclosureGitTrailerOptions = {}) -> string {
+  return __append_trailer_block(message, git_trailers(chain, options))
 }

--- a/docs/src/stdlib/disclosure.md
+++ b/docs/src/stdlib/disclosure.md
@@ -6,7 +6,7 @@ same actor chain represented in a surface-native form such as Git trailers,
 a Slack byline, or a GitHub author-mode decision.
 
 ```harn
-import { render } from "std/disclosure"
+import { append_git_trailers, render } from "std/disclosure"
 
 pipeline default() {
   let chain = {
@@ -15,6 +15,7 @@ pipeline default() {
   }
 
   let trailers = render(chain, "git")
+  let commit_message = append_git_trailers("Fix the merge gate", chain)
   let byline = render(chain, "slack")
   let github = render(chain, "github")
 }
@@ -27,6 +28,14 @@ Built-in surfaces:
 | `git` | Trailer block string |
 | `slack` | Byline string |
 | `github` | `{kind: "github_author_choice", mode, author, co_author, principals, actor_chain}` |
+
+`git_trailers(chain, options?)` is a typed convenience wrapper around the
+`git` surface. `append_git_trailers(message, chain, options?)` appends that
+block to a commit message or PR body, deduping exact trailer lines. Pass
+`{enabled: false}` / `{suppress: true}`, or set those fields on
+`[surfaces.git]`, to leave the text unchanged. DCO sign-off stays human-only:
+`Signed-off-by:` lines for non-human actor-chain principals are omitted even
+when an overlaid template includes them.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- add std/disclosure git_trailers and append_git_trailers wrappers over the B1 git disclosure surface
- filter non-human Signed-off-by trailers while preserving human signatures, with append-time dedupe and suppression support
- add conformance coverage, docs, and a changelog fragment

#3327's A1-A5 child issues (#3332-#3336) are already closed; this finishes the remaining identity provenance Git trailer surface.

## Verification
- CARGO_TARGET_DIR=/tmp/harn-target-3338 cargo run --quiet --bin harn -- test conformance --filter disclosure_git_trailers
- CARGO_TARGET_DIR=/tmp/harn-target-3338 cargo run --quiet --bin harn -- test conformance --filter disclosure
- CARGO_TARGET_DIR=/tmp/harn-target-3338 cargo test -p harn-stdlib
- CARGO_TARGET_DIR=/tmp/harn-target-3338 make lint-harn fmt-harn
- CARGO_TARGET_DIR=/tmp/harn-target-3338 make check-docs-snippets
- CARGO_TARGET_DIR=/tmp/harn-target-3338 make lint-test-patterns
- CARGO_TARGET_DIR=/tmp/harn-target-3338 make test (7604 passed, 2 skipped)

Closes #3338.
Closes #3327.