### PR TITLE
[codex] Clarify regex flag capture semantics

### DIFF
--- a/changelog.d/regex-flags-captures.changed.md
+++ b/changelog.d/regex-flags-captures.changed.md
@@ -1,0 +1,4 @@
+- **Regex builtin docs and conformance now pin flag and capture semantics.**
+  `regex_match`, `regex_replace`, and `regex_captures` document and test
+  inline `(?is)` flags, trailing `i`/`s` flags, newline-spanning lazy captures,
+  and the exact `regex_captures` result shape.

--- a/conformance/tests/stdlib/regex_flags_captures.expected
+++ b/conformance/tests/stdlib/regex_flags_captures.expected
@@ -1,0 +1,1 @@
+[harn] regex capture flags ok

--- a/conformance/tests/stdlib/regex_flags_captures.harn
+++ b/conformance/tests/stdlib/regex_flags_captures.harn
@@ -1,0 +1,25 @@
+pipeline test(task) {
+  let text = "before\n<Tool_Result id=\"42\">\nAlpha\nbeta\n</Tool_Result>\nafter"
+  let inline = regex_captures("(?is)<tool_result\\b([^>]*)>(.*?)</tool_result>", text)
+  assert_eq(len(inline), 1)
+  assert_eq(inline[0].match, "<Tool_Result id=\"42\">\nAlpha\nbeta\n</Tool_Result>")
+  assert_eq(inline[0].groups, [" id=\"42\"", "\nAlpha\nbeta\n"])
+  assert_eq(inline[0].start, 7)
+  assert_eq(inline[0].end, 54)
+  assert_eq(inline[0].line, 2)
+  let trailing = regex_captures("<tool_result\\b([^>]*)>(.*?)</tool_result>", text, "is")
+  assert_eq(trailing, inline)
+  let class_any = regex_captures("(?i)<tool_result\\b([^>]*)>([\\s\\S]*?)</tool_result>", text)
+  assert_eq(class_any, inline)
+  let named = regex_captures("(?is)<(?P<tag>tool_result)\\b([^>]*)>(.*?)</(?P<tag_close>tool_result)>", text)
+  assert_eq(named[0].tag, "Tool_Result")
+  assert_eq(named[0].tag_close, "Tool_Result")
+  assert_eq(named[0].groups, ["Tool_Result", " id=\"42\"", "\nAlpha\nbeta\n", "Tool_Result"])
+  assert_eq(regex_match("^beta$", text, "im"), ["beta"])
+  assert_eq(regex_match("<tool_result\\b.*?</tool_result>", text, "is"), [inline[0].match])
+  assert_eq(
+    regex_replace("<tool_result\\b.*?</tool_result>", "RESULT", text, "is"),
+    "before\nRESULT\nafter",
+  )
+  log("regex capture flags ok")
+}

--- a/crates/harn-lsp/src/constants.rs
+++ b/crates/harn-lsp/src/constants.rs
@@ -71,15 +71,23 @@ pub(crate) const BUILTINS: &[(&str, &str)] = &[
     ("timestamp", "timestamp() -> float"),
     ("exit", "exit(code) -> nil"),
     // Regex
-    ("regex_match", "regex_match(pattern, text) -> list"),
+    (
+        "regex_match",
+        "regex_match(pattern, text, flags?) -> list | nil",
+    ),
     (
         "regex_replace",
-        "regex_replace(pattern, replacement, text) -> string",
+        "regex_replace(pattern, replacement, text, flags?) -> string",
     ),
     (
         "regex_replace_all",
-        "regex_replace_all(pattern, replacement, text) -> string (alias of regex_replace)",
+        "regex_replace_all(pattern, replacement, text, flags?) -> string (alias of regex_replace)",
     ),
+    (
+        "regex_captures",
+        "regex_captures(pattern, text, flags?) -> list",
+    ),
+    ("regex_split", "regex_split(text, pattern, flags?) -> list"),
     // HTTP
     ("http_get", "http_get(url) -> dict"),
     ("http_post", "http_post(url, body, headers?) -> dict"),
@@ -838,13 +846,15 @@ pub(crate) fn builtin_doc(name: &str) -> Option<String> {
         "read_file" => "**read_file(path)** → string — Read file contents",
         "write_file" => "**write_file(path, content)** → nil — Write string to file",
         "exit" => "**exit(code)** — Terminate process with exit code",
-        "regex_match" => "**regex_match(pattern, text)** → list | nil — Find all regex matches",
+        "regex_match" => "**regex_match(pattern, text, flags?)** → list | nil — Find all non-overlapping regex matches. Optional flags: `i`, `m`, `s`, `x`.",
         "regex_replace" => {
-            "**regex_replace(pattern, replacement, text)** → string — Replace every regex match; supports `$1`, `$2`, `${name}` backrefs"
+            "**regex_replace(pattern, replacement, text, flags?)** → string — Replace every regex match; supports `$1`, `$2`, `${name}` backrefs and optional `i`/`m`/`s`/`x` flags"
         }
         "regex_replace_all" => {
-            "**regex_replace_all(pattern, replacement, text)** → string — Alias of `regex_replace`; same semantics, different spelling"
+            "**regex_replace_all(pattern, replacement, text, flags?)** → string — Alias of `regex_replace`; same semantics, different spelling"
         }
+        "regex_captures" => "**regex_captures(pattern, text, flags?)** → list — Find matches with `{match, groups, start, end, line}` plus named capture keys. Optional flags: `i`, `m`, `s`, `x`.",
+        "regex_split" => "**regex_split(text, pattern, flags?)** → list — Split text by regex matches. Optional flags: `i`, `m`, `s`, `x`.",
         "http_get" => "**http_get(url)** → string — HTTP GET request",
         "http_post" => "**http_post(url, body, headers?)** → string — HTTP POST request",
         "llm_call" => "**llm_call(prompt, system?, options?)** → dict — Call an LLM API\n\nReturns: `{text, model, input_tokens, output_tokens, transcript?}`",

--- a/crates/harn-vm/src/stdlib/regex.rs
+++ b/crates/harn-vm/src/stdlib/regex.rs
@@ -504,6 +504,59 @@ mod tests {
     }
 
     #[test]
+    fn captures_inline_and_trailing_flags_span_newlines() {
+        let mut vm = vm();
+        let text = "before\n<Tool_Result id=\"42\">\nAlpha\nbeta\n</Tool_Result>\nafter";
+
+        let inline = call(
+            &mut vm,
+            "regex_captures",
+            vec![
+                s(r"(?is)<tool_result\b([^>]*)>(.*?)</tool_result>"),
+                s(text),
+            ],
+        )
+        .unwrap();
+        let inline_list = unwrap_list(&inline);
+        assert_eq!(inline_list.len(), 1);
+        let inline_cap = inline_list[0].as_dict().unwrap();
+        assert_eq!(
+            inline_cap.get("match").unwrap().display(),
+            "<Tool_Result id=\"42\">\nAlpha\nbeta\n</Tool_Result>"
+        );
+        let inline_groups = unwrap_list(inline_cap.get("groups").unwrap());
+        assert_eq!(inline_groups.len(), 2);
+        assert_eq!(inline_groups[0].display(), " id=\"42\"");
+        assert_eq!(inline_groups[1].display(), "\nAlpha\nbeta\n");
+        assert_eq!(inline_cap.get("start").unwrap().as_int(), Some(7));
+        assert_eq!(inline_cap.get("end").unwrap().as_int(), Some(54));
+        assert_eq!(inline_cap.get("line").unwrap().as_int(), Some(2));
+
+        let trailing = call(
+            &mut vm,
+            "regex_captures",
+            vec![
+                s(r"<tool_result\b([^>]*)>(.*?)</tool_result>"),
+                s(text),
+                s("is"),
+            ],
+        )
+        .unwrap();
+        assert_eq!(trailing.display(), inline.display());
+
+        let class_any = call(
+            &mut vm,
+            "regex_captures",
+            vec![
+                s(r"(?i)<tool_result\b([^>]*)>([\s\S]*?)</tool_result>"),
+                s(text),
+            ],
+        )
+        .unwrap();
+        assert_eq!(class_any.display(), inline.display());
+    }
+
+    #[test]
     fn nil_flags_arg_means_no_flags() {
         // Forwarding an unset optional (`opts?.flags`) lands a literal `nil` in
         // the flags slot; it must behave like an absent arg, not stringify to

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -937,11 +937,17 @@ let captures = regex_captures("(?P<day>[A-Z][a-z]+)", "Mon Tue")
 let words    = regex_split("a, b, c", ",\\s*")
 let ci       = regex_match("hello", "HeLLo", "i")
 let fixed_ci = regex_replace("hello", "hi", "HeLLo", "i")
+let body     = regex_captures("(?is)<body\\b[^>]*>(.*?)</body>", html)
+let body2    = regex_captures("<body\\b[^>]*>(.*?)</body>", html, "is")
 ```
 
 `regex_replace` and `regex_replace_all` both replace every match and
 both support `$1`, `$2`, `${name}` backrefs plus the same optional
-`i`/`m`/`s`/`x` flags as `regex_match`.
+`i`/`m`/`s`/`x` flags as `regex_match`. Inline regex flags such as
+`(?is)` use the same semantics as the trailing flags argument. Each
+`regex_captures` result has `match`, positional `groups` excluding the
+full match, character offsets `start`/`end`, 1-based `line`, and any
+named capture groups as top-level keys.
 
 ## Encoding, bytes, and compression
 

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -5154,9 +5154,15 @@ database.
 
 | Function | Description |
 |---|---|
-| `regex_match(pattern, str)` | Returns match data if `str` matches `pattern`, or `nil` |
-| `regex_replace(pattern, str, replacement)` | Replaces all matches of `pattern` in `str` |
-| `regex_captures(pattern, str)` | Returns a list of capture group dicts for all matches |
+| `regex_match(pattern, text, flags?)` | Returns a list of all non-overlapping matches, or `nil` if none match |
+| `regex_replace(pattern, replacement, text, flags?)` | Replaces all matches of `pattern` in `text` |
+| `regex_captures(pattern, text, flags?)` | Returns a list of capture group dicts for all matches |
+| `regex_split(text, pattern, flags?)` | Splits `text` by regex matches |
+
+The optional `flags` string supports `i` (case-insensitive), `m`
+(multi-line anchors), `s` (dot matches newlines), and `x` (ignore
+pattern whitespace). Regex inline flags such as `(?is)` use the same
+underlying semantics.
 
 #### regex_captures
 
@@ -5164,18 +5170,26 @@ database.
 and returns a list of dicts, one per match. Each dict contains:
 
 - `match`: the full match string
-- `groups`: a list of positional capture group strings (from `(...)`)
+- `groups`: a list of positional capture group values (from `(...)`), in
+  source order and excluding the full match. Unmatched optional groups are
+  `nil`.
+- `start` / `end`: character (code-point) offsets of the full match in
+  `text`
+- `line`: 1-based line number of the match start
 - Any named capture groups (from `(?P<name>...)`) as additional keys
 
 ```harn
 let results = regex_captures("(\\w+)@(\\w+)", "alice@example bob@test")
 // results == [
-//   {match: "alice@example", groups: ["alice", "example"]},
-//   {match: "bob@test", groups: ["bob", "test"]}
+//   {match: "alice@example", groups: ["alice", "example"], start: 0, end: 13, line: 1},
+//   {match: "bob@test", groups: ["bob", "test"], start: 14, end: 22, line: 1}
 // ]
 
 let named = regex_captures("(?P<user>\\w+):(?P<role>\\w+)", "alice:admin")
 // named == [{match: "alice:admin", groups: ["alice", "admin"], user: "alice", role: "admin"}]
+
+let body = regex_captures("(?is)<body\\b[^>]*>(.*?)</body>", html)
+let also_body = regex_captures("<body\\b[^>]*>(.*?)</body>", html, "is")
 ```
 
 Returns an empty list if there are no matches.

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -5152,9 +5152,15 @@ database.
 
 | Function | Description |
 |---|---|
-| `regex_match(pattern, str)` | Returns match data if `str` matches `pattern`, or `nil` |
-| `regex_replace(pattern, str, replacement)` | Replaces all matches of `pattern` in `str` |
-| `regex_captures(pattern, str)` | Returns a list of capture group dicts for all matches |
+| `regex_match(pattern, text, flags?)` | Returns a list of all non-overlapping matches, or `nil` if none match |
+| `regex_replace(pattern, replacement, text, flags?)` | Replaces all matches of `pattern` in `text` |
+| `regex_captures(pattern, text, flags?)` | Returns a list of capture group dicts for all matches |
+| `regex_split(text, pattern, flags?)` | Splits `text` by regex matches |
+
+The optional `flags` string supports `i` (case-insensitive), `m`
+(multi-line anchors), `s` (dot matches newlines), and `x` (ignore
+pattern whitespace). Regex inline flags such as `(?is)` use the same
+underlying semantics.
 
 #### regex_captures
 
@@ -5162,18 +5168,26 @@ database.
 and returns a list of dicts, one per match. Each dict contains:
 
 - `match`: the full match string
-- `groups`: a list of positional capture group strings (from `(...)`)
+- `groups`: a list of positional capture group values (from `(...)`), in
+  source order and excluding the full match. Unmatched optional groups are
+  `nil`.
+- `start` / `end`: character (code-point) offsets of the full match in
+  `text`
+- `line`: 1-based line number of the match start
 - Any named capture groups (from `(?P<name>...)`) as additional keys
 
 ```harn
 let results = regex_captures("(\\w+)@(\\w+)", "alice@example bob@test")
 // results == [
-//   {match: "alice@example", groups: ["alice", "example"]},
-//   {match: "bob@test", groups: ["bob", "test"]}
+//   {match: "alice@example", groups: ["alice", "example"], start: 0, end: 13, line: 1},
+//   {match: "bob@test", groups: ["bob", "test"], start: 14, end: 22, line: 1}
 // ]
 
 let named = regex_captures("(?P<user>\\w+):(?P<role>\\w+)", "alice:admin")
 // named == [{match: "alice:admin", groups: ["alice", "admin"], user: "alice", role: "admin"}]
+
+let body = regex_captures("(?is)<body\\b[^>]*>(.*?)</body>", html)
+let also_body = regex_captures("<body\\b[^>]*>(.*?)</body>", html, "is")
 ```
 
 Returns an empty list if there are no matches.


### PR DESCRIPTION
## Summary

- Add executable regex conformance coverage for inline `(?is)` flags, trailing `i`/`s` flags, lazy newline-spanning captures, `[\s\S]*?`, and exact `regex_captures` result shape.
- Add VM unit coverage for the same core capture semantics.
- Update the canonical language spec, generated docs mirror, quickref, and LSP builtin metadata so the public API advertises `flags?`, `regex_captures`, `regex_split`, offsets, line numbers, and named capture keys.

## Root cause

I reproduced the Burin-triggering shapes in Harn proper before changing anything. The VM implementation already delegates inline flags to Rust `regex` and applies trailing `i/m/s/x` flags through `RegexBuilder`, so `(?is)`, trailing `"is"`, lazy `.*?`, and `[\s\S]*?` all work at runtime when expressed as Harn regex strings. The Harn-side problem was a contract gap: conformance did not pin these combined multiline capture cases, the canonical spec still showed stale regex signatures and omitted flags/position fields, and the LSP builtin metadata hid the optional flags and omitted `regex_captures`/`regex_split` from the compact list. That made the API easier to misread and left the important behavior unprotected.

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-target-regex-api cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/harn-target-regex-api cargo run --quiet --bin harn -- fmt --check conformance/tests/stdlib/regex_flags_captures.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-regex-api cargo run --quiet --bin harn -- check conformance/tests/stdlib/regex_flags_captures.harn`
- `CARGO_TARGET_DIR=/tmp/harn-target-regex-api cargo test -p harn-vm stdlib::regex::tests`
- `CARGO_TARGET_DIR=/tmp/harn-target-regex-api cargo run --quiet --bin harn -- test conformance --filter regex`
- `make check-language-spec`
- `CARGO_TARGET_DIR=/tmp/harn-target-regex-api cargo test -p harn-lsp`
- `CARGO_TARGET_DIR=/tmp/harn-target-regex-api cargo run --quiet --bin harn -- lint conformance/tests/stdlib/regex_flags_captures.harn`
- `make lint-md`
- `make check-docs-snippets`
- pre-commit hook passed, including changed-package clippy for `harn-vm` and `harn-lsp`
- pre-push hook passed, including targeted local checks, Harn lint/format, language-spec mirror, and highlight keyword drift checks