### PR TITLE
[codex] Raise release binary size budget

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -87,6 +87,9 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
   SCCACHE_GHA_ENABLED: "true"
+  # Keep a narrow release-size ratchet while allowing the current stripped
+  # Linux x86_64 binary, which is 185.20 MiB at v0.8.120.
+  BINARY_SIZE_BUDGET_MB: "186"
 
 jobs:
   setup:

--- a/changelog.d/3432.changed.md
+++ b/changelog.d/3432.changed.md
@@ -1,0 +1,3 @@
+- **Release binary size gate now allows the current stripped Linux binary (#3432).**
+  The release artifact budget was raised to 186 MiB so v0.8.120 binary builds can
+  publish without failing just above the previous threshold.

--- a/scripts/check_binary_size.sh
+++ b/scripts/check_binary_size.sh
@@ -10,7 +10,7 @@ build_release=1
 emit_bloat=1
 target="${HARN_RELEASE_TARGET:-}"
 harn_bin="${HARN_BIN:-}"
-budget_mb="${BINARY_SIZE_BUDGET_MB:-185}"
+budget_mb="${BINARY_SIZE_BUDGET_MB:-186}"
 report_dir="${BINARY_SIZE_REPORT_DIR:-}"
 
 usage() {
@@ -24,7 +24,7 @@ Options:
   --no-build           Check an already-built release binary
   --target TARGET      Cargo target triple to build/check
   --bin PATH           Override the harn binary path
-  --budget-mb MB       Maximum binary size in MiB (default: 185)
+  --budget-mb MB       Maximum binary size in MiB (default: 186)
   --report-dir DIR     Directory for binary-size and cargo-bloat reports
   --skip-bloat         Only write binary-size.txt; do not run cargo-bloat
   -h, --help           Show this help


### PR DESCRIPTION
## Summary
- raise the release binary size budget from 185 MiB to 186 MiB
- set the workflow-level budget so v0.8.120 recovery dispatches can reuse the existing tag without moving it
- keep the script default and help text aligned

## Why
The v0.8.120 Linux x86_64 release binary built successfully at 185.20 MiB and failed the current 185.00 MiB gate by 0.20 MiB. This keeps the ratchet narrow while unblocking the patch release assets.

## Validation
- bash -n scripts/check_binary_size.sh
- git diff --check
- pre-commit / pre-push hooks