### PR TITLE
Add GitHub author mode disclosure

### DIFF
--- a/changelog.d/3339.added.md
+++ b/changelog.d/3339.added.md
@@ -1,0 +1,3 @@
+- Added `std/disclosure` GitHub `author_mode` output so commit and PR
+  adapters can choose between human-authored commits with actor-chain trailers
+  and GitHub App bot-authored writes.

--- a/conformance/tests/stdlib/disclosure_github_author_mode.expected
+++ b/conformance/tests/stdlib/disclosure_github_author_mode.expected
@@ -1,0 +1,23 @@
+human
+human_author_agent_coauthor
+user
+any
+user
+user:kenneth
+agent:merge-captain
+Kenneth Sinder
+kenneth@example.com
+true
+true
+Co-Authored-By: Merge Captain <merge-captain@bots.example>
+bot
+bot_author
+github_app
+github_app
+github_app
+agent:merge-captain
+true
+true
+true
+false
+std/disclosure: github.author_mode must be `human` or `bot`, got `robot`

--- a/conformance/tests/stdlib/disclosure_github_author_mode.harn
+++ b/conformance/tests/stdlib/disclosure_github_author_mode.harn
@@ -1,0 +1,45 @@
+import { render } from "std/disclosure"
+
+pipeline default() {
+  let chain = {sub: "user:kenneth", act: {sub: "agent:merge-captain"}}
+  let config = {
+    identities: {
+      "user:kenneth": {name: "Kenneth Sinder", email: "kenneth@example.com", github: "kennethsinder"},
+      "agent:merge-captain": {name: "Merge Captain", email: "merge-captain@bots.example", github: "merge-captain-bot"},
+    },
+  }
+  let options = {project: false, env: false, config: config}
+  let human = render(chain, "github", options)
+  __io_println(human.author_mode)
+  __io_println(human.mode)
+  __io_println(human.required_auth_identity)
+  __io_println(human.commit_auth_identity)
+  __io_println(human.pull_request_auth_identity)
+  __io_println(human.author.subject)
+  __io_println(human.co_author.subject)
+  __io_println(human.commit_author.name)
+  __io_println(human.commit_author.email)
+  __io_println(to_string(human.commit_committer == nil))
+  __io_println(to_string(human.append_git_trailers))
+  __io_println(human.trailers)
+  let root = path_join(harness.fs.temp_dir(), "harn-disclosure-github-mode-" + uuid())
+  harness.fs.mkdir(root)
+  let project_config = "[disclosure.surfaces.github]\n" + "author_mode = \"bot\"\n"
+  harness.fs.write_text(path_join(root, "harn.toml"), project_config)
+  let bot = render(chain, "github", options + {project: true, project_root: root})
+  __io_println(bot.author_mode)
+  __io_println(bot.mode)
+  __io_println(bot.required_auth_identity)
+  __io_println(bot.commit_auth_identity)
+  __io_println(bot.pull_request_auth_identity)
+  __io_println(bot.author.subject)
+  __io_println(to_string(bot.co_author == nil))
+  __io_println(to_string(bot.commit_author == nil))
+  __io_println(to_string(bot.omit_custom_commit_author))
+  __io_println(to_string(bot.append_git_trailers))
+  let invalid = try {
+    render(chain, "github", options + {config: {surfaces: {github: {author_mode: "robot"}}}})
+  }
+  require is_err(invalid), "invalid github author_mode must fail"
+  __io_println(unwrap_err(invalid))
+}

--- a/crates/harn-hostlib/tests/process_tools.rs
+++ b/crates/harn-hostlib/tests/process_tools.rs
@@ -1005,25 +1005,55 @@ fn cancel_handle_can_wait_for_timed_out_result() {
     let start = require_dict(call("hostlib_tools_run_command", start_req).unwrap());
     let handle_id = require_str(&start, "handle_id");
 
-    let mut cancel_req = dict();
-    cancel_req.insert("handle_id".into(), vstr(&handle_id));
-    cancel_req.insert("wait_result_ms".into(), VmValue::Int(500));
-    cancel_req.insert("timed_out".into(), VmValue::Bool(true));
-    let cancel = require_dict(call("hostlib_tools_cancel_handle", cancel_req).unwrap());
+    let completion_rx =
+        register_completion_notifier(&handle_id).expect("handle should still be live");
+    let cancel_handle_id = handle_id.clone();
+    let cancel_thread = std::thread::spawn(move || {
+        let mut cancel_req = dict();
+        cancel_req.insert("handle_id".into(), vstr(&cancel_handle_id));
+        cancel_req.insert("wait_result_ms".into(), VmValue::Int(60_000));
+        cancel_req.insert("timed_out".into(), VmValue::Bool(true));
+        let cancel = require_dict(call("hostlib_tools_cancel_handle", cancel_req).unwrap());
 
-    assert!(require_bool(&cancel, "cancelled"));
-    let result = require_nested_dict(&cancel, "result");
-    assert_eq!(require_str(&result, "handle_id"), handle_id);
-    assert_eq!(require_str(&result, "status"), "timed_out");
-    assert!(require_bool(&result, "timed_out"));
-    assert_eq!(require_int(&result, "exit_code"), -1);
-    assert_eq!(require_str(&result, "stdout"), "before timeout\n");
-    assert!(require_str(&result, "output_path").contains("combined.txt"));
+        assert!(require_bool(&cancel, "cancelled"));
+        let result = require_nested_dict(&cancel, "result");
+        (
+            require_str(&cancel, "handle_id"),
+            require_str(&result, "handle_id"),
+            require_str(&result, "status"),
+            require_bool(&result, "timed_out"),
+            require_int(&result, "exit_code"),
+            require_str(&result, "stdout"),
+            require_str(&result, "output_path"),
+            require_str(&result, "stdout_path"),
+            require_int(&result, "byte_count"),
+        )
+    });
+    completion_rx.recv().expect("waiter completion never fired");
+    let (
+        cancelled_handle_id,
+        result_handle_id,
+        status,
+        timed_out,
+        exit_code,
+        stdout,
+        output_path,
+        stdout_path,
+        byte_count,
+    ) = cancel_thread.join().expect("cancel thread panicked");
+
+    assert_eq!(cancelled_handle_id, handle_id);
+    assert_eq!(result_handle_id, handle_id);
+    assert_eq!(status, "timed_out");
+    assert!(timed_out);
+    assert_eq!(exit_code, -1);
+    assert_eq!(stdout, "before timeout\n");
+    assert!(output_path.contains("combined.txt"));
     assert_eq!(
-        std::fs::read_to_string(require_str(&result, "stdout_path")).unwrap(),
+        std::fs::read_to_string(stdout_path).unwrap(),
         "before timeout\n"
     );
-    assert!(require_int(&result, "byte_count") >= 15);
+    assert!(byte_count >= 15);
 
     let items = harn_vm::orchestration::agent_inbox::drain(&session_id);
     assert!(

--- a/crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn
@@ -28,9 +28,10 @@ template = "AI-assisted by {{ current.label }} for {{ origin.label }}."
 
 [surfaces.github]
 kind = "github_author_choice"
-mode = "human_author_agent_coauthor"
+author_mode = "human"
 author = "origin"
 co_author = "current"
+bot_author = "current"
 """
 
 fn __dict(value) -> dict {
@@ -281,18 +282,95 @@ fn __render_text(surface_config: dict, ctx: dict) -> string {
   return render_string(to_string(template), ctx)
 }
 
-fn __render_github(surface_config: dict, ctx: dict) -> dict {
-  let author = __select_principal(ctx, surface_config?.author ?? "origin")
-  var co_author = __select_principal(ctx, surface_config?.co_author ?? "current")
-  if author != nil && co_author != nil && author.subject == co_author.subject {
+fn __github_author_mode(surface_config: dict) -> string {
+  let mode = lowercase(trim(to_string(surface_config?.author_mode ?? "human")))
+  if mode == "human" || mode == "bot" {
+    return mode
+  }
+  throw "std/disclosure: github.author_mode must be `human` or `bot`, got `" + mode + "`"
+}
+
+fn __github_mode_label(author_mode: string) -> string {
+  if author_mode == "bot" {
+    return "bot_author"
+  }
+  return "human_author_agent_coauthor"
+}
+
+fn __git_identity(principal) {
+  if principal == nil {
+    return nil
+  }
+  return {name: principal.name, email: principal.email}
+}
+
+fn __github_auth_identity(author_mode: string) -> string {
+  if author_mode == "bot" {
+    return "github_app"
+  }
+  return "user"
+}
+
+fn __github_commit_auth_identity(author_mode: string) -> string {
+  if author_mode == "bot" {
+    return "github_app"
+  }
+  return "any"
+}
+
+fn __github_trailers(config: dict, ctx: dict) -> string {
+  let surface_config = __surface_config(config, "git")
+  if !__git_trailers_switch_enabled(surface_config) {
+    return ""
+  }
+  return __safe_git_trailers(__render_text(surface_config, ctx), ctx)
+}
+
+fn __render_github(surface_config: dict, ctx: dict, config: dict) -> dict {
+  let author_mode = __github_author_mode(surface_config)
+  let human_author = __select_principal(ctx, surface_config?.author ?? "origin")
+  let bot_author = __select_principal(ctx, surface_config?.bot_author ?? "current")
+  let selected_author = if author_mode == "bot" {
+    bot_author
+  } else {
+    human_author
+  }
+  var co_author = if author_mode == "bot" {
+    nil
+  } else {
+    __select_principal(ctx, surface_config?.co_author ?? "current")
+  }
+  if selected_author != nil && co_author != nil && selected_author.subject == co_author.subject {
     co_author = nil
+  }
+  let trailers = if author_mode == "human" {
+    __github_trailers(config, ctx)
+  } else {
+    ""
+  }
+  let custom_commit_author = if author_mode == "human" {
+    __git_identity(human_author)
+  } else {
+    nil
   }
   return {
     surface: "github",
     kind: "github_author_choice",
-    mode: to_string(surface_config?.mode ?? "human_author_agent_coauthor"),
-    author: author,
+    author_mode: author_mode,
+    mode: __github_mode_label(author_mode),
+    auth_identity: __github_auth_identity(author_mode),
+    required_auth_identity: __github_auth_identity(author_mode),
+    commit_auth_identity: __github_commit_auth_identity(author_mode),
+    pull_request_auth_identity: __github_auth_identity(author_mode),
+    author: selected_author,
+    human_author: human_author,
+    bot_author: bot_author,
     co_author: co_author,
+    commit_author: custom_commit_author,
+    commit_committer: nil,
+    omit_custom_commit_author: author_mode == "bot",
+    append_git_trailers: author_mode == "human" && trailers != "",
+    trailers: trailers,
     principals: ctx.principals,
     actor_chain: ctx.chain,
   }
@@ -421,7 +499,7 @@ pub fn render(chain, surface: string, options: DisclosureRenderOptions = {}) -> 
     return __render_text(surface_config, ctx)
   }
   if kind == "github_author_choice" {
-    return __render_github(surface_config, ctx)
+    return __render_github(surface_config, ctx, config)
   }
   throw "std/disclosure: unsupported disclosure surface kind `" + kind + "`"
 }

--- a/docs/src/stdlib/disclosure.md
+++ b/docs/src/stdlib/disclosure.md
@@ -27,7 +27,7 @@ Built-in surfaces:
 |---|---|
 | `git` | Trailer block string |
 | `slack` | Byline string |
-| `github` | `{kind: "github_author_choice", mode, author, co_author, principals, actor_chain}` |
+| `github` | `{kind: "github_author_choice", author_mode, commit_auth_identity, pull_request_auth_identity, author, co_author, commit_author, trailers, principals, actor_chain}` |
 
 `git_trailers(chain, options?)` is a typed convenience wrapper around the
 `git` surface. `append_git_trailers(message, chain, options?)` appends that
@@ -68,7 +68,22 @@ github = "merge-captain-bot"
 [disclosure.surfaces.slack]
 kind = "text"
 template = "AI-assisted by {{ current.label }} for {{ origin.label }}."
+
+[disclosure.surfaces.github]
+kind = "github_author_choice"
+author_mode = "human" # "human" or "bot"
 ```
+
+The GitHub surface defaults to `author_mode = "human"`. Human mode selects the
+origin principal as the commit author, keeps the current agent as `co_author`,
+and exposes the Git trailer block that commit and PR adapters should append.
+For human mode, commit adapters can send the explicit `commit_author`, while PR
+adapters need user auth because GitHub assigns PR authorship from the
+authenticated identity. Bot mode selects the current agent as the display
+author, sets both auth-identity hints to `github_app`, and sets
+`omit_custom_commit_author` so write adapters route through the authenticated
+GitHub App `[bot]` identity instead of sending custom author or committer
+fields.
 
 Text surfaces use the regular Harn prompt-template renderer with these
 bindings:


### PR DESCRIPTION
## Summary
- add `std/disclosure` GitHub `author_mode` output for human-authored vs GitHub App bot-authored flows
- expose commit/PR auth identity hints, selected commit author, bot omission flags, and actor-chain trailers
- add conformance/docs/changelog coverage and deflake the long-running cancel result test found during the full gate

Closes #3339.

Supporting connector PR: burin-labs/harn-github-connector#109

## Verification
- `cargo run --quiet --bin harn -- test conformance --filter disclosure_github_author_mode`
- `cargo run --quiet --bin harn -- test conformance --filter disclosure`
- `cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn conformance/tests/stdlib/disclosure_github_author_mode.harn`
- `cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn conformance/tests/stdlib/disclosure_github_author_mode.harn`
- `make fmt-harn`
- `make lint-harn`
- `make check-docs-snippets`
- `cargo nextest run -p harn-hostlib --test process_tools`
- `make test`