### PR TITLE
docs(skills): surface the HARN-* code index in the diagnostics skill

### DIFF
--- a/changelog.d/3454.added.md
+++ b/changelog.d/3454.added.md
@@ -1,0 +1,4 @@
+- **The `harn-diagnostics` skill now indexes the HARN-* error codes.** `harn
+  skills get harn-diagnostics` points at how to look up any `HARN-<CAT>-<NNN>`
+  code — `harn explain <CODE>` (and `--json`), the full `harn explain --catalog`
+  index, and the committed `docs/src/diagnostics.md` / `docs/diagnostics-catalog.json`.

--- a/crates/harn-skills/src/corpus/harn-diagnostics/SKILL.md
+++ b/crates/harn-skills/src/corpus/harn-diagnostics/SKILL.md
@@ -1,15 +1,42 @@
 ---
 name: harn-diagnostics
-short: Diagnostics, explain output, repair plans, and fix-safety classes.
-description: Use for Harn diagnostics, error codes, explain output, repair metadata, and fix application safety.
-when_to_use: Use when working on typechecker diagnostics, lint diagnostics, harn explain, or repair flows.
+short: Diagnostics, the HARN-* error-code index, explain output, repair plans, and fix-safety classes.
+description: Use for Harn diagnostics, looking up any HARN-* error code, the full code index/catalog, explain output, repair metadata, and fix application safety.
+when_to_use: Use when working on typechecker diagnostics, lint diagnostics, harn explain, or repair flows — or when you hit a `HARN-<CAT>-<NNN>` code and want to look up what it means.
 ---
 
 # Harn diagnostics
 
-Use this skill when changing errors, warnings, explain output, repair metadata, or fix application behavior.
+Use this skill when changing errors, warnings, explain output, repair metadata,
+or fix application behavior — or when you need to look up what a
+`HARN-<CAT>-<NNN>` code means.
 
 Pair it with [[harn-language]] for syntax and type contracts and [[harn-agent]] for autonomy gating.
+
+## Code index (look up any HARN-* code)
+
+Every diagnostic `harn check`, `harn lint`, and `harn fmt` emit carries a stable
+`HARN-<CAT>-<NNN>` code. The code registry is the single source of truth
+(`crates/harn-parser/src/diagnostic_codes.rs` plus the per-code explanation in
+`crates/harn-parser/src/diagnostic_codes/explanations/<CODE>.md`); everything
+below is generated from it, so never hand-maintain a parallel list.
+
+- **Look up one code:** `harn explain HARN-TYP-014` (human-readable) or
+  `harn explain HARN-TYP-014 --json` (structured: category, summary, repair,
+  safety class, related codes).
+- **Full index of every code:** `harn explain --catalog` (add
+  `--format markdown` or `--format json`). This is the complete cheat sheet —
+  one entry per code with its summary, repair, and safety class.
+- **Committed artifacts** (kept in sync by CI):
+  - `docs/src/diagnostics.md` — the rendered index, grouped by category.
+  - `docs/diagnostics-catalog.json` — `schemaVersion: 1` structured contract
+    consumed by downstream tooling (IDE diagnostic panels, hosted error pages).
+    Tools should read this, not regex prose.
+- **Regenerate** after changing the registry or an explanation:
+  `make sync-diagnostics-catalog` (CI guard: `make check-diagnostics-catalog`).
+
+The category prefixes below are the mental map for the index; `harn explain`
+resolves any individual code.
 
 ## Start here
 


### PR DESCRIPTION
## What

The `harn-diagnostics` skill explained how to *author* diagnostics but never told an agent how to *look one up*. When you hit a `HARN-<CAT>-<NNN>` code, `harn skills get harn-diagnostics` gave no path to its meaning.

This adds a **"Code index (look up any HARN-* code)"** section pointing at the existing, generated single-source-of-truth artifacts:

- `harn explain HARN-<CAT>-<NNN>` (+ `--json`) — one code.
- `harn explain --catalog` (+ `--format markdown|json`) — the full index/cheat sheet (one entry per code: summary, repair, safety class).
- the committed `docs/src/diagnostics.md` (rendered index) and `docs/diagnostics-catalog.json` (`schemaVersion: 1` tooling contract).

## Why this shape (DRY)

No new catalog is introduced. The code registry (`crates/harn-parser/src/diagnostic_codes.rs` + per-code explanation files) is the single source of truth, and `harn explain --catalog` / `docs/src/diagnostics.md` are generated from it via `make sync-diagnostics-catalog` (CI-guarded). The skill just makes those discoverable — it doesn't duplicate the ~190-code list, so it can't drift.

Frontmatter `short`/`description`/`when_to_use` now mention code lookup so `harn skills get` surfaces this skill for that intent.

## Verification

- `harn skills get harn-diagnostics --full` renders the new section; `harn skills list` shows the updated `short`.
- Every command referenced was exercised: `harn explain HARN-TYP-014` (+ `--json`), `harn explain --catalog --format markdown|json`.
- Pre-commit lint (markdown + clippy + harn lint) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)