### PR TITLE
perf(vm): in-place concat for dynamically-typed accumulators

### DIFF
--- a/changelog.d/inplace-concat-untyped-accumulator.changed.md
+++ b/changelog.d/inplace-concat-untyped-accumulator.changed.md
@@ -1,0 +1,7 @@
+- **In-place list/dict concat now also speeds up dynamically-typed
+  accumulators.** The `out = out + [item]` / `out += [item]` loop already
+  extended the accumulator's buffer in place (amortized O(n)) when its type was
+  statically known to be a list or dict. A new fused `ConcatAssignLocal` opcode
+  gates that in-place extend on the *runtime* value instead, so untyped (`any`)
+  accumulators get the same O(n²) → O(n) win — and a throwing `+=` on a scalar
+  now reliably leaves the binding at its previous value.

--- a/conformance/tests/collections/list_inplace_concat.expected
+++ b/conformance/tests/collections/list_inplace_concat.expected
@@ -2,6 +2,8 @@
 [harn] [10, 20, 30]
 [harn] [0, 1, 2, 3, 4, 99]
 [harn] [1, 2, 1, 2]
+[harn] [1, 2]
+[harn] [1]
 [harn] {a: 1, b: 2, c: 3}
 [harn] 8
 [harn] abcd

--- a/conformance/tests/collections/list_inplace_concat.harn
+++ b/conformance/tests/collections/list_inplace_concat.harn
@@ -25,6 +25,13 @@ pipeline test(task) {
   var z = [1, 2]
   z = z + z
   log(z)
+  // Aliasing via a separate binding: the in-place extend must observe that
+  // `a`'s buffer is still shared with `b` and copy instead of mutating it.
+  var a = [1]
+  let b = a
+  a = a + [2]
+  log(a)
+  log(b)
   // Dict merge accumulator.
   var d = {a: 1}
   d = d + {b: 2}

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -650,7 +650,7 @@ fn op_stack_delta(op: Op, count: u16) -> Option<i32> {
         // `SetProperty` and the local-slot stores read their target by name
         // or slot index, so they only pop the value being stored.
         DefLet | DefVar | SetVar | DefLocalSlot | SetLocalSlot | SetProperty
-        | SetLocalSlotProperty | Pop => -1,
+        | SetLocalSlotProperty | ConcatAssignLocal | Pop => -1,
         // Value-preserving: unary ops, by-name lookups/checks, and scope /
         // iterator / exception-handler bookkeeping (the last three touch
         // side stacks, not the operand stack).
@@ -771,7 +771,7 @@ impl Chunk {
         self.columns.push(col);
         if matches!(
             op,
-            Op::GetProperty | Op::GetPropertyOpt | Op::MethodCallSpread
+            Op::GetProperty | Op::GetPropertyOpt | Op::MethodCallSpread | Op::ConcatAssignLocal
         ) {
             self.register_inline_cache(op_offset);
         }

--- a/crates/harn-vm/src/compiler/statements.rs
+++ b/crates/harn-vm/src/compiler/statements.rs
@@ -326,11 +326,48 @@ impl Compiler {
     ) -> Result<bool, CompileError> {
         fn is_collection(t: Option<&TypeExpr>) -> bool {
             matches!(t, Some(TypeExpr::List(_)) | Some(TypeExpr::DictType(_, _)))
+                || matches!(t, Some(TypeExpr::Named(n)) if n == "list" || n == "dict")
+        }
+        // A type whose `+` should keep its specialized scalar opcode
+        // (`i += 1`, `total += x`) rather than route through the collection
+        // concat path. `None` (unknown) is deliberately excluded so untyped
+        // accumulators still reach the in-place opcode.
+        fn is_known_scalar(t: Option<&TypeExpr>) -> bool {
+            matches!(
+                t,
+                Some(TypeExpr::Named(n))
+                    if matches!(
+                        n.as_str(),
+                        "int" | "float" | "bool" | "string" | "nil" | "decimal" | "duration"
+                    )
+            )
         }
         if !self.options.optimizations_enabled() {
             return Ok(false);
         }
         let rhs_type = self.infer_expr_type(rhs);
+
+        // Local-slot accumulator: emit the fused `ConcatAssignLocal` opcode.
+        // It reads the slot at runtime and only takes the value in place when
+        // it is actually a List/Dict, so dynamically-typed accumulators get
+        // the amortized-O(n) in-place extend too — not just statically-typed
+        // ones — while a throwing add on a scalar leaves the binding intact.
+        // Skip only when both operands are known scalars so the specialized
+        // numeric opcode keeps its fast lane.
+        if let Some(binding) = self.resolve_local_slot(name) {
+            if is_known_scalar(left_type) && is_known_scalar(rhs_type.as_ref()) {
+                return Ok(false);
+            }
+            self.compile_node(rhs)?; // [e]  (slot live: aliasing rhs sees real x)
+            self.chunk
+                .emit_u16(Op::ConcatAssignLocal, binding.slot, self.line); // x = x + e
+            return Ok(true);
+        }
+
+        // Non-local binding (module-level `var`, global): no slot to take, so
+        // fall back to clearing the binding's reference between `e` and `Add`
+        // so the runtime `try_unwrap` fast path can still fire. Gated to
+        // statically-known collections to preserve existing behavior.
         if !is_collection(left_type) && !is_collection(rhs_type.as_ref()) {
             return Ok(false);
         }

--- a/crates/harn-vm/src/compiler/tests.rs
+++ b/crates/harn-vm/src/compiler/tests.rs
@@ -725,40 +725,47 @@ pipeline default() {}
 }
 
 #[test]
-fn inplace_list_concat_clears_binding_before_add() {
-    // `x = x + [i]` on a list compiles to the in-place accumulator form: the
-    // binding's reference is cleared (`NIL; SET_LOCAL_SLOT`) before the `ADD`
-    // so the runtime concat's `Arc::try_unwrap` extends the existing
-    // allocation rather than cloning it (O(n^2) -> O(1) amortized). The signal
-    // is a *single* assignment emitting *two* SET_LOCAL_SLOT (clear + store).
+fn inplace_list_concat_uses_fused_opcode() {
+    // `x = x + [i]` on a local list accumulator compiles to the single fused
+    // `CONCAT_ASSIGN_LOCAL` opcode. At runtime it takes the slot's value in
+    // place before the concat so `Arc::try_unwrap` extends the existing
+    // allocation rather than cloning it (O(n^2) -> O(1) amortized).
     let chunk = compile_source("pipeline t(task) {\n  var x = []\n  x = x + [1]\n}");
     let d = chunk.disassemble("t");
-    assert_eq!(
-        d.matches("SET_LOCAL_SLOT").count(),
-        2,
-        "in-place list concat should emit clear-binding + store:\n{d}"
-    );
     assert!(
-        d.contains("NIL"),
-        "expected a NIL clear before the concat:\n{d}"
+        d.contains("CONCAT_ASSIGN_LOCAL"),
+        "in-place list concat should emit the fused opcode:\n{d}"
     );
     assert!(
         !d.contains("ADD_INT"),
-        "a list concat must use the generic list ADD, not a scalar op:\n{d}"
+        "a list concat must not use a scalar op:\n{d}"
     );
 }
 
 #[test]
 fn inplace_list_concat_compound_assign_form() {
-    // `x += [i]` gets the same in-place treatment as `x = x + [i]`.
+    // `x += [i]` gets the same fused opcode as `x = x + [i]`.
     let chunk = compile_source("pipeline t(task) {\n  var x = []\n  x += [1]\n}");
     let d = chunk.disassemble("t");
-    assert_eq!(
-        d.matches("SET_LOCAL_SLOT").count(),
-        2,
-        "compound `x += [..]` should also emit the in-place form:\n{d}"
+    assert!(
+        d.contains("CONCAT_ASSIGN_LOCAL"),
+        "compound `x += [..]` should also emit the fused opcode:\n{d}"
     );
-    assert!(d.contains("NIL"), "{d}");
+}
+
+#[test]
+fn inplace_concat_fires_for_untyped_local_accumulator() {
+    // The fused opcode is gated on the *runtime* value, so an accumulator
+    // whose static type is unknown (`any`-returning helper) still gets the
+    // in-place path — the gap the compile-time-typed peephole could not close.
+    let chunk = compile_source(
+        "fn seed() -> any { return [] }\npipeline t(task) {\n  var x = seed()\n  x = x + [1]\n}",
+    );
+    let d = chunk.disassemble("t");
+    assert!(
+        d.contains("CONCAT_ASSIGN_LOCAL"),
+        "untyped local accumulator should still use the fused opcode:\n{d}"
+    );
 }
 
 #[test]

--- a/crates/harn-vm/src/vm/ops/arithmetic.rs
+++ b/crates/harn-vm/src/vm/ops/arithmetic.rs
@@ -79,18 +79,36 @@ impl super::super::Vm {
             let cache_slot = frame.chunk.inline_cache_slot(op_offset);
             (cache_id, slot_count, cache_slot)
         };
+        let b = self.pop()?;
+        let a = self.pop()?;
+        let result = self.adaptive_binary_compute(op, a, b, cache_id, slot_count, cache_slot)?;
+        self.stack.push(result);
+        Ok(())
+    }
+
+    /// Shared adaptive-binary core: apply `op` to owned `a`/`b`, consulting and
+    /// updating the inline cache slot. Split out of [`Vm::execute_adaptive_binary`]
+    /// so other opcodes that synthesize a binary op on operands they already
+    /// hold — notably `ConcatAssignLocal` for the `x = x + e` / `x += e`
+    /// accumulator — keep the same specialization (e.g. `Int`/`Float` add
+    /// quickening) instead of falling back to the generic match on every call.
+    pub(super) fn adaptive_binary_compute(
+        &mut self,
+        op: AdaptiveBinaryOp,
+        a: VmValue,
+        b: VmValue,
+        cache_id: u64,
+        slot_count: usize,
+        cache_slot: Option<usize>,
+    ) -> Result<VmValue, VmError> {
         let cached_state = cache_slot
             .and_then(|slot| self.peek_adaptive_binary_cache_by_key(cache_id, slot_count, slot))
             .filter(|(cached_op, _)| *cached_op == op)
             .map(|(_, state)| state);
 
-        let b = self.pop()?;
-        let a = self.pop()?;
         let shape = BinaryShape::for_values(op, &a, &b);
 
-        let result = if let Some((result, next_state)) =
-            Self::try_specialized_binary(op, cached_state, &a, &b)
-        {
+        if let Some((result, next_state)) = Self::try_specialized_binary(op, cached_state, &a, &b) {
             if let Some(slot) = cache_slot {
                 self.set_inline_cache_entry_by_key(
                     cache_id,
@@ -102,7 +120,7 @@ impl super::super::Vm {
                     },
                 );
             }
-            result
+            Ok(result)
         } else {
             let result = Self::generic_binary_result(self, op, a, b)?;
             if let (Some(slot), Some(shape)) = (cache_slot, shape) {
@@ -117,11 +135,8 @@ impl super::super::Vm {
                     },
                 );
             }
-            result
-        };
-
-        self.stack.push(result);
-        Ok(())
+            Ok(result)
+        }
     }
 
     /// Adaptive-binary specialization fast path. The caller supplies the

--- a/crates/harn-vm/src/vm/ops/mod.rs
+++ b/crates/harn-vm/src/vm/ops/mod.rs
@@ -196,6 +196,7 @@ harn_opcode_macros::define_opcodes! {
     GetLocalSlot { sync(self.execute_get_local_slot()), disasm: local_slot_u16("GET_LOCAL_SLOT") };
     DefLocalSlot { sync(self.execute_def_local_slot()), disasm: local_slot_u16("DEF_LOCAL_SLOT") };
     SetLocalSlot { sync(self.execute_set_local_slot()), disasm: local_slot_u16("SET_LOCAL_SLOT") };
+    ConcatAssignLocal { sync(self.execute_concat_assign_local()), disasm: local_slot_u16("CONCAT_ASSIGN_LOCAL") };
 }
 
 impl super::Vm {

--- a/crates/harn-vm/src/vm/ops/stack.rs
+++ b/crates/harn-vm/src/vm/ops/stack.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::chunk::{Chunk, Constant};
+use crate::chunk::{AdaptiveBinaryOp, Chunk, Constant};
 use crate::value::{VmError, VmValue};
 
 impl super::super::Vm {
@@ -221,6 +221,86 @@ impl super::super::Vm {
         // Tear down any nested value being overwritten iteratively so a deep
         // local cannot overflow the stack on drop (scalars are a no-op).
         crate::value::recursion::dismantle(std::mem::replace(&mut slot.value, val));
+        slot.synced = false;
+        Ok(())
+    }
+
+    /// In-place `+`-concat into a local slot: the runtime for `x = x + e` and
+    /// `x += e` where `x` resolves to a local slot.
+    ///
+    /// Pops `e`, reads slot `x`, and stores `x + e`. When `x` and `e` are
+    /// matching collection kinds (`list + list` / `dict + dict` — adds that
+    /// always succeed), `x`'s value is *taken* out of the slot before the add,
+    /// so the slot no longer aliases the buffer and `Arc::try_unwrap` extends
+    /// it in place — turning the `out = out + [item]` / `out += [item]`
+    /// accumulator loop from O(n^2) into amortized O(n). The earlier
+    /// compile-time emission only fired this fast path for statically-typed
+    /// collections; gating on the *runtime* shapes here also covers
+    /// dynamically-typed (`any`) accumulators.
+    ///
+    /// Every other case clones the slot value and routes the add through the
+    /// shared adaptive-binary core, so (a) numeric accumulators keep their
+    /// `Int`/`Float` inline-cache specialization and (b) a throwing add (e.g.
+    /// `x += y` with incompatible operands) leaves the binding at its previous
+    /// value rather than a placeholder — the take only happens for adds proven
+    /// to succeed.
+    pub(super) fn execute_concat_assign_local(&mut self) -> Result<(), VmError> {
+        let (slot_idx, cache_id, slot_count, cache_slot) = {
+            let frame = self.frames.last_mut().unwrap();
+            let op_offset = frame.ip.saturating_sub(1);
+            let slot_idx = frame.chunk.read_u16(frame.ip) as usize;
+            frame.ip += 2;
+            let cache_id = frame.chunk.cache_id();
+            let slot_count = frame.chunk.inline_cache_slot_count();
+            let cache_slot = frame.chunk.inline_cache_slot(op_offset);
+            (slot_idx, cache_id, slot_count, cache_slot)
+        };
+        let rhs = self.pop()?;
+        let frame = self.frames.last_mut().unwrap();
+        let Some(info) = frame.chunk.local_slots.get(slot_idx) else {
+            return Err(VmError::Runtime(format!(
+                "Invalid local slot index: {slot_idx}"
+            )));
+        };
+        if !info.mutable {
+            return Err(VmError::ImmutableAssignment(info.name.clone()));
+        }
+        let Some(slot) = frame.local_slots.get_mut(slot_idx) else {
+            return Err(VmError::Runtime(format!(
+                "Invalid local slot index: {slot_idx}"
+            )));
+        };
+        if !slot.initialized {
+            return Err(VmError::UndefinedVariable(info.name.clone()));
+        }
+        // Take the value in place only when the add is guaranteed to succeed
+        // (matching collection kinds). Releasing the slot's reference lets the
+        // concat's `Arc::try_unwrap` extend the buffer in place when it is not
+        // otherwise aliased; for everything else the slot is cloned so a
+        // throwing add leaves the binding intact.
+        let take_in_place = matches!(
+            (&slot.value, &rhs),
+            (VmValue::List(_), VmValue::List(_)) | (VmValue::Dict(_), VmValue::Dict(_))
+        );
+        let lhs = if take_in_place {
+            std::mem::replace(&mut slot.value, VmValue::Nil)
+        } else {
+            slot.value.clone()
+        };
+        let result = self.adaptive_binary_compute(
+            AdaptiveBinaryOp::Add,
+            lhs,
+            rhs,
+            cache_id,
+            slot_count,
+            cache_slot,
+        )?;
+        let frame = self.frames.last_mut().unwrap();
+        let slot = frame
+            .local_slots
+            .get_mut(slot_idx)
+            .expect("slot index validated above");
+        crate::value::recursion::dismantle(std::mem::replace(&mut slot.value, result));
         slot.synced = false;
         Ok(())
     }

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -2877,3 +2877,43 @@ fn monomorphic_counter_loop_result_is_correct() {
     let (out, _) = run_harn(source);
     assert_eq!(out.trim_end(), "[harn] 140");
 }
+
+#[test]
+fn inplace_concat_untyped_accumulator_builds_correctly() {
+    // An accumulator whose static type is unknown (`any`-returning seed) goes
+    // through the fused `ConcatAssignLocal` opcode, which gates the in-place
+    // take on the runtime value. The accumulated list must be correct.
+    let source = r#"
+fn seed() -> any { return [] }
+pipeline t(task) {
+  var x = seed()
+  for i in [1, 2, 3] {
+    x = x + [i]
+  }
+  var y = seed()
+  for i in [4, 5] {
+    y += [i]
+  }
+  log("${x} ${y}")
+}"#;
+    assert_eq!(run_output(source), "[harn] [1, 2, 3] [4, 5]");
+}
+
+#[test]
+fn inplace_concat_preserves_binding_when_add_throws() {
+    // The fused opcode only takes the slot in place for List/Dict values. A
+    // scalar accumulator hit with an incompatible `+=` throws, and the binding
+    // must retain its previous value (it was cloned, not taken) rather than be
+    // left as the placeholder.
+    let source = r#"
+pipeline t(task) {
+  var x = 5
+  try {
+    x += [1]
+  } catch (e) {
+    log("caught")
+  }
+  log("${x}")
+}"#;
+    assert_eq!(run_output(source), "[harn] caught\n[harn] 5");
+}


### PR DESCRIPTION
## What

`out = out + [item]` / `out += [item]` already extended the accumulator's buffer **in place** (amortized O(n) via `Arc::try_unwrap`) — but only when the compiler could *statically* prove the accumulator was a list or dict (`try_emit_inplace_concat_assign`'s type gate). Untyped (`any`) accumulators fell back to the O(n²) clone-per-iteration path.

This introduces a fused **`ConcatAssignLocal`** opcode that local-slot accumulators compile to. At runtime it:

- **takes the value in place** only when slot and rhs are *matching collection kinds* (`list+list` / `dict+dict` — adds that always succeed), so `Arc::try_unwrap` extends the unaliased buffer in place; and
- otherwise **clones** the slot value and routes the add through a shared **adaptive-binary core** (factored out of `execute_adaptive_binary`), so numeric accumulators keep their `Int`/`Float` inline-cache specialization, and a throwing `+=` (incompatible operands) leaves the binding at its previous value rather than a placeholder.

The opcode gets its own inline-cache slot. Non-local (module/global) accumulators keep the existing release-before-add emission.

## Why

This is item 2 of a VM perf pass. SOTA review (Dyon, Rhai, Roc, Starlark-rust) confirmed the right fix for value-semantic list growth is copy-on-write on the contiguous buffer (which Harn already had) — the gap was purely that the in-place path never fired for dynamically-typed accumulators, which are common in unannotated Harn scripts.

## Correctness

- New conformance case: in-place extend must observe aliasing through a *separate* binding (`b = a; a = a + [2]`) and copy, not mutate `b`.
- New runtime tests: untyped accumulator builds correctly; a throwing scalar `+=` preserves the binding.
- The two adaptive-inline-cache tests (untyped numeric accumulators) still pass — the opcode drives the same specialization via its own cache slot.

No surface API change. Full `harn-vm` test suite + targeted conformance green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)