### PR TITLE
feat(llm): tool-call dialect validity gate — remove the harness footgun

### DIFF
--- a/changelog.d/3460.added.md
+++ b/changelog.d/3460.added.md
@@ -1,0 +1,9 @@
+- Tool-call dialect validity gate: the provider/model capability registry now
+  *enforces* `tool_mode_parity` instead of leaving it advisory. A requested
+  `tool_format` whose wire channel a route is known not to return parseable tool
+  calls on (e.g. a `native` pin on the `native_unreliable` DeepSeek V3.2 route,
+  which silently drops to unparsed DSML text) is auto-corrected to the route's
+  `preferred_tool_format`, with an actionable message naming the bad combo and
+  the working alternative. Enforced at `resolve_model_info` and at the
+  tool-bearing `llm_call` seam, so a harness can no longer silently get
+  vanishing tool calls from an invalid model×provider×tool_format combination.

--- a/changelog.d/3460.added.md
+++ b/changelog.d/3460.added.md
@@ -1,9 +1,13 @@
 - Tool-call dialect validity gate: the provider/model capability registry now
-  *enforces* `tool_mode_parity` instead of leaving it advisory. A requested
-  `tool_format` whose wire channel a route is known not to return parseable tool
-  calls on (e.g. a `native` pin on the `native_unreliable` DeepSeek V3.2 route,
-  which silently drops to unparsed DSML text) is auto-corrected to the route's
-  `preferred_tool_format`, with an actionable message naming the bad combo and
-  the working alternative. Enforced at `resolve_model_info` and at the
-  tool-bearing `llm_call` seam, so a harness can no longer silently get
-  vanishing tool calls from an invalid model×provider×tool_format combination.
+  *enforces* its tool-call dialect facts instead of leaving them advisory. A
+  requested `tool_format` whose wire channel a route is known not to return
+  parseable tool calls on — by `tool_mode_parity` (e.g. a `native` pin on the
+  `native_unreliable` DeepSeek V3.2 route, which silently drops to unparsed DSML
+  text) or by an explicit `text_tool_wire_format_supported = false` (e.g. the
+  native-only local Ollama Qwen3 route) — is auto-corrected to a working channel,
+  preferring the route's `preferred_tool_format`, with an actionable message
+  naming the bad combo and the working alternative. A route with no working
+  channel at all passes through untouched rather than rewriting to another broken
+  format. Enforced at `resolve_model_info` and at the tool-bearing `llm_call`
+  seam, so a harness can no longer silently get vanishing tool calls from an
+  invalid model×provider×tool_format combination.

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -911,15 +911,44 @@ impl ToolFormatDecision {
 }
 
 /// True when a route's `tool_mode_parity` says the native (provider JSON)
-/// channel cannot be trusted to yield parseable tool calls.
+/// channel cannot be trusted to yield parseable tool calls. `unsupported`
+/// (no working channel) is intentionally excluded: there is no better format
+/// to steer to, so the gate leaves such a route alone rather than rewriting to
+/// another broken channel under a misleading "Using X instead" message.
 fn parity_forbids_native(parity: &str) -> bool {
-    matches!(parity, "native_unreliable" | "text_only" | "unsupported")
+    matches!(parity, "native_unreliable" | "text_only")
 }
 
 /// True when a route's `tool_mode_parity` says a text-channel grammar cannot be
-/// trusted to yield parseable tool calls.
+/// trusted to yield parseable tool calls. See [`parity_forbids_native`] for why
+/// `unsupported` is excluded.
 fn parity_forbids_text(parity: &str) -> bool {
-    matches!(parity, "text_unreliable" | "native_only" | "unsupported")
+    matches!(parity, "text_unreliable" | "native_only")
+}
+
+/// True when the requested wire channel is known not to return parseable tool
+/// calls for a route. The gate auto-corrects only on *positive* evidence of
+/// breakage, never on a "we don't know" default:
+///
+/// - `tool_mode_parity` is an explicit verdict (`parity_forbids_*`).
+/// - `text_tool_wire_format_supported = false` is an explicit declaration that
+///   the text channel does not survive this route (e.g. native-only local
+///   Ollama Qwen3 rows that omit a parity string). It defaults to `true`, so an
+///   unknown route is never wrongly judged text-broken.
+///
+/// `native_tools` is deliberately NOT consulted here: it defaults to `false`
+/// for unknown providers, so treating `!native_tools` as "native is broken"
+/// would wrongly rewrite a custom proxy that does support native tools. The
+/// hard `native` + `!native_tools` capability gate in `extract_llm_options`
+/// already rejects a genuine native-on-non-native mismatch loudly.
+fn channel_forbidden(wire: ToolFormatWire, caps: &Capabilities) -> bool {
+    let parity = caps.tool_mode_parity.as_deref().unwrap_or("unknown");
+    match wire {
+        ToolFormatWire::Native => parity_forbids_native(parity),
+        ToolFormatWire::Text => {
+            parity_forbids_text(parity) || !caps.text_tool_wire_format_supported
+        }
+    }
 }
 
 /// Validate (and, where the registry knows better, auto-correct) a requested
@@ -931,10 +960,13 @@ fn parity_forbids_text(parity: &str) -> bool {
 /// (`preferred_tool_format`). Before this function those fields were advisory
 /// metadata that any alias pin or explicit `--tool-format` flag could silently
 /// override — the footgun behind the DeepSeek V3.2 DSML "vanishing tool calls"
-/// dead-abstain. Now any combo whose requested channel is forbidden by the
-/// route's parity is rewritten to the route's `preferred_tool_format`, with a
-/// `correction` message naming both. Unknown formats and routes with no parity
-/// signal (`unknown`/`interchangeable`) pass through unchanged.
+/// dead-abstain. Now any combo whose requested channel is forbidden — by the
+/// route's `tool_mode_parity` verdict OR by an explicit
+/// `text_tool_wire_format_supported = false` declaration — is rewritten to a
+/// working channel (preferring the route's `preferred_tool_format`), with a
+/// `correction` message naming both. Unknown formats, routes with no adverse
+/// signal (`unknown`/`interchangeable`), and routes with no working channel at
+/// all pass through unchanged.
 pub fn validate_tool_format(provider: &str, model: &str, requested: &str) -> ToolFormatDecision {
     let caps = lookup(provider, model);
     validate_tool_format_with_caps(provider, model, requested, &caps)
@@ -954,27 +986,34 @@ pub fn validate_tool_format_with_caps(
         return ToolFormatDecision::accepted(requested.to_string());
     };
 
-    let parity = caps.tool_mode_parity.as_deref().unwrap_or("unknown");
-    let forbidden = match wire {
-        ToolFormatWire::Native => parity_forbids_native(parity),
-        ToolFormatWire::Text => parity_forbids_text(parity),
-    };
-    if !forbidden {
+    if !channel_forbidden(wire, caps) {
         return ToolFormatDecision::accepted(requested.to_string());
     }
 
-    // The combo is known-broken. Steer to the route's preferred format. If the
-    // preferred format is somehow the very channel we just rejected (a data
-    // bug), fall back across channels so we never hand back the broken combo.
+    // The requested channel is known-broken for this route. Pick the opposite
+    // channel as the steer target, preferring the route's declared
+    // `preferred_tool_format` when it lands on a channel that is itself not
+    // forbidden. If BOTH channels are forbidden (a route with no working tool
+    // surface), there is nothing better to offer — pass the request through
+    // unchanged rather than rewrite to an equally-broken format under a
+    // misleading correction message.
+    let opposite = match wire {
+        ToolFormatWire::Native => ToolFormatWire::Text,
+        ToolFormatWire::Text => ToolFormatWire::Native,
+    };
+    if channel_forbidden(opposite, caps) {
+        return ToolFormatDecision::accepted(requested.to_string());
+    }
     let preferred = caps
         .preferred_tool_format
         .clone()
-        .filter(|fmt| ToolFormatWire::classify(fmt) != Some(wire))
-        .unwrap_or_else(|| match wire {
-            ToolFormatWire::Native => "json".to_string(),
-            ToolFormatWire::Text => "native".to_string(),
+        .filter(|fmt| ToolFormatWire::classify(fmt) == Some(opposite))
+        .unwrap_or_else(|| match opposite {
+            ToolFormatWire::Native => "native".to_string(),
+            ToolFormatWire::Text => "json".to_string(),
         });
 
+    let parity = caps.tool_mode_parity.as_deref().unwrap_or("unknown");
     let mut correction = format!(
         "tool_format `{requested}` is not safe for {provider}/{model} \
          (tool_mode_parity = `{parity}`): this route does not return parseable \
@@ -3000,5 +3039,57 @@ native_tools = true
             .correction
             .expect("text on native_only is corrected");
         assert!(reason.contains("native_only"));
+    }
+
+    #[test]
+    fn validate_tool_format_honors_structural_text_unsupported_bit() {
+        reset();
+        // Real shipping route: ollama/qwen3* declares native_tools = true and
+        // text_tool_wire_format_supported = false with NO tool_mode_parity
+        // string. The gate's contract ("always yields parseable tool calls")
+        // must hold from the structural bit alone — a text/json request is
+        // steered to native, not passed through onto an unsupported channel.
+        let caps = lookup("ollama", "qwen3-coder:30b");
+        assert!(!caps.text_tool_wire_format_supported);
+        for requested in ["text", "json"] {
+            let decision =
+                validate_tool_format_with_caps("ollama", "qwen3-coder:30b", requested, &caps);
+            assert_eq!(
+                decision.effective, "native",
+                "{requested} must be steered to native on a text-unsupported route"
+            );
+            assert!(decision.correction.is_some());
+        }
+        // native is the route's working channel — untouched.
+        let native = validate_tool_format_with_caps("ollama", "qwen3-coder:30b", "native", &caps);
+        assert_eq!(native.effective, "native");
+        assert!(native.correction.is_none());
+    }
+
+    #[test]
+    fn validate_tool_format_passes_through_when_no_channel_works() {
+        reset();
+        // A route with no working tool surface — text_only parity forbids the
+        // native channel, and text_tool_wire_format_supported = false forbids
+        // the text channel — so BOTH channels are forbidden. The gate has
+        // nothing better to steer to; it must NOT rewrite to an equally broken
+        // format under a misleading correction. Pass through unchanged.
+        let overrides: CapabilitiesFile = toml::from_str(
+            "[[provider.acme]]\n\
+             model_match = \"no-tools-*\"\n\
+             native_tools = false\n\
+             tool_mode_parity = \"text_only\"\n\
+             text_tool_wire_format_supported = false\n",
+        )
+        .expect("override parses");
+        let caps = lookup_with_user_overrides("acme", "no-tools-1", Some(&overrides));
+        for requested in ["native", "text", "json"] {
+            let decision = validate_tool_format_with_caps("acme", "no-tools-1", requested, &caps);
+            assert_eq!(
+                decision.effective, requested,
+                "{requested} passes through unchanged"
+            );
+            assert!(decision.correction.is_none());
+        }
     }
 }

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -855,6 +855,150 @@ pub fn lookup_with_user_overrides(
     caps
 }
 
+/// The wire channel a `tool_format` string flows through. `native` is the
+/// provider's structured `tool_calls` JSON channel; `text` and `json` are
+/// text-channel grammars carried in assistant content. Mirrors
+/// `llm_config::ToolFormatChannel`, kept local so the capability registry
+/// (the single source of truth for tool-call dialect validity) has no
+/// dependency on the resolver.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolFormatWire {
+    /// Provider-native JSON tool calling (`tool_format = "native"`).
+    Native,
+    /// A text-channel grammar (`tool_format = "text"` or `"json"`).
+    Text,
+}
+
+impl ToolFormatWire {
+    /// Classify a `tool_format` string. Returns `None` for unknown values so
+    /// callers can reject typos loudly rather than guessing a channel.
+    pub fn classify(tool_format: &str) -> Option<Self> {
+        match tool_format {
+            "native" => Some(Self::Native),
+            "text" | "json" => Some(Self::Text),
+            _ => None,
+        }
+    }
+}
+
+/// Outcome of validating a requested `(provider, model, tool_format)` combo
+/// against the capability registry's tool-call dialect validity model.
+///
+/// This is the FOOTGUN-REMOVAL contract: a harness developer can ask for any
+/// tool_format, and the registry guarantees the resolved format is one that
+/// actually yields parseable tool calls for that route — auto-correcting a
+/// known-broken combo (e.g. a `native` pin on a `native_unreliable` route that
+/// silently drops to unparsed DSML text) and explaining why.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolFormatDecision {
+    /// The tool_format that should actually be used on the wire. Equal to the
+    /// requested format when the combo was already valid; otherwise the
+    /// registry's `preferred_tool_format` for the route.
+    pub effective: String,
+    /// Set when the requested format was overridden. Human-readable, names the
+    /// bad combo and the working alternative — surface this to the harness
+    /// developer so vanishing tool calls are never silent.
+    pub correction: Option<String>,
+}
+
+impl ToolFormatDecision {
+    fn accepted(format: String) -> Self {
+        Self {
+            effective: format,
+            correction: None,
+        }
+    }
+}
+
+/// True when a route's `tool_mode_parity` says the native (provider JSON)
+/// channel cannot be trusted to yield parseable tool calls.
+fn parity_forbids_native(parity: &str) -> bool {
+    matches!(parity, "native_unreliable" | "text_only" | "unsupported")
+}
+
+/// True when a route's `tool_mode_parity` says a text-channel grammar cannot be
+/// trusted to yield parseable tool calls.
+fn parity_forbids_text(parity: &str) -> bool {
+    matches!(parity, "text_unreliable" | "native_only" | "unsupported")
+}
+
+/// Validate (and, where the registry knows better, auto-correct) a requested
+/// `tool_format` for a `(provider, model)` route.
+///
+/// This is the single enforcement seam for tool-call dialect validity. The
+/// capability registry already declares, per route, which channel actually
+/// returns parseable tool calls (`tool_mode_parity`) and which format to use
+/// (`preferred_tool_format`). Before this function those fields were advisory
+/// metadata that any alias pin or explicit `--tool-format` flag could silently
+/// override — the footgun behind the DeepSeek V3.2 DSML "vanishing tool calls"
+/// dead-abstain. Now any combo whose requested channel is forbidden by the
+/// route's parity is rewritten to the route's `preferred_tool_format`, with a
+/// `correction` message naming both. Unknown formats and routes with no parity
+/// signal (`unknown`/`interchangeable`) pass through unchanged.
+pub fn validate_tool_format(provider: &str, model: &str, requested: &str) -> ToolFormatDecision {
+    let caps = lookup(provider, model);
+    validate_tool_format_with_caps(provider, model, requested, &caps)
+}
+
+/// `validate_tool_format` against an already-resolved [`Capabilities`], so hot
+/// callers that already hold one avoid a second matrix lookup.
+pub fn validate_tool_format_with_caps(
+    provider: &str,
+    model: &str,
+    requested: &str,
+    caps: &Capabilities,
+) -> ToolFormatDecision {
+    // Unknown / unclassifiable formats are not ours to second-guess — the
+    // exhaustive-match guard elsewhere already rejects typos loudly.
+    let Some(wire) = ToolFormatWire::classify(requested) else {
+        return ToolFormatDecision::accepted(requested.to_string());
+    };
+
+    let parity = caps.tool_mode_parity.as_deref().unwrap_or("unknown");
+    let forbidden = match wire {
+        ToolFormatWire::Native => parity_forbids_native(parity),
+        ToolFormatWire::Text => parity_forbids_text(parity),
+    };
+    if !forbidden {
+        return ToolFormatDecision::accepted(requested.to_string());
+    }
+
+    // The combo is known-broken. Steer to the route's preferred format. If the
+    // preferred format is somehow the very channel we just rejected (a data
+    // bug), fall back across channels so we never hand back the broken combo.
+    let preferred = caps
+        .preferred_tool_format
+        .clone()
+        .filter(|fmt| ToolFormatWire::classify(fmt) != Some(wire))
+        .unwrap_or_else(|| match wire {
+            ToolFormatWire::Native => "json".to_string(),
+            ToolFormatWire::Text => "native".to_string(),
+        });
+
+    let mut correction = format!(
+        "tool_format `{requested}` is not safe for {provider}/{model} \
+         (tool_mode_parity = `{parity}`): this route does not return parseable \
+         tool calls on the {} channel, so calls would silently vanish. \
+         Using `{preferred}` instead.",
+        match wire {
+            ToolFormatWire::Native => "provider-native",
+            ToolFormatWire::Text => "text",
+        }
+    );
+    if let Some(note) = caps.tool_mode_parity_notes.as_deref() {
+        if !note.is_empty() {
+            correction.push_str(" (");
+            correction.push_str(note);
+            correction.push(')');
+        }
+    }
+
+    ToolFormatDecision {
+        effective: preferred,
+        correction: Some(correction),
+    }
+}
+
 /// Return the currently-effective provider capability rule matrix. User
 /// override rows, when installed for the current thread, are emitted before
 /// built-in rows so the display mirrors lookup precedence.
@@ -2781,5 +2925,80 @@ native_tools = true
                 && row.json_schema.as_deref() == Some("native")
                 && row.source == "builtin"
         }));
+    }
+
+    #[test]
+    fn validate_tool_format_autocorrects_native_pin_on_native_unreliable_route() {
+        reset();
+        // DeepSeek V3.2 on OpenRouter: tool_mode_parity = native_unreliable,
+        // preferred_tool_format = text. A `native` request is the footgun — it
+        // drops to unparsed DSML text and gets rejected. The gate must steer it
+        // to the route's preferred text-channel format and explain why.
+        let decision = validate_tool_format("openrouter", "deepseek/deepseek-v3.2", "native");
+        assert_eq!(
+            decision.effective, "text",
+            "native must be auto-corrected to the route's preferred text format"
+        );
+        let reason = decision.correction.expect("a correction must be reported");
+        assert!(reason.contains("native"), "names the rejected format");
+        assert!(reason.contains("native_unreliable"), "names the parity");
+        assert!(reason.contains("text"), "names the working alternative");
+    }
+
+    #[test]
+    fn validate_tool_format_passes_through_safe_combos() {
+        reset();
+        // A native-capable route with no adverse parity keeps the requested
+        // native format untouched (no spurious correction).
+        let decision = validate_tool_format("openrouter", "deepseek/deepseek-v3-base", "native");
+        assert_eq!(decision.effective, "native");
+        assert!(decision.correction.is_none());
+
+        // The same native_unreliable route is fine when text is requested.
+        let decision = validate_tool_format("openrouter", "deepseek/deepseek-v3.2", "text");
+        assert_eq!(decision.effective, "text");
+        assert!(decision.correction.is_none());
+
+        // json is also a text-channel grammar and is accepted on a text route.
+        let decision = validate_tool_format("openrouter", "deepseek/deepseek-v3.2", "json");
+        assert_eq!(decision.effective, "json");
+        assert!(decision.correction.is_none());
+    }
+
+    #[test]
+    fn validate_tool_format_leaves_unknown_routes_and_formats_alone() {
+        reset();
+        // Unknown provider/model has parity = unknown -> no opinion, pass through.
+        let decision = validate_tool_format("my-proxy", "mystery-1", "native");
+        assert_eq!(decision.effective, "native");
+        assert!(decision.correction.is_none());
+
+        // An unclassifiable tool_format string is not ours to rewrite.
+        let decision = validate_tool_format("openrouter", "deepseek/deepseek-v3.2", "frobnicate");
+        assert_eq!(decision.effective, "frobnicate");
+        assert!(decision.correction.is_none());
+    }
+
+    #[test]
+    fn validate_tool_format_steers_off_text_on_native_only_route() {
+        reset();
+        // Synthesize a native_only route via a project override and confirm a
+        // text request is steered to native (the symmetric direction).
+        let overrides: CapabilitiesFile = toml::from_str(
+            "[[provider.acme]]\n\
+             model_match = \"native-only-*\"\n\
+             native_tools = true\n\
+             text_tool_wire_format_supported = false\n\
+             tool_mode_parity = \"native_only\"\n\
+             preferred_tool_format = \"native\"\n",
+        )
+        .expect("override parses");
+        let caps = lookup_with_user_overrides("acme", "native-only-1", Some(&overrides));
+        let decision = validate_tool_format_with_caps("acme", "native-only-1", "text", &caps);
+        assert_eq!(decision.effective, "native");
+        let reason = decision
+            .correction
+            .expect("text on native_only is corrected");
+        assert!(reason.contains("native_only"));
     }
 }

--- a/crates/harn-vm/src/llm/helpers/options/extract.rs
+++ b/crates/harn-vm/src/llm/helpers/options/extract.rs
@@ -331,8 +331,28 @@ pub(crate) fn extract_llm_options(
         .and_then(|o| o.get("tools"))
         .filter(|value| !matches!(value, VmValue::Nil))
         .cloned();
-    let tool_format = opt_str(&options, "tool_format")
+    let requested_tool_format = opt_str(&options, "tool_format")
         .unwrap_or_else(|| crate::llm_config::default_tool_format(&model, &provider));
+    // FOOTGUN-REMOVAL: a tool-bearing call must use a tool_format whose channel
+    // the capability registry trusts to return parseable tool calls for this
+    // route. An explicit pin (or alias) can request a channel the route is
+    // known to drop silently (the DeepSeek V3.2 `native` -> unparsed DSML
+    // text case); steer it to the route's safe format instead of letting the
+    // calls vanish. Calls without tools keep the requested format verbatim.
+    let tool_format = if enforce_capability_gates && tools_val.is_some() {
+        let decision = crate::llm::capabilities::validate_tool_format_with_caps(
+            &provider,
+            &model,
+            &requested_tool_format,
+            &caps,
+        );
+        if let Some(reason) = &decision.correction {
+            tracing::warn!(target: "harn::llm::tool_format", "{reason}");
+        }
+        decision.effective
+    } else {
+        requested_tool_format
+    };
     if enforce_capability_gates
         && tools_val.is_some()
         && tool_format == "native"

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -1226,10 +1226,11 @@ pub fn resolve_model_info(selector: &str) -> ResolvedModel {
     if let Some(alias) = config.aliases.get(selector) {
         let id = alias.id.clone();
         let provider = alias.provider.clone();
-        let tool_format = alias
+        let requested = alias
             .tool_format
             .clone()
             .unwrap_or_else(|| default_tool_format_with_config(&config, &id, &provider));
+        let tool_format = guard_tool_format(&provider, &id, &requested, Some(selector));
         return ResolvedModel {
             tier: model_tier_with_config(&config, &id),
             family: model_family_with_config(&config, &provider, &id),
@@ -1245,7 +1246,8 @@ pub fn resolve_model_info(selector: &str) -> ResolvedModel {
     let inference = infer_provider_with_config(&config, selector);
     let source = inference.source;
     let provider = inference.provider;
-    let tool_format = default_tool_format_with_config(&config, &id, &provider);
+    let requested = default_tool_format_with_config(&config, &id, &provider);
+    let tool_format = guard_tool_format(&provider, &id, &requested, None);
     let tier = model_tier_with_config(&config, &id);
     let family = model_family_with_inference_source(&config, &provider, &id, source);
     let lineage = model_lineage_with_inference_source(&config, &provider, &id, source);
@@ -1258,6 +1260,24 @@ pub fn resolve_model_info(selector: &str) -> ResolvedModel {
         family,
         lineage,
     }
+}
+
+/// Run the requested `tool_format` through the capability registry's
+/// dialect-validity gate, returning the safe format to actually use. When the
+/// registry auto-corrects a known-broken combo (e.g. a `native` pin on a
+/// `native_unreliable` route that silently drops to unparsed DSML text), the
+/// correction is logged once at resolution time so a harness developer sees
+/// *why* their pinned format was not honored — never a silent vanishing.
+fn guard_tool_format(provider: &str, model: &str, requested: &str, alias: Option<&str>) -> String {
+    let decision = crate::llm::capabilities::validate_tool_format(provider, model, requested);
+    if let Some(reason) = &decision.correction {
+        tracing::warn!(
+            target: "harn::llm::tool_format",
+            alias = alias.unwrap_or(""),
+            "{reason}"
+        );
+    }
+    decision.effective
 }
 
 /// Infer provider from a model ID using inference rules.
@@ -2637,6 +2657,38 @@ mod tests {
     use super::*;
 
     fn reset_overrides() {
+        clear_user_overrides();
+    }
+
+    #[test]
+    fn resolve_model_info_guards_bad_native_pin_on_unreliable_route() {
+        reset_overrides();
+        // An alias that pins tool_format = "native" for DeepSeek V3.2 on
+        // OpenRouter — a route the capability registry knows is
+        // native_unreliable (drops to unparsed DSML text). Before the
+        // footgun-removal gate this bad pin survived resolution verbatim and
+        // produced vanishing tool calls; now it is steered to the route's safe
+        // text-channel format.
+        let overlay = parse_config_toml(
+            "[aliases.guard-ds]\nid = \"deepseek/deepseek-v3.2\"\nprovider = \"openrouter\"\ntool_format = \"native\"\n",
+        )
+        .expect("overlay parses");
+        set_user_overrides(Some(overlay));
+        let resolved = resolve_model_info("guard-ds");
+        assert_eq!(
+            resolved.tool_format, "text",
+            "a native pin on a native_unreliable route must be auto-corrected to text"
+        );
+        clear_user_overrides();
+
+        // A safe native pin (a route with no adverse parity) is untouched.
+        let overlay_ok = parse_config_toml(
+            "[aliases.guard-ds-ok]\nid = \"deepseek/deepseek-v3-base\"\nprovider = \"openrouter\"\ntool_format = \"native\"\n",
+        )
+        .expect("overlay parses");
+        set_user_overrides(Some(overlay_ok));
+        let resolved_ok = resolve_model_info("guard-ds-ok");
+        assert_eq!(resolved_ok.tool_format, "native");
         clear_user_overrides();
     }
 


### PR DESCRIPTION
## Problem — Harn lets a harness developer silently footgun on tool calls

Reproduced today in burin-code's eval rubric judge: running the same agentic judge with different judge models exposed a different failure per provider, all rooted in **tool-call/reasoning dialect handling, not model capability**. The dominant case: **DeepSeek V3.2 via OpenRouter** emits tool calls as DeepSeek **DSML text markup** (`<｜DSML｜invoke name="...">...`) in assistant content rather than the structured `tool_calls` JSON channel. With the route pinned to `tool_format = "native"`, those calls land as text → `native_tool_fallback = "reject"` throws away the recovered calls → the model loops forever and dead-abstains on all 13 calibration cases.

### Root cause (exact code path)

The capability registry **already declared the right facts as data**:

```toml
# capability_sources/20-providers/40-deepseek-reasoning.toml
[[provider.openrouter]]
model_match = "deepseek/deepseek-v3.2*"
native_tools = true
preferred_tool_format = "text"
tool_mode_parity = "native_unreliable"
tool_mode_parity_notes = "...default to Harn text tools and recover DSML markers."
```

But `tool_mode_parity` was **purely advisory** — read nowhere in the runtime resolution path. `resolve_model_info` (`llm_config.rs`) lets an alias `tool_format` pin (or an explicit `--tool-format`) win over the matrix with no validation, so a `native` pin on this `native_unreliable` route survived verbatim and produced vanishing tool calls.

Reproduced deterministically before fixing: `resolve_model_info` on a `native`-pinned alias for `deepseek/deepseek-v3.2` returned `tool_format = native` while the matrix said `parity = native_unreliable, preferred = text`.

## Fix — make the registry's dialect facts a gate, not a note

A single enforcement seam, `capabilities::validate_tool_format`, rewrites any requested `tool_format` whose wire channel a route is known not to return parseable tool calls on — by `tool_mode_parity` **or** an explicit `text_tool_wire_format_supported = false` — to a working channel (preferring the route's `preferred_tool_format`), returning an actionable correction that names the bad combo and the working alternative.

Wired into:
- **`resolve_model_info`** (both alias-pin and inference paths) — the catalog-facing resolution.
- **The tool-bearing `llm_call` seam** in `helpers/options/extract.rs` — covers an explicit `options.tool_format` pin that bypasses the resolver. Respects mock-replay mode so recorded fixtures are not rewritten.

Design notes:
- Single per-route registry stays the source of truth — no scattered model-name special-cases.
- `native_tools` is deliberately not treated as "native broken" (defaults false for unknown providers → would wrongly rewrite custom proxies); the existing hard `native + !native_tools` gate in `extract_llm_options` covers a genuine mismatch.
- A route with **no** working channel passes through unchanged rather than rewriting to an equally broken format under a misleading message.

## Verification

- New repro confirmed the footgun, then the gate removes it (`resolve_model_info_guards_bad_native_pin_on_unreliable_route`).
- 6 unit tests on `validate_tool_format` (auto-correct, safe pass-through, unknown routes/formats, symmetric native_only, real Ollama Qwen3 structural bit, both-channels-forbidden).
- Full `harn-vm` lib suite: **3875 passed**. `cargo clippy -p harn-vm` clean, `cargo fmt --all --check` clean, `cargo check --workspace` clean.
- Adversarial review confirmed: idempotent gate, single effective correction seam, **zero shipping-model resolved-format regressions** (the only `native_unreliable` routes already default to `text`; no catalog alias pins `native` on one), no native-serialization bypass.

## Empirical citations (web research)

- DeepSeek DSML format & `<｜DSML｜>` unicode markers: [DeepSeek-V4 encoding README](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/encoding/README.md); malformed-DSML reports [vllm#36654](https://github.com/vllm-project/vllm/issues/36654), [sglang#14695](https://github.com/sgl-project/sglang/issues/14695).
- vLLM/SGLang model→`--tool-call-parser`/`--reasoning-parser` map: [vLLM tool calling](https://docs.vllm.ai/en/latest/features/tool_calling/), [vLLM reasoning](https://docs.vllm.ai/en/latest/features/reasoning_outputs/), [SGLang tool parser](https://docs.sglang.io/advanced_features/tool_parser.html).
- Gemini-via-OpenRouter `thought_signature` loss (the reasoning-channel case): [Gemini function-calling](https://ai.google.dev/gemini-api/docs/function-calling), [OpenRouter reasoning tokens](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens), [Roo-Code#10307](https://github.com/RooCodeInc/Roo-Code/issues/10307).

## Remaining (follow-up, documented in code)

This PR is the **footgun-removal layer** (deliberately prioritized). Remaining dialect-normalizer work for follow-up agents:
1. **`native_tool_fallback` default policy** in `harn-stdlib/src/stdlib/agent/loop.harn` (`__detect_native_fallback`): when the text parser recovers known-dialect calls (DSML/Mistral markup) but the format is `native`, the default `reject` policy discards them. Consider `allow`/`allow_once` for routes whose parity says native is unreliable but text recovery works.
2. **Gemini reasoning-channel / `thought_signature` round-trip** in the OpenRouter adapter (a `reasoning_required_for_tools`-style gate already exists for gpt-oss; extend the validity model to flag Gemini-thinking tool routes).
3. **DeepSeek DSML parser** already exists (`tools/parse/tagged.rs::parse_deepseek_dsml_calls`); it is reached on the text channel — this PR ensures DeepSeek V3.2 routes *use* the text channel so that parser actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)