### PR TITLE
fix(vm): promote integer arithmetic to float on i64 overflow

### DIFF
--- a/changelog.d/integer-overflow-promotes.changed.md
+++ b/changelog.d/integer-overflow-promotes.changed.md
@@ -1,0 +1,7 @@
+- **Scalar integer arithmetic now promotes to float on `i64` overflow instead
+  of silently wrapping.** `a + b`, `a - b`, `a * b`, `a ** b`, and unary `-a`
+  previously wrapped two's-complement (e.g. `i64::MAX + 1` became a large
+  negative number); they now promote to `float`, matching the language's own
+  aggregate policy — `sum`/`abs` already promote on overflow. In-range integer
+  arithmetic is unchanged. The compile-time constant folder defers the same
+  overflow cases to the runtime so folded and unfolded expressions agree.

--- a/conformance/tests/language/integer_overflow_promotes.expected
+++ b/conformance/tests/language/integer_overflow_promotes.expected
@@ -1,0 +1,4 @@
+[harn] float
+[harn] true
+[harn] int
+[harn] 5

--- a/conformance/tests/language/integer_overflow_promotes.harn
+++ b/conformance/tests/language/integer_overflow_promotes.harn
@@ -1,0 +1,15 @@
+/**
+ * Scalar integer arithmetic that overflows i64 promotes to float instead of
+ * silently wrapping two's-complement. This matches the language's aggregate
+ * policy (`sum`/`abs` already promote on i64 overflow) and avoids returning a
+ * wrong, wrapped magnitude. In-range arithmetic stays int. Operands are `let`
+ * bindings so the runtime arithmetic path is exercised, not just folding.
+ */
+pipeline test(task) {
+  let big = 9223372036854775807
+  let one = 1
+  log(type_of(big + one))
+  log(big + one > 9000000000000000000.0)
+  log(type_of(2 + 3))
+  log(2 + 3)
+}

--- a/crates/harn-vm/src/compiler/optimizer.rs
+++ b/crates/harn-vm/src/compiler/optimizer.rs
@@ -87,7 +87,10 @@ fn constant_value(expr: &SNode) -> Option<VmValue> {
 
 fn fold_unary(op: &str, value: VmValue) -> Option<VmValue> {
     match (op, value) {
-        ("-", VmValue::Int(value)) => Some(VmValue::Int(value.wrapping_neg())),
+        // Decline to fold the one overflowing case (`-i64::MIN`); the runtime
+        // negate op promotes it to float. Folding to a wrapped `i64::MIN` here
+        // would disagree with the VM.
+        ("-", VmValue::Int(value)) => value.checked_neg().map(VmValue::Int),
         ("-", VmValue::Float(value)) => Some(VmValue::Float(-value)),
         ("!", value) => Some(VmValue::Bool(!value.is_truthy())),
         _ => None,
@@ -135,7 +138,7 @@ fn fold_binary(op: &str, left: VmValue, right: VmValue) -> Option<VmValue> {
 
 fn fold_add(left: VmValue, right: VmValue) -> Option<VmValue> {
     match (left, right) {
-        (VmValue::Int(left), VmValue::Int(right)) => Some(VmValue::Int(left.wrapping_add(right))),
+        (VmValue::Int(left), VmValue::Int(right)) => left.checked_add(right).map(VmValue::Int),
         (VmValue::Float(left), VmValue::Float(right)) => Some(VmValue::Float(left + right)),
         (VmValue::Int(left), VmValue::Float(right)) => Some(VmValue::Float(left as f64 + right)),
         (VmValue::Float(left), VmValue::Int(right)) => Some(VmValue::Float(left + right as f64)),
@@ -178,7 +181,7 @@ fn fold_add(left: VmValue, right: VmValue) -> Option<VmValue> {
 
 fn fold_sub(left: VmValue, right: VmValue) -> Option<VmValue> {
     match (left, right) {
-        (VmValue::Int(left), VmValue::Int(right)) => Some(VmValue::Int(left.wrapping_sub(right))),
+        (VmValue::Int(left), VmValue::Int(right)) => left.checked_sub(right).map(VmValue::Int),
         (VmValue::Float(left), VmValue::Float(right)) => Some(VmValue::Float(left - right)),
         (VmValue::Int(left), VmValue::Float(right)) => Some(VmValue::Float(left as f64 - right)),
         (VmValue::Float(left), VmValue::Int(right)) => Some(VmValue::Float(left - right as f64)),
@@ -188,7 +191,7 @@ fn fold_sub(left: VmValue, right: VmValue) -> Option<VmValue> {
 
 fn fold_mul(left: VmValue, right: VmValue) -> Option<VmValue> {
     match (left, right) {
-        (VmValue::Int(left), VmValue::Int(right)) => Some(VmValue::Int(left.wrapping_mul(right))),
+        (VmValue::Int(left), VmValue::Int(right)) => left.checked_mul(right).map(VmValue::Int),
         (VmValue::Float(left), VmValue::Float(right)) => Some(VmValue::Float(left * right)),
         (VmValue::Int(left), VmValue::Float(right)) => Some(VmValue::Float(left as f64 * right)),
         (VmValue::Float(left), VmValue::Int(right)) => Some(VmValue::Float(left * right as f64)),
@@ -207,6 +210,9 @@ fn fold_mul(left: VmValue, right: VmValue) -> Option<VmValue> {
 
 fn fold_div(left: VmValue, right: VmValue) -> Option<VmValue> {
     match (left, right) {
+        // Integer division by zero is declined here so the runtime raises;
+        // float division by zero deliberately follows IEEE-754 (±inf / NaN),
+        // matching the runtime float-div op and the documented design.
         (VmValue::Int(_), VmValue::Int(0)) => None,
         (VmValue::Int(left), VmValue::Int(right)) => left.checked_div(right).map(VmValue::Int),
         (VmValue::Float(left), VmValue::Float(right)) => Some(VmValue::Float(left / right)),
@@ -233,8 +239,8 @@ fn fold_mod(left: VmValue, right: VmValue) -> Option<VmValue> {
 fn fold_pow(left: VmValue, right: VmValue) -> Option<VmValue> {
     match (left, right) {
         (VmValue::Int(base), VmValue::Int(exp)) => {
-            if u32::try_from(exp).is_ok() {
-                Some(VmValue::Int(base.wrapping_pow(exp as u32)))
+            if let Ok(exp) = u32::try_from(exp) {
+                base.checked_pow(exp).map(VmValue::Int)
             } else {
                 Some(VmValue::Float((base as f64).powf(exp as f64)))
             }

--- a/crates/harn-vm/src/vm/ops/arithmetic.rs
+++ b/crates/harn-vm/src/vm/ops/arithmetic.rs
@@ -14,6 +14,43 @@ fn decimal_result(value: Option<rust_decimal::Decimal>, op: &str) -> Result<VmVa
         .ok_or_else(|| VmError::Runtime(format!("decimal {op} overflowed")))
 }
 
+// Scalar `i64` arithmetic that promotes to `f64` on overflow instead of
+// silently wrapping two's-complement. This matches the language's own
+// aggregate policy — `sum`/`abs` already promote on `i64` overflow (see
+// `vm/methods/list.rs` and `vm/methods/iter.rs`) — so a bare `a + b` no
+// longer disagrees with `[a, b].sum()`. A wrap produces a wrong magnitude
+// silently; promotion preserves it (with float precision), the way Python's
+// int→float-on-need and JS's single number tower behave. Decimal keeps its
+// own checked-overflow-to-error path (exact money math must not go lossy).
+fn int_add(x: i64, y: i64) -> VmValue {
+    x.checked_add(y)
+        .map_or_else(|| VmValue::Float(x as f64 + y as f64), VmValue::Int)
+}
+
+fn int_sub(x: i64, y: i64) -> VmValue {
+    x.checked_sub(y)
+        .map_or_else(|| VmValue::Float(x as f64 - y as f64), VmValue::Int)
+}
+
+fn int_mul(x: i64, y: i64) -> VmValue {
+    x.checked_mul(y)
+        .map_or_else(|| VmValue::Float(x as f64 * y as f64), VmValue::Int)
+}
+
+fn int_neg(n: i64) -> VmValue {
+    // Only `i64::MIN` overflows negation; promote it rather than wrapping
+    // back to `i64::MIN` (the classic surprise). Mirrors `abs(i64::MIN)`.
+    n.checked_neg()
+        .map_or_else(|| VmValue::Float(-(n as f64)), VmValue::Int)
+}
+
+fn int_pow(base: i64, exp: u32) -> VmValue {
+    base.checked_pow(exp).map_or_else(
+        || VmValue::Float((base as f64).powf(exp as f64)),
+        VmValue::Int,
+    )
+}
+
 impl super::super::Vm {
     fn push_binary_result(
         &mut self,
@@ -53,7 +90,7 @@ impl super::super::Vm {
     pub(super) fn execute_negate(&mut self) -> Result<(), VmError> {
         let v = self.pop()?;
         self.stack.push(match v {
-            VmValue::Int(n) => VmValue::Int(n.wrapping_neg()),
+            VmValue::Int(n) => int_neg(n),
             VmValue::Float(n) => VmValue::Float(-n),
             VmValue::Decimal(d) => VmValue::Decimal(-d),
             _ => {
@@ -244,13 +281,13 @@ impl super::super::Vm {
     ) -> Option<VmValue> {
         match (op, shape, a, b) {
             (AdaptiveBinaryOp::Add, BinaryShape::Int, VmValue::Int(x), VmValue::Int(y)) => {
-                Some(VmValue::Int(x.wrapping_add(*y)))
+                Some(int_add(*x, *y))
             }
             (AdaptiveBinaryOp::Sub, BinaryShape::Int, VmValue::Int(x), VmValue::Int(y)) => {
-                Some(VmValue::Int(x.wrapping_sub(*y)))
+                Some(int_sub(*x, *y))
             }
             (AdaptiveBinaryOp::Mul, BinaryShape::Int, VmValue::Int(x), VmValue::Int(y)) => {
-                Some(VmValue::Int(x.wrapping_mul(*y)))
+                Some(int_mul(*x, *y))
             }
             (AdaptiveBinaryOp::Div, BinaryShape::Int, VmValue::Int(_), VmValue::Int(0))
             | (AdaptiveBinaryOp::Mod, BinaryShape::Int, VmValue::Int(_), VmValue::Int(0)) => None,
@@ -379,21 +416,21 @@ impl super::super::Vm {
 
     pub(super) fn execute_add_int(&mut self) -> Result<(), VmError> {
         self.run_typed_binary(AdaptiveBinaryOp::Add, |a, b| match (a, b) {
-            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(VmValue::Int(x.wrapping_add(*y)))),
+            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(int_add(*x, *y))),
             _ => None,
         })
     }
 
     pub(super) fn execute_sub_int(&mut self) -> Result<(), VmError> {
         self.run_typed_binary(AdaptiveBinaryOp::Sub, |a, b| match (a, b) {
-            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(VmValue::Int(x.wrapping_sub(*y)))),
+            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(int_sub(*x, *y))),
             _ => None,
         })
     }
 
     pub(super) fn execute_mul_int(&mut self) -> Result<(), VmError> {
         self.run_typed_binary(AdaptiveBinaryOp::Mul, |a, b| match (a, b) {
-            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(VmValue::Int(x.wrapping_mul(*y)))),
+            (VmValue::Int(x), VmValue::Int(y)) => Some(Ok(int_mul(*x, *y))),
             _ => None,
         })
     }
@@ -454,7 +491,7 @@ impl super::super::Vm {
 
     fn add(&self, a: VmValue, b: VmValue) -> Result<VmValue, VmError> {
         match (a, b) {
-            (VmValue::Int(x), VmValue::Int(y)) => Ok(VmValue::Int(x.wrapping_add(y))),
+            (VmValue::Int(x), VmValue::Int(y)) => Ok(int_add(x, y)),
             (VmValue::Float(x), VmValue::Float(y)) => Ok(VmValue::Float(x + y)),
             (VmValue::Int(x), VmValue::Float(y)) => Ok(VmValue::Float(x as f64 + y)),
             (VmValue::Float(x), VmValue::Int(y)) => Ok(VmValue::Float(x + y as f64)),
@@ -527,7 +564,7 @@ impl super::super::Vm {
 
     fn sub(&self, a: VmValue, b: VmValue) -> Result<VmValue, VmError> {
         match (&a, &b) {
-            (VmValue::Int(x), VmValue::Int(y)) => Ok(VmValue::Int(x.wrapping_sub(*y))),
+            (VmValue::Int(x), VmValue::Int(y)) => Ok(int_sub(*x, *y)),
             (VmValue::Float(x), VmValue::Float(y)) => Ok(VmValue::Float(x - y)),
             (VmValue::Int(x), VmValue::Float(y)) => Ok(VmValue::Float(*x as f64 - y)),
             (VmValue::Float(x), VmValue::Int(y)) => Ok(VmValue::Float(x - *y as f64)),
@@ -552,7 +589,7 @@ impl super::super::Vm {
 
     fn mul(&self, a: VmValue, b: VmValue) -> Result<VmValue, VmError> {
         match (&a, &b) {
-            (VmValue::Int(x), VmValue::Int(y)) => Ok(VmValue::Int(x.wrapping_mul(*y))),
+            (VmValue::Int(x), VmValue::Int(y)) => Ok(int_mul(*x, *y)),
             (VmValue::Float(x), VmValue::Float(y)) => Ok(VmValue::Float(x * y)),
             (VmValue::Int(x), VmValue::Float(y)) => Ok(VmValue::Float(*x as f64 * y)),
             (VmValue::Float(x), VmValue::Int(y)) => Ok(VmValue::Float(x * *y as f64)),
@@ -652,7 +689,7 @@ impl super::super::Vm {
         match (&a, &b) {
             (VmValue::Int(base), VmValue::Int(exp)) => {
                 if u32::try_from(*exp).is_ok() {
-                    Ok(VmValue::Int(base.wrapping_pow(*exp as u32)))
+                    Ok(int_pow(*base, *exp as u32))
                 } else {
                     Ok(VmValue::Float((*base as f64).powf(*exp as f64)))
                 }
@@ -694,5 +731,37 @@ impl BinaryShape {
             }
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod overflow_promotion_tests {
+    use super::*;
+
+    #[test]
+    fn add_sub_mul_promote_to_float_on_overflow() {
+        assert!(matches!(int_add(2, 3), VmValue::Int(5)));
+        assert!(matches!(int_add(i64::MAX, 1), VmValue::Float(_)));
+        assert!(matches!(int_sub(i64::MIN, 1), VmValue::Float(_)));
+        assert!(matches!(int_mul(i64::MAX, 2), VmValue::Float(_)));
+        // In-range stays int.
+        assert!(matches!(int_mul(1000, 1000), VmValue::Int(1_000_000)));
+    }
+
+    #[test]
+    fn neg_of_i64_min_promotes_instead_of_wrapping() {
+        // The classic two's-complement surprise: `-i64::MIN` wraps back to
+        // `i64::MIN`. Promotion yields the correct positive magnitude.
+        match int_neg(i64::MIN) {
+            VmValue::Float(f) => assert!(f > 0.0),
+            other => panic!("expected promoted float, got {other:?}"),
+        }
+        assert!(matches!(int_neg(5), VmValue::Int(-5)));
+    }
+
+    #[test]
+    fn pow_promotes_on_overflow() {
+        assert!(matches!(int_pow(2, 10), VmValue::Int(1024)));
+        assert!(matches!(int_pow(2, 100), VmValue::Float(_)));
     }
 }

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -1150,7 +1150,7 @@ Comparison between other types returns 0 (equal).
 
 | Left | Right | `+` | `-` | `*` | `/` |
 |---|---|---|---|---|---|
-| int | int | int | int | int | int (truncating) |
+| int | int | int¹ | int¹ | int¹ | int (truncating) |
 | float | float | float | float | float | float |
 | int | float | float | float | float | float |
 | float | int | float | float | float | float |
@@ -1160,6 +1160,12 @@ Comparison between other types returns 0 (equal).
 | list | list | list (concatenation) | **TypeError** | **TypeError** | **TypeError** |
 | dict | dict | dict (merge, right wins) | **TypeError** | **TypeError** | **TypeError** |
 | other | other | **TypeError** | **TypeError** | **TypeError** | **TypeError** |
+
+¹ When an `int` result would overflow the 64-bit range, it promotes to
+`float` rather than wrapping two's-complement (so `i64::MAX + 1` is a large
+`float`, not a negative `int`). This matches `sum`/`abs`, which already promote
+on overflow. In-range integer arithmetic stays `int`. The same applies to
+unary negation (`-i64::MIN`) and `**` (see below).
 
 Division by zero depends on the result type. Integer division by zero
 (`int / int`) raises a runtime error that propagates like any other thrown
@@ -1185,7 +1191,7 @@ regardless of operand types (unlike float division, it never yields `NaN`).
 `2 ** (3 ** 2)`.
 
 - `int ** int` returns `int` for non-negative exponents that fit in `u32`,
-  using wrapping integer exponentiation.
+  promoting to `float` if the result overflows the 64-bit range.
 - Negative or very large integer exponents promote to `float`.
 - Any case involving a `float` returns `float`.
 - Non-numeric operands raise `TypeError`.

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -1148,7 +1148,7 @@ Comparison between other types returns 0 (equal).
 
 | Left | Right | `+` | `-` | `*` | `/` |
 |---|---|---|---|---|---|
-| int | int | int | int | int | int (truncating) |
+| int | int | int¹ | int¹ | int¹ | int (truncating) |
 | float | float | float | float | float | float |
 | int | float | float | float | float | float |
 | float | int | float | float | float | float |
@@ -1158,6 +1158,12 @@ Comparison between other types returns 0 (equal).
 | list | list | list (concatenation) | **TypeError** | **TypeError** | **TypeError** |
 | dict | dict | dict (merge, right wins) | **TypeError** | **TypeError** | **TypeError** |
 | other | other | **TypeError** | **TypeError** | **TypeError** | **TypeError** |
+
+¹ When an `int` result would overflow the 64-bit range, it promotes to
+`float` rather than wrapping two's-complement (so `i64::MAX + 1` is a large
+`float`, not a negative `int`). This matches `sum`/`abs`, which already promote
+on overflow. In-range integer arithmetic stays `int`. The same applies to
+unary negation (`-i64::MIN`) and `**` (see below).
 
 Division by zero depends on the result type. Integer division by zero
 (`int / int`) raises a runtime error that propagates like any other thrown
@@ -1183,7 +1189,7 @@ regardless of operand types (unlike float division, it never yields `NaN`).
 `2 ** (3 ** 2)`.
 
 - `int ** int` returns `int` for non-negative exponents that fit in `u32`,
-  using wrapping integer exponentiation.
+  promoting to `float` if the result overflows the 64-bit range.
 - Negative or very large integer exponents promote to `float`.
 - Any case involving a `float` returns `float`.
 - Non-numeric operands raise `TypeError`.


### PR DESCRIPTION
## What

Scalar integer `+ - * **` and unary `-` silently **wrapped** two's-complement on `i64` overflow:

```harn
let big = 9223372036854775807
log(big + 1)   // was: -9223372036854775808  (silent wrong magnitude)
               // now: 9223372036854776000   (float)
```

This contradicted the language's **own** policy — `sum`/`abs` already promote to float on `i64` overflow (`vm/methods/list.rs`, `vm/methods/iter.rs`). A wrap returns a silently-wrong value; promotion preserves the magnitude (with float precision), the way Python's int→float and JS's single number tower behave. **SOTA:** Lua 5.3+ wraps (documented), but Python/JS never silently wrap; Harn's internal `sum`/`abs` precedent settles it toward promotion.

## How
- Added `int_add`/`int_sub`/`int_mul`/`int_neg`/`int_pow` (`checked_*` with float fallback), wired through **all** integer-arith paths: adaptive fast path, typed `*_int` ops, slow path, negate, and pow.
- The compile-time constant folder (`optimizer.rs`) now declines to fold the overflowing cases (defers to runtime), so folded and unfolded expressions agree (verified with `HARN_BYTECODE_CACHE=0`).

## Explicitly out of scope
Float `/0`→`±inf` and `0.0/0.0`→`NaN` are a **documented, regression-tested** IEEE-754 design choice (`division_by_zero_float.harn`, `signed_zero_division.harn`) — left unchanged. Only the integer-overflow inconsistency is fixed.

## Tests
- Unit tests for the promotion helpers (in-range stays int; overflow → float; `-i64::MIN` promotes).
- Conformance fixture `integer_overflow_promotes` (runtime + constant paths).
- Spec "Binary operator semantics" updated (mirror synced). Full conformance: 1635 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)