### PR TITLE
fix(release): bypass sccache during post-bump prepare

### DIFF
--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -373,17 +373,15 @@ updated = re.sub(r'tag = "v\d+\.\d+\.\d+"', f'tag = "v{next_version}"', text)
 if updated != text:
     doc.write_text(updated)
 PY
-  # The audit lanes that ran before prepare populate `target/debug/incremental/`
-  # with object-file references keyed to the *old* version's crate hashes.
-  # Once `bump_version` rewrites Cargo.toml the workspace crates rebuild with
-  # fresh hashes, and the stale incremental directory has dangling .o refs —
-  # cargo aborts with "failed to open object file ... No such file or
-  # directory" and "extern location for harn_modules does not exist". Forcing
-  # `CARGO_INCREMENTAL=0` for the prepare-time cargo calls skips the
-  # incremental fast path entirely (these are one-shot builds anyway). Export
-  # so child make/cargo invocations downstream of release_ship.sh's
-  # `regenerate_derived_files` step inherit it too.
+  # The audit lanes that ran before prepare populate cache state keyed to the
+  # old workspace crate hashes. Once `bump_version` rewrites Cargo.toml, the
+  # prepare-time cargo calls are one-shot rebuilds of generated-artifact
+  # helpers; caching them has little value and has failed under macOS sccache
+  # file-descriptor pressure. Use direct rustc and skip incremental state for
+  # this post-bump phase.
   export CARGO_INCREMENTAL=0
+  export RUSTC_WRAPPER=
+  export SCCACHE_DISABLE=1
   make gen-protocol-artifacts
   cargo check --workspace --all-targets >/dev/null
   echo "Version updated: $current -> $next"

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -544,12 +544,13 @@ prepare_here() {
     exit 1
   fi
 
-  # `release_gate.sh prepare` already exported CARGO_INCREMENTAL=0 to
-  # work around incremental-cache corruption after parallel audit builds
-  # + a Cargo.toml version bump. That export does not survive the
-  # subprocess boundary, so re-apply it for the cargo invocations
-  # `regenerate_derived_files` runs in this shell.
+  # `release_gate.sh prepare` disables cargo/sccache state for post-bump
+  # one-shot rebuilds. That export does not survive the subprocess boundary,
+  # so re-apply it for the cargo invocations `regenerate_derived_files` runs in
+  # this shell.
   export CARGO_INCREMENTAL=0
+  export RUSTC_WRAPPER=
+  export SCCACHE_DISABLE=1
   regenerate_derived_files
 
   log_step "Stage release content"


### PR DESCRIPTION
## Summary
- Bypass `sccache` and cargo incremental state for release prepare's post-version-bump generated-artifact rebuilds.
- Keep the expensive audit lanes unchanged; this only affects the one-shot post-bump regenerate/check phase.

## Why
The v0.8.123 release prepare failed after the audit and publish dry-run because `sccache` hit macOS file-descriptor pressure while rebuilding generated protocol artifacts after the workspace version bump. Direct `rustc` for that narrow phase avoids the fragile cache path without weakening release validation.

## Validation
- `bash -n scripts/release_gate.sh scripts/release_ship.sh`
- pre-commit hooks passed
- pre-push hooks passed
