### PR TITLE
fix(vm): normalize harmony marker tool wrappers

### DIFF
--- a/changelog.d/harmony-constrain-marker.fixed.md
+++ b/changelog.d/harmony-constrain-marker.fixed.md
@@ -1,0 +1,4 @@
+- **Provider-native tool-call normalization.** Harmony marker-wrapper tool names
+  such as `<|constrain|>json` now normalize command-shaped calls before policy
+  checks, preventing valid provider-native tool calls from tripping tool-ceiling
+  enforcement before dispatch.

--- a/crates/harn-vm/src/llm/tools/compat.rs
+++ b/crates/harn-vm/src/llm/tools/compat.rs
@@ -4,8 +4,9 @@
 //! structured tool calls. GPT-OSS/Harmony is the common case: a call can arrive
 //! as a generic `tool`/`tool.call`/`tool.exec` function whose arguments contain
 //! the real `{ name, args }`, or the tool name can carry a channel suffix such
-//! as `run<|channel|>commentary`. Normalize those shapes before policy and
-//! dispatch see them.
+//! as `run<|channel|>commentary`. Some providers also surface marker-only
+//! wrapper names such as `<|constrain|>json`; normalize those shapes before
+//! policy and dispatch see them.
 
 const HARMONY_CHANNEL_MARKERS: &[&str] =
     &["<|channel|>", "<|message|>", "<|recipient|>", "<|end|>"];
@@ -31,12 +32,19 @@ pub(crate) fn normalize_tool_call_shape(
     arguments: serde_json::Value,
 ) -> (String, serde_json::Value) {
     let normalized_name = normalize_tool_name(name);
-    if !is_generic_wrapper_name(&normalized_name) {
+    let is_marker_wrapper = is_harmony_marker_wrapper_name(&normalized_name);
+    if !is_generic_wrapper_name(&normalized_name) && !is_marker_wrapper {
         return (normalized_name, arguments);
     }
 
     if let Some((inner_name, inner_arguments)) = unwrap_generic_tool_arguments(&arguments) {
         return (normalize_tool_name(&inner_name), inner_arguments);
+    }
+
+    if is_marker_wrapper {
+        if let Some(inferred_name) = infer_tool_name_from_arguments(&arguments) {
+            return (inferred_name, arguments);
+        }
     }
 
     (normalized_name, arguments)
@@ -47,6 +55,25 @@ fn is_generic_wrapper_name(name: &str) -> bool {
         name,
         "tool" | "tool.call" | "tool.exec" | "function" | "function.call" | "call"
     )
+}
+
+fn is_harmony_marker_wrapper_name(name: &str) -> bool {
+    let trimmed = name.trim();
+    trimmed.starts_with("<|") && trimmed.contains("|>")
+}
+
+fn infer_tool_name_from_arguments(arguments: &serde_json::Value) -> Option<String> {
+    let object = arguments.as_object()?;
+    let has_command_shape = object
+        .get("command")
+        .or_else(|| object.get("commands"))
+        .or_else(|| object.get("cmd"))
+        .is_some();
+    if has_command_shape {
+        return Some("run".to_string());
+    }
+
+    None
 }
 
 fn unwrap_generic_tool_arguments(
@@ -99,6 +126,26 @@ mod tests {
         assert_eq!(name, "look");
         assert_eq!(arguments["intent"], "read");
         assert_eq!(arguments["file"], "src/lib.rs");
+    }
+
+    #[test]
+    fn infers_run_from_harmony_marker_wrapper_command_shape() {
+        let arguments = serde_json::json!({"command": "cargo test"});
+        let (name, normalized_arguments) =
+            normalize_tool_call_shape("<|constrain|>json", arguments.clone());
+
+        assert_eq!(name, "run");
+        assert_eq!(normalized_arguments, arguments);
+    }
+
+    #[test]
+    fn preserves_unrecognized_harmony_marker_wrapper_shape() {
+        let arguments = serde_json::json!({"intent": "read", "file": "src/lib.rs"});
+        let (name, normalized_arguments) =
+            normalize_tool_call_shape("<|constrain|>json", arguments.clone());
+
+        assert_eq!(name, "<|constrain|>json");
+        assert_eq!(normalized_arguments, arguments);
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -645,6 +645,21 @@ fn native_json_fallback_strips_harmony_channel_suffix() {
 }
 
 #[test]
+fn native_json_fallback_infers_run_from_harmony_marker_wrapper() {
+    let known = known_tools_set();
+    let text = r#"{"name":"<|constrain|>json","arguments":{"command":"cargo test"}}"#;
+    let (calls, errors) = parse_native_json_tool_calls(text, &known);
+    assert!(errors.is_empty(), "no errors expected: {errors:?}");
+    assert_eq!(
+        calls.len(),
+        1,
+        "marker wrapper command shape should parse: {calls:?}"
+    );
+    assert_eq!(calls[0]["name"], json!("run"));
+    assert_eq!(calls[0]["arguments"]["command"], json!("cargo test"));
+}
+
+#[test]
 fn native_json_fallback_parses_flat_envelope_with_string_encoded_arguments() {
     // Regression: OpenAI's on-the-wire flat shape encodes `arguments` as a JSON
     // STRING (`{"name":"read","arguments":"{\"path\":\"a\"}"}`), which local


### PR DESCRIPTION
## Summary

Normalize Harmony marker-wrapper tool names such as `<|constrain|>json` before policy and dispatch see them.

The live Burin baseline saw Fireworks GPT-OSS return a provider-native function named `<|constrain|>json` with a canonical command-shaped argument payload. The agent then recovered and passed, but Harn correctly recorded a policy denial because the raw marker name reached tool-ceiling enforcement first. This fix keeps generic wrapper unwrapping first, then conservatively infers `run` only for marker-wrapper calls with an explicit command-shaped argument object.

## Root Cause

`normalize_tool_call_shape` handled generic wrappers (`tool`, `tool.call`, etc.) and Harmony suffixes (`run<|channel|>commentary`), but not marker-only wrapper names where the tool name was entirely provider syntax. Those names could trip tool policy before the native JSON fallback normalized an otherwise valid call.

## Validation

- `cargo fmt --package harn-vm`
- `cargo test -p harn-vm --lib native_json_fallback_infers_run_from_harmony_marker_wrapper -- --nocapture`
- `cargo test -p harn-vm --lib llm::tools::compat -- --nocapture`
- `git diff --check`
- pre-commit changed-package gate, including markdown, rustfmt, and clippy for `harn-vm`
- pre-push targeted local checks
