### PR TITLE
fix(scripts): clean up spec-verify scratch dir on every exit path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,11 @@ __pycache__/
 .serena/
 meta_scratch/
 
+# Scratch dir from `scripts/verify_language_spec.harn` (the runtime sandbox
+# forces it into the workspace root; normally removed, but an interrupted run
+# can leak it).
+harn-spec-verify-*/
+
 # Conformance skill fixtures deliberately ship a .harn/ subdir so the
 # project-layer loader (issue #73) has something to discover. The blanket
 # `.harn/` ignore above would drop them otherwise.

--- a/scripts/verify_language_spec.harn
+++ b/scripts/verify_language_spec.harn
@@ -262,6 +262,13 @@ pipeline main(task) {
     return 1
   }
   let tmpbase = mk.stdout.trim()
+  /* Remove the scratch directory on every exit path — including an early
+   * return or a throw from `write_text`/`spawn_captured` below. Without this
+   * an interrupted run leaks a `harn-spec-verify-*` directory into the
+   * workspace root, where it shows up as a confusing untracked entry. */
+  defer {
+    harness.process.spawn_captured({cmd: "rm", args: ["-rf", tmpbase]})
+  }
   var manifest_lines = []
   var idx = 0
   for fence in fences {
@@ -280,7 +287,6 @@ pipeline main(task) {
   let check_args = argv_prefix.slice(1, argv_prefix.count) + [tmpbase]
   let result = harness.process
     .spawn_captured({cmd: bin, args: check_args})
-  harness.process.spawn_captured({cmd: "rm", args: ["-rf", tmpbase]})
   if result.exit_code != 0 {
     __io_eprintln("language spec verification failed")
     __io_eprintln("")


### PR DESCRIPTION
## What

A stray `harn-spec-verify-SSgqB2/` directory was showing up untracked in the repo root. Traced it to `scripts/verify_language_spec.harn`, which `mktemp -d`s a scratch dir **in the workspace root** (the runtime sandbox only permits writes there) and removes it with a single `rm -rf` after the check. An interrupted run — or a throw from `write_text`/`spawn_captured` — skips that line and leaks the directory.

## Fix
- Move the `rm -rf` into a `defer` right after the dir is created, so cleanup runs on **every** exit path (early return or throw).
- Add `harn-spec-verify-*/` to `.gitignore` as a backstop for cases `defer` can't cover (SIGKILL / hard interrupt).

The pre-existing leaked directory was deleted separately (it was untracked/vestigial).

## Verification
Ran `verify_language_spec.harn` end-to-end: it verifies all spec fences, exits 0, and leaves **no** scratch directory behind. `git status` shows only the two intended changes (the transient scratch dir is now ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)