### PR TITLE
perf(vm): execute chunks via Arc instead of deep-cloning bytecode

### DIFF
--- a/changelog.d/execute-arc-no-chunk-clone.changed.md
+++ b/changelog.d/execute-arc-no-chunk-clone.changed.md
@@ -1,0 +1,7 @@
+- **Running a compiled chunk no longer deep-copies its bytecode.** `Vm::execute`
+  used to clone the entire `Chunk` (bytecode + constant pool + side tables) on
+  every top-level run. The internal run path now threads the shared
+  `Arc<Chunk>` straight into the call frame, and a new `Vm::execute_arc(ChunkRef)`
+  entry point lets callers that re-run the same chunk (the `harn serve` request
+  path, ACP, record filters) pay a refcount bump instead of an `O(code)` copy.
+  `Vm::execute(&Chunk)` is unchanged for one-shot callers.

--- a/crates/harn-serve/src/adapters/acp/execute.rs
+++ b/crates/harn-serve/src/adapters/acp/execute.rs
@@ -211,7 +211,7 @@ pub(super) async fn execute_chunk(
     };
     harn_vm::stdlib::process::set_thread_execution_context(Some(execution));
     let execute_started = Instant::now();
-    let result = match vm.execute(&chunk).await {
+    let result = match vm.execute_arc(std::sync::Arc::new(chunk)).await {
         Ok(_) => Ok(vm.output().to_string()),
         Err(e) => {
             let formatted = vm.format_runtime_error(&e);

--- a/crates/harn-serve/src/core.rs
+++ b/crates/harn-serve/src/core.rs
@@ -627,9 +627,11 @@ impl DispatchCore {
                 self.config.script_path.display()
             ))
         })?;
-        let chunk = harn_vm::Compiler::new()
-            .compile_named(&program, &function.name)
-            .map_err(|error| DispatchError::Validation(format!("compile error: {error}")))?;
+        let chunk = Arc::new(
+            harn_vm::Compiler::new()
+                .compile_named(&program, &function.name)
+                .map_err(|error| DispatchError::Validation(format!("compile error: {error}")))?,
+        );
         let globals = build_pipeline_globals(&request.arguments, function)?;
         let script_path = self.config.script_path.clone();
         let cancel_token = request
@@ -676,7 +678,7 @@ impl DispatchCore {
                     vm.set_global(&name, value);
                 }
 
-                let result = vm.execute(&chunk).await;
+                let result = vm.execute_arc(Arc::clone(&chunk)).await;
 
                 match result {
                     Ok(_) => {

--- a/crates/harn-vm/src/record_filter.rs
+++ b/crates/harn-vm/src/record_filter.rs
@@ -2,16 +2,16 @@ use std::sync::Arc;
 
 use serde_json::Value as JsonValue;
 
+use crate::chunk::ChunkRef;
 use crate::stdlib::json_to_vm_value;
 use crate::value::{VmClosure, VmError};
 use crate::vm::Vm;
-use crate::Chunk;
 
 const FILTER_FN_NAME: &str = "__harn_record_filter";
 
 pub struct CompiledRecordFilter {
     vm: Vm,
-    chunk: Chunk,
+    chunk: ChunkRef,
     closure: Option<Arc<VmClosure>>,
     normalized_expr: String,
 }
@@ -33,7 +33,7 @@ fn {FILTER_FN_NAME}(record) {{
         );
         Ok(Self {
             vm: Vm::new(),
-            chunk: crate::compile_source(&source)?,
+            chunk: Arc::new(crate::compile_source(&source)?),
             closure: None,
             normalized_expr,
         })
@@ -45,7 +45,7 @@ fn {FILTER_FN_NAME}(record) {{
 
     pub async fn matches(&mut self, record: &JsonValue) -> Result<bool, VmError> {
         if self.closure.is_none() {
-            self.vm.execute(&self.chunk).await?;
+            self.vm.execute_arc(Arc::clone(&self.chunk)).await?;
             self.closure = self.vm.resolve_named_closure(FILTER_FN_NAME);
         }
         let closure = self.closure.as_ref().ok_or_else(|| {

--- a/crates/harn-vm/src/vm/execution.rs
+++ b/crates/harn-vm/src/vm/execution.rs
@@ -31,7 +31,23 @@ impl Vm {
     }
 
     /// Execute a compiled chunk.
+    ///
+    /// Convenience entry point for callers that hold a borrowed [`Chunk`] and
+    /// run it once (tests, one-shot CLI invocations). It clones the chunk once
+    /// to obtain the owned [`ChunkRef`] the call frame requires. Callers that
+    /// re-run the same compiled chunk (servers, record filters, triggers)
+    /// should hold a [`ChunkRef`] and call [`Vm::execute_arc`] to skip the
+    /// per-execution deep copy of the bytecode + constant pool.
     pub async fn execute(&mut self, chunk: &Chunk) -> Result<VmValue, VmError> {
+        self.execute_arc(Arc::new(chunk.clone())).await
+    }
+
+    /// Execute a shared compiled chunk without cloning its bytecode.
+    ///
+    /// Threads the existing [`ChunkRef`] straight into the call frame, so
+    /// re-running the same chunk is a refcount bump rather than an
+    /// `O(code + constants)` copy.
+    pub async fn execute_arc(&mut self, chunk: ChunkRef) -> Result<VmValue, VmError> {
         let registry = self.pool_registry.clone();
         crate::stdlib::pool::with_pool_registry_scope(registry, async {
             self.execute_scoped(chunk).await
@@ -39,7 +55,7 @@ impl Vm {
         .await
     }
 
-    async fn execute_scoped(&mut self, chunk: &Chunk) -> Result<VmValue, VmError> {
+    async fn execute_scoped(&mut self, chunk: ChunkRef) -> Result<VmValue, VmError> {
         let _execution_activity = self
             .wait_for_graph
             .register_task(self.runtime_context.task_id.clone());
@@ -234,28 +250,8 @@ impl Vm {
         }
     }
 
-    pub(crate) async fn run_chunk(&mut self, chunk: &Chunk) -> Result<VmValue, VmError> {
-        self.run_chunk_entry(chunk, 0, None, None, None, None).await
-    }
-
-    pub(crate) async fn run_chunk_entry(
-        &mut self,
-        chunk: &Chunk,
-        argc: usize,
-        saved_source_dir: Option<std::path::PathBuf>,
-        module_functions: Option<ModuleFunctionRegistry>,
-        module_state: Option<crate::value::ModuleState>,
-        local_slots: Option<Vec<LocalSlot>>,
-    ) -> Result<VmValue, VmError> {
-        self.run_chunk_ref(
-            Arc::new(chunk.clone()),
-            argc,
-            saved_source_dir,
-            module_functions,
-            module_state,
-            local_slots,
-        )
-        .await
+    pub(crate) async fn run_chunk(&mut self, chunk: ChunkRef) -> Result<VmValue, VmError> {
+        self.run_chunk_ref(chunk, 0, None, None, None, None).await
     }
 
     pub(crate) async fn run_chunk_ref(

--- a/crates/harn-vm/src/vm/modules.rs
+++ b/crates/harn-vm/src/vm/modules.rs
@@ -191,7 +191,7 @@ impl Vm {
                 // so module loading is invisible to the step-tracking
                 // surface.
                 let active_context = crate::step_runtime::take_active_context();
-                let init_result = self.run_chunk(&fresh_init_chunk).await;
+                let init_result = self.run_chunk(std::sync::Arc::new(fresh_init_chunk)).await;
                 crate::step_runtime::restore_active_context(active_context);
                 init_env = std::mem::replace(&mut self.env, saved_env);
                 self.frames = saved_frames;


### PR DESCRIPTION
## What

`Vm::execute` cloned the **entire** `Chunk` — bytecode, constant pool, and side tables — on every top-level run, via `run_chunk_entry`'s `Arc::new(chunk.clone())`. This thread the shared `Arc<Chunk>` straight into the call frame instead.

- New `Vm::execute_arc(ChunkRef)` entry point: callers that hold an `Arc<Chunk>` pay a refcount bump, not an `O(code + constants)` copy.
- `Vm::execute(&Chunk)` is unchanged for one-shot callers (tests, CLI) — it now wraps once and delegates to `execute_arc`.
- Collapsed the redundant `run_chunk_entry` cloning layer into `run_chunk`, which now takes a `ChunkRef` directly.
- Migrated the re-running call sites to the Arc path: `harn serve` per-request dispatch (`core.rs`), the ACP adapter, and the record filter.

## Why

This is item 3 of a VM performance pass. The deep clone was pure waste on every execution — closures already used `Arc::clone` for their chunks; only the top-level entry path cloned. For an orchestration server re-dispatching compiled pipelines, this removes an `O(code-size)` allocation per request.

## Risk / compatibility

No API removed. `execute(&Chunk)` keeps working identically (one clone, same as before). Inline-cache keying is unaffected — `cache_id` is preserved across the existing `Chunk::clone`, and the Arc path doesn't clone at all. Full workspace build + `harn-vm` lib tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)