### PR TITLE
[codex] Fix OpenRouter GPT-OSS tool defaults

### DIFF
--- a/changelog.d/openrouter-gpt-oss-json-tools.fixed.md
+++ b/changelog.d/openrouter-gpt-oss-json-tools.fixed.md
@@ -1,0 +1,4 @@
+- **OpenRouter GPT-OSS now defaults to JSON text-channel tools.** The provider
+  capability matrix no longer advertises native tool calls for
+  `openrouter/openai/gpt-oss-*`, while direct Cerebras, DeepInfra, and Groq
+  GPT-OSS routes stay on native tools.

--- a/conformance/tests/scenarios/provider_capabilities_basic.harn
+++ b/conformance/tests/scenarios/provider_capabilities_basic.harn
@@ -86,6 +86,16 @@ pipeline test(task) {
   let together_gpt_oss = provider_capabilities("together", "openai/gpt-oss-120b")
   assert(together_gpt_oss.thinking_modes[0] == "effort", "Together GPT-OSS exposes effort thinking")
   assert(together_gpt_oss.reasoning_effort_supported, "Together GPT-OSS accepts reasoning_effort")
+  let openrouter_gpt_oss = provider_capabilities("openrouter", "openai/gpt-oss-120b")
+  assert(!openrouter_gpt_oss.native_tools, "OpenRouter GPT-OSS disables native tools")
+  assert(
+    openrouter_gpt_oss.preferred_tool_format == "json",
+    "OpenRouter GPT-OSS defaults to JSON text tools",
+  )
+  assert(
+    openrouter_gpt_oss.text_tool_wire_format_supported,
+    "OpenRouter GPT-OSS supports text tool formatting",
+  )
   let fireworks_gpt_oss = provider_capabilities("fireworks", "accounts/fireworks/models/gpt-oss-120b")
   assert(!fireworks_gpt_oss.native_tools, "Fireworks GPT-OSS disables native tools")
   assert(
@@ -96,6 +106,15 @@ pipeline test(task) {
     fireworks_gpt_oss.text_tool_wire_format_supported,
     "Fireworks GPT-OSS supports text tool formatting",
   )
+  let cerebras_gpt_oss = provider_capabilities("cerebras", "gpt-oss-120b")
+  assert(cerebras_gpt_oss.native_tools, "Cerebras GPT-OSS keeps native tools")
+  assert(cerebras_gpt_oss.preferred_tool_format == "native", "Cerebras GPT-OSS defaults native")
+  let deepinfra_gpt_oss = provider_capabilities("deepinfra", "openai/gpt-oss-120b")
+  assert(deepinfra_gpt_oss.native_tools, "DeepInfra GPT-OSS keeps native tools")
+  assert(deepinfra_gpt_oss.preferred_tool_format == "native", "DeepInfra GPT-OSS defaults native")
+  let groq_gpt_oss = provider_capabilities("groq", "openai/gpt-oss-120b")
+  assert(groq_gpt_oss.native_tools, "Groq GPT-OSS keeps native tools")
+  assert(groq_gpt_oss.preferred_tool_format == "native", "Groq GPT-OSS defaults native")
   let together_kimi = provider_capabilities("together", "moonshotai/Kimi-K2.5")
   assert(together_kimi.thinking_modes[0] == "enabled", "Together Kimi exposes reasoning.enabled")
   assert(

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -2355,24 +2355,26 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
     }
 
     #[test]
-    fn routed_gpt_oss_requires_reasoning_for_tools_with_provider_specific_tool_wire() {
+    fn gpt_oss_requires_reasoning_for_tools_with_provider_specific_tool_wire() {
         // gpt-oss (Harmony) calls tools INSIDE the chain-of-thought channel, so
         // reasoning-off breaks tool calling. Provider catch-all rules carry no
         // reasoning fields, so without a dedicated `*gpt-oss*` row gpt-oss
         // would fall through to reasoning-OFF and the eval loop would bill a
-        // noncommittal. Tool wire support is provider-specific: Fireworks'
-        // native channel currently bills empty eval completions, while
-        // DeepInfra/SambaNova still use the native Harmony channel.
+        // noncommittal. Tool wire support is provider-specific: OpenRouter and
+        // Fireworks use Harn's JSON text-channel tools, while the direct
+        // Cerebras/DeepInfra/Groq routes still use provider-native tools.
         reset();
         for (provider, model, native_tools, preferred_tool_format) in [
+            ("openrouter", "openai/gpt-oss-120b", false, "json"),
             (
                 "fireworks",
                 "accounts/fireworks/models/gpt-oss-120b",
                 false,
                 "json",
             ),
+            ("cerebras", "gpt-oss-120b", true, "native"),
             ("deepinfra", "openai/gpt-oss-120b", true, "native"),
-            ("sambanova", "gpt-oss-120b", true, "native"),
+            ("groq", "openai/gpt-oss-120b", true, "native"),
         ] {
             let caps = lookup(provider, model);
             assert!(

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -3671,10 +3671,10 @@ prefers_xml_tools = false
 thinking_block_style = "none"
 
 # OpenAI gpt-oss (Harmony) served via OpenRouter. Without an explicit row this
-# slug fell through provider_family openrouter -> openai, matched no `gpt-*`
+# slug falls through provider_family openrouter -> openai, matches no `gpt-*`
 # rule (the `openai/` prefix and the unparseable `oss` "version" both fail the
-# match), and landed on a capability-less catch-all that declares NO reasoning
-# support — so the policy resolver could not even materialize reasoning.
+# match), and lands on a capability-less catch-all that declares NO reasoning
+# support — so the policy resolver cannot even materialize reasoning.
 #
 # `reasoning_required_for_tools = true`: gpt-oss performs tool calls INSIDE the
 # Harmony chain-of-thought channel, so disabling reasoning breaks tool calling.
@@ -3687,26 +3687,24 @@ thinking_block_style = "none"
 # required-for-tools flag keeps the auto policy from flooring tool tasks to off.
 # Must NOT carry a Qwen-style `auto_reasoning_overrides = "off"`.
 #
-# SECOND footgun — the OpenRouter sub-provider lottery. `openai/gpt-oss-120b`
-# fans out across ~17 upstreams on OpenRouter; even with reasoning ON, some
-# mis-serialize the Harmony tool call and finish billed-noncommittal (0
-# tool_calls). The bad upstreams are intermittent and hard to enumerate, so we
-# ALLOWLIST the known-clean ones instead of denylisting the bad ones.
+# OpenRouter's provider-native tool surface is not stable enough to expose as
+# the default abstraction for this aggregate route. Burin's committed-tree smoke
+# (2026-06-19, openrouter/openai/gpt-oss-120b) passes when it selects Harn's
+# JSON text-channel tools, while the old Harn row still recommended native and
+# produced misleading `recommended_format=native requested_format=json`
+# observability. Keep the quirk in the provider matrix: text tools are the
+# recommended route for OpenRouter GPT-OSS, while direct Cerebras/Groq/DeepInfra
+# GPT-OSS rows remain native.
+#
+# The OpenRouter sub-provider lottery still matters. `openai/gpt-oss-120b` fans
+# out across many upstreams; even with reasoning ON, some mis-serialize Harmony
+# turns and finish billed-noncommittal. Keep the known-clean upstream allowlist:
 # `openrouter_provider_order = ["Cerebras", "Groq"]` materializes to
-# `provider: { order: ["Cerebras","Groq"], allow_fallbacks: false }`, so the
-# route only ever lands on those two upstreams. Live OpenRouter probe
-# (openai/gpt-oss-120b, 2026-06-13, reasoning effort=low, weather-tool request):
-#   - free routing (lottery) x12          -> Groq, 12/12 clean tool calls
-#   - order=[Cerebras,Groq] pin x6        -> Cerebras, 6/6 clean, 0 noncommittal
-#   - Cerebras-only pin x3 / Groq-only x3 -> 6/6 clean
-#   - Together pin x3                      -> 1/3 clean (2 "Provider returned
-#                                             error") -> NOT allowlisted
-# Cerebras and Groq are the blessed upstreams. The footgun gate (capability
-# audit) requires this pin on any reasoning_required_for_tools OpenRouter route.
+# `provider: { order: ["Cerebras","Groq"], allow_fallbacks: false }`.
 [[provider.openrouter]]
 model_match = "openai/gpt-oss-*"
-native_tools = true
-preferred_tool_format = "native"
+native_tools = false
+preferred_tool_format = "json"
 structured_output = "native"
 thinking_modes = ["effort"]
 reasoning_effort_supported = true

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/99-openrouter-new-families.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/99-openrouter-new-families.toml
@@ -62,10 +62,10 @@ prefers_xml_tools = false
 thinking_block_style = "none"
 
 # OpenAI gpt-oss (Harmony) served via OpenRouter. Without an explicit row this
-# slug fell through provider_family openrouter -> openai, matched no `gpt-*`
+# slug falls through provider_family openrouter -> openai, matches no `gpt-*`
 # rule (the `openai/` prefix and the unparseable `oss` "version" both fail the
-# match), and landed on a capability-less catch-all that declares NO reasoning
-# support — so the policy resolver could not even materialize reasoning.
+# match), and lands on a capability-less catch-all that declares NO reasoning
+# support — so the policy resolver cannot even materialize reasoning.
 #
 # `reasoning_required_for_tools = true`: gpt-oss performs tool calls INSIDE the
 # Harmony chain-of-thought channel, so disabling reasoning breaks tool calling.
@@ -78,26 +78,24 @@ thinking_block_style = "none"
 # required-for-tools flag keeps the auto policy from flooring tool tasks to off.
 # Must NOT carry a Qwen-style `auto_reasoning_overrides = "off"`.
 #
-# SECOND footgun — the OpenRouter sub-provider lottery. `openai/gpt-oss-120b`
-# fans out across ~17 upstreams on OpenRouter; even with reasoning ON, some
-# mis-serialize the Harmony tool call and finish billed-noncommittal (0
-# tool_calls). The bad upstreams are intermittent and hard to enumerate, so we
-# ALLOWLIST the known-clean ones instead of denylisting the bad ones.
+# OpenRouter's provider-native tool surface is not stable enough to expose as
+# the default abstraction for this aggregate route. Burin's committed-tree smoke
+# (2026-06-19, openrouter/openai/gpt-oss-120b) passes when it selects Harn's
+# JSON text-channel tools, while the old Harn row still recommended native and
+# produced misleading `recommended_format=native requested_format=json`
+# observability. Keep the quirk in the provider matrix: text tools are the
+# recommended route for OpenRouter GPT-OSS, while direct Cerebras/Groq/DeepInfra
+# GPT-OSS rows remain native.
+#
+# The OpenRouter sub-provider lottery still matters. `openai/gpt-oss-120b` fans
+# out across many upstreams; even with reasoning ON, some mis-serialize Harmony
+# turns and finish billed-noncommittal. Keep the known-clean upstream allowlist:
 # `openrouter_provider_order = ["Cerebras", "Groq"]` materializes to
-# `provider: { order: ["Cerebras","Groq"], allow_fallbacks: false }`, so the
-# route only ever lands on those two upstreams. Live OpenRouter probe
-# (openai/gpt-oss-120b, 2026-06-13, reasoning effort=low, weather-tool request):
-#   - free routing (lottery) x12          -> Groq, 12/12 clean tool calls
-#   - order=[Cerebras,Groq] pin x6        -> Cerebras, 6/6 clean, 0 noncommittal
-#   - Cerebras-only pin x3 / Groq-only x3 -> 6/6 clean
-#   - Together pin x3                      -> 1/3 clean (2 "Provider returned
-#                                             error") -> NOT allowlisted
-# Cerebras and Groq are the blessed upstreams. The footgun gate (capability
-# audit) requires this pin on any reasoning_required_for_tools OpenRouter route.
+# `provider: { order: ["Cerebras","Groq"], allow_fallbacks: false }`.
 [[provider.openrouter]]
 model_match = "openai/gpt-oss-*"
-native_tools = true
-preferred_tool_format = "native"
+native_tools = false
+preferred_tool_format = "json"
 structured_output = "native"
 thinking_modes = ["effort"]
 reasoning_effort_supported = true

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -3387,6 +3387,23 @@ mod tests {
             default_tool_format("qwen/qwen3-coder-flash", "openrouter"),
             "text"
         );
+        // GPT-OSS tool defaults are provider-specific: aggregate OpenRouter
+        // and Fireworks routes use Harn's JSON text-channel tools, while direct
+        // native-capable hosts stay on provider-native tool calls.
+        assert_eq!(
+            default_tool_format("openai/gpt-oss-120b", "openrouter"),
+            "json"
+        );
+        assert_eq!(
+            default_tool_format("accounts/fireworks/models/gpt-oss-120b", "fireworks"),
+            "json"
+        );
+        assert_eq!(default_tool_format("gpt-oss-120b", "cerebras"), "native");
+        assert_eq!(
+            default_tool_format("openai/gpt-oss-120b", "deepinfra"),
+            "native"
+        );
+        assert_eq!(default_tool_format("openai/gpt-oss-120b", "groq"), "native");
     }
 
     #[test]

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -156,7 +156,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `openrouter` | `minimax/minimax-m2*` | `any` | no | no | no | no | no | yes | no | `delimited` | `plain` | `none` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `z-ai/glm-5*` | `any` | no | no | no | no | no | yes | no | `native` | `plain` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `kwaipilot/kat-coder-pro-v2` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `interchangeable` | yes | yes |
-| `openrouter` | `openai/gpt-oss-*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `openrouter` | `openai/gpt-oss-*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `json` | no | yes | `text_only` | yes | no |
 | `openrouter` | `stepfun/step-3.7-flash` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `interchangeable` | yes | yes |
 | `sambanova` | `*deepseek*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `sambanova` | `*llama*` | `any` | no | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
@@ -269,7 +269,7 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `openrouter` | `mistralai/mistral-small-2603` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `moonshotai/kimi-k2.6` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `moonshotai/kimi-k2.7-code` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
-| `openrouter` | `openai/gpt-oss-120b` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `openrouter` | `openai/gpt-oss-120b` | `json` | `text_only` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `qwen/qwen3-coder` | `text` | `native_unreliable` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `qwen/qwen3.7-max` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `qwen/qwen3.7-plus` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -7747,10 +7747,10 @@ public let harnProviderCatalogJSON = #"""
         ]
       },
       "tool_support": {
-        "native": true,
+        "native": false,
         "text": true,
-        "preferred_format": "native",
-        "parity": "unknown",
+        "preferred_format": "json",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "native",

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -7483,10 +7483,10 @@ export const harnProviderCatalog: HarnProviderCatalog = {
         ]
       },
       "tool_support": {
-        "native": true,
+        "native": false,
         "text": true,
-        "preferred_format": "native",
-        "parity": "unknown",
+        "preferred_format": "json",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "native",

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -7229,10 +7229,10 @@
         ]
       },
       "tool_support": {
-        "native": true,
+        "native": false,
         "text": true,
-        "preferred_format": "native",
-        "parity": "unknown",
+        "preferred_format": "json",
+        "parity": "text_only",
         "tool_search": []
       },
       "structured_output": "native",


### PR DESCRIPTION
## Summary

Root cause: the Fireworks GPT-OSS row already lives in Harn-owned capability TOML as a JSON text-tool route, but the OpenRouter `openai/gpt-oss-*` row in `crates/harn-vm/src/llm/capability_sources/20-providers/99-openrouter-new-families.toml` still declared `native_tools = true` and `preferred_tool_format = "native"`. That made Harn's provider capabilities and `tool_format_override` observability recommend native even when the caller explicitly selected JSON.

This PR changes the OpenRouter GPT-OSS capability row to `native_tools = false` and `preferred_tool_format = "json"`, keeps its reasoning-required and OpenRouter upstream allowlist metadata, regenerates `capabilities.toml` and `docs/src/provider-matrix.md`, and adds focused tests that keep OpenRouter/Fireworks on JSON text tools while Cerebras/DeepInfra/Groq GPT-OSS remain native.

## Verification

- `cargo fmt --check`
- `harn fmt --check conformance/tests/scenarios/provider_capabilities_basic.harn`
- `cargo test -p harn-vm gpt_oss`
- `cargo test -p harn-vm test_default_tool_format_uses_capability_matrix`
- `harn test conformance --filter provider_capabilities_basic`
- `harn providers build-capabilities --check`
- `harn providers matrix --check`
- `harn providers support --check`
- pre-commit hook passed
- pre-push hook passed

## Release note

This does not cut a Harn release. After this lands, release Harn and then update Burin Code to the new Harn version so Burin picks up the provider-matrix change.