### PR TITLE
fix(precompile): resolve imports so builtin-colliding stdlib calls compile

### DIFF
--- a/changelog.d/precompile-import-shadows-builtin.fixed.md
+++ b/changelog.d/precompile-import-shadows-builtin.fixed.md
@@ -1,0 +1,9 @@
+- **`harn precompile` now resolves imports before type-checking, so an
+  imported symbol that shares a name with a builtin no longer reports phantom
+  type errors.** Calling `render` imported from `std/disclosure` (or any
+  stdlib/user export colliding with a builtin such as the `render` template
+  helper) compiled and ran fine under `harn run` but failed `harn precompile`,
+  because the precompiler checked the call against the builtin's signature
+  instead of the import. Precompile now derives the import graph like
+  `harn run`/`harn check`, and an imported name shadows a same-named builtin in
+  the type checker.

--- a/crates/harn-cli/src/commands/bench.rs
+++ b/crates/harn-cli/src/commands/bench.rs
@@ -73,17 +73,10 @@ pub(crate) async fn run_bench(path: &str, iterations: usize, profile: RunProfile
         eprintln!("error: {error}");
         process::exit(1);
     }
-    let graph = harn_modules::build(&[file_path.to_path_buf()]);
-    let mut checker = harn_parser::TypeChecker::new();
-    if let Some(imported) = graph.imported_names_for_file(file_path) {
-        checker = checker.with_imported_names(imported);
-    }
-    if let Some(imported) = graph.imported_type_declarations_for_file(file_path) {
-        checker = checker.with_imported_type_decls(imported);
-    }
-    if let Some(imported) = graph.imported_callable_declarations_for_file(file_path) {
-        checker = checker.with_imported_callable_decls(imported);
-    }
+    let checker = crate::typecheck_imports::checker_with_resolved_imports(
+        harn_parser::TypeChecker::new(),
+        file_path,
+    );
     let type_diagnostics = checker.check_with_source(&program, &source);
     let mut had_type_error = false;
     for diag in &type_diagnostics {

--- a/crates/harn-cli/src/commands/counterfactual.rs
+++ b/crates/harn-cli/src/commands/counterfactual.rs
@@ -174,17 +174,8 @@ fn run_plan_source_inner(source: &str, plan_path: &Path) -> Result<JsonValue, St
         .parse()
         .map_err(|error| format!("counterfactual plan parse error: {error}"))?;
 
-    let mut checker = TypeChecker::new();
-    let graph = harn_modules::build(&[plan_path.to_path_buf()]);
-    if let Some(imported) = graph.imported_names_for_file(plan_path) {
-        checker = checker.with_imported_names(imported);
-    }
-    if let Some(imported) = graph.imported_type_declarations_for_file(plan_path) {
-        checker = checker.with_imported_type_decls(imported);
-    }
-    if let Some(imported) = graph.imported_callable_declarations_for_file(plan_path) {
-        checker = checker.with_imported_callable_decls(imported);
-    }
+    let checker =
+        crate::typecheck_imports::checker_with_resolved_imports(TypeChecker::new(), plan_path);
     for diag in checker.check(&program) {
         if matches!(diag.severity, DiagnosticSeverity::Error) {
             return Err(format!("counterfactual plan type error: {}", diag.message));

--- a/crates/harn-cli/src/commands/precompile.rs
+++ b/crates/harn-cli/src/commands/precompile.rs
@@ -33,6 +33,7 @@ use crate::commands::collect_harn_files;
 use crate::dispatch;
 use crate::env_guard::ScopedEnvVar;
 use crate::parse_source_file;
+use crate::typecheck_imports::checker_with_resolved_imports;
 
 /// Env var the embedded `cli/precompile` script reads to find the
 /// running `harn` binary path. Set from `std::env::current_exe()` so
@@ -171,9 +172,13 @@ fn precompile_one(
     let (parsed_source, program) = parse_source_file(&path_str);
     debug_assert_eq!(parsed_source, source);
 
+    // Resolve imports like `execute`/`harn check` so a call to an imported
+    // symbol that shadows a builtin is checked against the right signature.
+    let checker = checker_with_resolved_imports(harn_parser::TypeChecker::new(), source_path);
+
     let mut had_type_error = false;
     let mut messages = String::new();
-    for diag in harn_parser::TypeChecker::new().check_with_source(&program, &source) {
+    for diag in checker.check_with_source(&program, &source) {
         let rendered = harn_parser::diagnostic::render_type_diagnostic(&source, &path_str, &diag);
         if matches!(diag.severity, DiagnosticSeverity::Error) {
             had_type_error = true;

--- a/crates/harn-cli/src/commands/run/mod.rs
+++ b/crates/harn-cli/src/commands/run/mod.rs
@@ -432,17 +432,10 @@ fn typecheck_with_imports(
         eprintln!("error: {error}");
         process::exit(1);
     }
-    let graph = harn_modules::build(&[path.to_path_buf()]);
-    let mut checker = harn_parser::TypeChecker::new();
-    if let Some(imported) = graph.imported_names_for_file(path) {
-        checker = checker.with_imported_names(imported);
-    }
-    if let Some(imported) = graph.imported_type_declarations_for_file(path) {
-        checker = checker.with_imported_type_decls(imported);
-    }
-    if let Some(imported) = graph.imported_callable_declarations_for_file(path) {
-        checker = checker.with_imported_callable_decls(imported);
-    }
+    let checker = crate::typecheck_imports::checker_with_resolved_imports(
+        harn_parser::TypeChecker::new(),
+        path,
+    );
     checker.check_with_source(program, source)
 }
 

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -19,6 +19,7 @@ pub mod test_report;
 pub mod test_runner;
 #[doc(hidden)]
 pub mod tests;
+mod typecheck_imports;
 
 pub use harn_skills::{get_embedded_skill, list_embedded_skills, EmbeddedSkill, SkillFrontmatter};
 
@@ -3109,16 +3110,7 @@ async fn execute_with_skill_dirs_and_optional_harness(
     // is no importing file context; we fall back to no-imports checking.
     let mut checker = TypeChecker::new();
     if let Some(path) = source_path {
-        let graph = harn_modules::build(&[path.to_path_buf()]);
-        if let Some(imported) = graph.imported_names_for_file(path) {
-            checker = checker.with_imported_names(imported);
-        }
-        if let Some(imported) = graph.imported_type_declarations_for_file(path) {
-            checker = checker.with_imported_type_decls(imported);
-        }
-        if let Some(imported) = graph.imported_callable_declarations_for_file(path) {
-            checker = checker.with_imported_callable_decls(imported);
-        }
+        checker = crate::typecheck_imports::checker_with_resolved_imports(checker, path);
     }
     let type_diagnostics = checker.check(&program);
     let mut warning_lines = Vec::new();

--- a/crates/harn-cli/src/typecheck_imports.rs
+++ b/crates/harn-cli/src/typecheck_imports.rs
@@ -1,0 +1,28 @@
+//! Shared import-graph resolution for the CLI's type-check entry points.
+//!
+//! `harn run`, `precompile`, `bench`, and `counterfactual` each type-check
+//! a single file but must resolve that file's imports first — otherwise a
+//! call to an imported symbol is checked against nothing (or, worse, a
+//! same-named builtin). Factoring the resolution here keeps every entry
+//! point consistent with `execute`/`harn check`.
+
+use std::path::Path;
+
+use harn_parser::TypeChecker;
+
+/// Configure `checker` with the resolved imports of the module rooted at
+/// `path`, so a call to an imported symbol is checked against its real
+/// signature (and an imported name shadows a same-named builtin).
+pub(crate) fn checker_with_resolved_imports(mut checker: TypeChecker, path: &Path) -> TypeChecker {
+    let graph = harn_modules::build(&[path.to_path_buf()]);
+    if let Some(imported) = graph.imported_names_for_file(path) {
+        checker = checker.with_imported_names(imported);
+    }
+    if let Some(imported) = graph.imported_type_declarations_for_file(path) {
+        checker = checker.with_imported_type_decls(imported);
+    }
+    if let Some(imported) = graph.imported_callable_declarations_for_file(path) {
+        checker = checker.with_imported_callable_decls(imported);
+    }
+    checker
+}

--- a/crates/harn-cli/tests/precompile_dispatch.rs
+++ b/crates/harn-cli/tests/precompile_dispatch.rs
@@ -89,6 +89,44 @@ fn directory_dispatch_emits_artifacts_for_every_source() {
     assert_eq!(sort_lines(&harn.stdout), sort_lines(&rust.stdout));
 }
 
+/// A pipeline that calls a stdlib export whose name collides with a
+/// builtin (`std/disclosure::render` vs the `template.render` builtin)
+/// must precompile. Regression for the import-graph resolution that
+/// `precompile_one` was missing: without it the call was checked against
+/// the builtin signature and failed with phantom type errors, even though
+/// `harn run` resolves the import correctly.
+#[test]
+fn precompiles_call_to_builtin_colliding_stdlib_import() {
+    let workdir = tempfile::tempdir().expect("workdir");
+    let source = workdir.path().join("disclose.harn");
+    std::fs::write(
+        &source,
+        r#"import { render } from "std/disclosure"
+
+pipeline default(task) {
+  let chain = {sub: "user:k", act: {sub: "agent:b"}}
+  log(render(chain, "git", {project: false, env: false, config: {}}))
+}
+"#,
+    )
+    .expect("write disclose.harn");
+
+    let outcome = run_precompile(
+        &[source.to_string_lossy().as_ref()],
+        &[("HARN_CLI_IMPL", "rust")],
+    );
+    assert_eq!(
+        outcome.exit_code, 0,
+        "precompile should succeed; stderr:\n{}",
+        outcome.stderr
+    );
+    assert!(
+        outcome.stderr.contains("1 succeeded, 0 failed"),
+        "stderr should report 1/0; got:\n{}",
+        outcome.stderr
+    );
+}
+
 #[test]
 fn out_directory_mirrors_source_tree_under_target() {
     let workdir = tempfile::tempdir().expect("workdir");

--- a/crates/harn-parser/src/typechecker/inference/calls.rs
+++ b/crates/harn-parser/src/typechecker/inference/calls.rs
@@ -1475,12 +1475,31 @@ impl TypeChecker {
                     }
                 }
             }
-        } else if let Some(sig) = builtin_signatures::lookup(name) {
+        } else if let Some(sig) =
+            builtin_signatures::lookup(name).filter(|_| !self.name_is_imported(name))
+        {
+            // An explicit `import { name } from ...` shadows a same-named
+            // builtin, matching the VM's runtime resolution. Guards the
+            // case where an imported symbol is known by name but its
+            // signature was not resolved into scope: without this, e.g.
+            // `render` imported from `std/disclosure` (3 params) would be
+            // checked against the `render` builtin (`path: string?,
+            // bindings: dict`) and report phantom errors. Like every other
+            // imported call in that mode, we then only check the arguments.
             self.check_builtin_signature_call(name, sig, type_args, args, has_spread, scope, span);
         } else {
             for arg in args {
                 self.check_node(arg, scope);
             }
         }
+    }
+
+    /// Whether `name` was brought into scope by an `import` in the
+    /// resolved cross-module mode (`with_imported_names`). Outside that
+    /// mode there is no import set, so builtins are never shadowed.
+    fn name_is_imported(&self, name: &str) -> bool {
+        self.imported_names
+            .as_ref()
+            .is_some_and(|names| names.contains(name))
     }
 }

--- a/crates/harn-parser/src/typechecker/tests/strict_types.rs
+++ b/crates/harn-parser/src/typechecker/tests/strict_types.rs
@@ -258,6 +258,29 @@ fn test_cross_module_imported_call_is_allowed() {
 }
 
 #[test]
+fn test_imported_name_shadows_same_named_builtin() {
+    // `render` is a builtin (`template.render(path: string?, bindings: dict)`),
+    // but here it is imported from a module (e.g. `std/disclosure`, which
+    // exports a 3-arg `render`). The import must shadow the builtin so the
+    // call is not checked against the builtin's signature — otherwise
+    // precompile reports phantom arity/argument-type errors that `harn run`
+    // never hits.
+    let diags = check_source_with_imports(
+        r#"pipeline t(task) { render({sub: "user:k"}, "github", {project: false}) }"#,
+        &["render"],
+    );
+    let noise: Vec<&String> = diags
+        .iter()
+        .filter(|d| d.message.contains("render"))
+        .map(|d| &d.message)
+        .collect();
+    assert!(
+        noise.is_empty(),
+        "imported `render` must shadow the builtin, got: {noise:?}"
+    );
+}
+
+#[test]
 fn test_renamed_stdlib_call_suggests_replacement() {
     let diags = check_source_with_imports(
         r"pipeline t(task) { retry_with_backoff(1, 0, fn() { return true }) }",


### PR DESCRIPTION
## Problem
A host pipeline that calls `std/disclosure`'s `render` (Identity B1, #3337) — e.g. to render an authorship trailer from an actor chain — runs fine under `harn run` but **fails `harn precompile`** with phantom type errors:

```
warning[HARN-STD-003]: Builtin function 'render' expects 1-2 arguments, got 3
error[HARN-TYP-006]: argument 1 `path`: expected string?, found {sub: string, …}
error[HARN-TYP-006]: argument 2 `bindings`: expected dict, found string
```

Root cause: `precompile` type-checked each file with a bare `TypeChecker::new()`, **without** deriving the import graph that `harn run`/`harn check` build. So the imported `render` was resolved to the same-named `template.render` builtin (`path: string?, bindings: dict`) and checked against the wrong signature. `harn run` resolves the import correctly, so the inconsistency only bit precompile — silently blocking any bundled host-pipeline that uses the disclosure helper.

## Fix
- **`precompile_one`** now builds the module graph and threads imported names / type-decls / callable-decls into the checker, mirroring `execute` (`lib.rs`). The imported `render`'s real 3-param signature is now in scope.
- **The type checker** lets an imported name shadow a same-named builtin in the call check (`name_is_imported` guard), matching the VM's runtime resolution — defense for the name-only cross-module mode.

## Tests
- `typechecker::tests::strict_types::test_imported_name_shadows_same_named_builtin` — imported `render` is not checked against the builtin.
- `precompile_dispatch::precompiles_call_to_builtin_colliding_stdlib_import` — a pipeline calling `std/disclosure::render` precompiles cleanly (exit 0, `1 succeeded`).

Found while wiring the disclosure helper into Burin's commit flow (Identity B5). No behavior change for `harn run`/`harn check`; brings `harn precompile` in line with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)