### PR TITLE
Add harness secrets primitive

### DIFF
--- a/changelog.d/499.added.md
+++ b/changelog.d/499.added.md
@@ -1,0 +1,4 @@
+- **`harness.secrets` now exposes host-owned secret management primitives
+  (#499).** Embedders can attach a `SecretProvider` that backs scoped
+  read/write/rotate/lease operations while Harn supplies the typed VM surface,
+  audit context propagation, and binary-safe variants.

--- a/crates/harn-parser/src/harness_methods.rs
+++ b/crates/harn-parser/src/harness_methods.rs
@@ -126,6 +126,13 @@ pub fn harness_llm_ambient(method: &str) -> Option<&'static str> {
     }
 }
 
+pub fn harness_secrets_ambient(method: &str) -> Option<&'static str> {
+    match method {
+        "read" | "read_bytes" | "write" | "rotate" | "lease" | "lease_bytes" => None,
+        _ => None,
+    }
+}
+
 pub fn harness_tenant_ambient(method: &str) -> Option<&'static str> {
     match method {
         "id" => Some("harness_tenant_id"),
@@ -173,6 +180,7 @@ pub fn harness_sub_handle_ambient(sub_handle: &str, method: &str) -> Option<&'st
         "process" => harness_process_ambient(method),
         "crypto" => harness_crypto_ambient(method),
         "system" => harness_system_ambient(method),
+        "secrets" => harness_secrets_ambient(method),
         "llm" => harness_llm_ambient(method),
         "tenant" => harness_tenant_ambient(method),
         "auth" => harness_auth_ambient(method),
@@ -193,6 +201,7 @@ pub fn harness_type_sub_handle(type_name: &str) -> Option<&'static str> {
         "HarnessProcess" => Some("process"),
         "HarnessCrypto" => Some("crypto"),
         "HarnessSystem" => Some("system"),
+        "HarnessSecrets" => Some("secrets"),
         "HarnessLlm" => Some("llm"),
         "HarnessTenant" => Some("tenant"),
         "HarnessAuth" => Some("auth"),

--- a/crates/harn-parser/src/typechecker/inference/expressions.rs
+++ b/crates/harn-parser/src/typechecker/inference/expressions.rs
@@ -1164,6 +1164,7 @@ impl TypeChecker {
                 "process" => Some(TypeExpr::Named("HarnessProcess".into())),
                 "crypto" => Some(TypeExpr::Named("HarnessCrypto".into())),
                 "system" => Some(TypeExpr::Named("HarnessSystem".into())),
+                "secrets" => Some(TypeExpr::Named("HarnessSecrets".into())),
                 "llm" => Some(TypeExpr::Named("HarnessLlm".into())),
                 "tenant" => Some(TypeExpr::Named("HarnessTenant".into())),
                 "auth" => Some(TypeExpr::Named("HarnessAuth".into())),

--- a/crates/harn-vm/src/harness.rs
+++ b/crates/harn-vm/src/harness.rs
@@ -4,10 +4,11 @@
 //! `Harness` is the Harn-language analog of an explicit-capability handle: a
 //! single value the runtime hands to a script's `main` so that stdio,
 //! terminal, clock, filesystem, environment, randomness, network, process,
-//! crypto, system, and LLM catalog access become surface in the type system
+//! crypto, system, secrets, and LLM catalog access become surface in the type system
 //! instead of ambient globals. Each sub-handle (`stdio`, `term`, `clock`, `fs`,
-//! `env`, `random`, `net`, `process`, `crypto`, `system`, `llm`) is a distinct
-//! named type that anchors the surface for its capability slice.
+//! `env`, `random`, `net`, `process`, `crypto`, `system`, `secrets`, `llm`,
+//! `tenant`, `auth`, `obs`) is a distinct named type that anchors the surface
+//! for its capability slice.
 //!
 //! This module defines:
 //!   * The runtime [`Harness`] value and its sub-handle wrappers.
@@ -43,6 +44,7 @@ pub enum HarnessKind {
     Process,
     Crypto,
     System,
+    Secrets,
     Llm,
     /// Tenant sub-handle exposing the ambient `TenantId` (if any) that
     /// the dispatching host bound to this call. See
@@ -78,6 +80,7 @@ impl HarnessKind {
             HarnessKind::Process => "HarnessProcess",
             HarnessKind::Crypto => "HarnessCrypto",
             HarnessKind::System => "HarnessSystem",
+            HarnessKind::Secrets => "HarnessSecrets",
             HarnessKind::Llm => "HarnessLlm",
             HarnessKind::Tenant => "HarnessTenant",
             HarnessKind::Auth => "HarnessAuth",
@@ -100,6 +103,7 @@ impl HarnessKind {
             HarnessKind::Process => Some("process"),
             HarnessKind::Crypto => Some("crypto"),
             HarnessKind::System => Some("system"),
+            HarnessKind::Secrets => Some("secrets"),
             HarnessKind::Llm => Some("llm"),
             HarnessKind::Tenant => Some("tenant"),
             HarnessKind::Auth => Some("auth"),
@@ -120,6 +124,7 @@ impl HarnessKind {
             "process" => Some(HarnessKind::Process),
             "crypto" => Some(HarnessKind::Crypto),
             "system" => Some(HarnessKind::System),
+            "secrets" => Some(HarnessKind::Secrets),
             "llm" => Some(HarnessKind::Llm),
             "tenant" => Some(HarnessKind::Tenant),
             "auth" => Some(HarnessKind::Auth),
@@ -140,6 +145,7 @@ impl HarnessKind {
         HarnessKind::Process,
         HarnessKind::Crypto,
         HarnessKind::System,
+        HarnessKind::Secrets,
         HarnessKind::Llm,
         HarnessKind::Tenant,
         HarnessKind::Auth,
@@ -159,6 +165,7 @@ impl HarnessKind {
         HarnessKind::Process,
         HarnessKind::Crypto,
         HarnessKind::System,
+        HarnessKind::Secrets,
         HarnessKind::Llm,
         HarnessKind::Tenant,
         HarnessKind::Auth,
@@ -171,7 +178,6 @@ impl HarnessKind {
 /// Method implementations (in `crate::vm::methods::harness`) borrow this to
 /// reach the concrete OS-backed primitives. Wrapped in `Arc` so handles are
 /// `Send + Sync` for VM contexts that move work onto other tasks.
-#[derive(Debug)]
 pub struct HarnessInner {
     clock: Arc<dyn Clock>,
     mode: HarnessMode,
@@ -180,6 +186,9 @@ pub struct HarnessInner {
     /// the process-wide `crate::egress` allowlist, if configured).
     /// See `Harness::with_net_policy` and `crate::harness_net`.
     net_policy: Option<crate::harness_net::NetPolicy>,
+    /// Optional provider backing `harness.secrets.*`. Runtime embedders install
+    /// the managed provider that owns custody, audit, leases, and rotation.
+    secret_provider: Option<Arc<dyn crate::secrets::SecretProvider>>,
     /// `true` once a request denied under `OnViolation::Quarantine`
     /// has fired. Sticky for the lifetime of the underlying
     /// `Arc<HarnessInner>` so downstream consumers can pin on the
@@ -187,6 +196,24 @@ pub struct HarnessInner {
     /// is per-`Arc` (i.e. per-`Harness` build) so unrelated harnesses
     /// stay independent.
     quarantined: Mutex<bool>,
+}
+
+impl fmt::Debug for HarnessInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HarnessInner")
+            .field("clock", &"<dyn Clock>")
+            .field("mode", &self.mode)
+            .field("net_policy", &self.net_policy)
+            .field(
+                "secret_provider",
+                &self
+                    .secret_provider
+                    .as_ref()
+                    .map(|provider| provider.namespace().to_string()),
+            )
+            .field("quarantined", &self.is_quarantined())
+            .finish()
+    }
 }
 
 impl HarnessInner {
@@ -200,6 +227,10 @@ impl HarnessInner {
 
     pub fn net_policy(&self) -> Option<&crate::harness_net::NetPolicy> {
         self.net_policy.as_ref()
+    }
+
+    pub fn secret_provider(&self) -> Option<&Arc<dyn crate::secrets::SecretProvider>> {
+        self.secret_provider.as_ref()
     }
 
     pub(crate) fn mark_quarantined(&self) {
@@ -511,6 +542,7 @@ impl Harness {
             clock,
             mode,
             net_policy: None,
+            secret_provider: None,
             quarantined: Mutex::new(false),
         });
         Self { inner }
@@ -531,20 +563,44 @@ impl Harness {
     /// source handle.
     pub fn with_net_policy(&self, policy: crate::harness_net::NetPolicy) -> Self {
         let clock = Arc::clone(&self.inner.clock);
-        let mode = match &self.inner.mode {
-            HarnessMode::Real => HarnessMode::Real,
-            HarnessMode::Null(_) => HarnessMode::Null(NullHarnessState::default()),
-            HarnessMode::Mock(state) => HarnessMode::Mock(Arc::clone(state)),
-        };
+        let mode = self.clone_mode_for_child();
         // See `with_mode` for the rationale on this suppression.
         #[allow(clippy::arc_with_non_send_sync)]
         let inner = Arc::new(HarnessInner {
             clock,
             mode,
             net_policy: Some(policy),
+            secret_provider: self.inner.secret_provider.clone(),
             quarantined: Mutex::new(self.is_quarantined()),
         });
         Self { inner }
+    }
+
+    /// Attach a provider for `harness.secrets.*`.
+    ///
+    /// The provider is intentionally embedder-supplied. Harn owns the typed
+    /// method contract; the host owns custody details such as KMS wrapping,
+    /// lease storage, audit sinks, and scope policy.
+    pub fn with_secret_provider(&self, provider: Arc<dyn crate::secrets::SecretProvider>) -> Self {
+        let clock = Arc::clone(&self.inner.clock);
+        let mode = self.clone_mode_for_child();
+        #[allow(clippy::arc_with_non_send_sync)]
+        let inner = Arc::new(HarnessInner {
+            clock,
+            mode,
+            net_policy: self.inner.net_policy.clone(),
+            secret_provider: Some(provider),
+            quarantined: Mutex::new(self.is_quarantined()),
+        });
+        Self { inner }
+    }
+
+    fn clone_mode_for_child(&self) -> HarnessMode {
+        match &self.inner.mode {
+            HarnessMode::Real => HarnessMode::Real,
+            HarnessMode::Null(_) => HarnessMode::Null(NullHarnessState::default()),
+            HarnessMode::Mock(state) => HarnessMode::Mock(Arc::clone(state)),
+        }
     }
 
     /// `true` if the harness has been marked quarantined by an
@@ -675,6 +731,13 @@ impl Harness {
         }
     }
 
+    /// Field access for `harness.secrets`.
+    pub fn secrets(&self) -> HarnessSecrets {
+        HarnessSecrets {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
     /// Field access for `harness.llm`.
     pub fn llm(&self) -> HarnessLlm {
         HarnessLlm {
@@ -801,6 +864,12 @@ pub struct HarnessSystem {
     inner: Arc<HarnessInner>,
 }
 
+/// secrets sub-handle: `read`, `write`, `rotate`, `lease`.
+#[derive(Debug, Clone)]
+pub struct HarnessSecrets {
+    inner: Arc<HarnessInner>,
+}
+
 /// llm sub-handle: `catalog`, `providers`.
 #[derive(Debug, Clone)]
 pub struct HarnessLlm {
@@ -865,6 +934,7 @@ sub_handle_inner!(
     HarnessProcess,
     HarnessCrypto,
     HarnessSystem,
+    HarnessSecrets,
     HarnessLlm,
     HarnessTenant,
     HarnessAuth,
@@ -996,6 +1066,260 @@ impl<C: Clock + 'static> Clock for MockAwareClock<C> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::secrets::SecretProvider;
+    use async_trait::async_trait;
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct SecretCall {
+        operation: &'static str,
+        id: crate::secrets::SecretId,
+        scope: crate::secrets::SecretScope,
+        request_id: Option<String>,
+        actor_subject: Option<String>,
+        actor_kind: Option<String>,
+        duration_ms: Option<u64>,
+        grace_ms: Option<u64>,
+        ttl_ms: Option<u64>,
+    }
+
+    #[derive(Clone, Default)]
+    struct RecordingSecretProvider {
+        inner: Arc<RecordingSecretProviderInner>,
+    }
+
+    #[derive(Default)]
+    struct RecordingSecretProviderInner {
+        versions: Mutex<BTreeMap<crate::secrets::SecretId, Vec<Vec<u8>>>>,
+        calls: Mutex<Vec<SecretCall>>,
+    }
+
+    impl RecordingSecretProvider {
+        fn calls(&self) -> Vec<SecretCall> {
+            self.inner
+                .calls
+                .lock()
+                .expect("calls lock poisoned")
+                .clone()
+        }
+
+        fn record(
+            &self,
+            operation: &'static str,
+            id: &crate::secrets::SecretId,
+            scope: &crate::secrets::SecretScope,
+            audit: &crate::secrets::SecretAuditContext,
+            duration_ms: Option<u64>,
+            grace_ms: Option<u64>,
+            ttl_ms: Option<u64>,
+        ) {
+            self.inner
+                .calls
+                .lock()
+                .expect("calls lock poisoned")
+                .push(SecretCall {
+                    operation,
+                    id: id.clone(),
+                    scope: scope.clone(),
+                    request_id: audit.request_id.clone(),
+                    actor_subject: audit.actor_subject.clone(),
+                    actor_kind: audit.actor_kind.clone(),
+                    duration_ms,
+                    grace_ms,
+                    ttl_ms,
+                });
+        }
+
+        fn read_latest(
+            &self,
+            id: &crate::secrets::SecretId,
+        ) -> Result<(u64, Vec<u8>), crate::secrets::SecretError> {
+            let versions = self.inner.versions.lock().expect("versions lock poisoned");
+            let values = versions
+                .get(id)
+                .filter(|values| !values.is_empty())
+                .ok_or_else(|| crate::secrets::SecretError::NotFound {
+                    provider: self.namespace().to_string(),
+                    id: id.clone(),
+                })?;
+            Ok((
+                values.len() as u64,
+                values.last().expect("non-empty").clone(),
+            ))
+        }
+
+        fn write_version(
+            &self,
+            id: &crate::secrets::SecretId,
+            value: &crate::secrets::SecretBytes,
+        ) -> u64 {
+            let mut versions = self.inner.versions.lock().expect("versions lock poisoned");
+            let values = versions.entry(id.clone()).or_default();
+            values.push(value.with_exposed(|bytes| bytes.to_vec()));
+            values.len() as u64
+        }
+    }
+
+    fn duration_ms(duration: Duration) -> u64 {
+        duration.as_millis().min(u128::from(u64::MAX)) as u64
+    }
+
+    #[async_trait]
+    impl crate::secrets::SecretProvider for RecordingSecretProvider {
+        async fn get(
+            &self,
+            id: &crate::secrets::SecretId,
+        ) -> Result<crate::secrets::SecretBytes, crate::secrets::SecretError> {
+            self.read_latest(id)
+                .map(|(_, value)| crate::secrets::SecretBytes::from(value))
+        }
+
+        async fn put(
+            &self,
+            id: &crate::secrets::SecretId,
+            value: crate::secrets::SecretBytes,
+        ) -> Result<(), crate::secrets::SecretError> {
+            self.write_version(id, &value);
+            Ok(())
+        }
+
+        async fn rotate(
+            &self,
+            id: &crate::secrets::SecretId,
+        ) -> Result<crate::secrets::RotationHandle, crate::secrets::SecretError> {
+            let (from_version, value) = self.read_latest(id)?;
+            let to_version =
+                self.write_version(id, &crate::secrets::SecretBytes::from(value.as_slice()));
+            Ok(crate::secrets::RotationHandle {
+                provider: self.namespace().to_string(),
+                id: id
+                    .clone()
+                    .with_version(crate::secrets::SecretVersion::Exact(to_version)),
+                from_version: Some(from_version),
+                to_version: Some(to_version),
+            })
+        }
+
+        async fn list(
+            &self,
+            _prefix: &crate::secrets::SecretId,
+        ) -> Result<Vec<crate::secrets::SecretMeta>, crate::secrets::SecretError> {
+            Ok(Vec::new())
+        }
+
+        async fn read_scoped(
+            &self,
+            request: crate::secrets::SecretReadRequest,
+        ) -> Result<crate::secrets::SecretBytes, crate::secrets::SecretError> {
+            self.record(
+                "read",
+                &request.id,
+                &request.scope,
+                &request.audit,
+                None,
+                None,
+                None,
+            );
+            self.read_latest(&request.id)
+                .map(|(_, value)| crate::secrets::SecretBytes::from(value))
+        }
+
+        async fn write_scoped(
+            &self,
+            request: crate::secrets::SecretWriteRequest,
+        ) -> Result<crate::secrets::SecretWriteReceipt, crate::secrets::SecretError> {
+            let ttl_ms = request.options.ttl.map(duration_ms);
+            self.record(
+                "write",
+                &request.id,
+                &request.scope,
+                &request.audit,
+                None,
+                None,
+                ttl_ms,
+            );
+            let version = self.write_version(&request.id, &request.value);
+            Ok(crate::secrets::SecretWriteReceipt {
+                provider: self.namespace().to_string(),
+                id: request
+                    .id
+                    .with_version(crate::secrets::SecretVersion::Exact(version)),
+                scope: request.scope,
+                version: Some(version),
+                expires_at_unix_ms: ttl_ms.map(|ttl| 1_700_000_000_000_i64 + ttl as i64),
+            })
+        }
+
+        async fn rotate_scoped(
+            &self,
+            request: crate::secrets::SecretRotateRequest,
+        ) -> Result<crate::secrets::SecretRotationReceipt, crate::secrets::SecretError> {
+            let grace_ms = request.options.grace.map(duration_ms);
+            let ttl_ms = request.options.ttl.map(duration_ms);
+            self.record(
+                "rotate",
+                &request.id,
+                &request.scope,
+                &request.audit,
+                None,
+                grace_ms,
+                ttl_ms,
+            );
+            let from_version = self
+                .inner
+                .versions
+                .lock()
+                .expect("versions lock poisoned")
+                .get(&request.id)
+                .map(|values| values.len() as u64);
+            let to_version = self.write_version(&request.id, &request.value);
+            Ok(crate::secrets::SecretRotationReceipt {
+                provider: self.namespace().to_string(),
+                id: request
+                    .id
+                    .with_version(crate::secrets::SecretVersion::Exact(to_version)),
+                scope: request.scope,
+                from_version,
+                to_version: Some(to_version),
+                grace_until_unix_ms: grace_ms.map(|grace| 1_700_000_000_000_i64 + grace as i64),
+                expires_at_unix_ms: ttl_ms.map(|ttl| 1_700_000_000_000_i64 + ttl as i64),
+            })
+        }
+
+        async fn lease_scoped(
+            &self,
+            request: crate::secrets::SecretLeaseRequest,
+        ) -> Result<crate::secrets::SecretLeaseGrant, crate::secrets::SecretError> {
+            let duration = duration_ms(request.duration);
+            self.record(
+                "lease",
+                &request.id,
+                &request.scope,
+                &request.audit,
+                Some(duration),
+                None,
+                None,
+            );
+            let (version, value) = self.read_latest(&request.id)?;
+            Ok(crate::secrets::SecretLeaseGrant {
+                provider: self.namespace().to_string(),
+                id: request
+                    .id
+                    .with_version(crate::secrets::SecretVersion::Exact(version)),
+                scope: request.scope,
+                lease_id: format!("lease-{version}"),
+                value: crate::secrets::SecretBytes::from(value),
+                expires_at_unix_ms: 1_700_000_000_000_i64 + duration as i64,
+            })
+        }
+
+        fn namespace(&self) -> &'static str {
+            "recording"
+        }
+
+        fn supports_versions(&self) -> bool {
+            true
+        }
+    }
 
     #[test]
     fn real_constructs_without_panic() {
@@ -1072,6 +1396,7 @@ mod tests {
             r#"fn main(harness: Harness) { harness.process.spawn_captured({cmd: "printf", args: ["x"]}) }"#,
             r#"fn main(harness: Harness) { harness.crypto.sha256("") }"#,
             r"fn main(harness: Harness) { harness.system.cpu() }",
+            r#"fn main(harness: Harness) { harness.secrets.read("blocked") }"#,
             r"fn main(harness: Harness) { harness.llm.catalog() }",
             r"fn main(harness: Harness) { harness.tenant.id() }",
             r"fn main(harness: Harness) { harness.auth.subject() }",
@@ -1102,6 +1427,7 @@ mod tests {
                 (HarnessKind::Process, "spawn_captured"),
                 (HarnessKind::Crypto, "sha256"),
                 (HarnessKind::System, "cpu"),
+                (HarnessKind::Secrets, "read"),
                 (HarnessKind::Llm, "catalog"),
                 (HarnessKind::Tenant, "id"),
                 (HarnessKind::Auth, "subject"),
@@ -1163,6 +1489,70 @@ fn main(harness: Harness) {
             error.contains("no principal bound"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn secrets_sub_handle_uses_provider_scope_and_audit_context() {
+        use crate::harness_auth::{enter_auth_principal, AuthPrincipal};
+        use crate::harness_tenant::enter_tenant;
+        use crate::observability::request_id::enter_request_id;
+
+        let provider = RecordingSecretProvider::default();
+        let harness = Harness::real().with_secret_provider(Arc::new(provider.clone()));
+        let _tenant = enter_tenant(crate::TenantId::new("tenant-a"));
+        let _request = enter_request_id("req-499");
+        let _principal = enter_auth_principal(AuthPrincipal {
+            subject: "api-key-1".to_string(),
+            scheme: "apikey".to_string(),
+            scopes: ["secrets:read", "secrets:write"]
+                .iter()
+                .map(|scope| scope.to_string())
+                .collect(),
+            kind: Some("tenant_api_key".to_string()),
+        });
+
+        let source = r#"
+fn main(harness: Harness) {
+  let scope = {kind: "workspace", id: "workspace-a"}
+  let written = harness.secrets.write("github.token", "v1", scope, 5000)
+  __io_println(written.provider)
+  __io_println(written.scope.kind)
+  __io_println(written.scope.id)
+  __io_println(written.id.namespace)
+  __io_println(written.version)
+  __io_println(harness.secrets.read("github.token", scope))
+  let rotated = harness.secrets.rotate("github.token", { -> "v2" }, scope, {grace_ms: 250, ttl_ms: 7500})
+  __io_println(rotated.from_version)
+  __io_println(rotated.to_version)
+  let grant = harness.secrets.lease("github.token", 1000, scope)
+  __io_println(grant.value)
+  __io_println(grant.scope.id)
+}
+"#;
+        let output = run_harness_source(source, harness).expect("dispatch succeeds");
+        assert_eq!(
+            output,
+            "recording\nworkspace\nworkspace-a\nharn.workspace.workspace-a\n1\nv1\n1\n2\nv2\nworkspace-a\n"
+        );
+
+        let calls = provider.calls();
+        assert_eq!(
+            calls.iter().map(|call| call.operation).collect::<Vec<_>>(),
+            vec!["write", "read", "rotate", "lease"]
+        );
+        for call in &calls {
+            assert_eq!(
+                call.scope,
+                crate::secrets::SecretScope::workspace("workspace-a")
+            );
+            assert_eq!(call.request_id.as_deref(), Some("req-499"));
+            assert_eq!(call.actor_subject.as_deref(), Some("api-key-1"));
+            assert_eq!(call.actor_kind.as_deref(), Some("tenant_api_key"));
+        }
+        assert_eq!(calls[0].ttl_ms, Some(5_000));
+        assert_eq!(calls[2].grace_ms, Some(250));
+        assert_eq!(calls[2].ttl_ms, Some(7_500));
+        assert_eq!(calls[3].duration_ms, Some(1_000));
     }
 
     #[test]

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -172,8 +172,9 @@ pub use corrections::{
 };
 pub use harness::{
     DenyEvent, Harness, HarnessCall, HarnessClock, HarnessCrypto, HarnessEnv, HarnessFs,
-    HarnessKind, HarnessLlm, HarnessNet, HarnessObs, HarnessProcess, HarnessRandom, HarnessStdio,
-    HarnessSystem, HarnessTenant, HarnessTerm, MockAwareClock, MockHarnessBuilder, VmHarness,
+    HarnessKind, HarnessLlm, HarnessNet, HarnessObs, HarnessProcess, HarnessRandom, HarnessSecrets,
+    HarnessStdio, HarnessSystem, HarnessTenant, HarnessTerm, MockAwareClock, MockHarnessBuilder,
+    VmHarness,
 };
 pub use harness_auth::{
     current_auth_principal, enter_auth_principal, AuthPrincipal, AuthPrincipalScopeGuard,

--- a/crates/harn-vm/src/secrets/mod.rs
+++ b/crates/harn-vm/src/secrets/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -73,6 +74,153 @@ pub struct RotationHandle {
     pub to_version: Option<u64>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SecretScope {
+    Tenant { id: Option<String> },
+    Workspace { id: String },
+    System,
+    Custom { kind: String, id: Option<String> },
+}
+
+impl Default for SecretScope {
+    fn default() -> Self {
+        Self::Tenant { id: None }
+    }
+}
+
+impl SecretScope {
+    pub fn tenant(id: Option<String>) -> Self {
+        Self::Tenant { id }
+    }
+
+    pub fn workspace(id: impl Into<String>) -> Self {
+        Self::Workspace { id: id.into() }
+    }
+
+    pub fn system() -> Self {
+        Self::System
+    }
+
+    pub fn custom(kind: impl Into<String>, id: Option<String>) -> Self {
+        Self::Custom {
+            kind: kind.into(),
+            id,
+        }
+    }
+
+    pub fn namespace(&self) -> String {
+        match self {
+            Self::Tenant { id: Some(id) } if !id.is_empty() => format!("harn.tenant.{id}"),
+            Self::Tenant { .. } => "harn.tenant".to_string(),
+            Self::Workspace { id } => format!("harn.workspace.{id}"),
+            Self::System => "harn.system".to_string(),
+            Self::Custom { kind, id: Some(id) } if !id.is_empty() => {
+                format!("harn.{kind}.{id}")
+            }
+            Self::Custom { kind, .. } => format!("harn.{kind}"),
+        }
+    }
+
+    pub fn kind(&self) -> &str {
+        match self {
+            Self::Tenant { .. } => "tenant",
+            Self::Workspace { .. } => "workspace",
+            Self::System => "system",
+            Self::Custom { kind, .. } => kind.as_str(),
+        }
+    }
+
+    pub fn id(&self) -> Option<&str> {
+        match self {
+            Self::Tenant { id } | Self::Custom { id, .. } => id.as_deref(),
+            Self::Workspace { id } => Some(id.as_str()),
+            Self::System => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SecretWriteOptions {
+    pub ttl: Option<Duration>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SecretRotationOptions {
+    pub grace: Option<Duration>,
+    pub ttl: Option<Duration>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SecretAuditContext {
+    pub request_id: Option<String>,
+    pub actor_subject: Option<String>,
+    pub actor_kind: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct SecretReadRequest {
+    pub id: SecretId,
+    pub scope: SecretScope,
+    pub audit: SecretAuditContext,
+}
+
+#[derive(Debug)]
+pub struct SecretWriteRequest {
+    pub id: SecretId,
+    pub scope: SecretScope,
+    pub value: SecretBytes,
+    pub options: SecretWriteOptions,
+    pub audit: SecretAuditContext,
+}
+
+#[derive(Debug)]
+pub struct SecretRotateRequest {
+    pub id: SecretId,
+    pub scope: SecretScope,
+    pub value: SecretBytes,
+    pub options: SecretRotationOptions,
+    pub audit: SecretAuditContext,
+}
+
+#[derive(Debug)]
+pub struct SecretLeaseRequest {
+    pub id: SecretId,
+    pub scope: SecretScope,
+    pub duration: Duration,
+    pub audit: SecretAuditContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SecretWriteReceipt {
+    pub provider: String,
+    pub id: SecretId,
+    pub scope: SecretScope,
+    pub version: Option<u64>,
+    pub expires_at_unix_ms: Option<i64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SecretRotationReceipt {
+    pub provider: String,
+    pub id: SecretId,
+    pub scope: SecretScope,
+    pub from_version: Option<u64>,
+    pub to_version: Option<u64>,
+    pub grace_until_unix_ms: Option<i64>,
+    pub expires_at_unix_ms: Option<i64>,
+}
+
+#[derive(Debug)]
+pub struct SecretLeaseGrant {
+    pub provider: String,
+    pub id: SecretId,
+    pub scope: SecretScope,
+    pub lease_id: String,
+    pub value: SecretBytes,
+    pub expires_at_unix_ms: i64,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SecretError {
     NotFound {
@@ -88,6 +236,7 @@ pub enum SecretError {
         message: String,
     },
     InvalidConfig(String),
+    InvalidInput(String),
     NoProviders {
         namespace: String,
     },
@@ -106,6 +255,7 @@ impl fmt::Display for SecretError {
             } => write!(f, "{provider}: operation '{operation}' is unsupported"),
             Self::Backend { provider, message } => write!(f, "{provider}: {message}"),
             Self::InvalidConfig(message) => write!(f, "{message}"),
+            Self::InvalidInput(message) => write!(f, "{message}"),
             Self::NoProviders { namespace } => {
                 write!(
                     f,
@@ -252,6 +402,52 @@ pub trait SecretProvider: Send + Sync {
     async fn put(&self, id: &SecretId, value: SecretBytes) -> Result<(), SecretError>;
     async fn rotate(&self, id: &SecretId) -> Result<RotationHandle, SecretError>;
     async fn list(&self, prefix: &SecretId) -> Result<Vec<SecretMeta>, SecretError>;
+
+    async fn read_scoped(&self, request: SecretReadRequest) -> Result<SecretBytes, SecretError> {
+        self.get(&request.id).await
+    }
+
+    async fn write_scoped(
+        &self,
+        request: SecretWriteRequest,
+    ) -> Result<SecretWriteReceipt, SecretError> {
+        if request.options.ttl.is_some() {
+            return Err(SecretError::Unsupported {
+                provider: self.namespace().to_string(),
+                operation: "write_ttl",
+            });
+        }
+        self.put(&request.id, request.value).await?;
+        Ok(SecretWriteReceipt {
+            provider: self.namespace().to_string(),
+            id: request.id,
+            scope: request.scope,
+            version: None,
+            expires_at_unix_ms: None,
+        })
+    }
+
+    async fn rotate_scoped(
+        &self,
+        request: SecretRotateRequest,
+    ) -> Result<SecretRotationReceipt, SecretError> {
+        let _ = request;
+        Err(SecretError::Unsupported {
+            provider: self.namespace().to_string(),
+            operation: "rotate_to",
+        })
+    }
+
+    async fn lease_scoped(
+        &self,
+        request: SecretLeaseRequest,
+    ) -> Result<SecretLeaseGrant, SecretError> {
+        let _ = request;
+        Err(SecretError::Unsupported {
+            provider: self.namespace().to_string(),
+            operation: "lease",
+        })
+    }
 
     fn namespace(&self) -> &str;
     fn supports_versions(&self) -> bool;

--- a/crates/harn-vm/src/vm/methods/harness.rs
+++ b/crates/harn-vm/src/vm/methods/harness.rs
@@ -1,6 +1,7 @@
 //! Method dispatch for the `Harness` capability handle and its
 //! sub-handles. Every sub-handle (`stdio`, `clock`, `fs`, `env`,
-//! `random`, `net`, `process`, `crypto`, `system`, `llm`, `tenant`, and `obs`)
+//! `random`, `net`, `process`, `crypto`, `system`, `secrets`, `llm`,
+//! `tenant`, and `obs`)
 //! is wired end-to-end in real, mock, and null modes;
 //! sandbox / egress rejections raised inside a sub-handle method are
 //! tagged with the `HARN-CAP-201` diagnostic code so callers can
@@ -91,6 +92,7 @@ impl crate::vm::Vm {
             HarnessKind::Net => self.call_harness_net_method(handle, method, args).await,
             HarnessKind::Process => self.call_harness_process_method(handle, method, args),
             HarnessKind::Crypto => self.call_harness_crypto_method(handle, method, args),
+            HarnessKind::Secrets => self.call_harness_secrets_method(handle, method, args).await,
             HarnessKind::Llm => self.call_harness_llm_method(handle, method, args).await,
             HarnessKind::Tenant => self.call_harness_tenant_method(handle, method, args),
             HarnessKind::Auth => self.call_harness_auth_method(handle, method, args),
@@ -131,6 +133,7 @@ impl crate::vm::Vm {
             | HarnessKind::Net
             | HarnessKind::Process
             | HarnessKind::System
+            | HarnessKind::Secrets
             | HarnessKind::Llm
             | HarnessKind::Obs => None,
         }
@@ -501,6 +504,7 @@ impl crate::vm::Vm {
             | HarnessKind::Fs
             | HarnessKind::Net
             | HarnessKind::Process
+            | HarnessKind::Secrets
             | HarnessKind::Llm
             | HarnessKind::Obs => None,
         };
@@ -673,6 +677,138 @@ impl crate::vm::Vm {
             _ => return Err(method_unsupported(handle, method)),
         };
         Ok(crate::stdlib::json_to_vm_value(&json))
+    }
+
+    async fn call_harness_secrets_method(
+        &mut self,
+        handle: &VmHarness,
+        method: &str,
+        args: &[VmValue],
+    ) -> Result<VmValue, VmError> {
+        let provider =
+            handle
+                .inner()
+                .secret_provider()
+                .cloned()
+                .ok_or_else(|| VmError::CategorizedError {
+                    message: "HarnessSecrets: no secret provider bound to this harness".to_string(),
+                    category: ErrorCategory::NotFound,
+                })?;
+        match method {
+            "read" | "read_bytes" => {
+                if args.len() > 2 {
+                    return Err(VmError::TypeError(format!(
+                        "{}.{method} expects name and optional scope",
+                        handle.type_name()
+                    )));
+                }
+                let name = secret_name_arg(handle, method, args.first())?;
+                let scope = secret_scope_arg(args.get(1))?;
+                let id = secret_id_for_scope(&name, &scope);
+                let secret = provider
+                    .read_scoped(crate::secrets::SecretReadRequest {
+                        id,
+                        scope,
+                        audit: secret_audit_context(),
+                    })
+                    .await
+                    .map_err(secret_error_to_vm)?;
+                if method == "read_bytes" {
+                    return Ok(VmValue::Bytes(std::sync::Arc::new(
+                        secret.with_exposed(|bytes| bytes.to_vec()),
+                    )));
+                }
+                let text = secret.with_exposed(|bytes| {
+                    std::str::from_utf8(bytes)
+                        .map(str::to_string)
+                        .map_err(|error| {
+                            VmError::TypeError(format!(
+                                "{}.read secret `{name}` was not UTF-8: {error}",
+                                handle.type_name()
+                            ))
+                        })
+                })?;
+                Ok(vm_string(text))
+            }
+            "write" => {
+                if args.len() > 4 {
+                    return Err(VmError::TypeError(format!(
+                        "{}.write expects name, value, optional scope, and optional ttl",
+                        handle.type_name()
+                    )));
+                }
+                let name = secret_name_arg(handle, method, args.first())?;
+                let value = secret_value_arg(handle, method, args.get(1), "value")?;
+                let scope = secret_scope_arg(args.get(2))?;
+                let ttl =
+                    optional_duration_arg(args.get(3), &format!("{}.write", handle.type_name()))?;
+                let receipt = provider
+                    .write_scoped(crate::secrets::SecretWriteRequest {
+                        id: secret_id_for_scope(&name, &scope),
+                        scope,
+                        value,
+                        options: crate::secrets::SecretWriteOptions { ttl },
+                        audit: secret_audit_context(),
+                    })
+                    .await
+                    .map_err(secret_error_to_vm)?;
+                Ok(secret_write_receipt_value(receipt))
+            }
+            "rotate" => {
+                if args.len() > 4 {
+                    return Err(VmError::TypeError(format!(
+                        "{}.rotate expects name, generator/value, optional scope, and optional options",
+                        handle.type_name()
+                    )));
+                }
+                let name = secret_name_arg(handle, method, args.first())?;
+                let value = match args.get(1) {
+                    Some(VmValue::Closure(closure)) => {
+                        let generated = self.call_closure_pub(closure, &[]).await?;
+                        secret_value_from_vm(handle, method, &generated, "generator result")?
+                    }
+                    other => secret_value_arg(handle, method, other, "value")?,
+                };
+                let scope = secret_scope_arg(args.get(2))?;
+                let options = secret_rotation_options_arg(args.get(3))?;
+                let receipt = provider
+                    .rotate_scoped(crate::secrets::SecretRotateRequest {
+                        id: secret_id_for_scope(&name, &scope),
+                        scope,
+                        value,
+                        options,
+                        audit: secret_audit_context(),
+                    })
+                    .await
+                    .map_err(secret_error_to_vm)?;
+                Ok(secret_rotation_receipt_value(receipt))
+            }
+            "lease" | "lease_bytes" => {
+                if args.len() > 3 {
+                    return Err(VmError::TypeError(format!(
+                        "{}.{method} expects name, duration, and optional scope",
+                        handle.type_name(),
+                    )));
+                }
+                let name = secret_name_arg(handle, method, args.first())?;
+                let duration = required_duration_arg(
+                    args.get(1),
+                    &format!("{}.{}", handle.type_name(), method),
+                )?;
+                let scope = secret_scope_arg(args.get(2))?;
+                let grant = provider
+                    .lease_scoped(crate::secrets::SecretLeaseRequest {
+                        id: secret_id_for_scope(&name, &scope),
+                        scope,
+                        duration,
+                        audit: secret_audit_context(),
+                    })
+                    .await
+                    .map_err(secret_error_to_vm)?;
+                Ok(secret_lease_grant_value(method == "lease_bytes", grant)?)
+            }
+            _ => Err(method_unsupported(handle, method)),
+        }
     }
 
     async fn call_harness_llm_method(
@@ -1195,6 +1331,7 @@ impl crate::vm::Vm {
             | HarnessKind::Random
             | HarnessKind::Crypto
             | HarnessKind::System
+            | HarnessKind::Secrets
             | HarnessKind::Tenant
             | HarnessKind::Auth => Err(method_unsupported(handle, method)),
             HarnessKind::Fs => match method {
@@ -2040,6 +2177,346 @@ fn optional_string_arg<'a>(
             index + 1,
             other.type_name()
         ))),
+    }
+}
+
+fn secret_name_arg(
+    handle: &VmHarness,
+    method: &str,
+    value: Option<&VmValue>,
+) -> Result<String, VmError> {
+    match value {
+        Some(VmValue::String(name)) if !name.trim().is_empty() => Ok(name.to_string()),
+        Some(VmValue::String(_)) => Err(VmError::TypeError(format!(
+            "{}.{method} expects a non-empty secret name",
+            handle.type_name()
+        ))),
+        Some(other) => Err(VmError::TypeError(format!(
+            "{}.{method} expects name: string, got {}",
+            handle.type_name(),
+            other.type_name()
+        ))),
+        None => Err(VmError::TypeError(format!(
+            "{}.{method} missing required name",
+            handle.type_name()
+        ))),
+    }
+}
+
+fn secret_value_arg(
+    handle: &VmHarness,
+    method: &str,
+    value: Option<&VmValue>,
+    field: &str,
+) -> Result<crate::secrets::SecretBytes, VmError> {
+    let value = value.ok_or_else(|| {
+        VmError::TypeError(format!(
+            "{}.{method} missing required {field}",
+            handle.type_name()
+        ))
+    })?;
+    secret_value_from_vm(handle, method, value, field)
+}
+
+fn secret_value_from_vm(
+    handle: &VmHarness,
+    method: &str,
+    value: &VmValue,
+    field: &str,
+) -> Result<crate::secrets::SecretBytes, VmError> {
+    match value {
+        VmValue::String(text) => Ok(crate::secrets::SecretBytes::from(text.as_ref())),
+        VmValue::Bytes(bytes) => Ok(crate::secrets::SecretBytes::from(bytes.as_slice())),
+        other => Err(VmError::TypeError(format!(
+            "{}.{method} expects {field}: string or bytes, got {}",
+            handle.type_name(),
+            other.type_name()
+        ))),
+    }
+}
+
+fn secret_scope_arg(value: Option<&VmValue>) -> Result<crate::secrets::SecretScope, VmError> {
+    match value {
+        None | Some(VmValue::Nil) => Ok(crate::secrets::SecretScope::tenant(
+            crate::harness_tenant::current_tenant_id().map(|tenant| tenant.0),
+        )),
+        Some(VmValue::String(scope)) => parse_secret_scope_string(scope.as_ref()),
+        Some(VmValue::Dict(dict)) => {
+            let kind = dict
+                .get("kind")
+                .and_then(|value| match value {
+                    VmValue::String(kind) => Some(kind.as_ref()),
+                    _ => None,
+                })
+                .ok_or_else(|| {
+                    VmError::TypeError(
+                        "HarnessSecrets scope dict requires string `kind`".to_string(),
+                    )
+                })?
+                .trim();
+            let id = match dict.get("id") {
+                None | Some(VmValue::Nil) => None,
+                Some(VmValue::String(id)) if !id.is_empty() => Some(id.to_string()),
+                Some(VmValue::String(_)) => None,
+                Some(other) => {
+                    return Err(VmError::TypeError(format!(
+                        "HarnessSecrets scope `id` must be a string or nil, got {}",
+                        other.type_name()
+                    )))
+                }
+            };
+            match kind {
+                "tenant" => Ok(crate::secrets::SecretScope::tenant(id.or_else(|| {
+                    crate::harness_tenant::current_tenant_id().map(|tenant| tenant.0)
+                }))),
+                "workspace" => id
+                    .map(crate::secrets::SecretScope::workspace)
+                    .ok_or_else(|| {
+                        VmError::TypeError(
+                            "HarnessSecrets workspace scope requires non-empty `id`".to_string(),
+                        )
+                    }),
+                "system" if id.is_none() => Ok(crate::secrets::SecretScope::system()),
+                "system" => Err(VmError::TypeError(
+                    "HarnessSecrets system scope does not take an `id`".to_string(),
+                )),
+                other if !other.trim().is_empty() => {
+                    Ok(crate::secrets::SecretScope::custom(other, id))
+                }
+                _ => Err(VmError::TypeError(
+                    "HarnessSecrets scope `kind` must not be empty".to_string(),
+                )),
+            }
+        }
+        Some(other) => Err(VmError::TypeError(format!(
+            "HarnessSecrets scope must be nil, string, or dict, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn parse_secret_scope_string(raw: &str) -> Result<crate::secrets::SecretScope, VmError> {
+    let value = raw.trim();
+    if value.is_empty() || value == "tenant" {
+        return Ok(crate::secrets::SecretScope::tenant(
+            crate::harness_tenant::current_tenant_id().map(|tenant| tenant.0),
+        ));
+    }
+    if value == "system" {
+        return Ok(crate::secrets::SecretScope::system());
+    }
+    if let Some(id) = value.strip_prefix("tenant:") {
+        return Ok(crate::secrets::SecretScope::tenant(
+            (!id.is_empty())
+                .then(|| id.to_string())
+                .or_else(|| crate::harness_tenant::current_tenant_id().map(|tenant| tenant.0)),
+        ));
+    }
+    if let Some(id) = value.strip_prefix("workspace:") {
+        if id.is_empty() {
+            return Err(VmError::TypeError(
+                "HarnessSecrets workspace scope requires an id".to_string(),
+            ));
+        }
+        return Ok(crate::secrets::SecretScope::workspace(id));
+    }
+    if let Some((kind, id)) = value.split_once(':') {
+        if kind.is_empty() {
+            return Err(VmError::TypeError(
+                "HarnessSecrets custom scope kind must not be empty".to_string(),
+            ));
+        }
+        return Ok(crate::secrets::SecretScope::custom(
+            kind,
+            (!id.is_empty()).then(|| id.to_string()),
+        ));
+    }
+    Ok(crate::secrets::SecretScope::custom(value, None))
+}
+
+fn secret_id_for_scope(
+    name: &str,
+    scope: &crate::secrets::SecretScope,
+) -> crate::secrets::SecretId {
+    crate::secrets::SecretId::new(scope.namespace(), name)
+}
+
+fn optional_duration_arg(
+    value: Option<&VmValue>,
+    callee: &str,
+) -> Result<Option<std::time::Duration>, VmError> {
+    match value {
+        None | Some(VmValue::Nil) => Ok(None),
+        Some(value) => required_duration_arg(Some(value), callee).map(Some),
+    }
+}
+
+fn required_duration_arg(
+    value: Option<&VmValue>,
+    callee: &str,
+) -> Result<std::time::Duration, VmError> {
+    let millis = match value {
+        Some(VmValue::Int(ms)) | Some(VmValue::Duration(ms)) => *ms,
+        Some(other) => {
+            return Err(VmError::TypeError(format!(
+                "{callee} expects duration as int milliseconds or duration, got {}",
+                other.type_name()
+            )))
+        }
+        None => {
+            return Err(VmError::TypeError(format!(
+                "{callee} expects duration as int milliseconds or duration"
+            )))
+        }
+    };
+    let millis = u64::try_from(millis)
+        .map_err(|_| VmError::TypeError(format!("{callee} duration must be non-negative")))?;
+    Ok(std::time::Duration::from_millis(millis))
+}
+
+fn secret_rotation_options_arg(
+    value: Option<&VmValue>,
+) -> Result<crate::secrets::SecretRotationOptions, VmError> {
+    let Some(value) = value else {
+        return Ok(crate::secrets::SecretRotationOptions::default());
+    };
+    match value {
+        VmValue::Nil => Ok(crate::secrets::SecretRotationOptions::default()),
+        VmValue::Dict(dict) => Ok(crate::secrets::SecretRotationOptions {
+            grace: optional_duration_arg(dict.get("grace_ms"), "HarnessSecrets.rotate grace_ms")?,
+            ttl: optional_duration_arg(dict.get("ttl_ms"), "HarnessSecrets.rotate ttl_ms")?,
+        }),
+        other => Err(VmError::TypeError(format!(
+            "HarnessSecrets.rotate options must be a dict or nil, got {}",
+            other.type_name()
+        ))),
+    }
+}
+
+fn secret_audit_context() -> crate::secrets::SecretAuditContext {
+    let principal = crate::harness_auth::current_auth_principal();
+    crate::secrets::SecretAuditContext {
+        request_id: crate::observability::request_id::current_request_id(),
+        actor_subject: principal
+            .as_ref()
+            .filter(|principal| !principal.subject.is_empty())
+            .map(|principal| principal.subject.clone()),
+        actor_kind: principal.and_then(|principal| principal.kind.clone()),
+    }
+}
+
+fn secret_scope_value(scope: &crate::secrets::SecretScope) -> VmValue {
+    let mut out = std::collections::BTreeMap::new();
+    out.put_str("kind", scope.kind());
+    out.put_opt_str("id", scope.id());
+    VmValue::dict(out)
+}
+
+fn secret_id_value(id: &crate::secrets::SecretId) -> VmValue {
+    let mut out = std::collections::BTreeMap::new();
+    out.put_str("namespace", &id.namespace);
+    out.put_str("name", &id.name);
+    match id.version {
+        crate::secrets::SecretVersion::Latest => out.put_str("version", "latest"),
+        crate::secrets::SecretVersion::Exact(version) => {
+            out.put_int("version", version.min(i64::MAX as u64) as i64);
+        }
+    }
+    VmValue::dict(out)
+}
+
+fn secret_write_receipt_value(receipt: crate::secrets::SecretWriteReceipt) -> VmValue {
+    let mut out = std::collections::BTreeMap::new();
+    out.put_str("provider", receipt.provider);
+    out.put("id", secret_id_value(&receipt.id));
+    out.put("scope", secret_scope_value(&receipt.scope));
+    out.put_opt(
+        "version",
+        receipt
+            .version
+            .map(|version| VmValue::Int(version.min(i64::MAX as u64) as i64)),
+    );
+    out.put_opt(
+        "expires_at_ms",
+        receipt.expires_at_unix_ms.map(VmValue::Int),
+    );
+    VmValue::dict(out)
+}
+
+fn secret_rotation_receipt_value(receipt: crate::secrets::SecretRotationReceipt) -> VmValue {
+    let mut out = std::collections::BTreeMap::new();
+    out.put_str("provider", receipt.provider);
+    out.put("id", secret_id_value(&receipt.id));
+    out.put("scope", secret_scope_value(&receipt.scope));
+    out.put_opt(
+        "from_version",
+        receipt
+            .from_version
+            .map(|version| VmValue::Int(version.min(i64::MAX as u64) as i64)),
+    );
+    out.put_opt(
+        "to_version",
+        receipt
+            .to_version
+            .map(|version| VmValue::Int(version.min(i64::MAX as u64) as i64)),
+    );
+    out.put_opt(
+        "grace_until_ms",
+        receipt.grace_until_unix_ms.map(VmValue::Int),
+    );
+    out.put_opt(
+        "expires_at_ms",
+        receipt.expires_at_unix_ms.map(VmValue::Int),
+    );
+    VmValue::dict(out)
+}
+
+fn secret_lease_grant_value(
+    bytes_value: bool,
+    grant: crate::secrets::SecretLeaseGrant,
+) -> Result<VmValue, VmError> {
+    let value = grant.value.with_exposed(|bytes| {
+        if bytes_value {
+            return Ok(VmValue::Bytes(std::sync::Arc::new(bytes.to_vec())));
+        }
+        std::str::from_utf8(bytes)
+            .map(str::to_string)
+            .map(vm_string)
+            .map_err(|error| {
+                VmError::TypeError(format!(
+                    "HarnessSecrets.lease secret `{}` was not UTF-8: {error}",
+                    grant.id.name
+                ))
+            })
+    })?;
+    let mut out = std::collections::BTreeMap::new();
+    out.put_str("provider", grant.provider);
+    out.put("id", secret_id_value(&grant.id));
+    out.put("scope", secret_scope_value(&grant.scope));
+    out.put_str("lease_id", grant.lease_id);
+    out.put("value", value);
+    out.put_int("expires_at_ms", grant.expires_at_unix_ms);
+    Ok(VmValue::dict(out))
+}
+
+fn secret_error_to_vm(error: crate::secrets::SecretError) -> VmError {
+    use crate::secrets::SecretError;
+    match error {
+        SecretError::NotFound { .. } | SecretError::NoProviders { .. } => {
+            VmError::CategorizedError {
+                message: error.to_string(),
+                category: ErrorCategory::NotFound,
+            }
+        }
+        SecretError::Unsupported { .. } | SecretError::InvalidInput(_) => {
+            VmError::TypeError(error.to_string())
+        }
+        SecretError::Backend { .. } | SecretError::InvalidConfig(_) | SecretError::All(_) => {
+            VmError::CategorizedError {
+                message: error.to_string(),
+                category: ErrorCategory::ToolError,
+            }
+        }
     }
 }
 

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -539,6 +539,7 @@ impl super::super::Vm {
             | crate::harness::HarnessKind::Net
             | crate::harness::HarnessKind::Process
             | crate::harness::HarnessKind::System
+            | crate::harness::HarnessKind::Secrets
             | crate::harness::HarnessKind::Llm
             | crate::harness::HarnessKind::Obs => false,
         };

--- a/docs/src/orchestrator/secrets.md
+++ b/docs/src/orchestrator/secrets.md
@@ -44,6 +44,41 @@ existing VM event sink with the secret id, provider name, caller span,
 mutation session id when present, and a timestamp. The event payload never
 contains the secret bytes.
 
+## Harness primitive
+
+Hosts can attach a managed provider to `Harness::real()` with
+`with_secret_provider(...)`. That enables scripts to use the typed
+`harness.secrets` sub-handle:
+
+```harn
+let scope = {kind: "workspace", id: "workspace-123"}
+let receipt = harness.secrets.write("github.token", "token-v1", scope, 3600000)
+let token = harness.secrets.read("github.token", scope)
+let rotated = harness.secrets.rotate(
+  "github.token",
+  { -> "token-v2" },
+  scope,
+  {grace_ms: 300000, ttl_ms: 3600000},
+)
+let lease = harness.secrets.lease("github.token", 60000, scope)
+```
+
+Methods:
+
+- `read(name, scope?) -> string`
+- `read_bytes(name, scope?) -> bytes`
+- `write(name, value, scope?, ttl_ms?) -> dict`
+- `rotate(name, generator_or_value, scope?, options?) -> dict`
+- `lease(name, duration_ms, scope?) -> dict`
+- `lease_bytes(name, duration_ms, scope?) -> dict`
+
+`scope` may be `nil`, `"tenant"`, `"tenant:<id>"`, `"system"`,
+`"workspace:<id>"`, `"<custom-kind>:<id>"`, or a dict with `{kind, id}`.
+Omitted tenant scope uses the ambient `harness.tenant` id when the host bound
+one. The VM passes the ambient request id and authenticated principal facts to
+the provider for audit, but the provider owns policy, encryption, rotation,
+lease persistence, and any external KMS or vault adapter.
+
 ## Provider chain configuration
 
 The provider order is controlled with `HARN_SECRET_PROVIDERS`:


### PR DESCRIPTION
## Summary
- add the typed `harness.secrets` sub-handle for read/read_bytes/write/rotate/lease/lease_bytes
- extend `SecretProvider` with scoped request/receipt types carrying scope and audit context
- document the host-owned secret primitive boundary and add a changelog fragment

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p harn-vm secrets_sub_handle_uses_provider_scope_and_audit_context -- --nocapture`
- `cargo check -p harn-parser -p harn-vm --all-targets`
- `cargo clippy -p harn-parser -p harn-vm --all-targets -- -D warnings`
- pre-commit and pre-push hooks