### PR TITLE
Add A2A actor-chain capability tracking

### DIFF
--- a/changelog.d/3329.added.md
+++ b/changelog.d/3329.added.md
@@ -1,0 +1,3 @@
+- Carry RFC 8693 actor-chain metadata across A2A dispatch, serve, and
+  push-trigger flows, and add draft-tracking OAuth token-exchange capability
+  rows for ID-JAG, transaction tokens, and WIMSE WIT/WPT.

--- a/conformance/tests/stdlib/oauth/oauth_token_exchange_capability_overlay.harn
+++ b/conformance/tests/stdlib/oauth/oauth_token_exchange_capability_overlay.harn
@@ -40,6 +40,51 @@ pipeline test(task) {
     "https://idp.example/exchange",
     "overlay row installed",
   )
+  assert_eq(
+    token_type("id-jag"),
+    "urn:ietf:params:oauth:token-type:id-jag",
+    "ID-JAG token alias normalized",
+  )
+  assert_eq(
+    token_type("txn_token"),
+    "urn:ietf:params:oauth:token-type:txn_token",
+    "transaction-token alias normalized",
+  )
+  assert_eq(
+    catalog["id-jag"].requested_token_types,
+    ["urn:ietf:params:oauth:token-type:id-jag"],
+    "ID-JAG requested token type pinned",
+  )
+  assert(
+    catalog["id-jag"].provider_metadata_fields
+      .contains("identity_chaining_requested_token_types_supported"),
+    "ID-JAG metadata detection field recorded",
+  )
+  assert_eq(
+    catalog["id-jag"].tracking.drafts[0].name,
+    "draft-ietf-oauth-identity-assertion-authz-grant-04",
+    "ID-JAG draft revision pinned",
+  )
+  assert_eq(
+    catalog["txn-token"].requested_token_types,
+    ["urn:ietf:params:oauth:token-type:txn_token"],
+    "transaction-token requested token type pinned",
+  )
+  assert_eq(
+    catalog["txn-token"].tracking.drafts[0].name,
+    "draft-ietf-oauth-transaction-tokens-08",
+    "transaction-token draft revision pinned",
+  )
+  assert_eq(catalog["wimse-wit-wpt"].supported, false, "WIMSE row is tracking-only")
+  assert(
+    catalog["wimse-wit-wpt"].provider_metadata_fields.contains("Workload-Proof-Token"),
+    "WIMSE WPT detection field recorded",
+  )
+  assert_eq(
+    catalog["wimse-wit-wpt"].tracking.drafts[0].name,
+    "draft-ietf-wimse-workload-creds-01",
+    "WIMSE workload credential draft revision pinned",
+  )
   catches_message(
     "malformed overlay entries fail closed",
     { -> token_exchange_catalog({broken: true}) },

--- a/crates/harn-serve/src/adapters/a2a.rs
+++ b/crates/harn-serve/src/adapters/a2a.rs
@@ -204,6 +204,7 @@ struct PreparedTask {
     auth: AuthRequest,
     caller: String,
     trace_id: Option<harn_vm::TraceId>,
+    actor_chain: Option<harn_vm::actor_chain::ActorChain>,
     cancel_token: Arc<AtomicBool>,
 }
 

--- a/crates/harn-serve/src/adapters/a2a/schema.rs
+++ b/crates/harn-serve/src/adapters/a2a/schema.rs
@@ -600,6 +600,32 @@ pub(super) fn caller_label(params: &JsonValue) -> String {
         .to_string()
 }
 
+pub(super) fn actor_chain_param(
+    params: &JsonValue,
+) -> Result<Option<harn_vm::actor_chain::ActorChain>, A2aPrepareError> {
+    let Some((pointer, value)) = harn_vm::a2a::actor_chain_metadata_candidate(params) else {
+        return Ok(None);
+    };
+    harn_vm::actor_chain::ActorChain::from_json_value(value)
+        .map(Some)
+        .map_err(|error| {
+            A2aPrepareError::new(
+                -32602,
+                format!("A2A actor_chain metadata is invalid at {pointer}: {error}"),
+            )
+        })
+}
+
+pub(super) fn actor_chain_task_metadata(
+    chain: &harn_vm::actor_chain::ActorChain,
+) -> BTreeMap<String, JsonValue> {
+    let chain = chain.to_json_value();
+    BTreeMap::from([
+        ("actor_chain".to_string(), chain.clone()),
+        ("harn".to_string(), json!({"actor_chain": chain})),
+    ])
+}
+
 /// Construct the A2A prepare-error for a scope mismatch. Shared by the
 /// task-prepare scope preflight and any future preflight at the protocol
 /// layer so the wire format (`-32003`, `data.required_scopes`, etc.) and

--- a/crates/harn-serve/src/adapters/a2a/tasks.rs
+++ b/crates/harn-serve/src/adapters/a2a/tasks.rs
@@ -45,6 +45,11 @@ impl A2aServer {
             .cloned()
             .or_else(|| context_id.clone())
             .map(harn_vm::TraceId);
+        let actor_chain = actor_chain_param(params)?;
+        let metadata = actor_chain
+            .as_ref()
+            .map(actor_chain_task_metadata)
+            .unwrap_or_default();
         let push_config = params
             .pointer("/configuration/pushNotificationConfig")
             .cloned();
@@ -59,7 +64,7 @@ impl A2aServer {
                 parts: parts.clone(),
             }],
             artifacts: a2a_artifacts_from_parts(&parts),
-            metadata: BTreeMap::new(),
+            metadata,
             events: Vec::new(),
             subscribers: Vec::new(),
             cancel_token: Some(cancel_token.clone()),
@@ -85,6 +90,7 @@ impl A2aServer {
             auth,
             caller: caller_label(params),
             trace_id,
+            actor_chain,
             cancel_token,
         })
     }
@@ -117,7 +123,7 @@ impl A2aServer {
                 metadata: BTreeMap::new(),
                 cancel_token: Some(task.cancel_token.clone()),
                 agent_session_id: Some(session_id.clone()),
-                actor_chain: None,
+                actor_chain: task.actor_chain.clone(),
                 actor_chain_hop: Some(self.agent_name.clone()),
                 progress: None,
                 tenant_id: None,

--- a/crates/harn-serve/src/adapters/a2a/tests/tasks.rs
+++ b/crates/harn-serve/src/adapters/a2a/tests/tasks.rs
@@ -39,6 +39,99 @@ pub fn triage(task: string) -> string {
 }
 
 #[tokio::test]
+async fn send_message_threads_actor_chain_into_task_and_session() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let script = dir.path().join("server.harn");
+    std::fs::write(
+        &script,
+        r#"
+pub fn actor_chain(task: string) -> string {
+  let chain = agent_session_actor_chain()
+  return chain.sub + "|" + chain.act.sub + "|" + chain.act.act.sub
+}
+"#,
+    )
+    .expect("write script");
+    let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
+    let server = Arc::new(A2aServer::new(A2aServerConfig::new(core)));
+    let request = harn_vm::jsonrpc::request(
+        "actor-chain-1",
+        "message/send",
+        json!({
+            "message": {
+                "metadata": {
+                    "target_agent": "actor_chain",
+                    "actor_chain": {
+                        "sub": "user:kenneth",
+                        "act": {"sub": "agent:caller"}
+                    }
+                },
+                "parts": [{"type": "text", "text": "hello"}]
+            }
+        }),
+    );
+
+    let processed = server.process_rpc(request, AuthRequest::default()).await;
+    let RpcOutcome::Json(response) = processed.outcome else {
+        panic!("expected json response");
+    };
+
+    assert_eq!(response["result"]["status"]["state"], "completed");
+    assert_eq!(
+        response["result"]["metadata"]["actor_chain"],
+        json!({"sub": "user:kenneth", "act": {"sub": "agent:caller"}}),
+    );
+    assert_eq!(
+        response["result"]["metadata"]["harn"]["actor_chain"],
+        response["result"]["metadata"]["actor_chain"],
+    );
+    assert_eq!(
+        response["result"]["history"][1]["parts"][0]["text"],
+        "user:kenneth|server|agent:caller",
+    );
+}
+
+#[tokio::test]
+async fn send_message_rejects_invalid_actor_chain_metadata() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let script = dir.path().join("server.harn");
+    std::fs::write(
+        &script,
+        r"
+pub fn triage(task: string) -> string {
+  return task
+}
+",
+    )
+    .expect("write script");
+    let core = DispatchCore::new(DispatchCoreConfig::for_script(&script)).expect("core");
+    let server = Arc::new(A2aServer::new(A2aServerConfig::new(core)));
+    let request = harn_vm::jsonrpc::request(
+        "actor-chain-invalid",
+        "message/send",
+        json!({
+            "message": {
+                "metadata": {
+                    "target_agent": "triage",
+                    "actor_chain": {"act": {"sub": "agent:caller"}}
+                },
+                "parts": [{"type": "text", "text": "hello"}]
+            }
+        }),
+    );
+
+    let processed = server.process_rpc(request, AuthRequest::default()).await;
+    let RpcOutcome::Json(response) = processed.outcome else {
+        panic!("expected json response");
+    };
+
+    assert_eq!(response["error"]["code"], -32602);
+    assert!(response["error"]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("actor_chain metadata is invalid")));
+}
+
+#[tokio::test]
 async fn send_message_round_trips_file_and_data_parts() {
     let dir = tempfile::tempdir().expect("tempdir");
     let script = dir.path().join("server.harn");

--- a/crates/harn-stdlib/src/stdlib/oauth/token_exchange.harn
+++ b/crates/harn-stdlib/src/stdlib/oauth/token_exchange.harn
@@ -23,6 +23,8 @@ type OAuthTokenExchangeCapability = {
   issued_token_types: list<string>,
   delegation: bool,
   impersonation: bool,
+  provider_metadata_fields: list<string>,
+  tracking?: dict,
   notes: list<string>,
 }
 
@@ -37,6 +39,15 @@ fn __normalize_token_type(name) {
   let key = lowercase(raw)
   if key == "access" {
     return __TOKEN_TYPE_PREFIX + "access_token"
+  }
+  if key == "id-jag" || key == "id_jag" {
+    return __TOKEN_TYPE_PREFIX + "id-jag"
+  }
+  if key == "txn" || key == "txn_token" {
+    return __TOKEN_TYPE_PREFIX + "txn_token"
+  }
+  if key == "self_signed" || key == "unsigned_json" {
+    return __TOKEN_TYPE_PREFIX + key
   }
   if key == "access_token"
     || key == "refresh_token"
@@ -80,6 +91,8 @@ fn __normalize_row(raw) {
     issued_token_types: __normalize_token_types(raw?.issued_token_types ?? raw?.requested_token_types ?? []),
     delegation: raw?.delegation ?? true,
     impersonation: raw?.impersonation ?? true,
+    provider_metadata_fields: raw?.provider_metadata_fields ?? [],
+    tracking: raw?.tracking,
     notes: raw?.notes ?? [],
   }
 }

--- a/crates/harn-stdlib/src/stdlib/oauth/token_exchange_catalog.harn
+++ b/crates/harn-stdlib/src/stdlib/oauth/token_exchange_catalog.harn
@@ -8,6 +8,20 @@ let __JWT = "urn:ietf:params:oauth:token-type:jwt"
 
 let __ACCESS_TOKEN = "urn:ietf:params:oauth:token-type:access_token"
 
+let __REFRESH_TOKEN = "urn:ietf:params:oauth:token-type:refresh_token"
+
+let __ID_TOKEN = "urn:ietf:params:oauth:token-type:id_token"
+
+let __SAML2 = "urn:ietf:params:oauth:token-type:saml2"
+
+let __ID_JAG = "urn:ietf:params:oauth:token-type:id-jag"
+
+let __TXN_TOKEN = "urn:ietf:params:oauth:token-type:txn_token"
+
+let __SELF_SIGNED = "urn:ietf:params:oauth:token-type:self_signed"
+
+let __UNSIGNED_JSON = "urn:ietf:params:oauth:token-type:unsigned_json"
+
 /**
  * token_exchange_capability_rows returns the shipped capability catalog.
  *
@@ -28,8 +42,96 @@ pub fn token_exchange_capability_rows() -> list {
       issued_token_types: [__ACCESS_TOKEN, __JWT],
       delegation: true,
       impersonation: true,
+      provider_metadata_fields: [],
+      tracking: {status: "reference", drafts: []},
       notes: [
         "Reference row used by conformance tests and examples. Real authorization servers should ship or pass their own overlay row.",
+      ],
+    },
+    {
+      id: "id-jag",
+      label: "Identity Assertion JWT Authorization Grant",
+      supported: true,
+      subject_token_types: [__ID_TOKEN, __SAML2, __REFRESH_TOKEN],
+      actor_token_types: [__JWT],
+      requested_token_types: [__ID_JAG],
+      issued_token_types: [__ID_JAG],
+      delegation: true,
+      impersonation: true,
+      provider_metadata_fields: ["identity_chaining_requested_token_types_supported", "authorization_grant_profiles_supported"],
+      tracking: {
+        status: "ietf-draft",
+        drafts: [
+          {
+            name: "draft-ietf-oauth-identity-assertion-authz-grant-04",
+            url: "https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/",
+          },
+          {
+            name: "draft-ietf-oauth-identity-chaining-14",
+            url: "https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-chaining/",
+          },
+        ],
+      },
+      notes: [
+        "ID-JAG support is detected when RFC 8414 metadata includes urn:ietf:params:oauth:token-type:id-jag in identity_chaining_requested_token_types_supported.",
+        "Resource authorization servers advertise the profile with urn:ietf:params:oauth:grant-profile:id-jag in authorization_grant_profiles_supported.",
+        "draft-ietf-oauth-identity-assertion-authz-grant-04 allows actor_token but leaves normative actor processing to future profiles.",
+      ],
+    },
+    {
+      id: "txn-token",
+      label: "OAuth Transaction Tokens",
+      supported: true,
+      subject_token_types: [__ACCESS_TOKEN, __JWT, __ID_TOKEN, __SAML2, __SELF_SIGNED, __UNSIGNED_JSON],
+      actor_token_types: [],
+      requested_token_types: [__TXN_TOKEN],
+      issued_token_types: [__TXN_TOKEN],
+      delegation: false,
+      impersonation: true,
+      provider_metadata_fields: [],
+      tracking: {
+        status: "ietf-draft",
+        drafts: [
+          {
+            name: "draft-ietf-oauth-transaction-tokens-08",
+            url: "https://datatracker.ietf.org/doc/draft-ietf-oauth-transaction-tokens/",
+          },
+          {
+            name: "draft-araut-oauth-transaction-tokens-for-agents-02",
+            url: "https://datatracker.ietf.org/doc/draft-araut-oauth-transaction-tokens-for-agents/",
+          },
+        ],
+      },
+      notes: [
+        "Transaction tokens use RFC 8693 token exchange with requested_token_type urn:ietf:params:oauth:token-type:txn_token.",
+        "The base draft defines self_signed and unsigned_json subject token type URNs and forbids refresh_token responses.",
+        "The agent draft tracks actor-chain usage by preserving existing sub and act claims rather than defining a new grant type.",
+      ],
+    },
+    {
+      id: "wimse-wit-wpt",
+      label: "WIMSE Workload Identity Token and Workload Proof Token",
+      supported: false,
+      subject_token_types: [__JWT],
+      actor_token_types: [],
+      requested_token_types: [],
+      issued_token_types: [],
+      delegation: false,
+      impersonation: false,
+      provider_metadata_fields: ["Workload-Identity-Token", "Workload-Proof-Token"],
+      tracking: {
+        status: "tracking-only",
+        drafts: [
+          {
+            name: "draft-ietf-wimse-workload-creds-01",
+            url: "https://datatracker.ietf.org/doc/draft-ietf-wimse-workload-creds/",
+          },
+          {name: "draft-ietf-wimse-wpt-01", url: "https://datatracker.ietf.org/doc/draft-ietf-wimse-wpt/"},
+        ],
+      },
+      notes: [
+        "WIMSE WIT is a workload credential and WPT is proof of possession, not a bearer token-exchange profile.",
+        "Do not treat a WIT as a bearer token; WPT validation must prove possession of the key bound in the WIT.",
       ],
     },
   ]

--- a/crates/harn-vm/src/a2a/mod.rs
+++ b/crates/harn-vm/src/a2a/mod.rs
@@ -17,6 +17,34 @@ const A2A_PROTOCOL_VERSION: &str = "0.3.0";
 const A2A_JSONRPC_TRANSPORT: &str = "JSONRPC";
 const A2A_PUSH_URL_ENV: &str = "HARN_A2A_PUSH_URL";
 const A2A_PUSH_TOKEN_ENV: &str = "HARN_A2A_PUSH_TOKEN";
+const A2A_ACTOR_CHAIN_METADATA_POINTERS: &[&str] = &[
+    "/actor_chain",
+    "/actorChain",
+    "/metadata/actor_chain",
+    "/metadata/actorChain",
+    "/metadata/harn/actor_chain",
+    "/metadata/harn/actorChain",
+    "/metadata/_harn/actorChain",
+    "/statusUpdate/actor_chain",
+    "/statusUpdate/actorChain",
+    "/statusUpdate/metadata/actor_chain",
+    "/statusUpdate/metadata/actorChain",
+    "/statusUpdate/metadata/harn/actor_chain",
+    "/statusUpdate/metadata/harn/actorChain",
+    "/statusUpdate/metadata/_harn/actorChain",
+    "/task/actor_chain",
+    "/task/actorChain",
+    "/task/metadata/actor_chain",
+    "/task/metadata/actorChain",
+    "/task/metadata/harn/actor_chain",
+    "/task/metadata/harn/actorChain",
+    "/task/metadata/_harn/actorChain",
+    "/message/metadata/actor_chain",
+    "/message/metadata/actorChain",
+    "/message/metadata/harn/actor_chain",
+    "/message/metadata/harn/actorChain",
+    "/message/metadata/_harn/actorChain",
+];
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResolvedA2aEndpoint {
@@ -110,6 +138,24 @@ impl A2aClient for RealA2aClient {
     }
 }
 
+/// Return the first actor-chain metadata candidate accepted by Harn's A2A
+/// surfaces. Callers that accept invalid metadata should use
+/// [`actor_chain_from_metadata`]; callers that must reject malformed input can
+/// parse the returned value themselves and keep the pointer for diagnostics.
+pub fn actor_chain_metadata_candidate(value: &Value) -> Option<(&'static str, &Value)> {
+    for pointer in A2A_ACTOR_CHAIN_METADATA_POINTERS {
+        if let Some(candidate) = value.pointer(pointer) {
+            return Some((pointer, candidate));
+        }
+    }
+    None
+}
+
+pub fn actor_chain_from_metadata(value: &Value) -> Option<crate::actor_chain::ActorChain> {
+    actor_chain_metadata_candidate(value)
+        .and_then(|(_, candidate)| crate::actor_chain::ActorChain::from_json_value(candidate).ok())
+}
+
 #[derive(Debug)]
 enum AgentCardFetchError {
     Cancelled(String),
@@ -143,7 +189,10 @@ pub async fn dispatch_trigger_event(
         }
     };
     let message_id = format!("{}.{}", event.trace_id.0, event.id.0);
-    let envelope = serde_json::json!({
+    let actor_chain = crate::agent_sessions::current_actor_chain()
+        .as_ref()
+        .map(crate::actor_chain::ActorChain::to_json_value);
+    let mut envelope = serde_json::json!({
         "kind": "harn.trigger.dispatch",
         "message_id": message_id,
         "trace_id": event.trace_id.0,
@@ -153,9 +202,24 @@ pub async fn dispatch_trigger_event(
         "target_agent": endpoint.target_agent,
         "event": event,
     });
+    if let Some(chain) = actor_chain.as_ref() {
+        envelope["actor_chain"] = chain.clone();
+    }
     let text = serde_json::to_string(&envelope)
         .map_err(|error| A2aClientError::Protocol(format!("serialize A2A envelope: {error}")))?;
     let push_config = push_notification_config();
+    let mut metadata = serde_json::json!({
+        "kind": "harn.trigger.dispatch",
+        "trace_id": event.trace_id.0,
+        "event_id": event.id.0,
+        "trigger_id": binding_id,
+        "binding_key": binding_key,
+        "target_agent": endpoint.target_agent,
+    });
+    if let Some(chain) = actor_chain.as_ref() {
+        metadata["actor_chain"] = chain.clone();
+        metadata["harn"] = serde_json::json!({"actor_chain": chain});
+    }
     let mut params = serde_json::json!({
         "contextId": event.trace_id.0,
         "message": {
@@ -165,14 +229,7 @@ pub async fn dispatch_trigger_event(
                 "type": "text",
                 "text": text,
             }],
-            "metadata": {
-                "kind": "harn.trigger.dispatch",
-                "trace_id": event.trace_id.0,
-                "event_id": event.id.0,
-                "trigger_id": binding_id,
-                "binding_key": binding_key,
-                "target_agent": endpoint.target_agent,
-            },
+            "metadata": metadata,
         },
     });
     if let Some(config) = push_config.clone() {

--- a/crates/harn-vm/src/connectors/a2a_push/mod.rs
+++ b/crates/harn-vm/src/connectors/a2a_push/mod.rs
@@ -72,6 +72,16 @@ struct A2aPushJwtClaims {
     iat: i64,
     exp: i64,
     jti: String,
+    #[serde(default)]
+    sub: Option<String>,
+    #[serde(default)]
+    act: Option<JsonValue>,
+    #[serde(default)]
+    may_act: Option<JsonValue>,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    scopes: Option<Vec<String>>,
     #[serde(default, rename = "taskId")]
     task_id_camel: Option<String>,
     #[serde(default)]
@@ -469,6 +479,9 @@ fn normalize_a2a_push(body: &JsonValue, claims: Option<&A2aPushJwtClaims>) -> A2
     let artifact_update = body.get("artifactUpdate");
     let task = body.get("task");
     let message = body.get("message");
+    let actor_chain = crate::a2a::actor_chain_from_metadata(body)
+        .map(|chain| chain.to_json_value())
+        .or_else(|| claims.and_then(A2aPushJwtClaims::actor_chain));
     let task_id = status_update
         .and_then(|value| value.get("taskId"))
         .or_else(|| artifact_update.and_then(|value| value.get("taskId")))
@@ -510,6 +523,7 @@ fn normalize_a2a_push(body: &JsonValue, claims: Option<&A2aPushJwtClaims>) -> A2
         task_state,
         artifact,
         sender,
+        actor_chain,
         raw: body.clone(),
         kind,
     }
@@ -518,6 +532,38 @@ fn normalize_a2a_push(body: &JsonValue, claims: Option<&A2aPushJwtClaims>) -> A2
 impl A2aPushJwtClaims {
     fn task_id(&self) -> Option<String> {
         self.task_id.clone().or_else(|| self.task_id_camel.clone())
+    }
+
+    fn actor_chain(&self) -> Option<JsonValue> {
+        let sub = self.sub.as_deref()?.trim();
+        if sub.is_empty() {
+            return None;
+        }
+        let mut root = serde_json::Map::new();
+        root.insert("sub".to_string(), JsonValue::String(sub.to_string()));
+        if let Some(act) = self.act.as_ref() {
+            root.insert("act".to_string(), act.clone());
+        }
+        if let Some(may_act) = self.may_act.as_ref() {
+            root.insert("may_act".to_string(), may_act.clone());
+        }
+        if let Some(scopes) = self.scopes.as_ref().filter(|scopes| !scopes.is_empty()) {
+            root.insert(
+                "scopes".to_string(),
+                JsonValue::Array(
+                    scopes
+                        .iter()
+                        .cloned()
+                        .map(JsonValue::String)
+                        .collect::<Vec<_>>(),
+                ),
+            );
+        } else if let Some(scope) = self.scope.as_ref().filter(|scope| !scope.trim().is_empty()) {
+            root.insert("scope".to_string(), JsonValue::String(scope.clone()));
+        }
+        crate::actor_chain::ActorChain::from_json_value(&JsonValue::Object(root))
+            .ok()
+            .map(|chain| chain.to_json_value())
     }
 }
 
@@ -677,6 +723,16 @@ mod tests {
     }
 
     fn jwt(jti: &str, token: &str) -> String {
+        jwt_with_actor_chain(jti, token, None, None, None)
+    }
+
+    fn jwt_with_actor_chain(
+        jti: &str,
+        token: &str,
+        sub: Option<&str>,
+        act: Option<JsonValue>,
+        scope: Option<&str>,
+    ) -> String {
         let mut header = Header::new(Algorithm::HS256);
         header.kid = Some("test-key".to_string());
         encode(
@@ -687,6 +743,11 @@ mod tests {
                 iat: OffsetDateTime::now_utc().unix_timestamp(),
                 exp: OffsetDateTime::now_utc().unix_timestamp() + 300,
                 jti: jti.to_string(),
+                sub: sub.map(ToString::to_string),
+                act,
+                may_act: None,
+                scope: scope.map(ToString::to_string),
+                scopes: None,
                 task_id_camel: Some("task-123".to_string()),
                 task_id: None,
                 token: Some(token.to_string()),
@@ -735,7 +796,13 @@ mod tests {
             "statusUpdate": {
                 "taskId": "task-123",
                 "contextId": "ctx-1",
-                "status": {"state": "completed"}
+                "status": {"state": "completed"},
+                "metadata": {
+                    "actor_chain": {
+                        "sub": "user:kenneth",
+                        "act": {"sub": "agent:reviewer"}
+                    }
+                }
             }
         }))
         .unwrap();
@@ -757,6 +824,53 @@ mod tests {
         };
         assert_eq!(payload.task_id.as_deref(), Some("task-123"));
         assert_eq!(payload.task_state.as_deref(), Some("completed"));
+        assert_eq!(
+            payload.actor_chain,
+            Some(json!({"sub": "user:kenneth", "act": {"sub": "agent:reviewer"}})),
+        );
+    }
+
+    #[tokio::test]
+    async fn normalizes_actor_chain_from_jwt_claims_when_metadata_is_absent() {
+        let (connector, _inbox) = connector_with_binding(jwt_binding()).await;
+        let body = serde_json::to_vec(&json!({
+            "statusUpdate": {
+                "taskId": "task-123",
+                "contextId": "ctx-1",
+                "status": {"state": "completed"}
+            }
+        }))
+        .unwrap();
+        let mut headers = BTreeMap::new();
+        headers.insert(
+            "authorization".to_string(),
+            format!(
+                "Bearer {}",
+                jwt_with_actor_chain(
+                    "jti-actor-chain",
+                    "opaque-token",
+                    Some("user:kenneth"),
+                    Some(json!({"sub": "agent:reviewer"})),
+                    Some("read write"),
+                ),
+            ),
+        );
+        let mut raw = RawInbound::new("", headers, body);
+        raw.metadata = json!({"binding_id": "reviewer-task-update"});
+
+        let event = connector.normalize_inbound(raw).await.unwrap();
+        let ProviderPayload::Known(KnownProviderPayload::A2aPush(payload)) = event.provider_payload
+        else {
+            panic!("expected a2a payload");
+        };
+        assert_eq!(
+            payload.actor_chain,
+            Some(json!({
+                "sub": "user:kenneth",
+                "scopes": ["read", "write"],
+                "act": {"sub": "agent:reviewer"}
+            })),
+        );
     }
 
     #[tokio::test]

--- a/crates/harn-vm/src/triggers/event/normalize.rs
+++ b/crates/harn-vm/src/triggers/event/normalize.rs
@@ -674,6 +674,8 @@ pub(super) fn a2a_push_payload(
     _headers: &BTreeMap<String, String>,
     raw: JsonValue,
 ) -> ProviderPayload {
+    let actor_chain =
+        crate::a2a::actor_chain_from_metadata(&raw).map(|chain| chain.to_json_value());
     let task_id = raw
         .get("task_id")
         .and_then(JsonValue::as_str)
@@ -703,6 +705,7 @@ pub(super) fn a2a_push_payload(
         task_state,
         artifact,
         sender,
+        actor_chain,
         raw,
         kind,
     }))

--- a/crates/harn-vm/src/triggers/event/payloads.rs
+++ b/crates/harn-vm/src/triggers/event/payloads.rs
@@ -617,6 +617,8 @@ pub struct A2aPushPayload {
     pub task_state: Option<String>,
     pub artifact: Option<JsonValue>,
     pub sender: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_chain: Option<JsonValue>,
     pub raw: JsonValue,
     pub kind: String,
 }

--- a/docs/src/connectors/a2a-push.md
+++ b/docs/src/connectors/a2a-push.md
@@ -54,7 +54,13 @@ The connector accepts A2A stream-response push payloads:
   "statusUpdate": {
     "taskId": "task-123",
     "contextId": "ctx-123",
-    "status": {"state": "completed"}
+    "status": {"state": "completed"},
+    "metadata": {
+      "actor_chain": {
+        "sub": "user:42",
+        "act": {"sub": "agent:reviewer"}
+      }
+    }
   }
 }
 ```
@@ -64,12 +70,21 @@ Task status updates map to `TriggerEvent.kind` values like
 Artifact and message pushes map to `a2a.task.artifact` and
 `a2a.task.message`.
 
+When a peer supports delegated actor-chain echo, Harn reads the RFC 8693
+chain from `metadata.actor_chain` on `statusUpdate`, `task`, or `message`
+objects. `metadata.actorChain`, `metadata.harn.actor_chain`, and
+`metadata._harn.actorChain` are accepted for peers that use camelCase or
+vendor metadata containers. If the metadata echo is absent, the JWT `sub`,
+`act`, `may_act`, and `scope`/`scopes` claims are used as a fallback actor-chain
+source.
+
 Handlers receive `provider_payload` with:
 
 - `task_id`
 - `task_state`
 - `artifact`
 - `sender`
+- `actor_chain`
 - `kind`
 - `raw`
 
@@ -78,6 +93,10 @@ Handlers receive `provider_payload` with:
 When `HARN_A2A_PUSH_URL` is set, outbound `a2a://...` dispatches include
 and register a `pushNotificationConfig` for pending tasks. Set
 `HARN_A2A_PUSH_TOKEN` to include a bearer credential in that config.
+Outbound dispatches from an active Harn agent session also include the current
+session actor chain as `message.metadata.actor_chain` and mirror it under
+`message.metadata.harn.actor_chain`, so the served peer can append its own
+actor hop and keep callbacks auditable.
 
 The built-in `harn serve a2a` adapter advertises push notification
 support, stores push configs, and posts `statusUpdate` payloads to each

--- a/docs/src/harn-serve.md
+++ b/docs/src/harn-serve.md
@@ -330,6 +330,9 @@ Behavior today:
 - one-cycle compatibility aliases for `a2a.*`, `tasks/send`,
   `tasks/send_and_wait`, `tasks/sendSubscribe`, and `tasks/list`, with
   `Deprecation: true` on legacy HTTP responses
+- RFC 8693 actor-chain metadata accepted at `message.metadata.actor_chain`;
+  the adapter stores the incoming chain on task metadata and appends the served
+  agent hop for the execution session
 - REST-style POST paths at `/message/send`, `/message/stream`,
   `/tasks/resubscribe`, and `/tasks/cancel`, plus deprecated `/tasks/send` and
   `/tasks/send_and_wait` aliases

--- a/docs/src/mcp-and-acp.md
+++ b/docs/src/mcp-and-acp.md
@@ -1370,6 +1370,12 @@ the legacy `a2a.*`, `tasks/send`, and `tasks/send_and_wait` names for one minor
 cycle and marks those HTTP responses with a `Deprecation` header. If the served
 file exports exactly one function, the function selector can be omitted.
 
+Delegated peers can include an RFC 8693 actor chain in
+`message.metadata.actor_chain`. Harn validates that shape, stores it on the A2A
+task metadata, and appends the served agent as the current `act` hop before
+executing the exported Harn function. Scripts can inspect the resulting chain
+with `agent_session_actor_chain()`.
+
 ### Canonical HTTP+JSON/REST binding
 
 The same task lifecycle is also exposed over the canonical A2A 0.3.0

--- a/docs/src/oauth.md
+++ b/docs/src/oauth.md
@@ -266,6 +266,20 @@ RFC 8693 nested `act` claims with actors ordered current-to-prior, so
 `delegated_claims({sub: "user"}, [{sub: "svc16"}, {sub: "svc77"}])`
 produces `{sub: "user", act: {sub: "svc16", act: {sub: "svc77"}}}`.
 
+The shipped catalog also records fast-moving identity-chain drafts so provider
+overlays can opt in without changing runtime code:
+
+| Row | Detection/tracking |
+| --- | --- |
+| `id-jag` | Detects `urn:ietf:params:oauth:token-type:id-jag` in `identity_chaining_requested_token_types_supported` and tracks `draft-ietf-oauth-identity-assertion-authz-grant-04` plus `draft-ietf-oauth-identity-chaining-14`. |
+| `txn-token` | Tracks `draft-ietf-oauth-transaction-tokens-08` and the agent-context companion `draft-araut-oauth-transaction-tokens-for-agents-02`. Uses `requested_token_type = urn:ietf:params:oauth:token-type:txn_token`. |
+| `wimse-wit-wpt` | Tracking-only row for `draft-ietf-wimse-workload-creds-01` and `draft-ietf-wimse-wpt-01`. WIT/WPT are proof-of-possession workload credentials, not a bearer token-exchange profile. |
+
+Rows expose `provider_metadata_fields` and `tracking.drafts` so applications can
+surface provider capability matches, keep draft links near policy decisions, and
+replace a tracking row with a stricter provider-specific overlay when an
+authorization server publishes concrete support.
+
 ## Device flow (`std/oauth/device_flow`)
 
 For CI runners, daemons, and IDE side panes that cannot redirect a

--- a/docs/src/triggers/dispatcher.md
+++ b/docs/src/triggers/dispatcher.md
@@ -62,7 +62,9 @@ For `a2a://host[:port]/path` routes, the dispatcher:
   read-only legacy fallback for peers that have not cut over yet
 - treats the URI path as the `target_agent` label that propagates into the
   outbound envelope and the action graph
-- sends the `TriggerEvent` envelope over `message/send`
+- sends the `TriggerEvent` envelope over `message/send`; when dispatch runs
+  inside an active agent session, the current RFC 8693 actor chain is included
+  as `message.metadata.actor_chain`
 - returns either the inline agent result (when the peer completes
   synchronously) or a pending task handle payload for the caller
 


### PR DESCRIPTION
## Summary
- Thread RFC 8693 actor-chain metadata through outbound A2A dispatch, harn serve a2a task execution, and a2a-push trigger payloads.
- Add OAuth token-exchange catalog tracking rows for ID-JAG, transaction tokens, and WIMSE WIT/WPT with pinned draft revisions.
- Document A2A actor-chain metadata and provider capability rows.

## Notes for reviewers
- Closes #3343
- Closes #3329

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-3329 cargo test -p harn-vm a2a_push -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-3329 cargo test -p harn-serve actor_chain -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/harn-target-3329 cargo run --quiet --bin harn -- test conformance --filter oauth_token_exchange_capability_overlay`
- `cargo fmt --check`
- `harn fmt --check crates/harn-stdlib/src/stdlib/oauth/token_exchange.harn crates/harn-stdlib/src/stdlib/oauth/token_exchange_catalog.harn conformance/tests/stdlib/oauth/oauth_token_exchange_capability_overlay.harn`
- `make lint-test-patterns`
- pre-commit and pre-push hooks passed
