### PR TITLE
Add MCP actor-chain token exchange

### DIFF
--- a/changelog.d/3342.added.md
+++ b/changelog.d/3342.added.md
@@ -1,0 +1,2 @@
+- Added opt-in RFC 8693 token exchange for HTTP MCP clients so servers can
+  receive transient delegated bearer tokens for active actor-chain sessions.

--- a/crates/harn-cli/src/commands/mcp/mod.rs
+++ b/crates/harn-cli/src/commands/mcp/mod.rs
@@ -36,7 +36,8 @@ pub(crate) struct ResolvedMcpServer {
 
 pub(crate) enum AuthResolution {
     None,
-    Bearer(String),
+    StaticBearer(String),
+    OAuthStore,
 }
 
 pub(crate) async fn handle_mcp_command(command: &McpCommand) {
@@ -318,7 +319,9 @@ async fn derive_server_status(server: &McpServerConfig) -> McpServerStatus {
             "connected".to_string()
         } else {
             match resolve_auth_for_server(server).await {
-                Ok(AuthResolution::Bearer(_)) => "connected".to_string(),
+                Ok(AuthResolution::StaticBearer(_) | AuthResolution::OAuthStore) => {
+                    "connected".to_string()
+                }
                 Ok(AuthResolution::None) => "auth_required".to_string(),
                 Err(error) => {
                     last_error = Some(error);
@@ -426,13 +429,13 @@ pub(crate) async fn resolve_auth_for_server(
             })?;
             let token =
                 crate::commands::connect::store::load_connect_secret_text(secret_id).await?;
-            return Ok(AuthResolution::Bearer(token));
+            return Ok(AuthResolution::StaticBearer(token));
         }
     }
 
     if let Some(token) = &server.auth_token {
         if !token.is_empty() {
-            return Ok(AuthResolution::Bearer(token.clone()));
+            return Ok(AuthResolution::StaticBearer(token.clone()));
         }
     }
 
@@ -442,7 +445,7 @@ pub(crate) async fn resolve_auth_for_server(
     }
 
     match mcp_oauth::resolve_bearer(&server.url).await? {
-        Some(bearer) => Ok(AuthResolution::Bearer(bearer)),
+        Some(_) => Ok(AuthResolution::OAuthStore),
         None => Ok(AuthResolution::None),
     }
 }
@@ -1140,6 +1143,47 @@ mod tests {
 
     fn parse_server(toml_table: &str) -> McpServerConfig {
         toml::from_str::<McpServerConfig>(toml_table).expect("mcp server config")
+    }
+
+    #[test]
+    fn mcp_server_config_parses_token_exchange_row() {
+        let server = parse_server(
+            r#"
+name = "api"
+transport = "http"
+url = "https://mcp.example/mcp"
+
+[token_exchange]
+token_url = "https://auth.example/token"
+actor_token = "agent.jwt"
+actor_token_type = "jwt"
+subject_token_type = "access_token"
+client_id = "agent-client"
+client_secret = "agent-secret"
+token_endpoint_auth_method = "client_secret_basic"
+scope = "repo"
+
+[token_exchange.extra_params]
+deployment = "enterprise"
+"#,
+        );
+        let exchange = server
+            .token_exchange
+            .as_ref()
+            .expect("token exchange row parsed");
+        assert_eq!(
+            exchange.token_url.as_deref(),
+            Some("https://auth.example/token")
+        );
+        assert_eq!(exchange.actor_token.as_deref(), Some("agent.jwt"));
+        assert_eq!(
+            exchange.token_endpoint_auth_method.as_deref(),
+            Some("client_secret_basic")
+        );
+        assert_eq!(
+            exchange.extra_params.get("deployment"),
+            Some(&serde_json::json!("enterprise"))
+        );
     }
 
     #[test]

--- a/crates/harn-cli/src/commands/run/mod.rs
+++ b/crates/harn-cli/src/commands/run/mod.rs
@@ -2332,9 +2332,11 @@ pub(crate) async fn connect_mcp_servers(
             "env": server.env,
             "url": server.url,
             "auth_token": match resolved_auth {
-                AuthResolution::Bearer(token) => Some(token),
+                AuthResolution::StaticBearer(token) => Some(token),
+                AuthResolution::OAuthStore => None,
                 AuthResolution::None => server.auth_token.clone(),
             },
+            "token_exchange": server.token_exchange.clone(),
             "protocol_version": server.protocol_version,
             "protocol_mode": server.protocol_mode,
             "proxy_server_name": server.proxy_server_name,

--- a/crates/harn-cli/src/package/manifest.rs
+++ b/crates/harn-cli/src/package/manifest.rs
@@ -759,6 +759,8 @@ pub struct McpServerConfig {
     #[serde(default)]
     pub auth_token: Option<String>,
     #[serde(default)]
+    pub token_exchange: Option<harn_vm::mcp_oauth::McpTokenExchangeConfig>,
+    #[serde(default)]
     pub auth: Option<McpAuthConfig>,
     #[serde(default)]
     pub client_id: Option<String>,

--- a/crates/harn-vm/src/mcp/connect.rs
+++ b/crates/harn-vm/src/mcp/connect.rs
@@ -65,14 +65,16 @@ pub(crate) async fn mcp_connect_http_impl(
         .protocol_version
         .clone()
         .unwrap_or_else(|| default_protocol_version(protocol_mode).to_string());
-    let auth_token = resolve_http_auth_token(spec).await;
+    let resolved_auth = resolve_http_auth_token_source(spec).await;
 
     let handle = VmMcpClientHandle {
         name: spec.name.clone(),
         inner: Arc::new(Mutex::new(Some(McpClientInner::Http(HttpMcpClientInner {
             client,
             url: spec.url.clone(),
-            auth_token,
+            auth_token: resolved_auth.token,
+            auth_token_source: resolved_auth.source,
+            token_exchange: spec.token_exchange.clone().map(Arc::new),
             protocol_mode,
             protocol_version,
             session_id: None,
@@ -90,28 +92,43 @@ pub(crate) async fn mcp_connect_http_impl(
     Ok(handle)
 }
 
-pub(crate) async fn resolve_http_auth_token(spec: &McpServerSpec) -> Option<String> {
-    resolve_http_auth_token_with(spec, |server_url| async move {
+pub(crate) async fn resolve_http_auth_token_source(spec: &McpServerSpec) -> ResolvedHttpAuthToken {
+    resolve_http_auth_token_source_with(spec, |server_url| async move {
         crate::mcp_oauth::resolve_bearer(&server_url).await
     })
     .await
 }
 
-pub(crate) async fn resolve_http_auth_token_with<R, Fut>(
+pub(crate) async fn resolve_http_auth_token_source_with<R, Fut>(
     spec: &McpServerSpec,
     resolver: R,
-) -> Option<String>
+) -> ResolvedHttpAuthToken
 where
     R: FnOnce(String) -> Fut,
     Fut: Future<Output = Result<Option<String>, String>>,
 {
     if let Some(token) = spec.auth_token.as_deref().filter(|token| !token.is_empty()) {
-        return Some(token.to_string());
+        return ResolvedHttpAuthToken {
+            token: Some(token.to_string()),
+            source: HttpAuthTokenSource::Config,
+        };
     }
     if spec.url.is_empty() {
-        return None;
+        return ResolvedHttpAuthToken {
+            token: None,
+            source: HttpAuthTokenSource::None,
+        };
     }
-    resolver(spec.url.clone()).await.unwrap_or(None)
+    match resolver(spec.url.clone()).await.unwrap_or(None) {
+        Some(token) => ResolvedHttpAuthToken {
+            token: Some(token),
+            source: HttpAuthTokenSource::OAuthStore,
+        },
+        None => ResolvedHttpAuthToken {
+            token: None,
+            source: HttpAuthTokenSource::None,
+        },
+    }
 }
 
 pub(crate) async fn initialize_client(handle: &VmMcpClientHandle) -> Result<(), VmError> {

--- a/crates/harn-vm/src/mcp/mod.rs
+++ b/crates/harn-vm/src/mcp/mod.rs
@@ -71,6 +71,8 @@ pub struct McpServerSpec {
     #[serde(default)]
     pub auth_token: Option<String>,
     #[serde(default)]
+    pub token_exchange: Option<crate::mcp_oauth::McpTokenExchangeConfig>,
+    #[serde(default)]
     pub protocol_version: Option<String>,
     #[serde(default)]
     pub protocol_mode: Option<String>,
@@ -101,6 +103,8 @@ pub(crate) struct HttpMcpClientInner {
     client: reqwest::Client,
     url: String,
     auth_token: Option<String>,
+    auth_token_source: HttpAuthTokenSource,
+    token_exchange: Option<Arc<crate::mcp_oauth::McpTokenExchangeConfig>>,
     protocol_mode: McpProtocolMode,
     protocol_version: String,
     session_id: Option<String>,
@@ -108,6 +112,19 @@ pub(crate) struct HttpMcpClientInner {
     proxy_server_name: Option<String>,
     get_stream_task: Option<tokio::task::JoinHandle<()>>,
     tool_headers: BTreeMap<String, Vec<McpToolHeader>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HttpAuthTokenSource {
+    None,
+    Config,
+    OAuthStore,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ResolvedHttpAuthToken {
+    pub token: Option<String>,
+    pub source: HttpAuthTokenSource,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/harn-vm/src/mcp/tests.rs
+++ b/crates/harn-vm/src/mcp/tests.rs
@@ -57,6 +57,7 @@ fn http_spec(url: &str, auth_token: Option<&str>) -> McpServerSpec {
         env: BTreeMap::new(),
         url: url.to_string(),
         auth_token: auth_token.map(str::to_string),
+        token_exchange: None,
         protocol_version: None,
         protocol_mode: None,
         proxy_server_name: None,
@@ -66,32 +67,35 @@ fn http_spec(url: &str, auth_token: Option<&str>) -> McpServerSpec {
 #[tokio::test]
 async fn http_auth_resolution_prefers_explicit_token() {
     let spec = http_spec("https://mcp.example/mcp", Some("configured"));
-    let token = resolve_http_auth_token_with(&spec, |_| async {
+    let resolved = resolve_http_auth_token_source_with(&spec, |_| async {
         panic!("resolver must not run when the config carries a bearer token")
     })
     .await;
-    assert_eq!(token.as_deref(), Some("configured"));
+    assert_eq!(resolved.token.as_deref(), Some("configured"));
+    assert_eq!(resolved.source, HttpAuthTokenSource::Config);
 }
 
 #[tokio::test]
 async fn http_auth_resolution_uses_harn_store_when_config_omits_token() {
     let spec = http_spec("https://mcp.example/mcp", Some(""));
-    let token = resolve_http_auth_token_with(&spec, |server_url| async move {
+    let resolved = resolve_http_auth_token_source_with(&spec, |server_url| async move {
         assert_eq!(server_url, "https://mcp.example/mcp");
         Ok(Some("stored".to_string()))
     })
     .await;
-    assert_eq!(token.as_deref(), Some("stored"));
+    assert_eq!(resolved.token.as_deref(), Some("stored"));
+    assert_eq!(resolved.source, HttpAuthTokenSource::OAuthStore);
 }
 
 #[tokio::test]
 async fn http_auth_resolution_leaves_unauthenticated_servers_probeable() {
     let spec = http_spec("https://mcp.example/mcp", None);
-    let token = resolve_http_auth_token_with(&spec, |_| async {
+    let resolved = resolve_http_auth_token_source_with(&spec, |_| async {
         Err("no protected-resource metadata".to_string())
     })
     .await;
-    assert_eq!(token, None);
+    assert_eq!(resolved.token, None);
+    assert_eq!(resolved.source, HttpAuthTokenSource::None);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -490,6 +494,124 @@ async fn modern_http_401_without_interactive_host_returns_auth_error() {
         .await;
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn modern_http_token_exchange_sends_delegated_bearer_for_actor_chain() {
+    let _guard = http_mcp_test_guard().await;
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (base_url, mut requests, mut exchanges) =
+                spawn_token_exchange_http_mcp_server(true, "Bearer delegated-token").await;
+            let spec = token_exchange_http_spec(&base_url);
+            let handle = connect_mcp_server_from_spec(&spec)
+                .await
+                .expect("modern HTTP MCP server should connect");
+            let actor_chain =
+                crate::actor_chain::ActorChain::new_with_scopes("user:kenneth", ["repo"])
+                    .pushed_with_scopes("agent:merge-captain", ["repo"]);
+            let session_id = crate::agent_sessions::open_or_create_with_actor_chain(
+                Some("mcp-token-exchange".to_string()),
+                Some(actor_chain),
+            );
+            let _session_guard = crate::agent_sessions::enter_current_session(session_id);
+
+            let result = call_mcp_tool(
+                &handle,
+                "execute_sql",
+                serde_json::json!({"region": "us-west1", "query": "select 1"}),
+            )
+            .await
+            .unwrap();
+            assert_eq!(result, serde_json::json!("ok"));
+
+            let discover = recv_recorded_request(&mut requests).await;
+            assert_modern_http_request(&discover, "server/discover", None);
+            assert_eq!(
+                discover.headers.get("authorization").map(String::as_str),
+                Some("Bearer base-token")
+            );
+            let tool_call = recv_recorded_request(&mut requests).await;
+            assert_modern_http_request(&tool_call, "tools/call", Some("execute_sql"));
+            assert_eq!(
+                tool_call.headers.get("authorization").map(String::as_str),
+                Some("Bearer delegated-token")
+            );
+
+            let exchange = recv_token_exchange_form(&mut exchanges).await;
+            assert_eq!(
+                exchange.get("grant_type").map(String::as_str),
+                Some("urn:ietf:params:oauth:grant-type:token-exchange")
+            );
+            assert_eq!(
+                exchange.get("subject_token").map(String::as_str),
+                Some("base-token")
+            );
+            assert_eq!(
+                exchange.get("subject_token_type").map(String::as_str),
+                Some("urn:ietf:params:oauth:token-type:access_token")
+            );
+            assert_eq!(
+                exchange.get("actor_token").map(String::as_str),
+                Some("agent.jwt")
+            );
+            assert_eq!(
+                exchange.get("actor_token_type").map(String::as_str),
+                Some("urn:ietf:params:oauth:token-type:jwt")
+            );
+            assert_eq!(exchange.get("scope").map(String::as_str), Some("repo"));
+            let expected_resource = format!("{base_url}/mcp");
+            assert_eq!(
+                exchange.get("resource").map(String::as_str),
+                Some(expected_resource.as_str())
+            );
+            handle.disconnect().await.unwrap();
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn modern_http_token_exchange_unsupported_grant_falls_back_to_plain_bearer() {
+    let _guard = http_mcp_test_guard().await;
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (base_url, mut requests, mut exchanges) =
+                spawn_token_exchange_http_mcp_server(false, "Bearer base-token").await;
+            let spec = token_exchange_http_spec(&base_url);
+            let handle = connect_mcp_server_from_spec(&spec)
+                .await
+                .expect("modern HTTP MCP server should connect");
+            let actor_chain =
+                crate::actor_chain::ActorChain::new("user:kenneth").pushed("agent:merge-captain");
+            let session_id = crate::agent_sessions::open_or_create_with_actor_chain(
+                Some("mcp-token-exchange-fallback".to_string()),
+                Some(actor_chain),
+            );
+            let _session_guard = crate::agent_sessions::enter_current_session(session_id);
+
+            let result = call_mcp_tool(
+                &handle,
+                "execute_sql",
+                serde_json::json!({"region": "us-west1", "query": "select 1"}),
+            )
+            .await
+            .unwrap();
+            assert_eq!(result, serde_json::json!("ok"));
+
+            let _discover = recv_recorded_request(&mut requests).await;
+            let tool_call = recv_recorded_request(&mut requests).await;
+            assert_eq!(
+                tool_call.headers.get("authorization").map(String::as_str),
+                Some("Bearer base-token")
+            );
+            let exchange = recv_token_exchange_form(&mut exchanges).await;
+            assert_eq!(
+                exchange.get("grant_type").map(String::as_str),
+                Some("urn:ietf:params:oauth:grant-type:token-exchange")
+            );
+            handle.disconnect().await.unwrap();
+        })
+        .await;
+}
+
 #[test]
 fn x_mcp_header_validation_filters_invalid_tools_and_encodes_values() {
     let tools = vec![
@@ -576,6 +698,7 @@ async fn modern_http_handle(base_url: &str) -> VmMcpClientHandle {
         env: BTreeMap::new(),
         url: format!("{base_url}/mcp"),
         auth_token: None,
+        token_exchange: None,
         protocol_version: Some(DRAFT_PROTOCOL_VERSION.to_string()),
         protocol_mode: Some("rc".to_string()),
         proxy_server_name: None,
@@ -583,6 +706,26 @@ async fn modern_http_handle(base_url: &str) -> VmMcpClientHandle {
     connect_mcp_server_from_spec(&spec)
         .await
         .expect("modern HTTP MCP server should connect")
+}
+
+fn token_exchange_http_spec(base_url: &str) -> McpServerSpec {
+    McpServerSpec {
+        name: "token-exchange-http".to_string(),
+        transport: McpTransport::Http,
+        command: String::new(),
+        args: Vec::new(),
+        env: BTreeMap::new(),
+        url: format!("{base_url}/mcp"),
+        auth_token: Some("base-token".to_string()),
+        token_exchange: Some(crate::mcp_oauth::McpTokenExchangeConfig {
+            token_url: Some(format!("{base_url}/token")),
+            actor_token: Some("agent.jwt".to_string()),
+            ..Default::default()
+        }),
+        protocol_version: Some(DRAFT_PROTOCOL_VERSION.to_string()),
+        protocol_mode: Some("rc".to_string()),
+        proxy_server_name: None,
+    }
 }
 
 fn assert_modern_http_request(request: &RecordedHttpRequest, method: &str, name: Option<&str>) {
@@ -704,6 +847,86 @@ async fn spawn_auth_required_modern_http_mcp_server() -> (
     });
 
     (format!("http://{addr}"), request_rx, auth_challenged_rx)
+}
+
+async fn spawn_token_exchange_http_mcp_server(
+    exchange_supported: bool,
+    expected_tool_authorization: &'static str,
+) -> (
+    String,
+    mpsc::UnboundedReceiver<RecordedHttpRequest>,
+    mpsc::UnboundedReceiver<BTreeMap<String, String>>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (request_tx, request_rx) = mpsc::unbounded_channel();
+    let (exchange_tx, exchange_rx) = mpsc::unbounded_channel();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            let Ok((request_line, headers, body)) = read_http_request(&mut stream).await else {
+                continue;
+            };
+            if request_line.starts_with("POST /token ") {
+                let form = url::form_urlencoded::parse(&body)
+                    .into_owned()
+                    .collect::<BTreeMap<_, _>>();
+                let _ = exchange_tx.send(form);
+                if exchange_supported {
+                    let body = serde_json::json!({
+                        "access_token": "delegated-token",
+                        "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+                        "token_type": "Bearer",
+                        "expires_in": 300,
+                    });
+                    let _ = write_http_json(&mut stream, "200 OK", &[], body).await;
+                } else {
+                    let body = serde_json::json!({"error": "unsupported_grant_type"});
+                    let _ = write_http_json(&mut stream, "400 Bad Request", &[], body).await;
+                }
+                continue;
+            }
+
+            let Ok(request) = serde_json::from_slice::<serde_json::Value>(&body) else {
+                let _ = write_http_empty(&mut stream, "400 Bad Request").await;
+                continue;
+            };
+            let _ = request_tx.send(RecordedHttpRequest {
+                headers: headers.clone(),
+                body: request.clone(),
+            });
+            let method = request.get("method").and_then(|value| value.as_str());
+            if method == Some("tools/call")
+                && headers.get("authorization").map(String::as_str)
+                    != Some(expected_tool_authorization)
+            {
+                let _ = write_http_json(
+                    &mut stream,
+                    "401 Unauthorized",
+                    &[("WWW-Authenticate", r#"Bearer scope="repo""#)],
+                    serde_json::json!({"error": "authorization required"}),
+                )
+                .await;
+                continue;
+            }
+            let response = modern_http_response(&request, method);
+            let _ = write_http_json(&mut stream, "200 OK", &[], response).await;
+        }
+    });
+
+    (format!("http://{addr}"), request_rx, exchange_rx)
+}
+
+async fn recv_token_exchange_form(
+    exchanges: &mut mpsc::UnboundedReceiver<BTreeMap<String, String>>,
+) -> BTreeMap<String, String> {
+    tokio::time::timeout(MCP_TIMEOUT, exchanges.recv())
+        .await
+        .expect("timed out waiting for token exchange request")
+        .expect("mock server closed before recording token exchange")
 }
 
 fn install_capturing_agent_sink(
@@ -1182,6 +1405,8 @@ async fn test_parse_sse_jsonrpc_body_uses_matching_jsonrpc_response() {
         client: reqwest::Client::new(),
         url: "http://127.0.0.1/mcp".to_string(),
         auth_token: None,
+        auth_token_source: HttpAuthTokenSource::None,
+        token_exchange: None,
         protocol_mode: McpProtocolMode::Legacy,
         protocol_version: PROTOCOL_VERSION.to_string(),
         session_id: None,
@@ -1284,6 +1509,8 @@ async fn roots_list_changed_notification_is_sent_once_per_snapshot() {
                     client: reqwest::Client::new(),
                     url: format!("{base_url}/mcp"),
                     auth_token: None,
+                    auth_token_source: HttpAuthTokenSource::None,
+                    token_exchange: None,
                     protocol_mode: McpProtocolMode::Legacy,
                     protocol_version: PROTOCOL_VERSION.to_string(),
                     session_id: None,

--- a/crates/harn-vm/src/mcp/transport.rs
+++ b/crates/harn-vm/src/mcp/transport.rs
@@ -337,6 +337,7 @@ async fn wait_for_http_mcp_authorization(
     .await
     .map_err(|error| mcp_auth_required_error(server_name, &inner.url, &error))?;
     inner.auth_token = Some(token.access_token);
+    inner.auth_token_source = HttpAuthTokenSource::OAuthStore;
     inner.abort_get_stream();
     Ok(())
 }
@@ -367,6 +368,7 @@ pub(crate) async fn send_http_request_once(
         payload["id"] = serde_json::json!(id);
     }
     let payload = wrap_http_payload(payload, inner.proxy_server_name.as_deref());
+    let auth_token = resolve_http_request_auth_token(inner).await?;
 
     let request = inner
         .client
@@ -376,7 +378,7 @@ pub(crate) async fn send_http_request_once(
         .json(&payload);
     let request = apply_http_headers(
         request,
-        &inner.auth_token,
+        &auth_token,
         inner.protocol_mode,
         &inner.protocol_version,
         legacy_session_id(inner),
@@ -390,6 +392,58 @@ pub(crate) async fn send_http_request_once(
         .send()
         .await
         .map_err(|e| VmError::Runtime(format!("MCP HTTP request error: {e}")))
+}
+
+async fn resolve_http_request_auth_token(
+    inner: &mut HttpMcpClientInner,
+) -> Result<Option<String>, VmError> {
+    let Some(base_token) = inner.auth_token.clone() else {
+        return Ok(None);
+    };
+    let Some(config) = inner
+        .token_exchange
+        .clone()
+        .filter(|config| config.is_enabled())
+    else {
+        return Ok(Some(base_token));
+    };
+    let Some(actor_chain) = crate::agent_sessions::current_actor_chain() else {
+        return Ok(Some(base_token));
+    };
+    if !actor_chain.is_delegated() {
+        return Ok(Some(base_token));
+    }
+
+    match inner.auth_token_source {
+        HttpAuthTokenSource::OAuthStore => {
+            match crate::mcp_oauth::resolve_delegated_bearer_from_store(
+                &inner.url,
+                &config,
+                &actor_chain,
+            )
+            .await
+            .map_err(|error| VmError::Runtime(format!("MCP token exchange failed: {error}")))?
+            {
+                Some(resolved) => {
+                    inner.auth_token = Some(resolved.base_bearer);
+                    Ok(Some(resolved.bearer))
+                }
+                None => Ok(Some(base_token)),
+            }
+        }
+        HttpAuthTokenSource::Config => {
+            let exchanged = crate::mcp_oauth::exchange_configured_bearer_for_actor_chain(
+                &inner.url,
+                &base_token,
+                &config,
+                &actor_chain,
+            )
+            .await
+            .map_err(|error| VmError::Runtime(format!("MCP token exchange failed: {error}")))?;
+            Ok(exchanged.or(Some(base_token)))
+        }
+        HttpAuthTokenSource::None => Ok(None),
+    }
 }
 
 pub(crate) fn ensure_http_get_stream(inner: &mut HttpMcpClientInner, server_name: &str) {

--- a/crates/harn-vm/src/mcp_oauth.rs
+++ b/crates/harn-vm/src/mcp_oauth.rs
@@ -26,7 +26,7 @@
 //! serialize concurrent refreshers (clients + daemon) so they don't stampede
 //! the token endpoint or revoke each other's rotated refresh tokens.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -68,6 +68,63 @@ const TOKEN_REFRESH_SKEW_SECS: i64 = 60;
 const MAX_PENDING_FLOWS: usize = 32;
 
 const AUTH_COMPLETION_CHANNEL_CAPACITY: usize = 64;
+const TOKEN_EXCHANGE_GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:token-exchange";
+const TOKEN_TYPE_PREFIX: &str = "urn:ietf:params:oauth:token-type:";
+const TOKEN_TYPE_ACCESS_TOKEN: &str = "urn:ietf:params:oauth:token-type:access_token";
+const TOKEN_TYPE_JWT: &str = "urn:ietf:params:oauth:token-type:jwt";
+
+/// Per-MCP-server opt-in for exchanging the stored subject bearer for a
+/// delegated request bearer before outbound HTTP MCP calls.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct McpTokenExchangeConfig {
+    /// `None` means enabled when the table is present. The enclosing
+    /// `Option<McpTokenExchangeConfig>` keeps the default server behavior off.
+    pub enabled: Option<bool>,
+    /// Override token endpoint. When absent, MCP OAuth discovery supplies the
+    /// authorization server token endpoint.
+    pub token_url: Option<String>,
+    pub actor_token: Option<String>,
+    pub actor_token_type: Option<String>,
+    pub subject_token_type: Option<String>,
+    pub requested_token_type: Option<String>,
+    /// Optional client authentication for the token-exchange request when the
+    /// subject bearer came from static config. Stored OAuth bearers use their
+    /// persisted client credentials by default.
+    pub client_id: Option<String>,
+    pub client_secret: Option<String>,
+    pub token_endpoint_auth_method: Option<String>,
+    /// Optional RFC 8693 `resource` parameter. Defaults to the MCP resource
+    /// indicator; accepts a string or list of strings.
+    pub resource: Option<serde_json::Value>,
+    /// Optional RFC 8693 `audience` parameter; accepts a string or list of
+    /// strings.
+    pub audience: Option<serde_json::Value>,
+    /// Optional requested scope string. Defaults to the current actor's scoped
+    /// hop when the session actor chain carries scopes.
+    pub scope: Option<String>,
+    /// Deployment-specific token-exchange form fields.
+    pub extra_params: BTreeMap<String, serde_json::Value>,
+}
+
+impl McpTokenExchangeConfig {
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.unwrap_or(true)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DelegatedMcpBearer {
+    pub bearer: String,
+    pub base_bearer: String,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct TokenExchangeClientAuth<'a> {
+    client_id: &'a str,
+    client_secret: Option<&'a str>,
+    token_endpoint_auth_method: &'a str,
+}
 
 /// A persisted MCP OAuth token plus everything needed to refresh it without
 /// re-running discovery. Keyed in the keyring by `(resource, issuer, client_id)`.
@@ -334,6 +391,107 @@ pub async fn complete_authorization(
 /// (single-flight) if it is within the expiry skew. Returns `None` when no
 /// token is stored (the caller should treat this as "auth required").
 pub async fn resolve_bearer(server_url: &str) -> Result<Option<String>, String> {
+    Ok(resolve_stored_token_with_discovery(server_url)
+        .await?
+        .map(|(token, _)| token.access_token))
+}
+
+/// Resolve a bearer for an MCP request by refreshing the stored subject token
+/// under the existing single-flight lock, then exchanging it for a transient
+/// delegated token when the server has opted in.
+pub async fn resolve_delegated_bearer_from_store(
+    server_url: &str,
+    config: &McpTokenExchangeConfig,
+    actor_chain: &crate::actor_chain::ActorChain,
+) -> Result<Option<DelegatedMcpBearer>, String> {
+    let Some((stored, discovery)) = resolve_stored_token_with_discovery(server_url).await? else {
+        return Ok(None);
+    };
+    validate_issuer_binding(&stored.issuer, &discovery.authorization_server_issuer)?;
+    let exchanged = exchange_bearer_for_actor_chain(
+        server_url,
+        &stored.access_token,
+        &discovery,
+        config,
+        actor_chain,
+        TokenExchangeClientAuth {
+            client_id: &stored.client_id,
+            client_secret: stored.client_secret.as_deref(),
+            token_endpoint_auth_method: &stored.token_endpoint_auth_method,
+        },
+    )
+    .await?;
+    let bearer = exchanged.unwrap_or_else(|| stored.access_token.clone());
+    Ok(Some(DelegatedMcpBearer {
+        bearer,
+        base_bearer: stored.access_token,
+    }))
+}
+
+/// Exchange a caller-supplied subject bearer. Used for static MCP bearer
+/// configs, which have no Harn-owned refresh token to update.
+pub async fn exchange_configured_bearer_for_actor_chain(
+    server_url: &str,
+    subject_bearer: &str,
+    config: &McpTokenExchangeConfig,
+    actor_chain: &crate::actor_chain::ActorChain,
+) -> Result<Option<String>, String> {
+    let discovery = if config
+        .token_url
+        .as_deref()
+        .is_some_and(|token_url| !token_url.trim().is_empty())
+    {
+        None
+    } else {
+        Some(discover(server_url).await?)
+    };
+    match discovery.as_ref() {
+        Some(discovery) => {
+            exchange_bearer_for_actor_chain(
+                server_url,
+                subject_bearer,
+                discovery,
+                config,
+                actor_chain,
+                config_token_exchange_client_auth(config),
+            )
+            .await
+        }
+        None => {
+            exchange_bearer_for_actor_chain_with_endpoint(
+                server_url,
+                subject_bearer,
+                config
+                    .token_url
+                    .as_deref()
+                    .expect("checked token_url presence above"),
+                config,
+                actor_chain,
+                config_token_exchange_client_auth(config),
+            )
+            .await
+        }
+    }
+}
+
+fn config_token_exchange_client_auth(
+    config: &McpTokenExchangeConfig,
+) -> TokenExchangeClientAuth<'_> {
+    TokenExchangeClientAuth {
+        client_id: config.client_id.as_deref().unwrap_or(""),
+        client_secret: config.client_secret.as_deref(),
+        token_endpoint_auth_method: config
+            .token_endpoint_auth_method
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("none"),
+    }
+}
+
+async fn resolve_stored_token_with_discovery(
+    server_url: &str,
+) -> Result<Option<(StoredMcpToken, McpOAuthDiscovery)>, String> {
     let discovery = discover(server_url).await?;
     let resource = canonical_resource_indicator(server_url).map_err(|e| e.to_string())?;
     let store = KeyringOAuthTokenStorage::default();
@@ -351,7 +509,7 @@ pub async fn resolve_bearer(server_url: &str) -> Result<Option<String>, String> 
     if token_needs_refresh(&stored) {
         stored = refresh_stored_token_with_store(&store, &stored, &discovery, None).await?;
     }
-    Ok(Some(stored.access_token))
+    Ok(Some((stored, discovery)))
 }
 
 /// Import an existing token into the canonical Harn MCP OAuth store.
@@ -633,6 +791,269 @@ async fn request_token(
         .json::<TokenResponse>()
         .await
         .map_err(|error| format!("Invalid token response: {error}"))
+}
+
+async fn exchange_bearer_for_actor_chain(
+    server_url: &str,
+    subject_bearer: &str,
+    discovery: &McpOAuthDiscovery,
+    config: &McpTokenExchangeConfig,
+    actor_chain: &crate::actor_chain::ActorChain,
+    client_auth: TokenExchangeClientAuth<'_>,
+) -> Result<Option<String>, String> {
+    let token_endpoint = config
+        .token_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(&discovery.authorization_server_metadata.token_endpoint);
+    exchange_bearer_for_actor_chain_with_endpoint(
+        server_url,
+        subject_bearer,
+        token_endpoint,
+        config,
+        actor_chain,
+        client_auth,
+    )
+    .await
+}
+
+async fn exchange_bearer_for_actor_chain_with_endpoint(
+    server_url: &str,
+    subject_bearer: &str,
+    token_endpoint: &str,
+    config: &McpTokenExchangeConfig,
+    actor_chain: &crate::actor_chain::ActorChain,
+    client_auth: TokenExchangeClientAuth<'_>,
+) -> Result<Option<String>, String> {
+    let Some(form) = token_exchange_form(server_url, subject_bearer, config, actor_chain)? else {
+        return Ok(None);
+    };
+    validate_token_endpoint_auth_method(client_auth.token_endpoint_auth_method)?;
+    let client = reqwest::Client::new();
+    let response = send_token_exchange_request(&client, token_endpoint, &form, client_auth).await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        if token_exchange_unsupported(status, &body) {
+            return Ok(None);
+        }
+        return Err(oauth_http_error("Token exchange failed", status, &body));
+    }
+    let token = response
+        .json::<TokenResponse>()
+        .await
+        .map_err(|error| format!("Invalid token exchange response: {error}"))?;
+    Ok(Some(token.access_token))
+}
+
+async fn send_token_exchange_request(
+    client: &reqwest::Client,
+    token_endpoint: &str,
+    form: &[(String, String)],
+    client_auth: TokenExchangeClientAuth<'_>,
+) -> Result<reqwest::Response, String> {
+    let mut request = client.post(token_endpoint).form(form);
+    match client_auth.token_endpoint_auth_method {
+        "client_secret_basic" => {
+            let client_secret = client_auth
+                .client_secret
+                .ok_or_else(|| "Missing client secret for client_secret_basic".to_string())?;
+            if client_auth.client_id.trim().is_empty() {
+                return Err("Missing client_id for client_secret_basic".to_string());
+            }
+            request = request.basic_auth(client_auth.client_id, Some(client_secret));
+        }
+        "client_secret_post" => {
+            let client_secret = client_auth
+                .client_secret
+                .ok_or_else(|| "Missing client secret for client_secret_post".to_string())?;
+            if client_auth.client_id.trim().is_empty() {
+                return Err("Missing client_id for client_secret_post".to_string());
+            }
+            let mut extended = form.to_vec();
+            extended.push(("client_id".to_string(), client_auth.client_id.to_string()));
+            extended.push(("client_secret".to_string(), client_secret.to_string()));
+            request = client.post(token_endpoint).form(&extended);
+        }
+        "none" => {}
+        other => {
+            return Err(format!(
+                "unsupported token auth method '{other}'; expected none, client_secret_post, or client_secret_basic"
+            ))
+        }
+    }
+    request
+        .send()
+        .await
+        .map_err(|error| format!("Token exchange request failed: {error}"))
+}
+
+fn token_exchange_form(
+    server_url: &str,
+    subject_bearer: &str,
+    config: &McpTokenExchangeConfig,
+    actor_chain: &crate::actor_chain::ActorChain,
+) -> Result<Option<Vec<(String, String)>>, String> {
+    if !config.is_enabled() || !actor_chain.is_delegated() {
+        return Ok(None);
+    }
+    let actor_token = match config
+        .actor_token
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(actor_token) => actor_token,
+        None => {
+            return Err(
+                "MCP token exchange actor_token is required for delegated actor-chain requests"
+                    .to_string(),
+            )
+        }
+    };
+    let subject_token_type = normalize_token_type(
+        config.subject_token_type.as_deref(),
+        TOKEN_TYPE_ACCESS_TOKEN,
+        "subject_token_type",
+    )?;
+    let actor_token_type = normalize_token_type(
+        config.actor_token_type.as_deref(),
+        TOKEN_TYPE_JWT,
+        "actor_token_type",
+    )?;
+    let requested_token_type = config
+        .requested_token_type
+        .as_deref()
+        .map(|value| {
+            normalize_token_type(Some(value), TOKEN_TYPE_ACCESS_TOKEN, "requested_token_type")
+        })
+        .transpose()?;
+    let mut form = vec![
+        (
+            "grant_type".to_string(),
+            TOKEN_EXCHANGE_GRANT_TYPE.to_string(),
+        ),
+        ("subject_token".to_string(), subject_bearer.to_string()),
+        ("subject_token_type".to_string(), subject_token_type),
+        ("actor_token".to_string(), actor_token.to_string()),
+        ("actor_token_type".to_string(), actor_token_type),
+    ];
+    if let Some(requested_token_type) = requested_token_type {
+        form.push(("requested_token_type".to_string(), requested_token_type));
+    }
+
+    match config.resource.as_ref() {
+        Some(value) => append_form_values(&mut form, "resource", value)?,
+        None => {
+            let resource =
+                canonical_resource_indicator(server_url).map_err(|error| error.to_string())?;
+            form.push(("resource".to_string(), resource));
+        }
+    }
+    if let Some(value) = config.audience.as_ref() {
+        append_form_values(&mut form, "audience", value)?;
+    }
+    if let Some(scope) = requested_scope(config, actor_chain) {
+        form.push(("scope".to_string(), scope));
+    }
+    for (key, value) in &config.extra_params {
+        append_form_values(&mut form, key, value)?;
+    }
+    Ok(Some(form))
+}
+
+fn requested_scope(
+    config: &McpTokenExchangeConfig,
+    actor_chain: &crate::actor_chain::ActorChain,
+) -> Option<String> {
+    config
+        .scope
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            let scopes = actor_chain.current_entry().scopes().collect::<Vec<_>>();
+            (!scopes.is_empty()).then(|| scopes.join(" "))
+        })
+}
+
+fn normalize_token_type(
+    value: Option<&str>,
+    default_value: &str,
+    field: &str,
+) -> Result<String, String> {
+    let raw = value.unwrap_or(default_value).trim();
+    if raw.is_empty() {
+        return Err(format!("MCP token exchange {field} must not be empty"));
+    }
+    if raw.starts_with("urn:") {
+        return Ok(raw.to_string());
+    }
+    let normalized = match raw.to_ascii_lowercase().as_str() {
+        "access" | "access_token" => "access_token",
+        "refresh_token" => "refresh_token",
+        "id_token" => "id_token",
+        "jwt" => "jwt",
+        "saml1" => "saml1",
+        "saml2" => "saml2",
+        _ => {
+            return Err(format!(
+                "MCP token exchange {field} uses unsupported token type `{raw}`"
+            ))
+        }
+    };
+    Ok(format!("{TOKEN_TYPE_PREFIX}{normalized}"))
+}
+
+fn append_form_values(
+    form: &mut Vec<(String, String)>,
+    key: &str,
+    value: &serde_json::Value,
+) -> Result<(), String> {
+    for item in form_value_strings(key, value)? {
+        form.push((key.to_string(), item));
+    }
+    Ok(())
+}
+
+fn form_value_strings(key: &str, value: &serde_json::Value) -> Result<Vec<String>, String> {
+    match value {
+        serde_json::Value::Null => Ok(Vec::new()),
+        serde_json::Value::String(value) => Ok(vec![value.clone()]),
+        serde_json::Value::Bool(value) => Ok(vec![value.to_string()]),
+        serde_json::Value::Number(value) => Ok(vec![value.to_string()]),
+        serde_json::Value::Array(values) => {
+            let mut out = Vec::new();
+            for value in values {
+                match value {
+                    serde_json::Value::String(value) => out.push(value.clone()),
+                    serde_json::Value::Bool(value) => out.push(value.to_string()),
+                    serde_json::Value::Number(value) => out.push(value.to_string()),
+                    serde_json::Value::Null => {}
+                    _ => return Err(format!("MCP token exchange `{key}` values must be scalars")),
+                }
+            }
+            Ok(out)
+        }
+        _ => Err(format!(
+            "MCP token exchange `{key}` must be a scalar or list"
+        )),
+    }
+}
+
+fn token_exchange_unsupported(status: reqwest::StatusCode, body: &str) -> bool {
+    if status != reqwest::StatusCode::BAD_REQUEST {
+        return false;
+    }
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
+        return false;
+    };
+    matches!(
+        value.get("error").and_then(serde_json::Value::as_str),
+        Some("unsupported_grant_type" | "unsupported_token_type")
+    )
 }
 
 fn token_needs_refresh(token: &StoredMcpToken) -> bool {

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -2305,11 +2305,21 @@ Each entry requires:
 | `transport` | string | `stdio` (default) or `http` |
 | `url` | string | Remote MCP server URL for HTTP transports |
 | `auth_token` | string | Optional explicit bearer token for HTTP transports |
+| `token_exchange` | dict | Optional RFC 8693 token-exchange opt-in for HTTP transports |
 | `client_id` | string | Optional pre-registered OAuth client ID for HTTP transports |
 | `client_secret` | string | Optional pre-registered OAuth client secret |
 | `scopes` | string | Optional OAuth scope string for login/consent |
 | `protocol_version` | string | Optional MCP protocol version override |
 | `protocol_mode` | string | Optional MCP client profile: `legacy` (default) or `rc` |
+
+`token_exchange` is off when omitted. When present, Harn exchanges the base
+bearer for a transient delegated bearer while a session actor chain is active,
+then sends the delegated token on the MCP HTTP request. The token is not stored
+as the base credential. Common keys are `token_url`, required `actor_token`,
+`actor_token_type` (`jwt` by default), `subject_token_type` (`access_token` by
+default), `requested_token_type`, `scope`, `resource`, `audience`, and optional
+client-auth fields `client_id`, `client_secret`, and
+`token_endpoint_auth_method`.
 
 The connected clients are available as properties on the `mcp` global dict:
 


### PR DESCRIPTION
Closes #3342

## Summary
- add per-server HTTP MCP token_exchange config and RFC 8693 delegated bearer exchange
- preserve OAuth-store token refresh/source tracking so delegated calls reuse the existing refresh path
- document the harn.toml option and add focused loopback coverage for delegated bearer and unsupported-grant fallback

## Verification
- cargo fmt --check
- git diff --check
- CARGO_TARGET_DIR=/tmp/harn-target-3342 cargo test -p harn-vm mcp -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-target-3342 cargo test -p harn-cli mcp_server_config_parses_token_exchange_row -- --nocapture
- CARGO_TARGET_DIR=/tmp/harn-target-3342 cargo check -p harn-cli
- pre-commit hook: markdown, rustfmt, prompt-prose lint, changed-package clippy
- pre-push hook: markdown and targeted local checks