### PR TITLE
fix(vm): bind imports across module cycles instead of silently dropping them

### DIFF
--- a/changelog.d/cyclic-import-late-binding.fixed.md
+++ b/changelog.d/cyclic-import-late-binding.fixed.md
@@ -1,0 +1,9 @@
+- **Imports across a module cycle now bind reliably.** A plain `import "m"`
+  or `import { name } from "m"` that resolved to a module still mid-load (an
+  import cycle) used to silently skip binding the name, so calling it later
+  failed with `Undefined builtin: <name>` — and which module got starved
+  depended on load order, making the failure look nondeterministic. Cyclic
+  imports are now bound late, once every module in the cycle finishes loading,
+  for both bare references and calls. A `pub import` re-export across a cycle
+  remains unsupported but now fails with a message that names the cycle
+  instead of the misleading "imported module was not loaded".

--- a/conformance/tests/modules/cyclic_import_call.expected
+++ b/conformance/tests/modules/cyclic_import_call.expected
@@ -1,0 +1,2 @@
+HELPER-OK
+x sees: HELPER-OK

--- a/conformance/tests/modules/cyclic_import_call.harn
+++ b/conformance/tests/modules/cyclic_import_call.harn
@@ -1,0 +1,10 @@
+// Importing `b` first forces the cycle to be closed at `x` (the module that
+// selectively imports `helper` from the still-loading `b`). The deferred-import
+// pass must bind `helper` into `x` before `x_render` runs.
+import { helper } from "cyclic_import_call_b"
+import { x_render } from "cyclic_import_call_x"
+
+pipeline default() {
+  __io_println(helper())
+  __io_println(x_render())
+}

--- a/conformance/tests/modules/cyclic_import_call_b.harn
+++ b/conformance/tests/modules/cyclic_import_call_b.harn
@@ -1,0 +1,7 @@
+// Owning module: defines the helper AND transitively pulls in `x` (the
+// cyclic edge). `b -> m -> x -> b` is a real import cycle.
+import "cyclic_import_call_m"
+
+pub fn helper() -> string {
+  return "HELPER-OK"
+}

--- a/conformance/tests/modules/cyclic_import_call_m.harn
+++ b/conformance/tests/modules/cyclic_import_call_m.harn
@@ -1,0 +1,5 @@
+import { x_render } from "cyclic_import_call_x"
+
+pub fn m_fn() -> string {
+  return x_render()
+}

--- a/conformance/tests/modules/cyclic_import_call_x.harn
+++ b/conformance/tests/modules/cyclic_import_call_x.harn
@@ -1,0 +1,8 @@
+// Selectively imports `helper` from `b` while `b` is still mid-load (cycle).
+// Calling the imported name from inside a module function is the case that
+// used to fail with `Undefined builtin: helper` in a load-order-dependent way.
+import { helper } from "cyclic_import_call_b"
+
+pub fn x_render() -> string {
+  return "x sees: " + helper()
+}

--- a/conformance/tests/modules/cyclic_reexport_error.error
+++ b/conformance/tests/modules/cyclic_reexport_error.error
@@ -1,0 +1,1 @@
+forms an import cycle with this module

--- a/conformance/tests/modules/cyclic_reexport_error.harn
+++ b/conformance/tests/modules/cyclic_reexport_error.harn
@@ -1,0 +1,6 @@
+import { helper } from "cyclic_reexport_error_b"
+import { x_render } from "cyclic_reexport_error_x"
+
+pipeline default() {
+  __io_println(x_render())
+}

--- a/conformance/tests/modules/cyclic_reexport_error_b.harn
+++ b/conformance/tests/modules/cyclic_reexport_error_b.harn
@@ -1,0 +1,5 @@
+import "cyclic_reexport_error_m"
+
+pub fn helper() -> string {
+  return "HELPER-OK"
+}

--- a/conformance/tests/modules/cyclic_reexport_error_m.harn
+++ b/conformance/tests/modules/cyclic_reexport_error_m.harn
@@ -1,0 +1,5 @@
+import { x_render } from "cyclic_reexport_error_x"
+
+pub fn m_fn() -> string {
+  return x_render()
+}

--- a/conformance/tests/modules/cyclic_reexport_error_x.harn
+++ b/conformance/tests/modules/cyclic_reexport_error_x.harn
@@ -1,0 +1,9 @@
+// `pub import` re-export across the b -> m -> x -> b cycle: x's public surface
+// must publish `helper` immediately, but `b` is still mid-load. This is a
+// hard error with an actionable message (unlike a plain `import`, which binds
+// late). See cyclic_import_call for the supported plain-import form.
+pub import { helper } from "cyclic_reexport_error_b"
+
+pub fn x_render() -> string {
+  return "x sees: " + helper()
+}

--- a/crates/harn-vm/src/vm/modules.rs
+++ b/crates/harn-vm/src/vm/modules.rs
@@ -42,6 +42,21 @@ pub(crate) struct LoadedModule {
     pub(crate) _module_state: crate::value::ModuleState,
 }
 
+/// An import whose target module was still mid-load (an import cycle) when the
+/// importing module reached it. The target's function closures don't exist yet
+/// at that point, so the binding can't happen inline. We record it here and
+/// resolve it once both modules are fully loaded — see
+/// [`Vm::flush_deferred_cyclic_imports`].
+#[derive(Clone, Debug)]
+pub(crate) struct DeferredCyclicImport {
+    /// Canonical path of the module that issued the import.
+    pub(crate) importer: PathBuf,
+    /// Canonical path of the cyclically-imported target module.
+    pub(crate) target: PathBuf,
+    /// Selectively-imported names, or `None` for a wildcard/side-effect import.
+    pub(crate) selected_names: Option<Vec<String>>,
+}
+
 pub fn resolve_module_import_path(base: &Path, path: &str) -> PathBuf {
     let synthetic_current_file = base.join("__harn_import_base__.harn");
     if let Some(resolved) = harn_modules::resolve_import_path(&synthetic_current_file, path) {
@@ -229,6 +244,21 @@ impl Vm {
         for import in artifact.imports.iter().filter(|import| import.is_pub) {
             let cache_key = self.cache_key_for_import(&import.path);
             let Some(loaded) = self.module_cache.get(&cache_key).cloned() else {
+                // A plain `import`/`import {...}` across a cycle is bound late
+                // by `flush_deferred_cyclic_imports`, but a `pub import`
+                // re-export has to publish the names into *this* module's
+                // public surface right now — and the target is still mid-load,
+                // so its surface does not exist yet. Name the cycle explicitly
+                // instead of the misleading "was not loaded".
+                if self.imported_paths.contains(&cache_key) {
+                    return Err(VmError::Runtime(format!(
+                        "Re-export error: cannot `pub import` from '{}' because it forms an \
+                         import cycle with this module (its public surface is still being \
+                         built). Use a plain `import` here, or re-export from a module that is \
+                         not part of the cycle.",
+                        import.path
+                    )));
+                }
                 return Err(VmError::Runtime(format!(
                     "Re-export error: imported module '{}' was not loaded",
                     import.path
@@ -348,6 +378,22 @@ impl Vm {
                 .canonicalize()
                 .unwrap_or_else(|_| file_path.clone());
             if self.imported_paths.contains(&canonical) {
+                // Import cycle: `canonical` is still mid-load (it sits on the
+                // import stack), so its function closures don't exist yet and
+                // we cannot bind the requested names inline. Record the import
+                // and resolve it once both modules finish loading — otherwise
+                // whichever module happens to close the cycle silently loses
+                // these bindings and fails with `Undefined builtin` at call
+                // time, in a load-order-dependent way.
+                if let Some(importer) = self.imported_paths.last().cloned() {
+                    if importer != canonical {
+                        self.deferred_cyclic_imports.push(DeferredCyclicImport {
+                            importer,
+                            target: canonical.clone(),
+                            selected_names: selected_names.map(<[String]>::to_vec),
+                        });
+                    }
+                }
                 return Ok(());
             }
             if let Some(loaded) = self.module_cache.get(&canonical).cloned() {
@@ -395,8 +441,68 @@ impl Vm {
             Arc::make_mut(&mut self.module_cache).insert(canonical.clone(), loaded.clone());
             self.export_loaded_module(&canonical, &loaded, selected_names)?;
 
+            // Once the import stack fully unwinds, every module reachable from
+            // this top-level import is cached, so any deferred cyclic imports
+            // can now bind against fully-loaded modules.
+            if self.imported_paths.is_empty() {
+                self.flush_deferred_cyclic_imports()?;
+            }
+
             Ok(())
         })
+    }
+
+    /// Bind imports that were deferred because their target module was still
+    /// mid-load (an import cycle). By the time the import stack has unwound,
+    /// both the importing and target modules are fully instantiated and cached,
+    /// so we can resolve the requested names against the target and define them
+    /// into the importer's shared, mutable `module_state`. That env is the one
+    /// every closure from the importing module consults (after its local env)
+    /// at call time, so the late binding becomes visible without needing to
+    /// rewrite the closures' captured lexical snapshots.
+    fn flush_deferred_cyclic_imports(&mut self) -> Result<(), VmError> {
+        if self.deferred_cyclic_imports.is_empty() {
+            return Ok(());
+        }
+        let deferred = std::mem::take(&mut self.deferred_cyclic_imports);
+        let mut still_pending = Vec::new();
+        for import in deferred {
+            let (Some(importer), Some(target)) = (
+                self.module_cache.get(&import.importer).cloned(),
+                self.module_cache.get(&import.target).cloned(),
+            ) else {
+                // One endpoint is not cached yet (a lazy import inside a
+                // function body can defer before the other side loads). Keep
+                // it for a later flush.
+                still_pending.push(import);
+                continue;
+            };
+
+            let export_names: Vec<String> = match &import.selected_names {
+                Some(names) => names.clone(),
+                None if !target.public_names.is_empty() => {
+                    target.public_names.iter().cloned().collect()
+                }
+                None => target.functions.keys().cloned().collect(),
+            };
+
+            let mut module_state = importer._module_state.lock();
+            for name in export_names {
+                let Some(closure) = target.functions.get(&name) else {
+                    return Err(VmError::Runtime(format!(
+                        "Import error: '{name}' is not defined in {}",
+                        import.target.display()
+                    )));
+                };
+                // A real local declaration (or an already-bound non-cyclic
+                // import) wins over the cyclic re-binding.
+                if module_state.get(&name).is_none() {
+                    module_state.define(&name, VmValue::Closure(Arc::clone(closure)), false)?;
+                }
+            }
+        }
+        self.deferred_cyclic_imports = still_pending;
+        Ok(())
     }
 
     /// Return the path key that `execute_import` would use to cache the

--- a/crates/harn-vm/src/vm/scope.rs
+++ b/crates/harn-vm/src/vm/scope.rs
@@ -69,10 +69,28 @@ impl Vm {
         if let Some(VmValue::Closure(closure)) = self.env.get(name) {
             return Some(closure);
         }
-        self.frames
+        if let Some(closure) = self
+            .frames
             .last()
             .and_then(|frame| frame.module_functions.as_ref())
             .and_then(|registry| registry.lock().get(name).cloned())
+        {
+            return Some(closure);
+        }
+        // Module-level bindings (top-level `var`/`let` closures and imports
+        // bound late by `flush_deferred_cyclic_imports`) live in the shared
+        // `module_state`. `execute_get_var` already consults it for bare
+        // references; consulting it here keeps name *calls* consistent with
+        // name *reads* and lets cyclically-imported functions resolve.
+        if let Some(VmValue::Closure(closure)) = self
+            .frames
+            .last()
+            .and_then(|frame| frame.module_state.as_ref())
+            .and_then(|state| state.lock().get(name))
+        {
+            return Some(closure);
+        }
+        None
     }
 
     fn prepare_closure_local_slots(

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -252,6 +252,10 @@ pub struct Vm {
     pub(crate) source_dir: Option<std::path::PathBuf>,
     /// Modules currently being imported (cycle prevention).
     pub(crate) imported_paths: Vec<std::path::PathBuf>,
+    /// Imports that hit an in-progress module (an import cycle) and so could
+    /// not bind inline. Drained by `flush_deferred_cyclic_imports` once the
+    /// involved modules finish loading.
+    pub(crate) deferred_cyclic_imports: Vec<super::modules::DeferredCyclicImport>,
     /// Loaded module cache keyed by canonical or synthetic module path.
     pub(crate) module_cache: Arc<BTreeMap<std::path::PathBuf, LoadedModule>>,
     /// Source text keyed by canonical or synthetic module path for debugger retrieval.
@@ -380,6 +384,7 @@ impl VmBaseline {
             last_line: 0,
             source_dir: self.source_dir.clone(),
             imported_paths: Vec::new(),
+            deferred_cyclic_imports: Vec::new(),
             module_cache: Arc::new(BTreeMap::new()),
             source_cache: Arc::new(source_cache),
             source_file: self.source_file.clone(),
@@ -608,6 +613,7 @@ impl Vm {
             last_line: 0,
             source_dir: None,
             imported_paths: Vec::new(),
+            deferred_cyclic_imports: Vec::new(),
             module_cache: Arc::new(BTreeMap::new()),
             source_cache: Arc::new(BTreeMap::new()),
             source_file: None,
@@ -760,6 +766,7 @@ impl Vm {
             last_line: 0,
             source_dir: self.source_dir.clone(),
             imported_paths: Vec::new(),
+            deferred_cyclic_imports: Vec::new(),
             module_cache: Arc::clone(&self.module_cache),
             source_cache: Arc::clone(&self.source_cache),
             source_file: self.source_file.clone(),

--- a/docs/src/language-spec.md
+++ b/docs/src/language-spec.md
@@ -1068,6 +1068,17 @@ conflict naming every contributing module.
 Imported pipelines are registered for later invocation.
 Non-pipeline top-level statements (fn declarations, let bindings) are executed immediately.
 
+Import cycles: modules may import each other (directly or transitively).
+A plain `import "m"` or selective `import { name } from "m"` that resolves
+to a module still mid-load is **bound late** — once every module in the
+cycle finishes loading, the name resolves for both bare references and
+calls, regardless of the order the modules happened to load in. A
+`pub import` re-export across a cycle is **not** supported: re-exporting
+must publish the name into the importing module's public surface
+immediately, but that surface does not exist yet while the cycle is
+loading, so it is a load error that names the cycle. Use a plain `import`
+inside the cycle and re-export from a module outside it.
+
 ### Static cross-module resolution
 
 `harn check`, `harn run`, `harn bench`, and the LSP build a **module graph**

--- a/spec/HARN_SPEC.md
+++ b/spec/HARN_SPEC.md
@@ -1066,6 +1066,17 @@ conflict naming every contributing module.
 Imported pipelines are registered for later invocation.
 Non-pipeline top-level statements (fn declarations, let bindings) are executed immediately.
 
+Import cycles: modules may import each other (directly or transitively).
+A plain `import "m"` or selective `import { name } from "m"` that resolves
+to a module still mid-load is **bound late** — once every module in the
+cycle finishes loading, the name resolves for both bare references and
+calls, regardless of the order the modules happened to load in. A
+`pub import` re-export across a cycle is **not** supported: re-exporting
+must publish the name into the importing module's public surface
+immediately, but that surface does not exist yet while the cycle is
+loading, so it is a load error that names the cycle. Use a plain `import`
+inside the cycle and re-export from a module outside it.
+
 ### Static cross-module resolution
 
 `harn check`, `harn run`, `harn bench`, and the LSP build a **module graph**


### PR DESCRIPTION
## What

A plain `import "m"` or `import { name } from "m"` that resolved to a module **still mid-load** (a real import cycle) hit the cycle-prevention early-return in `execute_import` and returned `Ok(())` **without binding** the requested names. The importing module finished loading — and got **cached** that way — missing those bindings, so calling the name later threw `Undefined builtin: <name>`.

Because which module gets starved depends on the order modules happen to load in, the same code **passes `harn check`** (the static module graph resolves the name) yet **fails at runtime** in a load-order-dependent, nondeterministic-looking way.

## How it surfaced

burin-code's `orient` tool: `orient.harn` selectively imports `build_workspace_outline` from `context/bootstrap`, and bootstrap transitively imports `tools/surface → tools/orient`, closing a cycle (`bootstrap → … → surface → orient → bootstrap`). Loading the graph via `runtime/loop` first closes the cycle at `orient`, starving its import — so `orient_render` crashed with `Undefined builtin: build_workspace_outline`. A downstream session diagnosed this as a "real Harn loader gap" and wrote a workaround; this PR removes the need for it.

## Fix

- When the cycle guard fires, record a **deferred binding** `(importer, target, selected_names)` instead of silently dropping it.
- Once the import stack fully unwinds (every module in the cycle is then instantiated and cached), `flush_deferred_cyclic_imports` resolves the target's exports and defines them into the importer's shared, mutable `module_state`. That env is what every closure from the importing module consults at call time, so the late binding is visible **without** rewriting the closures' captured lexical snapshots.
- `resolve_named_closure` now also consults `module_state` (it already backed bare `GetVar` reads via `execute_get_var`), making name **calls** consistent with name **reads**.
- `pub import` re-exports across a cycle stay unsupported — a re-export must publish into the importing module's public surface immediately, which doesn't exist mid-cycle — but now fail with a message that **names the cycle** instead of the misleading "imported module was not loaded".

## Verification

- New conformance `modules/cyclic_import_call` — plain + selective imports bind late across a cycle, verified to work regardless of load order.
- New conformance `modules/cyclic_reexport_error` — locks the actionable diagnostic for cyclic `pub import`.
- Confirmed the **original** burin-code `orient` test (`import { build_workspace_outline } from "../context/bootstrap"`, no workaround) now passes 7/7.
- `cargo test -p harn-vm` (27 binaries) green; clippy clean; conformance `language` (65), `modules` (13), `stdlib` (300), `scenarios` (245) all green.
- Spec (`spec/HARN_SPEC.md` + synced mirror) documents cycle binding semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)