### PR TITLE
Add Slack outbound disclosure artifacts

### DIFF
--- a/changelog.d/3340.added.md
+++ b/changelog.d/3340.added.md
@@ -1,0 +1,6 @@
+- **Slack outbound disclosure now carries actor-chain bylines and AI markers (#3340).**
+  `std/disclosure` exposes `slack_message_disclosure(...)`, and
+  `std/connectors/slack.post_message` attaches that artifact from an
+  `actor_chain` option so Slack connector packages can fall back to textual
+  bylines unless `chat:write.customize` is granted and can emit
+  machine-readable AI metadata where the surface supports it.

--- a/conformance/tests/stdlib/disclosure_slack_message.expected
+++ b/conformance/tests/stdlib/disclosure_slack_message.expected
@@ -1,0 +1,15 @@
+AI-assisted by Merge Captain for Kenneth Sinder.
+slack_message_disclosure
+AI-assisted by Merge Captain for Kenneth Sinder.
+chat:write.customize
+Merge Captain
+:harn:
+harn.ai_disclosure.v1
+ai_generated
+eu_ai_act_article_50
+agent:merge-captain
+true
+true
+true
+true
+user:kenneth

--- a/conformance/tests/stdlib/disclosure_slack_message.harn
+++ b/conformance/tests/stdlib/disclosure_slack_message.harn
@@ -1,0 +1,30 @@
+import { render, slack_message_disclosure } from "std/disclosure"
+
+pipeline default() {
+  let chain = {sub: "user:kenneth", act: {sub: "agent:merge-captain"}}
+  let config = {
+    identities: {
+      "user:kenneth": {name: "Kenneth Sinder", email: "kenneth@example.com"},
+      "agent:merge-captain": {name: "Merge Captain", label: "Merge Captain", email: "merge-captain@bots.example"},
+    },
+    surfaces: {slack: {customize_icon_emoji: ":harn:"}},
+  }
+  let options = {project: false, env: false, config: config}
+  let byline = render(chain, "slack", options)
+  let disclosure = slack_message_disclosure(chain, options)
+  __io_println(byline)
+  __io_println(disclosure.kind)
+  __io_println(disclosure.byline)
+  __io_println(disclosure.customize.scope)
+  __io_println(disclosure.customize.username)
+  __io_println(disclosure.customize.icon_emoji)
+  __io_println(disclosure.ai_mark.event_type)
+  __io_println(disclosure.ai_mark.event_payload.kind)
+  __io_println(disclosure.ai_mark.event_payload.standard)
+  __io_println(disclosure.ai_mark.event_payload.principals[0].subject)
+  __io_println(disclosure.ai_mark.event_payload.principals[0].email == nil)
+  __io_println(disclosure.ai_mark.event_payload.actor_chain[0].email == nil)
+  __io_println(disclosure.principals[0].email == nil)
+  __io_println(disclosure.actor_chain[0].email == nil)
+  __io_println(disclosure.ai_mark.event_payload.principals[1].subject)
+}

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -1437,6 +1437,10 @@ mod tests {
             "std/disclosure should export git_trailers"
         );
         assert!(
+            exports.contains("slack_message_disclosure"),
+            "std/disclosure should export slack_message_disclosure"
+        );
+        assert!(
             exports.contains("append_git_trailers"),
             "std/disclosure should export append_git_trailers"
         );

--- a/crates/harn-stdlib/src/stdlib/stdlib_connectors_slack.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_connectors_slack.harn
@@ -1,14 +1,27 @@
 import { filter_nil } from "std/collections"
+import { slack_message_disclosure } from "std/disclosure"
 import { merge } from "std/json"
 import { wait_for } from "std/monitors"
 
 var slack_connector_config = {}
 
+/**
+ * Configure default parameters merged into every Slack connector call.
+ *
+ * @effects: []
+ * @errors: []
+ */
 pub fn configure(config) {
   slack_connector_config = filter_nil(config ?? {})
   return slack_connector_config
 }
 
+/**
+ * Clear module-level Slack connector defaults.
+ *
+ * @effects: []
+ * @errors: []
+ */
 pub fn reset() {
   slack_connector_config = {}
 }
@@ -17,10 +30,52 @@ fn __call(method, params = {}) {
   return connector_call("slack", method, filter_nil(merge(slack_connector_config, params ?? {})))
 }
 
-pub fn post_message(channel, text, blocks = nil, options = nil) {
-  return __call("post_message", filter_nil(options ?? {} + {channel: channel, text: text, blocks: blocks}))
+fn __configured_slack_disclosure(options) {
+  return options?._harn?.disclosure?.slack ?? options?.slack_disclosure ?? options?.disclosure?.slack
 }
 
+fn __slack_actor_chain(options) {
+  return options?.actor_chain ?? options?._harn?.actor_chain ?? options?.harn_actor_chain
+}
+
+fn __slack_disclosure_options(options) {
+  return options?.disclosure_options ?? options?._harn?.disclosure_options ?? {}
+}
+
+fn __with_slack_disclosure(options) {
+  let opts = options ?? {}
+  if __configured_slack_disclosure(opts) != nil {
+    return opts
+  }
+  let chain = __slack_actor_chain(opts)
+  if chain == nil {
+    return opts
+  }
+  let disclosure = slack_message_disclosure(chain, __slack_disclosure_options(opts))
+  let harn = merge(opts?._harn ?? {}, {disclosure: merge(opts?._harn?.disclosure ?? {}, {slack: disclosure})})
+  return merge(opts, {_harn: harn})
+}
+
+/**
+ * Post a Slack channel or thread message.
+ *
+ * When `options.actor_chain` is present, the call carries Slack disclosure
+ * metadata for connector-side byline and AI-mark handling.
+ *
+ * @effects: [net]
+ * @errors: [ConnectorError]
+ */
+pub fn post_message(channel, text, blocks = nil, options = nil) {
+  let opts = __with_slack_disclosure(options)
+  return __call("post_message", filter_nil(merge(opts, {channel: channel, text: text, blocks: blocks})))
+}
+
+/**
+ * Update an existing Slack message.
+ *
+ * @effects: [net]
+ * @errors: [ConnectorError]
+ */
 pub fn update_message(channel, ts, text, blocks = nil, options = nil) {
   return __call(
     "update_message",
@@ -28,22 +83,52 @@ pub fn update_message(channel, ts, text, blocks = nil, options = nil) {
   )
 }
 
+/**
+ * Add a reaction to a Slack message.
+ *
+ * @effects: [net]
+ * @errors: [ConnectorError]
+ */
 pub fn add_reaction(channel, ts, name, options = nil) {
   return __call("add_reaction", options ?? {} + {channel: channel, ts: ts, name: name})
 }
 
+/**
+ * Open a Slack modal view for an interaction trigger.
+ *
+ * @effects: [net]
+ * @errors: [ConnectorError]
+ */
 pub fn open_view(trigger_id, view, options = nil) {
   return __call("open_view", options ?? {} + {trigger_id: trigger_id, view: view})
 }
 
+/**
+ * Fetch Slack user profile information.
+ *
+ * @effects: [net]
+ * @errors: [ConnectorError]
+ */
 pub fn user_info(user_id, options = nil) {
   return __call("user_info", options ?? {} + {user_id: user_id})
 }
 
+/**
+ * Call a raw Slack Web API method through the active connector.
+ *
+ * @effects: [net]
+ * @errors: [ConnectorError]
+ */
 pub fn api_call(method, args = nil, options = nil) {
   return __call("api_call", filter_nil(options ?? {} + {method: method, args: args ?? {}}))
 }
 
+/**
+ * Upload file content through the active Slack connector.
+ *
+ * @effects: [net]
+ * @errors: [ConnectorError]
+ */
 pub fn upload_file(filename, content, options = nil) {
   return __call("upload_file", options ?? {} + {filename: filename, content: content})
 }

--- a/crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn
@@ -25,6 +25,10 @@ template = "{{ if delegated }}Co-Authored-By: {{ current.name }} <{{ current.ema
 [surfaces.slack]
 kind = "text"
 template = "AI-assisted by {{ current.label }} for {{ origin.label }}."
+customize_name_template = "{{ current.label }}"
+ai_mark_enabled = true
+ai_mark_event_type = "harn.ai_disclosure.v1"
+ai_mark_standard = "eu_ai_act_article_50"
 
 [surfaces.github]
 kind = "github_author_choice"
@@ -282,6 +286,17 @@ fn __render_text(surface_config: dict, ctx: dict) -> string {
   return render_string(to_string(template), ctx)
 }
 
+fn __render_optional_template(template, ctx: dict) {
+  if template == nil || trim(to_string(template)) == "" {
+    return nil
+  }
+  let rendered = trim(render_string(to_string(template), ctx))
+  if rendered == "" {
+    return nil
+  }
+  return rendered
+}
+
 fn __github_author_mode(surface_config: dict) -> string {
   let mode = lowercase(trim(to_string(surface_config?.author_mode ?? "human")))
   if mode == "human" || mode == "bot" {
@@ -373,6 +388,77 @@ fn __render_github(surface_config: dict, ctx: dict, config: dict) -> dict {
     trailers: trailers,
     principals: ctx.principals,
     actor_chain: ctx.chain,
+  }
+}
+
+fn __public_principals(ctx: dict) -> list<dict> {
+  var principals = []
+  for principal in ctx.principals {
+    principals = principals
+      .push(
+      {
+        subject: principal.subject,
+        kind: principal.kind,
+        role: principal.role,
+        position: principal.position,
+        label: principal.label,
+        human: principal?.human,
+      },
+    )
+  }
+  return principals
+}
+
+fn __slack_customize(surface_config: dict, ctx: dict) -> dict {
+  let username = __render_optional_template(surface_config?.customize_name_template, ctx)
+  var customize = {scope: "chat:write.customize", enabled: surface_config?.customize_enabled != false}
+  if username != nil {
+    customize["username"] = username
+  }
+  if surface_config?.customize_icon_url != nil
+    && trim(to_string(surface_config.customize_icon_url)) != "" {
+    customize["icon_url"] = to_string(surface_config.customize_icon_url)
+  }
+  if surface_config?.customize_icon_emoji != nil
+    && trim(to_string(surface_config.customize_icon_emoji)) != "" {
+    customize["icon_emoji"] = to_string(surface_config.customize_icon_emoji)
+  }
+  return customize
+}
+
+fn __slack_ai_mark(surface_config: dict, ctx: dict, byline: string) -> dict {
+  let enabled = surface_config?.ai_mark_enabled != false
+  let standard = to_string(surface_config?.ai_mark_standard ?? "eu_ai_act_article_50")
+  let event_type = to_string(surface_config?.ai_mark_event_type ?? "harn.ai_disclosure.v1")
+  let principals = __public_principals(ctx)
+  return {
+    enabled: enabled,
+    event_type: event_type,
+    event_payload: {
+      kind: "ai_generated",
+      standard: standard,
+      generator: "harn",
+      surface: "slack",
+      disclosure: byline,
+      actor_chain: principals,
+      principals: principals,
+    },
+  }
+}
+
+fn __slack_message_disclosure(config: dict, ctx: dict) -> dict {
+  let surface_config = __surface_config(config, "slack")
+  let byline = __render_text(surface_config, ctx)
+  let principals = __public_principals(ctx)
+  return {
+    surface: "slack",
+    kind: "slack_message_disclosure",
+    byline: byline,
+    text_prefix: byline + "\n\n",
+    customize: __slack_customize(surface_config, ctx),
+    ai_mark: __slack_ai_mark(surface_config, ctx, byline),
+    principals: principals,
+    actor_chain: principals,
   }
 }
 
@@ -502,6 +588,23 @@ pub fn render(chain, surface: string, options: DisclosureRenderOptions = {}) -> 
     return __render_github(surface_config, ctx, config)
   }
   throw "std/disclosure: unsupported disclosure surface kind `" + kind + "`"
+}
+
+/**
+ * Render Slack outbound disclosure metadata for connector calls.
+ *
+ * `render(chain, "slack")` remains the human-readable byline string. This
+ * helper returns the structured payload consumed by Slack connector packages:
+ * textual fallback byline, optional `chat:write.customize` identity hints, and
+ * a default-on machine-readable AI marker.
+ *
+ * @effects: [fs-read, env-read]
+ * @errors: [TypeError, ValueError]
+ */
+pub fn slack_message_disclosure(chain, options: DisclosureRenderOptions = {}) -> dict {
+  let config = __config(options)
+  let ctx = __context(chain, config)
+  return __slack_message_disclosure(config, ctx)
 }
 
 /**

--- a/docs/src/stdlib/disclosure.md
+++ b/docs/src/stdlib/disclosure.md
@@ -6,7 +6,7 @@ same actor chain represented in a surface-native form such as Git trailers,
 a Slack byline, or a GitHub author-mode decision.
 
 ```harn
-import { append_git_trailers, render } from "std/disclosure"
+import { append_git_trailers, render, slack_message_disclosure } from "std/disclosure"
 
 pipeline default() {
   let chain = {
@@ -17,6 +17,7 @@ pipeline default() {
   let trailers = render(chain, "git")
   let commit_message = append_git_trailers("Fix the merge gate", chain)
   let byline = render(chain, "slack")
+  let slack = slack_message_disclosure(chain)
   let github = render(chain, "github")
 }
 ```
@@ -28,6 +29,13 @@ Built-in surfaces:
 | `git` | Trailer block string |
 | `slack` | Byline string |
 | `github` | `{kind: "github_author_choice", author_mode, commit_auth_identity, pull_request_auth_identity, author, co_author, commit_author, trailers, principals, actor_chain}` |
+
+`slack_message_disclosure(chain, options?)` returns the connector-facing Slack
+artifact: `{kind: "slack_message_disclosure", byline, customize, ai_mark,
+principals, actor_chain}`. Slack connector packages use `customize` only when
+the granted scopes include `chat:write.customize`; otherwise they post under
+the app identity and render `byline` as text. `ai_mark` is default-on and is
+designed to be embedded in surfaces that support machine-readable metadata.
 
 `git_trailers(chain, options?)` is a typed convenience wrapper around the
 `git` surface. `append_git_trailers(message, chain, options?)` appends that
@@ -68,6 +76,10 @@ github = "merge-captain-bot"
 [disclosure.surfaces.slack]
 kind = "text"
 template = "AI-assisted by {{ current.label }} for {{ origin.label }}."
+customize_name_template = "{{ current.label }}"
+customize_icon_emoji = ":robot_face:"
+ai_mark_enabled = true
+ai_mark_event_type = "harn.ai_disclosure.v1"
 
 [disclosure.surfaces.github]
 kind = "github_author_choice"


### PR DESCRIPTION
## Summary
- Add `std/disclosure.slack_message_disclosure(...)` with actor-chain byline text, `chat:write.customize` identity hints, and a default-on AI disclosure marker for Slack surfaces.
- Wire `std/connectors/slack.post_message` to attach that disclosure artifact when callers pass an `actor_chain`, while preserving `render(chain, "slack")` as the plain byline string.
- Document the Slack disclosure config and add conformance coverage for a 2-actor chain, scope hinting, default AI marking, and public-only metadata.

Companion connector PR: burin-labs/harn-slack-connector#104.

Closes #3340.

## Verification
- `cargo run --quiet --bin harn -- test conformance --filter disclosure_slack_message`
- `cargo run --quiet --bin harn -- test conformance --filter disclosure_`
- `cargo test -p harn-stdlib`
- `make lint-harn`
- `make fmt-harn`
- `make check-docs-snippets`
- `make lint-test-patterns`
- `make test`
- `harn connector test /Users/ksinder/projects/harn-slack-connector-wt/3340 --provider slack`