### PR TITLE
fix(stdlib): preserve float .0 in json + trim whitespace in to_int/to_float

### DIFF
--- a/changelog.d/json-float-roundtrip.fixed.md
+++ b/changelog.d/json-float-roundtrip.fixed.md
@@ -1,0 +1,5 @@
+- **`json_stringify` now preserves the decimal point on whole-number floats.**
+  A `float` like `2.0` serialized to `"2"` (so `json_parse` read it back as an
+  `int`) and disagreed with `json_stringify_pretty`, which emitted `"2.0"`.
+  Compact output now routes finite floats through the same serde `Number`
+  formatter as the pretty printer, so floats round-trip as floats.

--- a/changelog.d/numeric-coercion-trim.fixed.md
+++ b/changelog.d/numeric-coercion-trim.fixed.md
@@ -1,0 +1,4 @@
+- **`to_int` / `to_float` now trim surrounding whitespace before parsing.**
+  `to_int("  42  ")` and `to_float(" 1.5\n")` returned `nil`; they now parse to
+  `42` / `1.5`, matching the sibling `decimal(...)` builtin and Python/JS
+  numeric coercion. Non-numeric strings still return `nil`.

--- a/conformance/tests/stdlib/json_float_roundtrip.expected
+++ b/conformance/tests/stdlib/json_float_roundtrip.expected
@@ -1,0 +1,4 @@
+[harn] 2.0
+[harn] 2.0
+[harn] float
+[harn] {"n":3,"ratio":2.0}

--- a/conformance/tests/stdlib/json_float_roundtrip.harn
+++ b/conformance/tests/stdlib/json_float_roundtrip.harn
@@ -1,0 +1,11 @@
+/**
+ * A whole-number float must keep its decimal point through json_stringify so
+ * it round-trips back as a float (not an int), and the compact and pretty
+ * serializers must agree.
+ */
+pipeline test(task) {
+  log(json_stringify(2.0))
+  log(json_stringify_pretty(2.0))
+  log(type_of(json_parse(json_stringify(2.0))))
+  log(json_stringify({ratio: 2.0, n: 3}))
+}

--- a/crates/harn-vm/src/stdlib/json.rs
+++ b/crates/harn-vm/src/stdlib/json.rs
@@ -697,7 +697,15 @@ fn write_vm_value_to_json(val: &VmValue, out: &mut String) {
             out.push('}');
         }
         VmValue::Int(n) => out.push_str(&n.to_string()),
-        VmValue::Float(n) if n.is_finite() => out.push_str(&n.to_string()),
+        // Render finite floats through serde's `Number` so the compact output
+        // matches `json_stringify_pretty` (which goes through serde) byte for
+        // byte: a whole-number float keeps its `.0` and round-trips back as a
+        // `float` instead of `f64::to_string()` collapsing `2.0` to `"2"`
+        // (which `json_parse` would then read as an `int`).
+        VmValue::Float(n) if n.is_finite() => match serde_json::Number::from_f64(*n) {
+            Some(num) => out.push_str(&num.to_string()),
+            None => out.push_str("null"),
+        },
         VmValue::Float(_) => out.push_str("null"),
         // Decimal serializes as a JSON string to preserve exact precision.
         VmValue::Decimal(d) => out.push_str(&escape_json_string_vm(&d.to_string())),
@@ -829,6 +837,20 @@ mod tests {
     fn extract_from_code_fence() {
         let text = "Here is the result:\n```json\n{\"key\": \"value\"}\n```\nDone.";
         assert_eq!(extract_json_from_text(text), "{\"key\": \"value\"}");
+    }
+
+    #[test]
+    fn whole_number_float_keeps_decimal_point() {
+        // A `float` with no fractional part must serialize as `2.0`, not `2`,
+        // so it round-trips as a float and matches the pretty printer.
+        assert_eq!(vm_value_to_json(&VmValue::Float(2.0)), "2.0");
+        assert_eq!(vm_value_to_json(&VmValue::Float(-5.0)), "-5.0");
+        assert_eq!(vm_value_to_json(&VmValue::Float(2.5)), "2.5");
+        // Ints are still bare.
+        assert_eq!(vm_value_to_json(&VmValue::Int(2)), "2");
+        // Inside a container, too.
+        let list = VmValue::List(std::sync::Arc::new(vec![VmValue::Float(1.0)]));
+        assert_eq!(vm_value_to_json(&list), "[1.0]");
     }
 
     fn deep_list(depth: usize) -> VmValue {

--- a/crates/harn-vm/src/stdlib/types.rs
+++ b/crates/harn-vm/src/stdlib/types.rs
@@ -34,7 +34,15 @@ fn to_int_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> 
             Ok(d.trunc().to_i64().map(VmValue::Int).unwrap_or(VmValue::Nil))
         }
         VmValue::Bool(value) => Ok(VmValue::Int(i64::from(*value))),
-        VmValue::String(s) => Ok(s.parse::<i64>().map(VmValue::Int).unwrap_or(VmValue::Nil)),
+        // Trim surrounding whitespace before parsing, matching `decimal(...)`
+        // and Python's `int(" 42 ")`/JS `Number(" 42 ")`. A string is exactly
+        // the case `std/coerce` exists for (numbers rendered by an LLM/JSON),
+        // and a stray newline should not silently produce `nil`.
+        VmValue::String(s) => Ok(s
+            .trim()
+            .parse::<i64>()
+            .map(VmValue::Int)
+            .unwrap_or(VmValue::Nil)),
         _ => Ok(VmValue::Nil),
     }
 }
@@ -57,7 +65,11 @@ fn to_float_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError
             use rust_decimal::prelude::ToPrimitive;
             Ok(d.to_f64().map(VmValue::Float).unwrap_or(VmValue::Nil))
         }
-        VmValue::String(s) => Ok(s.parse::<f64>().map(VmValue::Float).unwrap_or(VmValue::Nil)),
+        VmValue::String(s) => Ok(s
+            .trim()
+            .parse::<f64>()
+            .map(VmValue::Float)
+            .unwrap_or(VmValue::Nil)),
         _ => Ok(VmValue::Nil),
     }
 }
@@ -301,5 +313,27 @@ mod tests {
             let converted = to_int_impl(&[VmValue::Float(value)], &mut String::new()).unwrap();
             assert!(matches!(converted, VmValue::Nil));
         }
+    }
+
+    #[test]
+    fn to_int_and_to_float_trim_surrounding_whitespace() {
+        let s = |text: &str| VmValue::String(std::sync::Arc::from(text));
+        assert!(matches!(
+            to_int_impl(&[s("  42  ")], &mut String::new()).unwrap(),
+            VmValue::Int(42)
+        ));
+        assert!(matches!(
+            to_int_impl(&[s("42\n")], &mut String::new()).unwrap(),
+            VmValue::Int(42)
+        ));
+        match to_float_impl(&[s("  1.5  ")], &mut String::new()).unwrap() {
+            VmValue::Float(f) => assert!((f - 1.5).abs() < 1e-9),
+            other => panic!("expected 1.5, got {other:?}"),
+        }
+        // Non-numeric strings still return nil.
+        assert!(matches!(
+            to_int_impl(&[s("nope")], &mut String::new()).unwrap(),
+            VmValue::Nil
+        ));
     }
 }

--- a/scripts/provider_catalog_fixtures/expected_drift_report.md
+++ b/scripts/provider_catalog_fixtures/expected_drift_report.md
@@ -38,8 +38,8 @@ _None._
 
 ## Cross-source conflicts (provider-owned wins)
 
-- `claude-haiku-4-5-20251001` (anthropic) `pricing.input_per_mtok`: kept 1 (provider-owned) over 1.5
-- `claude-haiku-4-5-20251001` (anthropic) `pricing.output_per_mtok`: kept 5 (provider-owned) over 7.5
+- `claude-haiku-4-5-20251001` (anthropic) `pricing.input_per_mtok`: kept 1.0 (provider-owned) over 1.5
+- `claude-haiku-4-5-20251001` (anthropic) `pricing.output_per_mtok`: kept 5.0 (provider-owned) over 7.5
 
 ## Unknown pricing
 


### PR DESCRIPTION
## What — two stdlib numeric-correctness fixes

### 1. `json_stringify` dropped the `.0` on whole-number floats
```harn
json_stringify(2.0)              // was "2"   → now "2.0"
type_of(json_parse(json_stringify(2.0)))  // was int → now float
json_stringify_pretty(2.0)       // already "2.0" — the two now agree
```
`f64::to_string()` renders `2.0` as `"2"`, so a float silently became an int across a round-trip and disagreed with the pretty printer (which goes through serde). Compact output now routes finite floats through the same `serde_json::Number` formatter. **SOTA:** Python/Ruby `json.dumps(2.0) == "2.0"`.

### 2. `to_int`/`to_float` didn't trim whitespace (but `decimal` does)
```harn
to_int("  42  ")    // was nil → now 42
to_float(" 1.5\n")  // was nil → now 1.5
decimal("  42  ")   // already 42 — now consistent
```
A string is exactly the LLM/JSON-output case these coercions exist for; a stray newline silently producing `nil` defeats `to_int_or`/`to_float_or`. **SOTA:** Python `int(" 42 ")`, JS `Number(" 42 ")`. Non-numeric strings still return `nil`.

## Tests
Unit tests (json round-trip incl. nested + negative; trim parity + non-numeric still nil), conformance fixture `json_float_roundtrip`. Full conformance: 1638 passed, 0 failed. clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)