### PR TITLE
Add OAuth token exchange stdlib support

### DIFF
--- a/changelog.d/3341.added.md
+++ b/changelog.d/3341.added.md
@@ -1,0 +1,2 @@
+- Added RFC 8693 OAuth token exchange to `std/oauth/client`, including data-backed provider capability rows,
+  delegation/impersonation validation, and nested `act` claim helpers.

--- a/conformance/tests/stdlib/oauth/oauth_token_exchange_capability_overlay.expected
+++ b/conformance/tests/stdlib/oauth/oauth_token_exchange_capability_overlay.expected
@@ -1,0 +1,1 @@
+[harn] oauth token exchange capability overlay ok

--- a/conformance/tests/stdlib/oauth/oauth_token_exchange_capability_overlay.harn
+++ b/conformance/tests/stdlib/oauth/oauth_token_exchange_capability_overlay.harn
@@ -1,0 +1,171 @@
+// std/oauth/token_exchange: provider capability rows are overlayable data.
+import { client, token_exchange } from "std/oauth/client"
+import { custom } from "std/oauth/providers"
+import { memory } from "std/oauth/storage"
+import {
+  token_exchange_capability,
+  token_exchange_catalog,
+  token_type,
+} from "std/oauth/token_exchange"
+
+fn catches_message(label, fn_call, needle) {
+  var matched = false
+  try {
+    let _ = fn_call()
+  } catch (err) {
+    matched = contains(to_string(err), needle)
+  }
+  require matched, label
+}
+
+pipeline test(task) {
+  let subject_type = token_type("access_token")
+  let actor_type = token_type("jwt")
+  let requested_type = token_type("access_token")
+  let overlay_row = {
+    id: "enterprise-as",
+    supported: true,
+    token_url: "https://idp.example/exchange",
+    subject_token_types: [subject_type],
+    actor_token_types: [actor_type],
+    requested_token_types: [requested_type],
+    issued_token_types: [requested_type],
+    delegation: true,
+    impersonation: false,
+    notes: ["test overlay"],
+  }
+  let catalog = token_exchange_catalog([overlay_row])
+  assert_eq(
+    catalog["enterprise-as"].token_url,
+    "https://idp.example/exchange",
+    "overlay row installed",
+  )
+  catches_message(
+    "malformed overlay entries fail closed",
+    { -> token_exchange_catalog({broken: true}) },
+    "must be a dict",
+  )
+  let overlay_capability = token_exchange_capability("enterprise-as", [overlay_row])
+  assert(overlay_capability != nil, "overlay capability should exist")
+  assert_eq(overlay_capability?.actor_token_types, [actor_type], "overlay lookup by id")
+  let bare_provider = custom(
+    {
+      id: "enterprise-as",
+      auth_url: "https://idp.example/authorize",
+      token_url: "https://idp.example/token",
+      default_scopes: [],
+    },
+  )
+  let bare_cli = client(bare_provider, {client_id: "cli-id", storage: memory()})
+  catches_message(
+    "unsupported provider should fail closed",
+    { -> token_exchange(
+      bare_cli,
+      {subject_token: "subject", subject_token_type: subject_type, requested_token_type: requested_type},
+    ) },
+    "not supported",
+  )
+  let incomplete_provider = custom(
+    {
+      id: "incomplete-as",
+      auth_url: "https://idp.example/authorize",
+      token_url: "https://idp.example/token",
+      default_scopes: [],
+      token_exchange: {supported: true},
+    },
+  )
+  let incomplete_cli = client(incomplete_provider, {client_id: "cli-id", storage: memory()})
+  catches_message(
+    "capability rows without token types fail closed",
+    { -> token_exchange(
+      incomplete_cli,
+      {subject_token: "subject", subject_token_type: subject_type, requested_token_type: requested_type},
+    ) },
+    "subject_token_type",
+  )
+  let provider = custom(
+    {
+      id: "enterprise-as",
+      auth_url: "https://idp.example/authorize",
+      token_url: "https://idp.example/token",
+      default_scopes: [],
+      token_exchange: overlay_row,
+    },
+  )
+  let cli = client(provider, {client_id: "cli-id", storage: memory()})
+  catches_message(
+    "overlay can disable impersonation",
+    { -> token_exchange(
+      cli,
+      {subject_token: "subject", subject_token_type: subject_type, requested_token_type: requested_type},
+    ) },
+    "impersonation",
+  )
+  catches_message(
+    "actor_token_type without actor_token is rejected",
+    { -> token_exchange(
+      cli,
+      {
+        subject_token: "subject",
+        subject_token_type: subject_type,
+        actor_token_type: actor_type,
+        requested_token_type: requested_type,
+      },
+    ) },
+    "without actor_token",
+  )
+  http_mock_clear()
+  http_mock(
+    "POST",
+    "https://idp.example/exchange",
+    {
+      status: 200,
+      body: "{\"access_token\":\"bad-issued\",\"issued_token_type\":\"urn:ietf:params:oauth:token-type:jwt\",\"token_type\":\"Bearer\",\"expires_in\":60}",
+      headers: {"content-type": "application/json"},
+    },
+  )
+  catches_message(
+    "overlay constrains issued token type",
+    { -> token_exchange(
+      cli,
+      {
+        subject_token: "subject",
+        subject_token_type: subject_type,
+        actor_token: "actor",
+        actor_token_type: actor_type,
+        requested_token_type: requested_type,
+      },
+    ) },
+    "issued_token_type",
+  )
+  http_mock_clear()
+  http_mock(
+    "POST",
+    "https://idp.example/exchange",
+    {
+      status: 200,
+      body: "{\"access_token\":\"delegated-access\",\"issued_token_type\":\"urn:ietf:params:oauth:token-type:access_token\",\"token_type\":\"Bearer\",\"expires_in\":60}",
+      headers: {"content-type": "application/json"},
+    },
+  )
+  let exchanged = token_exchange(
+    cli,
+    {
+      subject_token: "subject",
+      subject_token_type: subject_type,
+      actor_token: "actor",
+      actor_token_type: actor_type,
+      requested_token_type: requested_type,
+      store: true,
+      storage_key: "delegated/hr",
+    },
+  )
+  assert_eq(exchanged.access_token, "delegated-access", "overlay exchange returned token")
+  assert_eq(exchanged.token_exchange_mode, "delegation", "overlay exchange mode")
+  let calls = http_mock_calls({include_sensitive: true})
+  assert_eq(len(calls), 1, "one overlay token exchange call")
+  assert_eq(calls[0].url, "https://idp.example/exchange", "overlay token_url used")
+  assert(contains(calls[0].body, "actor_token=actor"), "actor token sent")
+  assert_eq(cli.current_token(), nil, "token exchange does not overwrite client access token")
+  log("oauth token exchange capability overlay ok")
+}

--- a/conformance/tests/stdlib/oauth/oauth_token_exchange_rfc8693.expected
+++ b/conformance/tests/stdlib/oauth/oauth_token_exchange_rfc8693.expected
@@ -1,0 +1,1 @@
+[harn] oauth token exchange rfc8693 ok

--- a/conformance/tests/stdlib/oauth/oauth_token_exchange_rfc8693.harn
+++ b/conformance/tests/stdlib/oauth/oauth_token_exchange_rfc8693.harn
@@ -1,0 +1,96 @@
+// std/oauth/client: RFC 8693 token exchange request/response shape.
+import { client, token_exchange } from "std/oauth/client"
+import { custom } from "std/oauth/providers"
+import { memory } from "std/oauth/storage"
+import { delegated_claims, token_type } from "std/oauth/token_exchange"
+
+pipeline test(task) {
+  let topic = "oauth.client.audit"
+  let cursor = event_log.latest(topic) ?? 0
+  let provider = custom(
+    {
+      id: "rfc8693",
+      auth_url: "https://as.example.com/as/authorize",
+      token_url: "https://as.example.com/as/token.oauth2",
+      default_scopes: [],
+    },
+  )
+  let cli = client(
+    provider,
+    {
+      client_id: "rs08",
+      client_secret: "long-secure-random-secret",
+      storage: memory(),
+      token_auth_method: "client_secret_basic",
+    },
+  )
+  http_mock_clear()
+  http_mock(
+    "POST",
+    "https://as.example.com/as/token.oauth2",
+    {
+      status: 200,
+      body: "{\"access_token\":\"delegated.jwt\",\"issued_token_type\":\"urn:ietf:params:oauth:token-type:jwt\",\"token_type\":\"N_A\",\"expires_in\":3600,\"scope\":\"status feed\"}",
+      headers: {"content-type": "application/json"},
+    },
+  )
+  let exchanged = token_exchange(
+    cli,
+    {
+      resource: "urn:example:cooperation-context",
+      subject_token: "subject.jwt",
+      subject_token_type: token_type("jwt"),
+      actor_token: "actor.jwt",
+      actor_token_type: token_type("jwt"),
+      requested_token_type: token_type("jwt"),
+      scope: ["status", "feed"],
+    },
+  )
+  assert_eq(exchanged.access_token, "delegated.jwt", "delegated token returned")
+  assert_eq(exchanged.issued_token_type, token_type("jwt"), "issued token type returned")
+  assert_eq(exchanged.token_exchange_mode, "delegation", "actor token selects delegation")
+  assert_eq(exchanged.scopes, ["status", "feed"], "response scopes split")
+  let calls = http_mock_calls({include_sensitive: true})
+  assert_eq(len(calls), 1, "one token-exchange request")
+  assert_eq(calls[0].method, "POST", "token exchange uses POST")
+  assert(starts_with(calls[0].headers.authorization, "Basic "), "client_secret_basic auth header")
+  let body = calls[0].body
+  assert(
+    contains(body, "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange"),
+    "token-exchange grant type",
+  )
+  assert(contains(body, "resource=urn%3Aexample%3Acooperation-context"), "resource parameter")
+  assert(contains(body, "subject_token=subject.jwt"), "subject token parameter")
+  assert(
+    contains(body, "subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Ajwt"),
+    "subject token type parameter",
+  )
+  assert(contains(body, "actor_token=actor.jwt"), "actor token parameter")
+  assert(
+    contains(body, "actor_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Ajwt"),
+    "actor token type parameter",
+  )
+  assert(contains(body, "scope=status%20feed"), "scope parameter")
+  let claims = delegated_claims(
+    {
+      aud: "https://service26.example.com",
+      iss: "https://issuer.example.com",
+      exp: 1443904100,
+      nbf: 1443904000,
+      sub: "user@example.com",
+    },
+    [{sub: "https://service16.example.com"}, {sub: "https://service77.example.com"}],
+  )
+  let round_trip = json_parse(json_stringify(claims))
+  assert_eq(round_trip.sub, "user@example.com", "RFC nested act subject")
+  assert_eq(round_trip.act.sub, "https://service16.example.com", "RFC nested act current actor")
+  assert_eq(round_trip.act.act.sub, "https://service77.example.com", "RFC nested act prior actor")
+  let stream = event_log.subscribe({topic: topic, from_cursor: cursor})
+  let logged = stream.next().value
+  assert_eq(logged.kind, "token_exchanged", "audit event kind")
+  assert_eq(logged.payload.provider, "rfc8693", "audit provider")
+  assert_eq(logged.payload.mode, "delegation", "audit mode")
+  assert_eq(logged.payload.next.has_access_token, true, "audit records access presence")
+  assert(logged.payload.next?.access_token == nil, "audit does not leak exchanged token")
+  log("oauth token exchange rfc8693 ok")
+}

--- a/crates/harn-serve/openapi.yaml
+++ b/crates/harn-serve/openapi.yaml
@@ -511,24 +511,6 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
-  /v1/sessions/{session_id}/view:
-    get:
-      tags: [Sessions]
-      operationId: getSessionView
-      summary: Retrieve the versioned harn.session_view.v1 projection for a Session.
-      parameters:
-        - $ref: "#/components/parameters/ProtocolVersion"
-        - $ref: "#/components/parameters/SessionId"
-      responses:
-        "200":
-          description: Stable Session projection.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SessionView"
-        default:
-          $ref: "#/components/responses/Error"
-
   /v1/sessions/{session_id}/close:
     post:
       tags: [Sessions]
@@ -1483,35 +1465,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EventList"
-        default:
-          $ref: "#/components/responses/Error"
-
-  /v1/workflow-trigger-runs:
-    get:
-      tags: [Events]
-      operationId: listWorkflowTriggerRuns
-      summary: Read recent trigger-dispatched workflow runs.
-      description: |
-        Returns dispatch observations from the Harn trigger outbox joined with
-        matching action-graph telemetry. This endpoint is read-only; connector
-        webhook parsing and workflow dispatch semantics remain owned by Harn.
-      parameters:
-        - $ref: "#/components/parameters/ProtocolVersion"
-        - name: limit
-          in: query
-          required: false
-          schema:
-            type: integer
-            minimum: 1
-            maximum: 500
-            default: 100
-      responses:
-        "200":
-          description: Recent workflow trigger runs, newest first.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/WorkflowTriggerRunList"
         default:
           $ref: "#/components/responses/Error"
 
@@ -2564,61 +2517,6 @@ components:
               oneOf:
                 - $ref: "#/components/schemas/Timestamp"
                 - type: "null"
-    SessionView:
-      type: object
-      required: [schema, schema_version, producer, session, projection, runs, history, metadata]
-      additionalProperties: true
-      properties:
-        schema:
-          type: string
-          enum: [harn.session_view.v1]
-        schema_version:
-          type: integer
-          enum: [1]
-        producer:
-          type: object
-          additionalProperties: true
-        session:
-          type: object
-          additionalProperties: true
-          required: [session_id, status, run_count, last_event_id, chain_root_hash]
-          properties:
-            session_id:
-              type: [string, "null"]
-            status:
-              type: string
-            run_count:
-              type: integer
-            last_event_id:
-              type: [integer, "null"]
-            chain_root_hash:
-              type: [string, "null"]
-        projection:
-          type: object
-          additionalProperties: true
-          required: [projection_id, projection_hash, prefix_hash, last_event_id]
-          properties:
-            projection_id:
-              type: string
-            projection_hash:
-              type: [string, "null"]
-            prefix_hash:
-              type: [string, "null"]
-            last_event_id:
-              type: [integer, "null"]
-        runs:
-          type: array
-          items:
-            type: object
-            additionalProperties: true
-        history:
-          type: array
-          items:
-            type: object
-            additionalProperties: true
-        metadata:
-          type: object
-          additionalProperties: true
     SessionList:
       allOf:
         - $ref: "#/components/schemas/PaginatedList"
@@ -3859,82 +3757,6 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/Event"
-    WorkflowTriggerRunList:
-      allOf:
-        - $ref: "#/components/schemas/PaginatedList"
-        - type: object
-          properties:
-            data:
-              type: array
-              items:
-                $ref: "#/components/schemas/WorkflowTriggerRun"
-    WorkflowTriggerRun:
-      type: object
-      required:
-        - id
-        - object
-        - event_log_id
-        - kind
-        - status
-        - occurred_at_ms
-        - action_graph
-      properties:
-        id:
-          type: string
-        object:
-          type: string
-          enum: [workflow_trigger_run]
-        event_log_id:
-          type: integer
-          minimum: 1
-        kind:
-          type: string
-          enum: [dispatch_succeeded, dispatch_failed, dispatch_skipped]
-        status:
-          type: string
-          enum: [succeeded, failed, skipped]
-        occurred_at_ms:
-          type: integer
-          format: int64
-        trigger_id:
-          type: [string, "null"]
-        event_id:
-          type: [string, "null"]
-        binding_key:
-          type: [string, "null"]
-        attempt:
-          type: [integer, "null"]
-          minimum: 0
-        replay_of_event_id:
-          type: [string, "null"]
-        handler_kind:
-          type: [string, "null"]
-        target_uri:
-          type: [string, "null"]
-        error:
-          type: [string, "null"]
-        result:
-          $ref: "#/components/schemas/JsonValue"
-        skip_stage:
-          type: [string, "null"]
-        detail:
-          $ref: "#/components/schemas/JsonValue"
-        action_graph:
-          oneOf:
-            - $ref: "#/components/schemas/ActionGraphObservation"
-            - type: "null"
-    ActionGraphObservation:
-      type: object
-      required: [nodes, edges]
-      properties:
-        nodes:
-          type: array
-          items:
-            $ref: "#/components/schemas/JsonObject"
-        edges:
-          type: array
-          items:
-            $ref: "#/components/schemas/JsonObject"
     EventStream:
       type: string
       description: UTF-8 Server-Sent Events. Each frame `data` field is an Event JSON object.

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -650,6 +650,14 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/oauth/providers.harn"),
     },
     StdlibSource {
+        module: "oauth/token_exchange_catalog",
+        source: include_str!("stdlib/oauth/token_exchange_catalog.harn"),
+    },
+    StdlibSource {
+        module: "oauth/token_exchange",
+        source: include_str!("stdlib/oauth/token_exchange.harn"),
+    },
+    StdlibSource {
         module: "oauth/storage",
         source: include_str!("stdlib/oauth/storage.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/oauth/client.harn
+++ b/crates/harn-stdlib/src/stdlib/oauth/client.harn
@@ -53,6 +53,11 @@
  * window narrow.
  */
 import { merge } from "std/json"
+import {
+  token_exchange_capability,
+  token_exchange_grant_type,
+  token_type,
+} from "std/oauth/token_exchange"
 
 let __DEFAULT_PKCE_VERIFIER_BYTES = 64
 
@@ -333,6 +338,10 @@ fn __safe_json_parse(text) {
 
 fn __build_token_set(parsed, scopes, issued_at, prev_refresh) {
   var token_set = {access_token: to_string(parsed.access_token), issued_at_unix: issued_at}
+  let issued_token_type = parsed?.issued_token_type
+  if issued_token_type != nil && to_string(issued_token_type) != "" {
+    token_set = token_set + {issued_token_type: to_string(issued_token_type)}
+  }
   let token_type = parsed?.token_type
   if token_type != nil {
     token_set = token_set + {token_type: to_string(token_type)}
@@ -374,6 +383,19 @@ fn __audit_refresh(provider_id, storage_key, prev, next, reason) {
 
 fn __audit_exchange(provider_id, storage_key, next) {
   let payload = {provider: to_string(provider_id), storage_key: to_string(storage_key), next: __redact_token(next)}
+  let _ = event_log.emit(__AUDIT_TOPIC, __AUDIT_KIND_EXCHANGE, payload, {provider: to_string(provider_id)})
+}
+
+fn __audit_token_exchange(provider_id, storage_key, next, mode, requested_token_type) {
+  let payload = {
+    provider: to_string(provider_id),
+    storage_key: storage_key,
+    grant_type: token_exchange_grant_type(),
+    mode: mode,
+    requested_token_type: requested_token_type,
+    issued_token_type: next?.issued_token_type,
+    next: __redact_token(next),
+  }
   let _ = event_log.emit(__AUDIT_TOPIC, __AUDIT_KIND_EXCHANGE, payload, {provider: to_string(provider_id)})
 }
 
@@ -555,6 +577,186 @@ fn __exchange_code(harness: Harness, cfg, pkce, code, state) {
   return token_set
 }
 
+fn __append_repeated_form_values(form, key, values) {
+  if values == nil {
+    return form
+  }
+  if type_of(values) == "list" {
+    var out = form
+    for value in values {
+      if value != nil && to_string(value) != "" {
+        out = out + [{key: key, value: value}]
+      }
+    }
+    return out
+  }
+  if to_string(values) == "" {
+    return form
+  }
+  return form + [{key: key, value: values}]
+}
+
+fn __scope_string(scope) {
+  if scope == nil {
+    return nil
+  }
+  if type_of(scope) == "list" {
+    return __join_scopes(scope, " ")
+  }
+  let text = trim(to_string(scope))
+  return text == "" ? nil : text
+}
+
+fn __scope_list(scope) {
+  if scope == nil {
+    return nil
+  }
+  if type_of(scope) == "list" {
+    var out = []
+    for raw in scope {
+      let text = trim(to_string(raw ?? ""))
+      if text != "" {
+        out = out + [text]
+      }
+    }
+    return out
+  }
+  let text = trim(to_string(scope))
+  if text == "" {
+    return nil
+  }
+  var out = []
+  for raw in split(text, " ") {
+    let part = trim(to_string(raw ?? ""))
+    if part != "" {
+      out = out + [part]
+    }
+  }
+  return out
+}
+
+fn __list_allows(values, value) {
+  if value == nil {
+    return true
+  }
+  if values == nil || len(values) == 0 {
+    return false
+  }
+  return values.contains(value)
+}
+
+fn __require_token_exchange_capability(cfg) {
+  let capability = token_exchange_capability({id: cfg.provider_id, token_exchange: cfg.token_exchange})
+  if capability == nil || !capability.supported {
+    throw "std/oauth/client: token exchange is not supported for provider `" + cfg.provider_id + "`"
+  }
+  return capability
+}
+
+fn __validate_token_exchange(capability, subject_token_type, actor_token_type, requested_token_type) {
+  if !__list_allows(capability?.subject_token_types, subject_token_type) {
+    throw "std/oauth/client: subject_token_type `" + subject_token_type + "` is not supported by "
+      + capability.id
+  }
+  if actor_token_type != nil && !__list_allows(capability?.actor_token_types, actor_token_type) {
+    throw "std/oauth/client: actor_token_type `" + actor_token_type + "` is not supported by "
+      + capability.id
+  }
+  if requested_token_type != nil
+    && !__list_allows(capability?.requested_token_types, requested_token_type) {
+    throw "std/oauth/client: requested_token_type `" + requested_token_type + "` is not supported by "
+      + capability.id
+  }
+  if actor_token_type == nil && !(capability?.impersonation ?? true) {
+    throw "std/oauth/client: token exchange impersonation is not supported by " + capability.id
+  }
+  if actor_token_type != nil && !(capability?.delegation ?? true) {
+    throw "std/oauth/client: token exchange delegation is not supported by " + capability.id
+  }
+}
+
+fn __token_exchange(harness: Harness, cfg, opts) {
+  if type_of(opts) != "dict" {
+    throw "std/oauth/client: token_exchange opts must be a dict"
+  }
+  let capability = __require_token_exchange_capability(cfg)
+  let subject_token = __require_string(opts?.subject_token, "opts.subject_token")
+  let subject_token_type = token_type(__require_string(opts?.subject_token_type, "opts.subject_token_type"))
+  let actor_token = opts?.actor_token
+  let has_actor = actor_token != nil && to_string(actor_token) != ""
+  let actor_token_type = if has_actor {
+    token_type(__require_string(opts?.actor_token_type, "opts.actor_token_type"))
+  } else {
+    nil
+  }
+  if !has_actor && opts?.actor_token_type != nil {
+    throw "std/oauth/client: actor_token_type must not be sent without actor_token"
+  }
+  let requested_token_type = if opts?.requested_token_type == nil {
+    nil
+  } else {
+    token_type(opts.requested_token_type)
+  }
+  __validate_token_exchange(capability, subject_token_type, actor_token_type, requested_token_type)
+  var form = [
+    {key: "grant_type", value: token_exchange_grant_type()},
+    {key: "subject_token", value: subject_token},
+    {key: "subject_token_type", value: subject_token_type},
+  ]
+  form = __append_repeated_form_values(form, "resource", opts?.resource)
+  form = __append_repeated_form_values(form, "audience", opts?.audience)
+  let scope = __scope_string(opts?.scope)
+  if scope != nil {
+    form = form + [{key: "scope", value: scope}]
+  }
+  if requested_token_type != nil {
+    form = form + [{key: "requested_token_type", value: requested_token_type}]
+  }
+  if has_actor {
+    form = form
+      + [{key: "actor_token", value: actor_token}, {key: "actor_token_type", value: actor_token_type}]
+  }
+  if opts?.extra_params != nil {
+    for key in opts.extra_params.keys() {
+      form = __append_repeated_form_values(form, key, opts.extra_params[key])
+    }
+  }
+  let issued_at = __now_seconds(harness)
+  let parsed = __post_token_request(
+    harness,
+    capability?.token_url ?? cfg.token_url,
+    cfg.client_id,
+    cfg.client_secret,
+    cfg.token_auth_method,
+    form,
+  )
+  let issued_token_type = token_type(__require_string(parsed?.issued_token_type, "token response issued_token_type"))
+  if !__list_allows(capability?.issued_token_types, issued_token_type) {
+    throw "std/oauth/client: issued_token_type `" + issued_token_type + "` is not supported by "
+      + capability.id
+  }
+  var token_set = __build_token_set(parsed, __scope_list(opts?.scope), issued_at, nil)
+  let mode = has_actor ? "delegation" : "impersonation"
+  token_set = token_set
+    + {
+    issued_token_type: issued_token_type,
+    token_exchange_mode: mode,
+    subject_token_type: subject_token_type,
+    actor_token_type: actor_token_type,
+    requested_token_type: requested_token_type,
+  }
+  var storage_key = nil
+  if opts?.store ?? false {
+    storage_key = trim(to_string(opts?.storage_key ?? ""))
+    if storage_key == "" {
+      throw "std/oauth/client: token_exchange store=true requires storage_key"
+    }
+    cfg.storage.set(storage_key, token_set)
+  }
+  __audit_token_exchange(cfg.provider_id, storage_key, token_set, mode, requested_token_type)
+  return token_set
+}
+
 fn __with_bearer(headers, access_token) {
   let base = headers ?? {}
   return merge(base, {Authorization: "Bearer " + to_string(access_token)})
@@ -630,6 +832,7 @@ pub fn client(provider, opts) -> OAuthClient {
     storage_key: storage_key,
     audience: opts?.audience,
     extra_auth_params: opts?.extra_auth_params,
+    token_exchange: provider_record?.token_exchange,
   }
   return {
     _namespace: "oauth_client",
@@ -645,6 +848,7 @@ pub fn client(provider, opts) -> OAuthClient {
     refresh: { -> __maybe_refresh(harness, cfg, "forced") },
     token: { -> __get_valid_token(harness, cfg).access_token },
     current_token: { -> cfg.storage.get(cfg.storage_key) },
+    token_exchange: { exchange_opts -> __token_exchange(harness, cfg, exchange_opts) },
     request: { method, url, http_opts = nil -> __token_request(harness, cfg, method, url, http_opts) },
     revoke: { -> __revoke_locked(harness, cfg) },
   }
@@ -735,6 +939,30 @@ pub fn exchange_code(cli, pkce, code, state) {
     throw "std/oauth/client: exchange_code() requires an OAuth client handle"
   }
   return cli.exchange_code(pkce, code, state)
+}
+
+/**
+ * token_exchange performs an RFC 8693 token-exchange grant.
+ *
+ * Required opts:
+ *   - subject_token:       token representing the subject.
+ *   - subject_token_type:  RFC 8693 token type URI or alias.
+ *
+ * Optional opts:
+ *   - actor_token / actor_token_type: present for delegation, absent
+ *     for impersonation.
+ *   - requested_token_type, resource, audience, scope, extra_params.
+ *   - store: true plus storage_key persists the returned TokenSet.
+ *
+ * @effects: [time, net]
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ */
+pub fn token_exchange(cli, opts) {
+  if type_of(cli) != "dict" || cli?._namespace != "oauth_client" {
+    throw "std/oauth/client: token_exchange() requires an OAuth client handle"
+  }
+  return cli.token_exchange(opts)
 }
 
 /**

--- a/crates/harn-stdlib/src/stdlib/oauth/providers.harn
+++ b/crates/harn-stdlib/src/stdlib/oauth/providers.harn
@@ -20,6 +20,7 @@ type OAuthProvider = {
   default_scopes: list<string>,
   pkce_required: bool,
   refresh_handling: OAuthRefreshHandling,
+  token_exchange?: dict,
   documented_quirks: list<string>,
   documentation_url: string?,
 }
@@ -575,6 +576,7 @@ pub fn custom(config, overrides = nil) -> OAuthProvider {
       userinfo_url: config?.userinfo_url,
       default_scopes: config?.default_scopes ?? [],
       pkce_required: config?.pkce_required ?? false,
+      token_exchange: config?.token_exchange,
       refresh_handling: config?.refresh_handling
         ?? __refresh(
         "custom provider; use token response metadata and provider documentation",

--- a/crates/harn-stdlib/src/stdlib/oauth/token_exchange.harn
+++ b/crates/harn-stdlib/src/stdlib/oauth/token_exchange.harn
@@ -1,0 +1,232 @@
+/**
+ * std/oauth/token_exchange — RFC 8693 constants, provider capability rows,
+ * and actor-claim helpers.
+ *
+ * Capability rows are data: callers can replace or extend the shipped rows
+ * with provider `token_exchange` overrides or by passing overlay rows to
+ * `token_exchange_catalog(...)`.
+ */
+import { token_exchange_capability_rows } from "std/oauth/token_exchange_catalog"
+
+let __GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
+
+let __TOKEN_TYPE_PREFIX = "urn:ietf:params:oauth:token-type:"
+
+type OAuthTokenExchangeCapability = {
+  id: string,
+  label?: string,
+  supported: bool,
+  token_url?: string,
+  subject_token_types: list<string>,
+  actor_token_types: list<string>,
+  requested_token_types: list<string>,
+  issued_token_types: list<string>,
+  delegation: bool,
+  impersonation: bool,
+  notes: list<string>,
+}
+
+fn __normalize_token_type(name) {
+  let raw = trim(to_string(name ?? ""))
+  if raw == "" {
+    throw "std/oauth/token_exchange: token type is required"
+  }
+  if starts_with(raw, "urn:") {
+    return raw
+  }
+  let key = lowercase(raw)
+  if key == "access" {
+    return __TOKEN_TYPE_PREFIX + "access_token"
+  }
+  if key == "access_token"
+    || key == "refresh_token"
+    || key == "id_token"
+    || key == "jwt"
+    || key == "saml1"
+    || key == "saml2" {
+    return __TOKEN_TYPE_PREFIX + key
+  }
+  throw "std/oauth/token_exchange: unsupported token type `" + raw + "`"
+}
+
+fn __normalize_token_types(values) {
+  var out = []
+  for value in values ?? [] {
+    out = out + [__normalize_token_type(value)]
+  }
+  return out
+}
+
+fn __default_rows() {
+  return token_exchange_capability_rows()
+}
+
+fn __normalize_row(raw) {
+  if type_of(raw) != "dict" {
+    throw "std/oauth/token_exchange: capability row must be a dict"
+  }
+  let id = trim(to_string(raw?.id ?? raw?.provider ?? raw?.authorization_server ?? ""))
+  if id == "" {
+    throw "std/oauth/token_exchange: capability row id is required"
+  }
+  return {
+    id: id,
+    label: raw?.label,
+    supported: raw?.supported ?? true,
+    token_url: raw?.token_url,
+    subject_token_types: __normalize_token_types(raw?.subject_token_types ?? []),
+    actor_token_types: __normalize_token_types(raw?.actor_token_types ?? []),
+    requested_token_types: __normalize_token_types(raw?.requested_token_types ?? []),
+    issued_token_types: __normalize_token_types(raw?.issued_token_types ?? raw?.requested_token_types ?? []),
+    delegation: raw?.delegation ?? true,
+    impersonation: raw?.impersonation ?? true,
+    notes: raw?.notes ?? [],
+  }
+}
+
+fn __catalog_from_rows(rows) {
+  var out = {}
+  for raw in rows ?? [] {
+    let row = __normalize_row(raw)
+    out = out + {[row.id]: row}
+  }
+  return out
+}
+
+fn __overlay_rows(overlays) {
+  if overlays == nil {
+    return []
+  }
+  if type_of(overlays) == "list" {
+    return overlays
+  }
+  if type_of(overlays) == "dict" {
+    var rows = []
+    for id in overlays.keys() {
+      let value = overlays[id]
+      if type_of(value) != "dict" {
+        throw "std/oauth/token_exchange: overlay `" + to_string(id) + "` must be a dict"
+      }
+      rows = rows + [value + {id: value?.id ?? id}]
+    }
+    return rows
+  }
+  throw "std/oauth/token_exchange: overlays must be a list or dict"
+}
+
+fn __provider_id(provider_or_id) {
+  if type_of(provider_or_id) == "dict" {
+    return trim(to_string(provider_or_id?.id ?? ""))
+  }
+  return trim(to_string(provider_or_id ?? ""))
+}
+
+/**
+ * token_exchange_grant_type returns the RFC 8693 extension grant URI.
+ *
+ * @effects: []
+ * @errors: []
+ * @api_stability: experimental
+ */
+pub fn token_exchange_grant_type() -> string {
+  return __GRANT_TYPE
+}
+
+/**
+ * token_type normalizes RFC 8693 token-type aliases to their URI values.
+ *
+ * @effects: []
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ * @example: token_type("access_token")
+ */
+pub fn token_type(name: string) -> string {
+  return __normalize_token_type(name)
+}
+
+/**
+ * token_exchange_catalog returns shipped capability rows plus overlays keyed by id.
+ *
+ * @effects: []
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ */
+pub fn token_exchange_catalog(overlays = nil) -> dict {
+  return __catalog_from_rows(__default_rows() + __overlay_rows(overlays))
+}
+
+/**
+ * token_exchange_capability returns the effective row for a provider id or record.
+ *
+ * A provider record's `token_exchange` field wins over the shipped catalog so
+ * package and project data can opt in without changing stdlib source.
+ *
+ * @effects: []
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ */
+pub fn token_exchange_capability(provider_or_id, overlays = nil) -> OAuthTokenExchangeCapability? {
+  if type_of(provider_or_id) == "dict" && provider_or_id?.token_exchange != nil {
+    return __normalize_row(provider_or_id.token_exchange + {id: provider_or_id?.id})
+  }
+  let id = __provider_id(provider_or_id)
+  if id == "" {
+    return nil
+  }
+  return token_exchange_catalog(overlays)[id]
+}
+
+fn __actor_dict(actor) {
+  if type_of(actor) == "dict" {
+    let sub = trim(to_string(actor?.sub ?? ""))
+    if sub == "" {
+      throw "std/oauth/token_exchange: actor.sub is required"
+    }
+    return actor
+  }
+  return {sub: trim(to_string(actor ?? ""))}
+}
+
+/**
+ * actor_claim builds the RFC 8693 nested `act` claim.
+ *
+ * Actors are ordered current-to-prior: `actor_claim([current, prior])`
+ * returns `{sub: current, act: {sub: prior}}`.
+ *
+ * @effects: []
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ */
+pub fn actor_claim(actors: list) -> dict {
+  if len(actors) == 0 {
+    throw "std/oauth/token_exchange: at least one actor is required"
+  }
+  var out = nil
+  var index = len(actors) - 1
+  while index >= 0 {
+    var actor = __actor_dict(actors[index])
+    if trim(to_string(actor.sub ?? "")) == "" {
+      throw "std/oauth/token_exchange: actor.sub is required"
+    }
+    if out != nil {
+      actor = actor + {act: out}
+    }
+    out = actor
+    index = index - 1
+  }
+  return out ?? {}
+}
+
+/**
+ * delegated_claims adds a nested RFC 8693 `act` claim to subject claims.
+ *
+ * @effects: []
+ * @errors: [invalid_argument]
+ * @api_stability: experimental
+ */
+pub fn delegated_claims(subject_claims: dict, actors: list) -> dict {
+  if type_of(subject_claims) != "dict" {
+    throw "std/oauth/token_exchange: subject_claims must be a dict"
+  }
+  return subject_claims + {act: actor_claim(actors)}
+}

--- a/crates/harn-stdlib/src/stdlib/oauth/token_exchange_catalog.harn
+++ b/crates/harn-stdlib/src/stdlib/oauth/token_exchange_catalog.harn
@@ -1,0 +1,36 @@
+/**
+ * Data rows for RFC 8693 token-exchange authorization-server capabilities.
+ *
+ * Keep this module declarative: helpers that interpret rows live in
+ * `std/oauth/token_exchange`.
+ */
+let __JWT = "urn:ietf:params:oauth:token-type:jwt"
+
+let __ACCESS_TOKEN = "urn:ietf:params:oauth:token-type:access_token"
+
+/**
+ * token_exchange_capability_rows returns the shipped capability catalog.
+ *
+ * @effects: []
+ * @errors: []
+ * @api_stability: experimental
+ */
+pub fn token_exchange_capability_rows() -> list {
+  return [
+    {
+      id: "rfc8693",
+      label: "RFC 8693 reference authorization server",
+      supported: true,
+      token_url: "https://as.example.com/as/token.oauth2",
+      subject_token_types: [__ACCESS_TOKEN, __JWT],
+      actor_token_types: [__JWT],
+      requested_token_types: [__ACCESS_TOKEN, __JWT],
+      issued_token_types: [__ACCESS_TOKEN, __JWT],
+      delegation: true,
+      impersonation: true,
+      notes: [
+        "Reference row used by conformance tests and examples. Real authorization servers should ship or pass their own overlay row.",
+      ],
+    },
+  ]
+}

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -4125,7 +4125,9 @@ import { providers } from "std/oauth/providers"             // github, slack, li
                                                             // github_enterprise, custom
 import { memory } from "std/oauth/storage"                  // memory, file, harn_cloud_*,
                                                             // custom
-import { client, request, token } from "std/oauth/client"   // RFC 6749 + 7636 + 9700
+import { client, request, token, token_exchange } from "std/oauth/client"
+                                                            // RFC 6749 + 7636 + 8693 + 9700
+import { delegated_claims, token_type } from "std/oauth/token_exchange"
 import { device_flow } from "std/oauth/device_flow"         // RFC 8628 (CI / headless)
 import { register_pattern } from "std/oauth/redaction"      // HARN-OAU-001 catalog
 ```
@@ -4142,7 +4144,7 @@ backend it's holding.
 ```harn
 import { providers } from "std/oauth/providers"
 import { memory } from "std/oauth/storage"
-import { client, exchange_code, start_authorization, token, request } from "std/oauth/client"
+import { client, exchange_code, request, start_authorization, token, token_exchange } from "std/oauth/client"
 
 let cli = client(
   providers().github,
@@ -4179,6 +4181,12 @@ let response = request(cli, "GET", "https://api.github.com/user")
   `oauth.client.audit` with `token_refreshed` / `token_exchanged`. The
   payload carries presence flags + expiry timestamps; it never
   includes the new access or refresh token.
+- **Token exchange.** `token_exchange(cli, opts)` performs RFC 8693:
+  `subject_token` and `subject_token_type` are required; `actor_token`
+  with `actor_token_type` selects delegation, and actor absence selects
+  impersonation. Provider support is data-gated by
+  `std/oauth/token_exchange` capability rows; custom providers opt in
+  with a `token_exchange` row.
 - **Concurrency.** Storage is the source of truth. Two concurrent
   `token(cli)` calls may both observe staleness and both refresh; the
   later `set` wins and both callers see the same token. Pre-refresh
@@ -4188,6 +4196,37 @@ let response = request(cli, "GET", "https://api.github.com/user")
 
 Full reference: conformance fixtures at
 `conformance/tests/stdlib/oauth/oauth_client_*.harn`.
+
+## OAuth token exchange (`std/oauth/token_exchange`)
+
+RFC 8693 constants, overlayable capability rows, and nested `act`
+claim helpers.
+
+```harn,ignore
+import { token_exchange } from "std/oauth/client"
+import { delegated_claims, token_type } from "std/oauth/token_exchange"
+
+let delegated = token_exchange(cli, {
+  subject_token: human_token,
+  subject_token_type: token_type("access_token"),
+  actor_token: agent_jwt,
+  actor_token_type: token_type("jwt"),
+  requested_token_type: token_type("access_token"),
+  audience: "hr-service",
+  scope: ["employee:read"],
+})
+
+let claims = delegated_claims(
+  {sub: "user@example.com"},
+  [{sub: "https://service16.example.com"}, {sub: "https://service77.example.com"}],
+)
+```
+
+Rows are data in `std/oauth/token_exchange_catalog`, not provider code.
+`token_exchange_catalog(overlays?)` returns rows keyed by authorization-server id, and
+`token_exchange_capability(provider_or_id, overlays?)` resolves the
+effective row. A provider record can carry `token_exchange: {...}` to
+override or add support for custom enterprise authorization servers.
 
 ## OAuth storage (`std/oauth/storage`)
 

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -5479,8 +5479,10 @@ code in the language runtime.
 | Module | Purpose |
 |---|---|
 | `std/oauth/providers` | Provider catalogue (10 built-ins plus `custom(...)` + `github_enterprise(...)`). Each record carries `auth_url`, `token_url`, `device_code_url?`, `revoke_url?`, `userinfo_url?`, `default_scopes`, `pkce_required`, `refresh_handling`, and `documented_quirks`. |
+| `std/oauth/token_exchange_catalog` | Shipped RFC 8693 authorization-server capability row data. |
+| `std/oauth/token_exchange` | RFC 8693 token-exchange grant URI/token-type helpers, overlayable row loading, and nested `act` claim helpers. |
 | `std/oauth/storage` | Token-storage trait with five interchangeable backends (`memory`, `file`, `harn_cloud_session`, `harn_cloud_org`, `custom`). Each backend exposes `get(key) -> TokenSet \| nil`, `set(key, token_set, ttl_seconds = nil) -> nil`, and `delete(key) -> nil`. |
-| `std/oauth/client` | Authorization-code grant with mandatory PKCE S256 and CSRF `state`, transparent refresh at >=75% TTL, RFC 7009 best-effort `revoke`, and a 401-bounded one-shot retry on `request(...)`. Refreshes that fail emit diagnostic `HARN-OAU-002`. |
+| `std/oauth/client` | Authorization-code grant with mandatory PKCE S256 and CSRF `state`, RFC 8693 token exchange, transparent refresh at >=75% TTL, RFC 7009 best-effort `revoke`, and a 401-bounded one-shot retry on `request(...)`. Refreshes that fail emit diagnostic `HARN-OAU-002`. |
 | `std/oauth/device_flow` | RFC 8628 device authorization grant for headless contexts. Persists the resulting TokenSet into the same storage backend the authorization-code client reads from. |
 | `std/oauth/dynamic_registration` | RFC 7591 client registration + RFC 8414 authorization-server metadata. Validation errors carry diagnostic `HARN-OAU-005`. |
 | `std/oauth/redaction` | Per-thread custom regex pattern registration on top of the runtime's default token-shape catalog. Each match emits diagnostic `HARN-OAU-001` to the audit ring drained via `drain_audit()`. |

--- a/docs/src/oauth.md
+++ b/docs/src/oauth.md
@@ -10,8 +10,10 @@ without provider-specific Rust code.
 | Module | RFC | Purpose |
 |---|---|---|
 | `std/oauth/providers` | — | Catalogue of preconfigured providers + `custom(...)` factory |
+| `std/oauth/token_exchange_catalog` | 8693 | Shipped token-exchange capability row data |
+| `std/oauth/token_exchange` | 8693 | Token-exchange row loading + `act` claim helpers |
 | `std/oauth/storage` | — | Five interchangeable token stores (memory, file, harn-cloud session/org, custom) |
-| `std/oauth/client` | 6749 + 7636 + 9700 | Authorization-code flow with PKCE S256, transparent refresh, 401-retry |
+| `std/oauth/client` | 6749 + 7636 + 8693 + 9700 | Authorization-code flow with PKCE S256, RFC 8693 token exchange, transparent refresh, 401-retry |
 | `std/oauth/device_flow` | 8628 | Headless device authorization grant |
 | `std/oauth/dynamic_registration` | 7591 + 8414 | Worker-side metadata + dynamic client registration |
 | `std/oauth/redaction` | — | OAuth-token catalog + `HARN-OAU-001` audit ring |
@@ -25,7 +27,7 @@ scripting API for code that runs *inside* a Harn pipeline.
 ```harn,ignore
 import { providers } from "std/oauth/providers"
 import { memory } from "std/oauth/storage"
-import { client, exchange_code, request, start_authorization, token } from "std/oauth/client"
+import { client, exchange_code, request, start_authorization, token, token_exchange } from "std/oauth/client"
 
 let cli = client(
   providers().github,
@@ -81,6 +83,7 @@ A provider record carries:
 | `default_scopes` | Used when `opts.scopes` is not set |
 | `pkce_required` | Informational; PKCE is unconditionally used by the client |
 | `refresh_handling` | `{strategy, refresh_grant, rotates_refresh_token, notes}` |
+| `token_exchange?` | RFC 8693 support row; custom providers can opt in with data |
 | `documented_quirks` | Provider-specific constraints and gotchas |
 | `documentation_url` | Vendor doc link for "go read the source" |
 
@@ -130,7 +133,16 @@ in [OAuth storage stdlib](./stdlib/oauth-storage.md).
 `client(provider, opts)` builds a handle that owns the token lifecycle.
 
 ```harn,ignore
-import { client, exchange_code, refresh, request, revoke, start_authorization, token } from "std/oauth/client"
+import {
+  client,
+  exchange_code,
+  refresh,
+  request,
+  revoke,
+  start_authorization,
+  token,
+  token_exchange,
+} from "std/oauth/client"
 
 let cli = client(provider, {
   client_id:          string,
@@ -155,6 +167,7 @@ standalone helper that takes the handle as the first argument:
 | `token(cli)` | Returns a valid access token (refresh on >=75% TTL) |
 | `refresh(cli)` | Forces a refresh, ignoring TTL |
 | `request(cli, method, url, opts?)` | Token-bearing HTTP with 1x 401 retry |
+| `token_exchange(cli, opts)` | RFC 8693 token exchange; `actor_token` present means delegation, absent means impersonation |
 | `revoke(cli)` | RFC 7009 best-effort + local storage delete |
 | `cli.current_token()` | Reads the stored TokenSet without refresh |
 
@@ -169,6 +182,11 @@ standalone helper that takes the handle as the first argument:
   refreshes if the stored TokenSet is past 75% TTL or already expired.
 - **One retry on 401.** `request(cli, ...)` performs a forced refresh
   and replays the request exactly once when the server returns 401.
+- **Token exchange is data-gated.** `token_exchange(cli, opts)` validates
+  subject, actor, and requested token types against `std/oauth/token_exchange`
+  capability rows. Custom providers opt in with a `token_exchange` row; the
+  grant returns a TokenSet and only persists it when `store: true` and
+  `storage_key` are supplied.
 - **Refresh-token preservation.** Token responses that omit a fresh
   `refresh_token` keep the prior one (relevant for Google + Slack +
   Discord, which only rotate on consent).
@@ -195,6 +213,58 @@ standalone helper that takes the handle as the first argument:
 `HARN-OAU-002` is the signal to drive a fresh `start_authorization` (or
 `device_flow`) — refresh failure is terminal until human consent runs
 again.
+
+## Token exchange (`std/oauth/token_exchange`)
+
+RFC 8693 lets an OAuth client trade one token for another at the token
+endpoint. Harn keeps provider support in overlayable data rows under
+`std/oauth/token_exchange_catalog`, not provider-specific code.
+
+```harn,ignore
+import { client, token_exchange } from "std/oauth/client"
+import { custom } from "std/oauth/providers"
+import { memory } from "std/oauth/storage"
+import { delegated_claims, token_type } from "std/oauth/token_exchange"
+
+let provider = custom({
+  id: "enterprise-as",
+  auth_url: "https://idp.example/authorize",
+  token_url: "https://idp.example/token",
+  token_exchange: {
+    supported: true,
+    token_url: "https://idp.example/token",
+    subject_token_types: [token_type("access_token")],
+    actor_token_types: [token_type("jwt")],
+    requested_token_types: [token_type("access_token")],
+    issued_token_types: [token_type("access_token")],
+    delegation: true,
+    impersonation: true,
+  },
+})
+
+let cli = client(provider, {client_id: "agent-client", storage: memory()})
+let delegated = token_exchange(cli, {
+  subject_token: user_access_token,
+  subject_token_type: token_type("access_token"),
+  actor_token: agent_jwt,
+  actor_token_type: token_type("jwt"),
+  requested_token_type: token_type("access_token"),
+  audience: "hr-service",
+  scope: ["employee:read"],
+})
+```
+
+`actor_token` present selects delegation; omitting it selects
+impersonation. `resource`, `audience`, and `scope` accept the RFC 8693
+targeting parameters, and `extra_params` carries deployment-specific
+fields. Returned tokens are not written to the client's normal
+`storage_key`; pass `{store: true, storage_key: "..."}` when the
+delegated token should be persisted separately.
+
+The companion `delegated_claims(subject_claims, actors)` helper builds
+RFC 8693 nested `act` claims with actors ordered current-to-prior, so
+`delegated_claims({sub: "user"}, [{sub: "svc16"}, {sub: "svc77"}])`
+produces `{sub: "user", act: {sub: "svc16", act: {sub: "svc77"}}}`.
 
 ## Device flow (`std/oauth/device_flow`)
 

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -5477,8 +5477,10 @@ code in the language runtime.
 | Module | Purpose |
 |---|---|
 | `std/oauth/providers` | Provider catalogue (10 built-ins plus `custom(...)` + `github_enterprise(...)`). Each record carries `auth_url`, `token_url`, `device_code_url?`, `revoke_url?`, `userinfo_url?`, `default_scopes`, `pkce_required`, `refresh_handling`, and `documented_quirks`. |
+| `std/oauth/token_exchange_catalog` | Shipped RFC 8693 authorization-server capability row data. |
+| `std/oauth/token_exchange` | RFC 8693 token-exchange grant URI/token-type helpers, overlayable row loading, and nested `act` claim helpers. |
 | `std/oauth/storage` | Token-storage trait with five interchangeable backends (`memory`, `file`, `harn_cloud_session`, `harn_cloud_org`, `custom`). Each backend exposes `get(key) -> TokenSet \| nil`, `set(key, token_set, ttl_seconds = nil) -> nil`, and `delete(key) -> nil`. |
-| `std/oauth/client` | Authorization-code grant with mandatory PKCE S256 and CSRF `state`, transparent refresh at >=75% TTL, RFC 7009 best-effort `revoke`, and a 401-bounded one-shot retry on `request(...)`. Refreshes that fail emit diagnostic `HARN-OAU-002`. |
+| `std/oauth/client` | Authorization-code grant with mandatory PKCE S256 and CSRF `state`, RFC 8693 token exchange, transparent refresh at >=75% TTL, RFC 7009 best-effort `revoke`, and a 401-bounded one-shot retry on `request(...)`. Refreshes that fail emit diagnostic `HARN-OAU-002`. |
 | `std/oauth/device_flow` | RFC 8628 device authorization grant for headless contexts. Persists the resulting TokenSet into the same storage backend the authorization-code client reads from. |
 | `std/oauth/dynamic_registration` | RFC 7591 client registration + RFC 8414 authorization-server metadata. Validation errors carry diagnostic `HARN-OAU-005`. |
 | `std/oauth/redaction` | Per-thread custom regex pattern registration on top of the runtime's default token-shape catalog. Each match emits diagnostic `HARN-OAU-001` to the audit ring drained via `drain_audit()`. |


### PR DESCRIPTION
Closes #3341

Summary:
- Added RFC 8693 OAuth token_exchange support to std/oauth/client, including delegation vs impersonation handling and redacted audit events.
- Added overlayable authorization-server token-exchange capability rows and helpers for token type normalization plus nested act claims.
- Added RFC/overlay conformance fixtures, docs/spec updates, and a changelog fragment.
- Refreshed the embedded harn-serve OpenAPI snapshot that the repo gate reported stale.

Verification:
- cargo run --quiet --bin harn -- test conformance conformance/tests/stdlib/oauth
- make all
- pre-commit and pre-push hooks passed