### PR TITLE
Pin Fireworks GPT-OSS to JSON text tools

### DIFF
--- a/changelog.d/3426.fixed.md
+++ b/changelog.d/3426.fixed.md
@@ -1,0 +1,4 @@
+- **Fireworks GPT-OSS provider capabilities (#3426).** Fireworks-hosted GPT-OSS
+  routes now default to fenced-JSON text tools instead of native tool calls, so
+  agent loops avoid billed empty native completions with no dispatchable tool
+  calls.

--- a/conformance/tests/scenarios/provider_capabilities_basic.harn
+++ b/conformance/tests/scenarios/provider_capabilities_basic.harn
@@ -86,6 +86,16 @@ pipeline test(task) {
   let together_gpt_oss = provider_capabilities("together", "openai/gpt-oss-120b")
   assert(together_gpt_oss.thinking_modes[0] == "effort", "Together GPT-OSS exposes effort thinking")
   assert(together_gpt_oss.reasoning_effort_supported, "Together GPT-OSS accepts reasoning_effort")
+  let fireworks_gpt_oss = provider_capabilities("fireworks", "accounts/fireworks/models/gpt-oss-120b")
+  assert(!fireworks_gpt_oss.native_tools, "Fireworks GPT-OSS disables native tools")
+  assert(
+    fireworks_gpt_oss.preferred_tool_format == "json",
+    "Fireworks GPT-OSS defaults to JSON text tools",
+  )
+  assert(
+    fireworks_gpt_oss.text_tool_wire_format_supported,
+    "Fireworks GPT-OSS supports text tool formatting",
+  )
   let together_kimi = provider_capabilities("together", "moonshotai/Kimi-K2.5")
   assert(together_kimi.thinking_modes[0] == "enabled", "Together Kimi exposes reasoning.enabled")
   assert(

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -2355,18 +2355,24 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
     }
 
     #[test]
-    fn fireworks_deepinfra_sambanova_gpt_oss_require_reasoning_for_tools() {
+    fn routed_gpt_oss_requires_reasoning_for_tools_with_provider_specific_tool_wire() {
         // gpt-oss (Harmony) calls tools INSIDE the chain-of-thought channel, so
-        // reasoning-off breaks tool calling. The fireworks/deepinfra/sambanova
-        // catch-all rules carry no reasoning fields, so without a dedicated
-        // `*gpt-oss*` row gpt-oss would fall through to reasoning-OFF and the
-        // eval loop would bill a noncommittal. These rows mirror the Cerebras
-        // gpt-oss capability row. Regression guard for that resolution.
+        // reasoning-off breaks tool calling. Provider catch-all rules carry no
+        // reasoning fields, so without a dedicated `*gpt-oss*` row gpt-oss
+        // would fall through to reasoning-OFF and the eval loop would bill a
+        // noncommittal. Tool wire support is provider-specific: Fireworks'
+        // native channel currently bills empty eval completions, while
+        // DeepInfra/SambaNova still use the native Harmony channel.
         reset();
-        for (provider, model) in [
-            ("fireworks", "accounts/fireworks/models/gpt-oss-120b"),
-            ("deepinfra", "openai/gpt-oss-120b"),
-            ("sambanova", "gpt-oss-120b"),
+        for (provider, model, native_tools, preferred_tool_format) in [
+            (
+                "fireworks",
+                "accounts/fireworks/models/gpt-oss-120b",
+                false,
+                "json",
+            ),
+            ("deepinfra", "openai/gpt-oss-120b", true, "native"),
+            ("sambanova", "gpt-oss-120b", true, "native"),
         ] {
             let caps = lookup(provider, model);
             assert!(
@@ -2384,9 +2390,13 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
             );
             assert_eq!(caps.thinking_modes, vec!["effort"], "{provider}/{model}");
             assert_eq!(
+                caps.native_tools, native_tools,
+                "{provider}/{model}: native_tools"
+            );
+            assert_eq!(
                 caps.preferred_tool_format.as_deref(),
-                Some("native"),
-                "{provider}/{model}: native tools"
+                Some(preferred_tool_format),
+                "{provider}/{model}: preferred tool format"
             );
             assert_eq!(
                 caps.thinking_block_style, "reasoning_summary",

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -1555,23 +1555,15 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
 
-# Fireworks-hosted GPT-OSS (`accounts/fireworks/models/gpt-oss-120b`) is the
-# same Harmony model as cerebras/groq/openrouter gpt-oss-120b. Without this
-# row gpt-oss would fall through to no fireworks-specific reasoning rule, so
-# `reasoning_required_for_tools` resolves OFF and the eval loop bills a
-# noncommittal (tools never fire inside the chain-of-thought channel). Mirror
-# the Cerebras gpt-oss capability row: NATIVE tool calls (gpt-oss emits a bare
-# `{"tool":..,"arguments":..}` dialect that the fenced-JSON/text parsers do
-# not recognize, so native is the only working channel), reasoning-effort
-# thinking with {low, medium, high}, and `reasoning_required_for_tools = true`
-# so an auto "off" floors to the lowest accepted effort rather than disabling
-# the channel tools call from. Must NOT carry a Qwen-style
-# `auto_reasoning_overrides = "off"` — that would break tool calling.
+# Fireworks-hosted GPT-OSS (`accounts/fireworks/models/gpt-oss-120b`) currently
+# bills empty native completions with no dispatchable tool calls in eval JSONL.
+# Keep this route on Harn's fenced-JSON text channel until Fireworks' native
+# tool-call path is proven clean.
 [[provider.fireworks]]
-model_match = "*gpt-oss*"
-native_tools = true
-preferred_tool_format = "native"
-structured_output = "native"
+model_match = "accounts/fireworks/models/gpt-oss-*"
+native_tools = false
+preferred_tool_format = "json"
+text_tool_wire_format_supported = true
 thinking_modes = ["effort"]
 reasoning_effort_supported = true
 reasoning_effort_levels = ["low", "medium", "high"]

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/30-qwen-routed.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/30-qwen-routed.toml
@@ -47,23 +47,15 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
 
-# Fireworks-hosted GPT-OSS (`accounts/fireworks/models/gpt-oss-120b`) is the
-# same Harmony model as cerebras/groq/openrouter gpt-oss-120b. Without this
-# row gpt-oss would fall through to no fireworks-specific reasoning rule, so
-# `reasoning_required_for_tools` resolves OFF and the eval loop bills a
-# noncommittal (tools never fire inside the chain-of-thought channel). Mirror
-# the Cerebras gpt-oss capability row: NATIVE tool calls (gpt-oss emits a bare
-# `{"tool":..,"arguments":..}` dialect that the fenced-JSON/text parsers do
-# not recognize, so native is the only working channel), reasoning-effort
-# thinking with {low, medium, high}, and `reasoning_required_for_tools = true`
-# so an auto "off" floors to the lowest accepted effort rather than disabling
-# the channel tools call from. Must NOT carry a Qwen-style
-# `auto_reasoning_overrides = "off"` — that would break tool calling.
+# Fireworks-hosted GPT-OSS (`accounts/fireworks/models/gpt-oss-120b`) currently
+# bills empty native completions with no dispatchable tool calls in eval JSONL.
+# Keep this route on Harn's fenced-JSON text channel until Fireworks' native
+# tool-call path is proven clean.
 [[provider.fireworks]]
-model_match = "*gpt-oss*"
-native_tools = true
-preferred_tool_format = "native"
-structured_output = "native"
+model_match = "accounts/fireworks/models/gpt-oss-*"
+native_tools = false
+preferred_tool_format = "json"
+text_tool_wire_format_supported = true
 thinking_modes = ["effort"]
 reasoning_effort_supported = true
 reasoning_effort_levels = ["low", "medium", "high"]

--- a/docs/provider-support.json
+++ b/docs/provider-support.json
@@ -444,23 +444,23 @@
         "FIREWORKS_API_KEY"
       ],
       "recommended": {
-        "selector": "fireworks:*gpt-oss*",
+        "selector": "fireworks:accounts/fireworks/models/gpt-oss-*",
         "provider": "fireworks",
-        "model": "*gpt-oss*",
+        "model": "accounts/fireworks/models/gpt-oss-*",
         "display_name": null,
-        "tool_format": "native",
+        "tool_format": "json",
         "harn_options": [
           "provider = \"fireworks\"",
-          "tool_format = \"native\"",
+          "tool_format = \"json\"",
           "structured_output_mode = \"native_json\""
         ]
       },
       "capabilities": {
-        "native_tools": true,
+        "native_tools": false,
         "text_tools": true,
-        "preferred_tool_format": "native",
-        "tool_mode_parity": "unknown",
-        "structured_output_transport": "native",
+        "preferred_tool_format": "json",
+        "tool_mode_parity": "text_only",
+        "structured_output_transport": "none",
         "structured_output_mode": "native_json",
         "streaming": true,
         "reasoning_knobs": [

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -55,7 +55,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `deepseek` | `deepseek-v4-flash*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `deepseek` | `deepseek-chat*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | yes |
 | `deepseek` | `deepseek-reasoner*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
-| `fireworks` | `*gpt-oss*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `fireworks` | `accounts/fireworks/models/gpt-oss-*` | `any` | `effort` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `json` | no | yes | `text_only` | yes | no |
 | `fireworks` | `*qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `fireworks` | `*qwen3p6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `fireworks` | `*qwen*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |

--- a/docs/src/provider-support.md
+++ b/docs/src/provider-support.md
@@ -19,7 +19,7 @@ No benchmark summary is baked into this checked-in page. To layer local empirica
 | `Dashscope` | OpenAI-compatible chat completions | `dashscope:qwen3.6*` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `provider_default` | `not_recorded` |
 | `Deepinfra` | OpenAI-compatible chat completions | `deepinfra:deepinfra/Qwen/Qwen3.6-35B-A3B` | `native` | yes | yes | `native` / `native_json` | `enabled` | no | `high` | `not_recorded` |
 | `Deepseek` | OpenAI-compatible chat completions | `deepseek:deepseek-v4-flash` | `native` | yes | yes | `native` / `native_json` | `enabled` | yes | `high` | `not_recorded` |
-| `Fireworks` | OpenAI-compatible chat completions | `fireworks:*gpt-oss*` | `native` | yes | yes | `native` / `native_json` | `effort,reasoning_effort` | no | `provider_default` | `not_recorded` |
+| `Fireworks` | OpenAI-compatible chat completions | `fireworks:accounts/fireworks/models/gpt-oss-*` | `json` | no | yes | `none` / `native_json` | `effort,reasoning_effort` | no | `provider_default` | `not_recorded` |
 | `Gemini API` | Gemini generateContent | `gemini:gemini-2.5-flash` | `native` | yes | yes | `native` / `native_json` | `adaptive,effort,enabled` | yes | `medium` | `not_recorded` |
 | `Groq` | OpenAI-compatible chat completions | `groq:llama-3.1-8b-instant` | `native` | yes | yes | `native` / `native_json` | none | no | `high` | `not_recorded` |
 | `Huggingface` | OpenAI-compatible chat completions | `huggingface:qwen/qwen3.6*` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `provider_default` | `not_recorded` |


### PR DESCRIPTION
## Summary

- Pin Fireworks `accounts/fireworks/models/gpt-oss-*` capability lookup to `native_tools = false` and `preferred_tool_format = "json"`.
- Preserve the GPT-OSS reasoning capability metadata while adding explicit text-tool support.
- Regenerate provider capability/support/matrix artifacts and cover the lookup in conformance.

## Why

Current eval JSONL shows Fireworks GPT-OSS native tool calls billing empty completions without dispatchable tool calls. This keeps that route on Harn's fenced-JSON text channel until the native path is proven clean.

## Validation

- `make check-provider-capabilities`
- `HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test conformance tests/scenarios/provider_capabilities_basic.harn`
- `make check-provider-support`
- `make check-provider-matrix`
- pre-commit hooks: markdownlint, Harn format, Harn lint, CI ratchets
- pre-push hooks: markdownlint, targeted local Rust/Harn checks