### PR TITLE
fix(tools): strip tool./functions. namespace prefix from native tool names (cheap-model dialect footgun)

### DIFF
--- a/changelog.d/tool-namespace-prefix-strip.fixed.md
+++ b/changelog.d/tool-namespace-prefix-strip.fixed.md
@@ -1,0 +1,12 @@
+- Tool-name normalization now strips a leading `tool.` / `tools.` / `functions.`
+  / `function.` namespace prefix that cheap OpenAI-compatible hosts (notably
+  `gpt-oss-120b`) prepend to native tool calls — `tool.look` → `look`,
+  `functions.search` → `search` — so the call resolves to a real tool instead of
+  being denied as an unknown name (which previously sent the model into give-up /
+  thrash loops). The strip is guarded against the generic-wrapper names
+  (`tool.call` / `tool.exec` / `function.call`), which still unwrap their inner
+  `{ name, args }` payload rather than collapsing to `call` / `exec`. The
+  unknown-tool feedback also recognizes cross-harness edit aliases
+  (`apply_patch`, `str_replace`, `str_replace_editor`, `edit_file`, `create_file`)
+  and points the model at the `edit` tool instead of issuing a bare denial. This
+  is the tool-name-normalization sibling to the tool-format dialect gate.

--- a/crates/harn-vm/src/llm/tools/compat.rs
+++ b/crates/harn-vm/src/llm/tools/compat.rs
@@ -11,6 +11,13 @@
 const HARMONY_CHANNEL_MARKERS: &[&str] =
     &["<|channel|>", "<|message|>", "<|recipient|>", "<|end|>"];
 
+/// Namespace prefixes that cheap/OpenAI-compatible hosts (notably gpt-oss-120b)
+/// prepend to otherwise-bare tool names, e.g. `tool.look`, `functions.search`.
+/// These are stripped only for names that are NOT generic wrappers, so that
+/// `tool.call`/`tool.exec`/`function.call` still route through
+/// [`unwrap_generic_tool_arguments`] to recover their inner `{ name, args }`.
+const TOOL_NAMESPACE_PREFIXES: &[&str] = &["tool.", "tools.", "functions.", "function."];
+
 /// Strip provider protocol tokens that were appended to a function name.
 pub(crate) fn normalize_tool_name(name: &str) -> String {
     let trimmed = name.trim();
@@ -25,6 +32,38 @@ pub(crate) fn normalize_tool_name(name: &str) -> String {
     trimmed.to_string()
 }
 
+/// Strip a leading `tool.`/`tools.`/`functions.`/`function.` namespace prefix
+/// from a tool name, e.g. `tool.look` -> `look`. Returns `None` when no prefix
+/// applies or when stripping would yield an empty name. Callers MUST guard
+/// against generic wrapper names (see [`is_generic_wrapper_name`]) before
+/// applying this, so that `tool.call`/`tool.exec`/`function.call` keep their
+/// wrapper-unwrapping path instead of collapsing to `call`/`exec`.
+fn strip_tool_namespace_prefix(name: &str) -> Option<String> {
+    let trimmed = name.trim();
+    for prefix in TOOL_NAMESPACE_PREFIXES {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            let bare = rest.trim();
+            if !bare.is_empty() {
+                return Some(bare.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Recover a bare tool name from a namespace-prefixed one (`tool.look` ->
+/// `look`), but only when the name is NOT a generic wrapper. The guard keeps
+/// `tool.call`/`tool.exec`/`function.call` intact so they are never collapsed
+/// to `call`/`exec` — those are unwrapped via [`unwrap_generic_tool_arguments`]
+/// before this is reached. Used both for the top-level name and for the inner
+/// name recovered from a generic wrapper.
+fn recover_namespaced_name(name: String) -> String {
+    if is_generic_wrapper_name(&name) {
+        return name;
+    }
+    strip_tool_namespace_prefix(&name).unwrap_or(name)
+}
+
 /// Normalize a parsed tool-call `(name, arguments)` pair into the dispatchable
 /// Harn shape.
 pub(crate) fn normalize_tool_call_shape(
@@ -34,11 +73,14 @@ pub(crate) fn normalize_tool_call_shape(
     let normalized_name = normalize_tool_name(name);
     let is_marker_wrapper = is_harmony_marker_wrapper_name(&normalized_name);
     if !is_generic_wrapper_name(&normalized_name) && !is_marker_wrapper {
-        return (normalized_name, arguments);
+        return (recover_namespaced_name(normalized_name), arguments);
     }
 
     if let Some((inner_name, inner_arguments)) = unwrap_generic_tool_arguments(&arguments) {
-        return (normalize_tool_name(&inner_name), inner_arguments);
+        return (
+            recover_namespaced_name(normalize_tool_name(&inner_name)),
+            inner_arguments,
+        );
     }
 
     if is_marker_wrapper {
@@ -154,6 +196,87 @@ mod tests {
         let (name, normalized_arguments) = normalize_tool_call_shape("run", arguments.clone());
 
         assert_eq!(name, "run");
+        assert_eq!(normalized_arguments, arguments);
+    }
+
+    #[test]
+    fn strips_tool_namespace_prefix_from_native_name() {
+        let arguments = serde_json::json!({"intent": "read", "file": "src/lib.rs"});
+        let (name, normalized_arguments) =
+            normalize_tool_call_shape("tool.look", arguments.clone());
+
+        assert_eq!(name, "look");
+        assert_eq!(normalized_arguments, arguments);
+    }
+
+    #[test]
+    fn strips_functions_namespace_prefix_from_native_name() {
+        let arguments = serde_json::json!({"query": "needle"});
+        let (name, normalized_arguments) =
+            normalize_tool_call_shape("functions.search", arguments.clone());
+
+        assert_eq!(name, "search");
+        assert_eq!(normalized_arguments, arguments);
+    }
+
+    #[test]
+    fn strips_tools_and_function_namespace_prefixes() {
+        let (name, _) = normalize_tool_call_shape("tools.run", serde_json::json!({}));
+        assert_eq!(name, "run");
+        // `function.edit` is NOT a generic wrapper (only `function.call` is), so
+        // it takes the prefix-strip path.
+        let (name, _) = normalize_tool_call_shape("function.edit", serde_json::json!({}));
+        assert_eq!(name, "edit");
+    }
+
+    #[test]
+    fn generic_tool_exec_wrapper_unwraps_inner_name_not_prefix_stripped() {
+        // Collision guard: `tool.exec` shares the `tool.` prefix but is a
+        // generic wrapper. It must unwrap its inner `{name, args}`, never be
+        // naively stripped to `exec`.
+        let (name, arguments) = normalize_tool_call_shape(
+            "tool.exec",
+            serde_json::json!({
+                "name": "run",
+                "args": {"command": "cargo test"}
+            }),
+        );
+
+        assert_eq!(name, "run");
+        assert_eq!(arguments["command"], "cargo test");
+    }
+
+    #[test]
+    fn generic_function_call_wrapper_is_not_prefix_stripped() {
+        // `function.call` shares the `function.` prefix but is a generic
+        // wrapper; it must unwrap rather than collapse to `call`.
+        let (name, arguments) = normalize_tool_call_shape(
+            "function.call",
+            serde_json::json!({
+                "name": "search",
+                "args": {"query": "needle"}
+            }),
+        );
+
+        assert_eq!(name, "search");
+        assert_eq!(arguments["query"], "needle");
+    }
+
+    #[test]
+    fn strips_namespace_prefix_after_harmony_suffix() {
+        // A name can carry both a namespace prefix and a harmony suffix; the
+        // suffix is removed first, then the prefix.
+        let (name, _) =
+            normalize_tool_call_shape("tool.run<|channel|>commentary", serde_json::json!({}));
+        assert_eq!(name, "run");
+    }
+
+    #[test]
+    fn leaves_already_bare_name_unchanged() {
+        let arguments = serde_json::json!({"intent": "read"});
+        let (name, normalized_arguments) = normalize_tool_call_shape("look", arguments.clone());
+
+        assert_eq!(name, "look");
         assert_eq!(normalized_arguments, arguments);
     }
 }

--- a/crates/harn-vm/src/llm/tools/parse/syntax.rs
+++ b/crates/harn-vm/src/llm/tools/parse/syntax.rs
@@ -80,8 +80,16 @@ fn tool_alias_hint(name: &str) -> Option<&'static str> {
         "read" | "read_file" | "readFile" | "cat" | "open" => {
             Some("Use `look({ intent: \"read\", ... })` to read a file.")
         }
-        "write" | "write_file" | "writeFile" => {
+        "write" | "write_file" | "writeFile" | "create_file" => {
             Some("Use `edit({ action: \"create\", ... })` to write a file.")
+        }
+        // Cross-harness edit aliases cheap models emit by habit (OpenAI/Codex
+        // `apply_patch`, Anthropic-style `str_replace`/`str_replace_editor`,
+        // generic `edit_file`). All map to Harn's single `edit` tool; the
+        // specific `action` is host-defined, so we point at `edit` without
+        // prescribing one rather than naming an action the host may not have.
+        "apply_patch" | "str_replace" | "str_replace_editor" | "edit_file" | "editFile" => {
+            Some("Use the `edit({ ... })` tool to modify a file.")
         }
         "list" | "ls" | "list_files" => {
             Some("Use `look({ intent: \"list\", ... })` to list files.")

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -776,6 +776,26 @@ fn native_json_unknown_read_suggests_look_alias() {
     );
 }
 
+// Cheap models commonly emit cross-harness edit aliases (`apply_patch`,
+// `str_replace`, `edit_file`). Instead of a hard "Unknown tool" denial that
+// thrashes the loop, the feedback must point at Harn's `edit` tool.
+#[test]
+fn native_json_unknown_apply_patch_suggests_edit_alias() {
+    let known: std::collections::BTreeSet<String> = ["edit", "look", "run"]
+        .into_iter()
+        .map(String::from)
+        .collect();
+    let text = r#"[{"function":{"name":"apply_patch","arguments":"{}"}}]"#;
+    let (calls, errors) = parse_native_json_tool_calls(text, &known);
+    assert_eq!(calls.len(), 0);
+    assert_eq!(errors.len(), 1, "errors: {errors:?}");
+    assert!(
+        errors[0].contains("edit("),
+        "apply_patch should be aliased to edit: {}",
+        errors[0]
+    );
+}
+
 #[test]
 fn native_json_fallback_reports_malformed_arguments() {
     let known = known_tools_set();


### PR DESCRIPTION
gpt-oss-120b (the primary eval candidate) emits native tool calls as `tool.look` / `functions.search`; those fell through `normalize_tool_name` unchanged → policy denied the unknown name → give-up/retry loops. `recover_namespaced_name` strips the `tool.`/`tools.`/`functions.`/`function.` prefix, guarded by `is_generic_wrapper_name` so `tool.call`/`tool.exec`/`function.call` still unwrap to their inner {name,args}. Tests included. Pairs with #3462 (validate_tool_format) — both gate honest gpt-oss eval runs once released + repinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)