### PR TITLE
perf(vm): O(1) set membership via a resident structural-key index

### DIFF
--- a/changelog.d/set-membership-index.changed.md
+++ b/changelog.d/set-membership-index.changed.md
@@ -1,0 +1,8 @@
+- **Set membership is now O(1).** `set` values previously stored only a plain
+  list and rebuilt a hash index from every element on each `contains` /
+  `union` / `intersect` / `difference` / subset/superset/disjoint call — O(n)
+  work (plus an allocation) per query. They now carry a resident structural-key
+  index alongside the items, so membership is O(1) and the set-algebra builtins
+  and methods drop from rebuild-per-call to a single probe per element.
+  Observable semantics (insertion-ordered iteration, structural dedup,
+  order-independent equality and hashing) are unchanged.

--- a/crates/harn-vm/src/schema/mod.rs
+++ b/crates/harn-vm/src/schema/mod.rs
@@ -53,8 +53,11 @@ fn vm_value_to_serde_json(value: &VmValue) -> serde_json::Value {
         VmValue::Float(value) => serde_json::json!(value),
         VmValue::String(value) => serde_json::Value::String(value.to_string()),
         VmValue::Bytes(bytes) => tagged_bytes_json(bytes),
-        VmValue::List(items) | VmValue::Set(items) => {
+        VmValue::List(items) => {
             serde_json::Value::Array(items.iter().map(vm_value_to_serde_json).collect())
+        }
+        VmValue::Set(set) => {
+            serde_json::Value::Array(set.iter().map(vm_value_to_serde_json).collect())
         }
         VmValue::Dict(items) => serde_json::Value::Object(
             items

--- a/crates/harn-vm/src/schema/validate.rs
+++ b/crates/harn-vm/src/schema/validate.rs
@@ -246,7 +246,8 @@ fn validate_against_schema_inner(
             errors.extend(next_errors);
             validate_enum_membership(&normalized, schema, path, &mut errors);
         }
-        VmValue::List(items) | VmValue::Set(items) => {
+        VmValue::List(_) | VmValue::Set(_) => {
+            let items = collection_items(&normalized);
             if let Some(min_items) = schema_i64(schema, "min_items") {
                 if (items.len() as i64) < min_items {
                     errors.push(format!(
@@ -285,7 +286,7 @@ fn validate_against_schema_inner(
                     }
                 }
                 normalized = match &normalized {
-                    VmValue::Set(_) => VmValue::Set(std::sync::Arc::new(normalized_items)),
+                    VmValue::Set(_) => VmValue::set(normalized_items),
                     _ => VmValue::List(std::sync::Arc::new(normalized_items)),
                 };
             }
@@ -512,11 +513,20 @@ fn validate_object_fields(
     (normalized, errors)
 }
 
+/// Borrow the element slice of a list or set; empty for any other value.
+fn collection_items(value: &VmValue) -> &[VmValue] {
+    match value {
+        VmValue::List(items) => items,
+        VmValue::Set(set) => set.items(),
+        _ => &[],
+    }
+}
+
 fn items_are_unique(value: &VmValue) -> bool {
-    let items = match value {
-        VmValue::List(items) | VmValue::Set(items) => items,
-        _ => return true,
-    };
+    if !matches!(value, VmValue::List(_) | VmValue::Set(_)) {
+        return true;
+    }
+    let items = collection_items(value);
     for (index, item) in items.iter().enumerate() {
         if items[index + 1..]
             .iter()

--- a/crates/harn-vm/src/stdlib/collections.rs
+++ b/crates/harn-vm/src/stdlib/collections.rs
@@ -26,7 +26,8 @@ fn keep_filter_nil(value: &VmValue) -> bool {
 
 fn key_list_arg<'a>(value: &'a VmValue, builtin: &str) -> Result<&'a [VmValue], VmError> {
     match value {
-        VmValue::List(items) | VmValue::Set(items) => Ok(items.as_slice()),
+        VmValue::List(items) => Ok(items.as_slice()),
+        VmValue::Set(set) => Ok(set.items()),
         other => Err(VmError::TypeError(format!(
             "{builtin}: keys argument must be a list or set, got {}",
             other.type_name()
@@ -504,8 +505,9 @@ fn deep_merge_value(a: &VmValue, b: &VmValue) -> Result<VmValue, VmError> {
 /// scripts) via `value_structural_hash_key`, so two structurally equal
 /// dicts collapse to a single entry.
 fn list_unique(value: &VmValue) -> Result<VmValue, VmError> {
-    let items = match value {
-        VmValue::List(items) | VmValue::Set(items) => Arc::clone(items),
+    let items: &[VmValue] = match value {
+        VmValue::List(items) => items,
+        VmValue::Set(set) => set.items(),
         VmValue::Nil => return Ok(VmValue::List(std::sync::Arc::new(Vec::new()))),
         other => {
             return Err(VmError::TypeError(format!(
@@ -530,8 +532,9 @@ fn list_unique(value: &VmValue) -> Result<VmValue, VmError> {
 /// later pairs override earlier ones — matching the `__dict_merge`
 /// right-wins convention.
 fn dict_from_pairs(value: &VmValue) -> Result<VmValue, VmError> {
-    let pairs = match value {
-        VmValue::List(items) | VmValue::Set(items) => Arc::clone(items),
+    let pairs: &[VmValue] = match value {
+        VmValue::List(items) => items,
+        VmValue::Set(set) => set.items(),
         VmValue::Nil => return Ok(VmValue::dict(BTreeMap::new())),
         other => {
             return Err(VmError::TypeError(format!(

--- a/crates/harn-vm/src/stdlib/json.rs
+++ b/crates/harn-vm/src/stdlib/json.rs
@@ -647,11 +647,12 @@ pub(crate) fn vm_value_to_data_value(value: &VmValue) -> serde_json::Value {
         VmValue::String(s) => serde_json::json!(s.as_ref()),
         VmValue::Bool(b) => serde_json::json!(b),
         VmValue::Nil => serde_json::Value::Null,
-        VmValue::List(items) | VmValue::Set(items) => {
-            crate::value::recursion::guard_recursion(|| {
-                serde_json::Value::Array(items.iter().map(vm_value_to_data_value).collect())
-            })
-        }
+        VmValue::List(items) => crate::value::recursion::guard_recursion(|| {
+            serde_json::Value::Array(items.iter().map(vm_value_to_data_value).collect())
+        }),
+        VmValue::Set(set) => crate::value::recursion::guard_recursion(|| {
+            serde_json::Value::Array(set.iter().map(vm_value_to_data_value).collect())
+        }),
         VmValue::Dict(map) => crate::value::recursion::guard_recursion(|| {
             serde_json::Value::Object(
                 map.iter()
@@ -703,7 +704,12 @@ fn write_vm_value_to_json(val: &VmValue, out: &mut String) {
         VmValue::Decimal(d) => out.push_str(&escape_json_string_vm(&d.to_string())),
         VmValue::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
         VmValue::Nil => out.push_str("null"),
-        VmValue::List(items) | VmValue::Set(items) => {
+        VmValue::List(_) | VmValue::Set(_) => {
+            let items: &[VmValue] = match val {
+                VmValue::Set(set) => set.items(),
+                VmValue::List(items) => items,
+                _ => &[],
+            };
             out.push('[');
             crate::value::recursion::guard_recursion(|| {
                 for (i, item) in items.iter().enumerate() {

--- a/crates/harn-vm/src/stdlib/json_query.rs
+++ b/crates/harn-vm/src/stdlib/json_query.rs
@@ -166,8 +166,11 @@ fn eval_path(input: &VmValue, steps: &[PathStep]) -> Vec<VmValue> {
                     _ => next.push(VmValue::Nil),
                 },
                 PathStep::Iterate => match value {
-                    VmValue::List(items) | VmValue::Set(items) => {
+                    VmValue::List(items) => {
                         next.extend(items.iter().cloned());
+                    }
+                    VmValue::Set(set) => {
+                        next.extend(set.iter().cloned());
                     }
                     VmValue::Dict(map) => {
                         next.extend(map.values().cloned());
@@ -222,8 +225,13 @@ fn normalize_bound(value: i64, len: i64) -> i64 {
 fn collect_recursive(value: &VmValue, out: &mut Vec<VmValue>) {
     out.push(value.clone());
     match value {
-        VmValue::List(items) | VmValue::Set(items) => {
+        VmValue::List(items) => {
             for item in items.iter() {
+                collect_recursive(item, out);
+            }
+        }
+        VmValue::Set(set) => {
+            for item in set.iter() {
                 collect_recursive(item, out);
             }
         }
@@ -248,7 +256,8 @@ fn eval_builtin(builtin: Builtin, input: &VmValue) -> VmValue {
         Builtin::Length => VmValue::Int(match input {
             VmValue::String(s) => string_char_count(s) as i64,
             VmValue::Bytes(bytes) => bytes.len() as i64,
-            VmValue::List(items) | VmValue::Set(items) => items.len() as i64,
+            VmValue::List(items) => items.len() as i64,
+            VmValue::Set(set) => set.len() as i64,
             VmValue::Dict(map) => map.len() as i64,
             VmValue::Nil => 0,
             _ => 1,
@@ -270,7 +279,8 @@ fn eval_builtin(builtin: Builtin, input: &VmValue) -> VmValue {
             VmValue::Dict(map) => {
                 VmValue::List(std::sync::Arc::new(map.values().cloned().collect()))
             }
-            VmValue::List(items) | VmValue::Set(items) => VmValue::List(items.clone()),
+            VmValue::List(items) => VmValue::List(items.clone()),
+            VmValue::Set(set) => VmValue::List(set.shared_items()),
             _ => VmValue::List(std::sync::Arc::new(Vec::new())),
         },
         Builtin::Type => VmValue::String(std::sync::Arc::from(jq_type_name(input))),

--- a/crates/harn-vm/src/stdlib/sets.rs
+++ b/crates/harn-vm/src/stdlib/sets.rs
@@ -1,21 +1,6 @@
-use std::collections::HashSet;
-
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
-use crate::value::{value_structural_hash_key, VmError, VmValue};
+use crate::value::{VmError, VmSet, VmValue};
 use crate::vm::Vm;
-
-/// Build a HashSet of structural hash keys for O(1) membership checks.
-fn hash_set_from_items(items: &[VmValue]) -> HashSet<String> {
-    items.iter().map(value_structural_hash_key).collect()
-}
-
-/// Deduplicated insert: adds `v` to `items` only if its hash key is new.
-fn dedup_insert(items: &mut Vec<VmValue>, seen: &mut HashSet<String>, v: &VmValue) {
-    let key = value_structural_hash_key(v);
-    if seen.insert(key) {
-        items.push(v.clone());
-    }
-}
 
 pub(crate) fn register_set_builtins(vm: &mut Vm) {
     for def in MODULE_BUILTINS {
@@ -23,160 +8,82 @@ pub(crate) fn register_set_builtins(vm: &mut Vm) {
     }
 }
 
+/// Extract the backing [`VmSet`] from a set argument, throwing `message` when
+/// the argument is not a set.
+fn expect_set<'a>(arg: Option<&'a VmValue>, message: &str) -> Result<&'a VmSet, VmError> {
+    match arg {
+        Some(VmValue::Set(set)) => Ok(set),
+        _ => Err(VmError::Thrown(VmValue::string(message))),
+    }
+}
+
 #[harn_builtin(sig = "set(...args: any) -> any", category = "sets")]
 fn set_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    let mut items: Vec<VmValue> = Vec::new();
-    let mut seen = HashSet::new();
+    let mut set = VmSet::new();
     for arg in args {
         match arg {
             VmValue::List(list) => {
-                for v in list.iter() {
-                    dedup_insert(&mut items, &mut seen, v);
+                for value in list.iter() {
+                    set.insert(value.clone());
                 }
             }
-            VmValue::Set(s) => {
-                for v in s.iter() {
-                    dedup_insert(&mut items, &mut seen, v);
+            VmValue::Set(other) => {
+                for value in other.iter() {
+                    set.insert(value.clone());
                 }
             }
             other => {
-                dedup_insert(&mut items, &mut seen, other);
+                set.insert(other.clone());
             }
         }
     }
-    Ok(VmValue::Set(std::sync::Arc::new(items)))
+    Ok(VmValue::set_value(set))
 }
 
 #[harn_builtin(sig = "set_add(s: any, value: any) -> any", category = "sets")]
 fn set_add_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    let s = match args.first() {
-        Some(VmValue::Set(s)) => s.clone(),
-        _ => {
-            return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
-                "set_add: first argument must be a set",
-            ))));
-        }
-    };
-    let val = args.get(1).cloned().unwrap_or(VmValue::Nil);
-    let val_key = value_structural_hash_key(&val);
-    let mut seen = hash_set_from_items(&s);
-    let mut items: Vec<VmValue> = (*s).clone();
-    if seen.insert(val_key) {
-        items.push(val);
-    }
-    Ok(VmValue::Set(std::sync::Arc::new(items)))
+    let mut set = expect_set(args.first(), "set_add: first argument must be a set")?.clone();
+    set.insert(args.get(1).cloned().unwrap_or(VmValue::Nil));
+    Ok(VmValue::set_value(set))
 }
 
 #[harn_builtin(sig = "set_remove(s: any, value: any) -> any", category = "sets")]
 fn set_remove_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    let s = match args.first() {
-        Some(VmValue::Set(s)) => s.clone(),
-        _ => {
-            return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
-                "set_remove: first argument must be a set",
-            ))));
-        }
-    };
-    let val = args.get(1).cloned().unwrap_or(VmValue::Nil);
-    let val_key = value_structural_hash_key(&val);
-    let items: Vec<VmValue> = s
-        .iter()
-        .filter(|x| value_structural_hash_key(x) != val_key)
-        .cloned()
-        .collect();
-    Ok(VmValue::Set(std::sync::Arc::new(items)))
+    let mut set = expect_set(args.first(), "set_remove: first argument must be a set")?.clone();
+    set.remove(args.get(1).unwrap_or(&VmValue::Nil));
+    Ok(VmValue::set_value(set))
 }
 
 #[harn_builtin(sig = "set_contains(s: any, value: any) -> bool", category = "sets")]
 fn set_contains_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    let s = match args.first() {
-        Some(VmValue::Set(s)) => s,
+    let set = match args.first() {
+        Some(VmValue::Set(set)) => set,
         _ => return Ok(VmValue::Bool(false)),
     };
-    let val = args.get(1).unwrap_or(&VmValue::Nil);
-    let val_key = value_structural_hash_key(val);
-    let keys = hash_set_from_items(s);
-    Ok(VmValue::Bool(keys.contains(&val_key)))
+    Ok(VmValue::Bool(
+        set.contains(args.get(1).unwrap_or(&VmValue::Nil)),
+    ))
 }
 
 #[harn_builtin(sig = "set_union(a: any, b: any) -> any", category = "sets")]
 fn set_union_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    let a = match args.first() {
-        Some(VmValue::Set(s)) => s,
-        _ => {
-            return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
-                "set_union: arguments must be sets",
-            ))));
-        }
-    };
-    let b = match args.get(1) {
-        Some(VmValue::Set(s)) => s,
-        _ => {
-            return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
-                "set_union: arguments must be sets",
-            ))));
-        }
-    };
-    let mut items: Vec<VmValue> = (**a).clone();
-    let mut seen = hash_set_from_items(a);
-    for v in b.iter() {
-        dedup_insert(&mut items, &mut seen, v);
-    }
-    Ok(VmValue::Set(std::sync::Arc::new(items)))
+    let a = expect_set(args.first(), "set_union: arguments must be sets")?;
+    let b = expect_set(args.get(1), "set_union: arguments must be sets")?;
+    Ok(VmValue::set_value(a.union(b)))
 }
 
 #[harn_builtin(sig = "set_intersect(a: any, b: any) -> any", category = "sets")]
 fn set_intersect_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    let a = match args.first() {
-        Some(VmValue::Set(s)) => s,
-        _ => {
-            return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
-                "set_intersect: arguments must be sets",
-            ))));
-        }
-    };
-    let b = match args.get(1) {
-        Some(VmValue::Set(s)) => s,
-        _ => {
-            return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
-                "set_intersect: arguments must be sets",
-            ))));
-        }
-    };
-    let b_keys = hash_set_from_items(b);
-    let items: Vec<VmValue> = a
-        .iter()
-        .filter(|x| b_keys.contains(&value_structural_hash_key(x)))
-        .cloned()
-        .collect();
-    Ok(VmValue::Set(std::sync::Arc::new(items)))
+    let a = expect_set(args.first(), "set_intersect: arguments must be sets")?;
+    let b = expect_set(args.get(1), "set_intersect: arguments must be sets")?;
+    Ok(VmValue::set_value(a.intersect(b)))
 }
 
 #[harn_builtin(sig = "set_difference(a: any, b: any) -> any", category = "sets")]
 fn set_difference_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    let a = match args.first() {
-        Some(VmValue::Set(s)) => s,
-        _ => {
-            return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
-                "set_difference: arguments must be sets",
-            ))));
-        }
-    };
-    let b = match args.get(1) {
-        Some(VmValue::Set(s)) => s,
-        _ => {
-            return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
-                "set_difference: arguments must be sets",
-            ))));
-        }
-    };
-    let b_keys = hash_set_from_items(b);
-    let items: Vec<VmValue> = a
-        .iter()
-        .filter(|x| !b_keys.contains(&value_structural_hash_key(x)))
-        .cloned()
-        .collect();
-    Ok(VmValue::Set(std::sync::Arc::new(items)))
+    let a = expect_set(args.first(), "set_difference: arguments must be sets")?;
+    let b = expect_set(args.get(1), "set_difference: arguments must be sets")?;
+    Ok(VmValue::set_value(a.difference(b)))
 }
 
 #[harn_builtin(
@@ -184,86 +91,39 @@ fn set_difference_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
     category = "sets"
 )]
 fn set_symmetric_difference_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    let a = match args.first() {
-        Some(VmValue::Set(s)) => s,
-        _ => {
-            return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
-                "set_symmetric_difference: arguments must be sets",
-            ))));
-        }
-    };
-    let b = match args.get(1) {
-        Some(VmValue::Set(s)) => s,
-        _ => {
-            return Err(VmError::Thrown(VmValue::String(std::sync::Arc::from(
-                "set_symmetric_difference: arguments must be sets",
-            ))));
-        }
-    };
-    let a_keys = hash_set_from_items(a);
-    let b_keys = hash_set_from_items(b);
-    let mut items: Vec<VmValue> = a
-        .iter()
-        .filter(|x| !b_keys.contains(&value_structural_hash_key(x)))
-        .cloned()
-        .collect();
-    for v in b.iter() {
-        if !a_keys.contains(&value_structural_hash_key(v)) {
-            items.push(v.clone());
-        }
-    }
-    Ok(VmValue::Set(std::sync::Arc::new(items)))
+    let a = expect_set(
+        args.first(),
+        "set_symmetric_difference: arguments must be sets",
+    )?;
+    let b = expect_set(
+        args.get(1),
+        "set_symmetric_difference: arguments must be sets",
+    )?;
+    Ok(VmValue::set_value(a.symmetric_difference(b)))
 }
 
 #[harn_builtin(sig = "set_is_subset(a: any, b: any) -> bool", category = "sets")]
 fn set_is_subset_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    let a = match args.first() {
-        Some(VmValue::Set(s)) => s,
-        _ => return Ok(VmValue::Bool(false)),
+    let (Some(VmValue::Set(a)), Some(VmValue::Set(b))) = (args.first(), args.get(1)) else {
+        return Ok(VmValue::Bool(false));
     };
-    let b = match args.get(1) {
-        Some(VmValue::Set(s)) => s,
-        _ => return Ok(VmValue::Bool(false)),
-    };
-    let b_keys = hash_set_from_items(b);
-    Ok(VmValue::Bool(
-        a.iter()
-            .all(|x| b_keys.contains(&value_structural_hash_key(x))),
-    ))
+    Ok(VmValue::Bool(a.is_subset(b)))
 }
 
 #[harn_builtin(sig = "set_is_superset(a: any, b: any) -> bool", category = "sets")]
 fn set_is_superset_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    let a = match args.first() {
-        Some(VmValue::Set(s)) => s,
-        _ => return Ok(VmValue::Bool(false)),
+    let (Some(VmValue::Set(a)), Some(VmValue::Set(b))) = (args.first(), args.get(1)) else {
+        return Ok(VmValue::Bool(false));
     };
-    let b = match args.get(1) {
-        Some(VmValue::Set(s)) => s,
-        _ => return Ok(VmValue::Bool(false)),
-    };
-    let a_keys = hash_set_from_items(a);
-    Ok(VmValue::Bool(
-        b.iter()
-            .all(|x| a_keys.contains(&value_structural_hash_key(x))),
-    ))
+    Ok(VmValue::Bool(a.is_superset(b)))
 }
 
 #[harn_builtin(sig = "set_is_disjoint(a: any, b: any) -> bool", category = "sets")]
 fn set_is_disjoint_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
-    let a = match args.first() {
-        Some(VmValue::Set(s)) => s,
-        _ => return Ok(VmValue::Bool(true)),
+    let (Some(VmValue::Set(a)), Some(VmValue::Set(b))) = (args.first(), args.get(1)) else {
+        return Ok(VmValue::Bool(true));
     };
-    let b = match args.get(1) {
-        Some(VmValue::Set(s)) => s,
-        _ => return Ok(VmValue::Bool(true)),
-    };
-    let b_keys = hash_set_from_items(b);
-    Ok(VmValue::Bool(
-        !a.iter()
-            .any(|x| b_keys.contains(&value_structural_hash_key(x))),
-    ))
+    Ok(VmValue::Bool(a.is_disjoint(b)))
 }
 
 pub(crate) const MODULE_BUILTINS: &[&VmBuiltinDef] = &[

--- a/crates/harn-vm/src/stdlib/template/filters.rs
+++ b/crates/harn-vm/src/stdlib/template/filters.rs
@@ -96,7 +96,7 @@ pub(super) fn apply_filter(
             need(0, args)?;
             Ok(match v {
                 VmValue::List(items) => items.first().cloned().unwrap_or(VmValue::Nil),
-                VmValue::Set(items) => items.first().cloned().unwrap_or(VmValue::Nil),
+                VmValue::Set(set) => set.items().first().cloned().unwrap_or(VmValue::Nil),
                 VmValue::String(s) => s
                     .chars()
                     .next()
@@ -109,7 +109,7 @@ pub(super) fn apply_filter(
             need(0, args)?;
             Ok(match v {
                 VmValue::List(items) => items.last().cloned().unwrap_or(VmValue::Nil),
-                VmValue::Set(items) => items.last().cloned().unwrap_or(VmValue::Nil),
+                VmValue::Set(set) => set.items().last().cloned().unwrap_or(VmValue::Nil),
                 VmValue::String(s) => s
                     .chars()
                     .last()

--- a/crates/harn-vm/src/stdlib/types.rs
+++ b/crates/harn-vm/src/stdlib/types.rs
@@ -191,7 +191,7 @@ fn unreachable_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
 #[harn_builtin(sig = "to_list(...args: any) -> list", category = "types")]
 fn to_list_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     match args.first().unwrap_or(&VmValue::Nil) {
-        VmValue::Set(s) => Ok(VmValue::List(std::sync::Arc::new(s.to_vec()))),
+        VmValue::Set(s) => Ok(VmValue::List(s.shared_items())),
         VmValue::List(l) => Ok(VmValue::List(l.clone())),
         other => Ok(VmValue::List(std::sync::Arc::new(vec![other.clone()]))),
     }

--- a/crates/harn-vm/src/stdlib/xml.rs
+++ b/crates/harn-vm/src/stdlib/xml.rs
@@ -157,7 +157,12 @@ fn write_node(
             out.push_str(&tag);
             out.push('>');
         }
-        VmValue::List(items) | VmValue::Set(items) => {
+        VmValue::List(_) | VmValue::Set(_) => {
+            let items: &[VmValue] = match value {
+                VmValue::Set(set) => set.items(),
+                VmValue::List(items) => items,
+                _ => &[],
+            };
             push_indent(out, opts, depth);
             out.push('<');
             out.push_str(&tag);

--- a/crates/harn-vm/src/value/core.rs
+++ b/crates/harn-vm/src/value/core.rs
@@ -8,7 +8,7 @@ use crate::mcp::VmMcpClientHandle;
 use crate::BuiltinId;
 
 use super::{
-    VmAtomicHandle, VmChannelHandle, VmClosure, VmError, VmGenerator, VmRange, VmRngHandle,
+    VmAtomicHandle, VmChannelHandle, VmClosure, VmError, VmGenerator, VmRange, VmRngHandle, VmSet,
     VmStream, VmSyncPermitHandle,
 };
 
@@ -197,7 +197,7 @@ pub enum VmValue {
     Rng(Shared<VmRngHandle>),
     SyncPermit(Shared<VmSyncPermitHandle>),
     McpClient(Shared<VmMcpClientHandle>),
-    Set(Shared<Vec<VmValue>>),
+    Set(Shared<VmSet>),
     Generator(Shared<VmGenerator>),
     Stream(Shared<VmStream>),
     /// Lazy numeric range. Boxed behind a `Shared` pointer so its 24-byte
@@ -305,6 +305,17 @@ impl VmValue {
     /// Construct a [`VmValue::Dict`] from an already-built [`DictMap`].
     pub fn dict_map(map: DictMap) -> Self {
         VmValue::Dict(Shared::new(map))
+    }
+
+    /// Construct a [`VmValue::Set`] from any iterator of values, deduplicating
+    /// by structural equality and preserving first-seen insertion order.
+    pub fn set(values: impl IntoIterator<Item = VmValue>) -> Self {
+        VmValue::Set(Shared::new(values.into_iter().collect::<VmSet>()))
+    }
+
+    /// Construct a [`VmValue::Set`] from an already-built [`VmSet`].
+    pub fn set_value(set: VmSet) -> Self {
+        VmValue::Set(Shared::new(set))
     }
 
     pub fn channel(handle: VmChannelHandle) -> Self {

--- a/crates/harn-vm/src/value/mod.rs
+++ b/crates/harn-vm/src/value/mod.rs
@@ -4,6 +4,7 @@ mod env;
 mod error;
 mod handles;
 pub(crate) mod recursion;
+mod set;
 mod storage_json;
 mod structural;
 
@@ -23,6 +24,7 @@ pub use handles::{
     VmAtomicHandle, VmChannelCloseState, VmChannelHandle, VmGenerator, VmJoinHandle, VmRange,
     VmRngHandle, VmStream, VmStreamCancel, VmSyncPermitHandle, VmTaskHandle,
 };
+pub use set::VmSet;
 pub(crate) use storage_json::vm_to_storage_json;
 pub use structural::{
     compare_values, dedup_values, try_compare_values, value_identity_key,

--- a/crates/harn-vm/src/value/recursion.rs
+++ b/crates/harn-vm/src/value/recursion.rs
@@ -71,8 +71,13 @@ pub fn depth_within(value: &VmValue, limit: usize) -> bool {
             return false;
         }
         match value {
-            VmValue::List(items) | VmValue::Set(items) => {
+            VmValue::List(items) => {
                 for item in items.iter() {
+                    stack.push((item, depth + 1));
+                }
+            }
+            VmValue::Set(set) => {
+                for item in set.iter() {
                     stack.push((item, depth + 1));
                 }
             }
@@ -122,9 +127,14 @@ pub fn dismantle_values<I: IntoIterator<Item = VmValue>>(values: I) {
     let mut stack: Vec<VmValue> = values.into_iter().collect();
     while let Some(value) = stack.pop() {
         match value {
-            VmValue::List(items) | VmValue::Set(items) => {
+            VmValue::List(items) => {
                 if let Some(mut items) = Arc::into_inner(items) {
                     stack.append(&mut items);
+                }
+            }
+            VmValue::Set(set) => {
+                if let Some(set) = Arc::into_inner(set) {
+                    stack.extend(set.into_items());
                 }
             }
             VmValue::Dict(map) => {

--- a/crates/harn-vm/src/value/set.rs
+++ b/crates/harn-vm/src/value/set.rs
@@ -1,0 +1,251 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use super::{value_structural_hash_key, VmValue};
+
+/// Backing store for [`VmValue::Set`](super::VmValue::Set).
+///
+/// A Harn set is an *ordered* collection that deduplicates by structural
+/// equality. Membership used to be answered by rebuilding a
+/// `HashSet<String>` of structural hash keys from the backing `Vec` on every
+/// `contains` / `union` / `intersect` / … call — O(n) work (plus an
+/// allocation) per query. `VmSet` keeps that index resident alongside the
+/// items, so membership is O(1) and the set-algebra builtins drop from
+/// rebuild-per-call to a single key computation per probe.
+///
+/// Invariants:
+/// * `keys` holds exactly one entry per item: `value_structural_hash_key(item)`.
+/// * Insertion order is preserved in `items` (iteration, display, and
+///   serialization are order-stable); equality and hashing stay
+///   order-independent, matching the language spec.
+#[derive(Debug, Clone, Default)]
+pub struct VmSet {
+    /// Items in insertion order. Stored behind an `Arc` so iteration can share
+    /// the backing buffer with a `VmIter`/`IterState` without copying, and
+    /// value-semantic mutation clones copy-on-write via `Arc::make_mut`.
+    items: Arc<Vec<VmValue>>,
+    keys: HashSet<String>,
+}
+
+impl VmSet {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            items: Arc::new(Vec::with_capacity(capacity)),
+            keys: HashSet::with_capacity(capacity),
+        }
+    }
+
+    /// Insert `value`, returning `true` when it was newly added (its structural
+    /// key was not already present).
+    pub fn insert(&mut self, value: VmValue) -> bool {
+        let key = value_structural_hash_key(&value);
+        if self.keys.insert(key) {
+            Arc::make_mut(&mut self.items).push(value);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// O(1) membership test by structural equality.
+    pub fn contains(&self, value: &VmValue) -> bool {
+        self.keys.contains(&value_structural_hash_key(value))
+    }
+
+    /// Remove `value` if present, returning `true` when it was removed.
+    pub fn remove(&mut self, value: &VmValue) -> bool {
+        let key = value_structural_hash_key(value);
+        if self.keys.remove(&key) {
+            Arc::make_mut(&mut self.items).retain(|item| value_structural_hash_key(item) != key);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, VmValue> {
+        self.items.iter()
+    }
+
+    pub fn items(&self) -> &[VmValue] {
+        self.items.as_slice()
+    }
+
+    /// The shared backing buffer, for iterators that walk a set without
+    /// copying its elements (a refcount bump rather than an O(n) clone).
+    pub fn shared_items(&self) -> Arc<Vec<VmValue>> {
+        Arc::clone(&self.items)
+    }
+
+    /// Consume the set, yielding its items in insertion order. Used by the
+    /// iterative teardown path so deeply nested sets drop without recursing.
+    pub fn into_items(self) -> Vec<VmValue> {
+        Arc::try_unwrap(self.items).unwrap_or_else(|items| (*items).clone())
+    }
+
+    /// `self ∪ other`, preserving `self`'s order then `other`'s new items.
+    pub fn union(&self, other: &VmSet) -> VmSet {
+        let mut out = self.clone();
+        for value in other.iter() {
+            out.insert(value.clone());
+        }
+        out
+    }
+
+    /// `self ∩ other` — items of `self` also present in `other`.
+    pub fn intersect(&self, other: &VmSet) -> VmSet {
+        self.items
+            .iter()
+            .filter(|item| other.contains(item))
+            .cloned()
+            .collect()
+    }
+
+    /// `self \ other` — items of `self` not present in `other`.
+    pub fn difference(&self, other: &VmSet) -> VmSet {
+        self.items
+            .iter()
+            .filter(|item| !other.contains(item))
+            .cloned()
+            .collect()
+    }
+
+    /// `self △ other` — items in exactly one of the two sets.
+    pub fn symmetric_difference(&self, other: &VmSet) -> VmSet {
+        let mut out: VmSet = self
+            .iter()
+            .filter(|item| !other.contains(item))
+            .cloned()
+            .collect();
+        for value in other.iter() {
+            if !self.contains(value) {
+                out.insert(value.clone());
+            }
+        }
+        out
+    }
+
+    pub fn is_subset(&self, other: &VmSet) -> bool {
+        self.items.iter().all(|item| other.contains(item))
+    }
+
+    pub fn is_superset(&self, other: &VmSet) -> bool {
+        other.is_subset(self)
+    }
+
+    pub fn is_disjoint(&self, other: &VmSet) -> bool {
+        !self.items.iter().any(|item| other.contains(item))
+    }
+
+    /// Structural keys in sorted order. Backs the order-independent set hash
+    /// in [`value_structural_hash_key`](super::value_structural_hash_key)
+    /// without re-deriving a key per element.
+    pub fn sorted_keys(&self) -> Vec<&str> {
+        let mut keys: Vec<&str> = self.keys.iter().map(String::as_str).collect();
+        keys.sort_unstable();
+        keys
+    }
+}
+
+impl FromIterator<VmValue> for VmSet {
+    fn from_iter<I: IntoIterator<Item = VmValue>>(iter: I) -> Self {
+        let iter = iter.into_iter();
+        let mut set = VmSet::with_capacity(iter.size_hint().0);
+        for value in iter {
+            set.insert(value);
+        }
+        set
+    }
+}
+
+impl<'a> IntoIterator for &'a VmSet {
+    type Item = &'a VmValue;
+    type IntoIter = std::slice::Iter<'a, VmValue>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value::{value_structural_hash_key, values_equal};
+
+    fn int_set(values: &[i64]) -> VmSet {
+        values.iter().map(|n| VmValue::Int(*n)).collect()
+    }
+
+    #[test]
+    fn insert_dedups_and_preserves_first_seen_order() {
+        let set = int_set(&[3, 1, 3, 2, 1]);
+        assert_eq!(set.len(), 3);
+        let order: Vec<i64> = set
+            .iter()
+            .map(|v| match v {
+                VmValue::Int(n) => *n,
+                _ => unreachable!(),
+            })
+            .collect();
+        assert_eq!(order, vec![3, 1, 2]);
+    }
+
+    #[test]
+    fn contains_is_structural() {
+        let set = int_set(&[1, 2, 3]);
+        assert!(set.contains(&VmValue::Int(2)));
+        assert!(!set.contains(&VmValue::Int(9)));
+        // `1` and `1.0` are structurally equal in Harn.
+        assert!(set.contains(&VmValue::Float(1.0)));
+    }
+
+    #[test]
+    fn remove_updates_index_and_order() {
+        let mut set = int_set(&[1, 2, 3]);
+        assert!(set.remove(&VmValue::Int(2)));
+        assert!(!set.remove(&VmValue::Int(2)));
+        assert!(!set.contains(&VmValue::Int(2)));
+        assert_eq!(set.len(), 2);
+    }
+
+    #[test]
+    fn set_algebra() {
+        let a = int_set(&[1, 2, 3]);
+        let b = int_set(&[2, 3, 4]);
+        assert_eq!(a.union(&b).len(), 4);
+        assert_eq!(a.intersect(&b).len(), 2);
+        assert!(a.intersect(&b).contains(&VmValue::Int(2)));
+        let diff = a.difference(&b);
+        assert_eq!(diff.len(), 1);
+        assert!(diff.contains(&VmValue::Int(1)));
+        let sym = a.symmetric_difference(&b);
+        assert_eq!(sym.len(), 2);
+        assert!(sym.contains(&VmValue::Int(1)) && sym.contains(&VmValue::Int(4)));
+        assert!(int_set(&[1, 2]).is_subset(&a));
+        assert!(a.is_superset(&int_set(&[1, 2])));
+        assert!(a.is_disjoint(&int_set(&[7, 8])));
+        assert!(!a.is_disjoint(&b));
+    }
+
+    #[test]
+    fn equality_and_hash_are_order_independent() {
+        let a = VmValue::set([VmValue::Int(1), VmValue::Int(2), VmValue::Int(3)]);
+        let b = VmValue::set([VmValue::Int(3), VmValue::Int(2), VmValue::Int(1)]);
+        assert!(values_equal(&a, &b));
+        assert_eq!(value_structural_hash_key(&a), value_structural_hash_key(&b));
+        let c = VmValue::set([VmValue::Int(1), VmValue::Int(2)]);
+        assert!(!values_equal(&a, &c));
+    }
+}

--- a/crates/harn-vm/src/value/structural.rs
+++ b/crates/harn-vm/src/value/structural.rs
@@ -129,13 +129,11 @@ fn write_structural_hash_key(v: &VmValue, out: &mut String) {
             });
             out.push('}');
         }
-        VmValue::Set(items) => {
-            // Sets need sorted keys for order-independence
-            let mut keys: Vec<String> =
-                guard_recursion(|| items.iter().map(value_structural_hash_key).collect());
-            keys.sort();
+        VmValue::Set(set) => {
+            // Sets hash order-independently via their already-resident sorted
+            // structural keys.
             out.push('S');
-            for k in &keys {
+            for k in set.sorted_keys() {
                 out.push_str(k);
                 out.push(',');
             }
@@ -292,8 +290,9 @@ pub fn values_equal(a: &VmValue, b: &VmValue) -> bool {
                 })
         }
         (VmValue::Set(a), VmValue::Set(b)) => {
-            a.len() == b.len()
-                && guard_recursion(|| a.iter().all(|x| b.iter().any(|y| values_equal(x, y))))
+            // Order-independent: equal length plus every member of `a` present
+            // in `b`, using `b`'s O(1) structural-key index.
+            a.len() == b.len() && a.iter().all(|x| b.contains(x))
         }
         (VmValue::Generator(_), VmValue::Generator(_)) => false, // generators are never equal
         (VmValue::Stream(_), VmValue::Stream(_)) => false,       // streams are never equal

--- a/crates/harn-vm/src/vm/iter.rs
+++ b/crates/harn-vm/src/vm/iter.rs
@@ -1166,7 +1166,10 @@ pub fn iter_from_value(v: VmValue) -> Result<VmValue, VmError> {
             done: range_initial_done(r.start, r.end, r.inclusive),
         },
         VmValue::List(items) => VmIter::Vec { items, idx: 0 },
-        VmValue::Set(items) => VmIter::Vec { items, idx: 0 },
+        VmValue::Set(set) => VmIter::Vec {
+            items: set.shared_items(),
+            idx: 0,
+        },
         VmValue::Dict(entries) => {
             let keys: Vec<String> = entries.keys().cloned().collect();
             VmIter::Dict {

--- a/crates/harn-vm/src/vm/methods/iter.rs
+++ b/crates/harn-vm/src/vm/methods/iter.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 
-use crate::value::{compare_values, values_equal, VmError, VmValue};
+use crate::value::{compare_values, VmError, VmValue};
 use crate::vm::iter::{drain, iter_from_value, next_handle, VmIter, VmIterHandle};
 
 impl crate::vm::Vm {
@@ -177,13 +177,7 @@ impl crate::vm::Vm {
             }
             "to_set" => {
                 let items = drain(&handle, self).await?;
-                let mut out: Vec<VmValue> = Vec::new();
-                for v in items {
-                    if !out.iter().any(|x| values_equal(x, &v)) {
-                        out.push(v);
-                    }
-                }
-                Ok(VmValue::Set(std::sync::Arc::new(out)))
+                Ok(VmValue::set(items))
             }
             "to_dict" => {
                 let items = drain(&handle, self).await?;

--- a/crates/harn-vm/src/vm/methods/list.rs
+++ b/crates/harn-vm/src/vm/methods/list.rs
@@ -354,15 +354,7 @@ impl crate::vm::Vm {
                 }
             }
             "to_list" => Ok(VmValue::List(Arc::clone(items))),
-            "to_set" => {
-                let mut out: Vec<VmValue> = Vec::with_capacity(items.len());
-                for v in items.iter() {
-                    if !out.iter().any(|x| values_equal(x, v)) {
-                        out.push(v.clone());
-                    }
-                }
-                Ok(VmValue::Set(std::sync::Arc::new(out)))
-            }
+            "to_set" => Ok(VmValue::set(items.iter().cloned())),
             _ => Err(VmError::Runtime(format!("list has no method `{method}`"))),
         };
         Some(result)

--- a/crates/harn-vm/src/vm/methods/set.rs
+++ b/crates/harn-vm/src/vm/methods/set.rs
@@ -1,126 +1,62 @@
 use std::sync::Arc;
 
-use crate::value::{values_equal, VmError, VmValue};
+use crate::value::{VmError, VmSet, VmValue};
 
 impl crate::vm::Vm {
     pub(super) fn call_set_method_sync(
-        items: &Arc<Vec<VmValue>>,
+        set: &Arc<VmSet>,
         method: &str,
         args: &[VmValue],
     ) -> Option<Result<VmValue, VmError>> {
         let result = match method {
-            "count" | "len" => Ok(VmValue::Int(items.len() as i64)),
-            "empty" => Ok(VmValue::Bool(items.is_empty())),
+            "count" | "len" => Ok(VmValue::Int(set.len() as i64)),
+            "empty" => Ok(VmValue::Bool(set.is_empty())),
             "contains" => {
                 let needle = args.first().unwrap_or(&VmValue::Nil);
-                Ok(VmValue::Bool(items.iter().any(|x| values_equal(x, needle))))
+                Ok(VmValue::Bool(set.contains(needle)))
             }
             "add" => {
-                let val = args.first().cloned().unwrap_or(VmValue::Nil);
-                let mut new_items = items.to_vec();
-                if !new_items.iter().any(|x| values_equal(x, &val)) {
-                    new_items.push(val);
-                }
-                Ok(VmValue::Set(std::sync::Arc::new(new_items)))
+                let mut new_set = (**set).clone();
+                new_set.insert(args.first().cloned().unwrap_or(VmValue::Nil));
+                Ok(VmValue::set_value(new_set))
             }
             "remove" | "delete" => {
-                let val = args.first().unwrap_or(&VmValue::Nil);
-                let new_items: Vec<VmValue> = items
-                    .iter()
-                    .filter(|x| !values_equal(x, val))
-                    .cloned()
-                    .collect();
-                Ok(VmValue::Set(std::sync::Arc::new(new_items)))
+                let mut new_set = (**set).clone();
+                new_set.remove(args.first().unwrap_or(&VmValue::Nil));
+                Ok(VmValue::set_value(new_set))
             }
-            "union" => {
-                if let Some(VmValue::Set(other)) = args.first() {
-                    let mut result = items.to_vec();
-                    for v in other.iter() {
-                        if !result.iter().any(|x| values_equal(x, v)) {
-                            result.push(v.clone());
-                        }
-                    }
-                    Ok(VmValue::Set(std::sync::Arc::new(result)))
-                } else {
-                    Ok(VmValue::Set(Arc::clone(items)))
+            "union" => match args.first() {
+                Some(VmValue::Set(other)) => Ok(VmValue::set_value(set.union(other))),
+                _ => Ok(VmValue::Set(Arc::clone(set))),
+            },
+            "intersect" | "intersection" => match args.first() {
+                Some(VmValue::Set(other)) => Ok(VmValue::set_value(set.intersect(other))),
+                _ => Ok(VmValue::set_value(VmSet::new())),
+            },
+            "difference" => match args.first() {
+                Some(VmValue::Set(other)) => Ok(VmValue::set_value(set.difference(other))),
+                _ => Ok(VmValue::Set(Arc::clone(set))),
+            },
+            "symmetric_difference" => match args.first() {
+                Some(VmValue::Set(other)) => {
+                    Ok(VmValue::set_value(set.symmetric_difference(other)))
                 }
-            }
-            "intersect" | "intersection" => {
-                if let Some(VmValue::Set(other)) = args.first() {
-                    let result: Vec<VmValue> = items
-                        .iter()
-                        .filter(|x| other.iter().any(|y| values_equal(x, y)))
-                        .cloned()
-                        .collect();
-                    Ok(VmValue::Set(std::sync::Arc::new(result)))
-                } else {
-                    Ok(VmValue::Set(std::sync::Arc::new(Vec::new())))
-                }
-            }
-            "difference" => {
-                if let Some(VmValue::Set(other)) = args.first() {
-                    let result: Vec<VmValue> = items
-                        .iter()
-                        .filter(|x| !other.iter().any(|y| values_equal(x, y)))
-                        .cloned()
-                        .collect();
-                    Ok(VmValue::Set(std::sync::Arc::new(result)))
-                } else {
-                    Ok(VmValue::Set(Arc::clone(items)))
-                }
-            }
-            "symmetric_difference" => {
-                if let Some(VmValue::Set(other)) = args.first() {
-                    let mut result: Vec<VmValue> = items
-                        .iter()
-                        .filter(|x| !other.iter().any(|y| values_equal(x, y)))
-                        .cloned()
-                        .collect();
-                    for v in other.iter() {
-                        if !items.iter().any(|x| values_equal(x, v)) {
-                            result.push(v.clone());
-                        }
-                    }
-                    Ok(VmValue::Set(std::sync::Arc::new(result)))
-                } else {
-                    Ok(VmValue::Set(Arc::clone(items)))
-                }
-            }
-            "is_subset" => {
-                if let Some(VmValue::Set(other)) = args.first() {
-                    Ok(VmValue::Bool(
-                        items
-                            .iter()
-                            .all(|x| other.iter().any(|y| values_equal(x, y))),
-                    ))
-                } else {
-                    Ok(VmValue::Bool(false))
-                }
-            }
-            "is_superset" => {
-                if let Some(VmValue::Set(other)) = args.first() {
-                    Ok(VmValue::Bool(
-                        other
-                            .iter()
-                            .all(|x| items.iter().any(|y| values_equal(x, y))),
-                    ))
-                } else {
-                    Ok(VmValue::Bool(false))
-                }
-            }
-            "is_disjoint" => {
-                if let Some(VmValue::Set(other)) = args.first() {
-                    Ok(VmValue::Bool(
-                        !items
-                            .iter()
-                            .any(|x| other.iter().any(|y| values_equal(x, y))),
-                    ))
-                } else {
-                    Ok(VmValue::Bool(true))
-                }
-            }
-            "to_list" => Ok(VmValue::List(std::sync::Arc::new(items.to_vec()))),
-            "to_set" => Ok(VmValue::Set(Arc::clone(items))),
+                _ => Ok(VmValue::Set(Arc::clone(set))),
+            },
+            "is_subset" => match args.first() {
+                Some(VmValue::Set(other)) => Ok(VmValue::Bool(set.is_subset(other))),
+                _ => Ok(VmValue::Bool(false)),
+            },
+            "is_superset" => match args.first() {
+                Some(VmValue::Set(other)) => Ok(VmValue::Bool(set.is_superset(other))),
+                _ => Ok(VmValue::Bool(false)),
+            },
+            "is_disjoint" => match args.first() {
+                Some(VmValue::Set(other)) => Ok(VmValue::Bool(set.is_disjoint(other))),
+                _ => Ok(VmValue::Bool(true)),
+            },
+            "to_list" => Ok(VmValue::List(set.shared_items())),
+            "to_set" => Ok(VmValue::Set(Arc::clone(set))),
             "map" | "filter" => {
                 if args.first().is_some_and(Self::is_callable_value) {
                     return None;
@@ -146,11 +82,11 @@ impl crate::vm::Vm {
 
     pub(super) async fn call_set_method(
         &mut self,
-        items: &Arc<Vec<VmValue>>,
+        set: &Arc<VmSet>,
         method: &str,
         args: &[VmValue],
     ) -> Result<VmValue, VmError> {
-        if let Some(result) = Self::call_set_method_sync(items, method, args) {
+        if let Some(result) = Self::call_set_method_sync(set, method, args) {
             return result;
         }
 
@@ -159,33 +95,31 @@ impl crate::vm::Vm {
                 let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
                     return Ok(VmValue::Nil);
                 };
-                let mut result = Vec::new();
-                for item in items.iter() {
+                let mut result = VmSet::new();
+                for item in set.iter() {
                     let mapped = self.call_callable_one(callable, item).await?;
-                    if !result.iter().any(|x| values_equal(x, &mapped)) {
-                        result.push(mapped);
-                    }
+                    result.insert(mapped);
                 }
-                Ok(VmValue::Set(std::sync::Arc::new(result)))
+                Ok(VmValue::set_value(result))
             }
             "filter" => {
                 let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
                     return Ok(VmValue::Nil);
                 };
-                let mut result = Vec::new();
-                for item in items.iter() {
+                let mut result = VmSet::new();
+                for item in set.iter() {
                     let keep = self.call_callable_one(callable, item).await?;
                     if keep.is_truthy() {
-                        result.push(item.clone());
+                        result.insert(item.clone());
                     }
                 }
-                Ok(VmValue::Set(std::sync::Arc::new(result)))
+                Ok(VmValue::set_value(result))
             }
             "any" => {
                 let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
                     return Ok(VmValue::Bool(false));
                 };
-                for item in items.iter() {
+                for item in set.iter() {
                     let result = self.call_callable_one(callable, item).await?;
                     if result.is_truthy() {
                         return Ok(VmValue::Bool(true));
@@ -197,7 +131,7 @@ impl crate::vm::Vm {
                 let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
                     return Ok(VmValue::Bool(true));
                 };
-                for item in items.iter() {
+                for item in set.iter() {
                     let result = self.call_callable_one(callable, item).await?;
                     if !result.is_truthy() {
                         return Ok(VmValue::Bool(false));

--- a/crates/harn-vm/src/vm/ops/iter.rs
+++ b/crates/harn-vm/src/vm/ops/iter.rs
@@ -46,9 +46,11 @@ impl super::super::Vm {
                     idx: 0,
                 });
             }
-            VmValue::Set(items) => {
-                self.iterators
-                    .push(super::super::IterState::Vec { items, idx: 0 });
+            VmValue::Set(set) => {
+                self.iterators.push(super::super::IterState::Vec {
+                    items: set.shared_items(),
+                    idx: 0,
+                });
             }
             VmValue::Channel(ch) => {
                 self.iterators.push(super::super::IterState::Channel {
@@ -348,9 +350,10 @@ mod tests {
     #[test]
     fn iter_init_set_keeps_shared_backing_store() {
         run_iter_init_test(async {
-            let items = Arc::new(vec![VmValue::Int(1), VmValue::Int(2)]);
+            let set: crate::value::VmSet = [VmValue::Int(1), VmValue::Int(2)].into_iter().collect();
+            let backing = set.shared_items();
             let mut vm = Vm::new();
-            vm.stack.push(VmValue::Set(items.clone()));
+            vm.stack.push(VmValue::set_value(set));
 
             vm.execute_iter_init().unwrap();
 
@@ -359,7 +362,7 @@ mod tests {
                     items: iter_items,
                     idx,
                 } => {
-                    assert!(Arc::ptr_eq(&items, iter_items));
+                    assert!(Arc::ptr_eq(&backing, iter_items));
                     assert_eq!(*idx, 0);
                 }
                 _ => panic!("expected vec iterator state"),


### PR DESCRIPTION
## What

`VmValue::Set` was backed by a plain `Arc<Vec<VmValue>>`. Every membership-style operation — `set_contains`, `set_union`, `set_intersect`, `set_difference`, `set_symmetric_difference`, subset/superset/disjoint — **rebuilt a `HashSet` of structural hash keys from the entire backing vector on each call** (O(n) work + an allocation per call). The set *methods* (`.contains`/`.union`/…) were worse: they scanned with `values_equal` (O(n·m)).

This introduces a dedicated **`VmSet`** type that keeps the structural-key index resident alongside the items:

- **membership is O(1)**; set algebra drops from rebuild-per-call to a single probe per element;
- all **11 `set_*` builtins** and the **set method surface** now delegate to `VmSet` — one source of truth (large DRY win, −~250 lines of duplicated logic);
- **iteration stays zero-copy** via a shared `Arc<Vec>` backing buffer; value-semantic mutation is **copy-on-write** through `Arc::make_mut`;
- the index **reuses the canonical `value_structural_hash_key`**, so dedup, equality, and order-independent hashing are byte-identical — no parallel hashing path to drift.

## Why

This is item 1 of a VM perf pass. An O(n)-per-`contains` "set" is an algorithmic surprise for anyone evaluating Harn as a dependency. SOTA review (Koto's `ValueKey`, CPython/Starlark fallible hashing) confirmed the index-resident approach; reusing the existing structural key (rather than introducing a `ValueKey` with its own `Hash`/`Eq`) is the more maintainable long-term choice for a codebase that already centralizes structural identity there.

## Correctness

Observable behavior — insertion-ordered iteration, structural dedup, order-independent equality/hashing, `len`, immutability — is unchanged. Verified by:
- existing set conformance (`set_builtins` / `set_methods` / `set_predicates` / `set_edge_cases`) — 46/46 pass;
- new `VmSet` unit tests (dedup/order, O(1) contains, remove, full set algebra, order-independent equality+hash);
- full `harn-vm` suite (3856) + dependent crates (harn-cli/serve/hostlib/lint) green.

No surface API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)