### PR TITLE
feat(llm): provider-side prompt caching for the stable system+tools prefix

### DIFF
--- a/changelog.d/prompt-cache-default-on.added.md
+++ b/changelog.d/prompt-cache-default-on.added.md
@@ -1,0 +1,12 @@
+- Provider-side prompt caching now defaults ON for routes whose capability
+  matrix declares `prompt_caching`. The stable system-prompt + tool-definitions
+  prefix re-sent on every turn of a multi-turn agent loop (and across the rubric
+  grader's turns×trials) is marked cacheable, so supporting providers discount
+  it heavily — Anthropic ephemeral caching (~90% off cached input), OpenRouter
+  `cache_control` passthrough, and implicit DeepSeek / gpt-oss caching. The win
+  is largest for the cheap value models the product steers toward. Routes that
+  do not advertise prompt caching are unaffected: the resolved `cache` flag
+  defaults to `false` for them, leaving the outgoing request byte-identical. An
+  explicit `cache:` option is always honoured verbatim — `cache: false` opts out
+  anywhere, and an explicit `cache: true` on a non-caching route still errors
+  loudly via the capability gate.

--- a/crates/harn-vm/src/llm/helpers/options/extract.rs
+++ b/crates/harn-vm/src/llm/helpers/options/extract.rs
@@ -126,7 +126,21 @@ pub(crate) fn extract_llm_options(
         opt_int(&options, "timeout_ms"),
     );
     let idle_timeout = opt_int(&options, "idle_timeout").map(|t| t as u64);
-    let cache = opt_bool(&options, "cache");
+    // Provider-side prompt caching now defaults ON for routes that support
+    // it. Marking the stable system+tools+history prefix cacheable discounts
+    // the re-sent prefix heavily across multi-turn agent loops and the rubric
+    // grader (Anthropic ephemeral ~90% off cached input; OpenRouter passes
+    // cache_control through; DeepSeek/gpt-oss cache implicitly). When the route
+    // does not support caching, the default resolves to `false` so the request
+    // stays byte-identical (and the strict gate below never fires on the
+    // default). An explicit `cache:` value is always honoured verbatim — an
+    // explicit `cache: true` on a non-supporting route still errors loudly via
+    // the capability gate so misconfiguration is surfaced, and `cache: false`
+    // opts out everywhere.
+    let cache = match options.as_ref().and_then(|o| o.get("cache")) {
+        Some(value) => value.is_truthy(),
+        None => caps.prompt_caching,
+    };
     let stream = options
         .as_ref()
         .and_then(|o| o.get("stream"))
@@ -757,6 +771,102 @@ pub(super) fn validate_options(opts: &crate::llm::api::LlmCallOptions) {
     }
     if opts.cache && !caps.prompt_caching {
         warn("cache");
+    }
+}
+
+#[cfg(test)]
+mod cache_default_tests {
+    use super::extract_llm_options;
+    use crate::value::{DictMap, VmDictExt, VmValue};
+
+    fn opts_with(options: DictMap) -> crate::llm::api::LlmCallOptions {
+        extract_llm_options(&[
+            VmValue::String(arcstr::ArcStr::from("hello")),
+            VmValue::Nil,
+            VmValue::dict(options),
+        ])
+        .expect("options")
+    }
+
+    fn try_opts_with(options: DictMap) -> Result<crate::llm::api::LlmCallOptions, super::VmError> {
+        extract_llm_options(&[
+            VmValue::String(arcstr::ArcStr::from("hello")),
+            VmValue::Nil,
+            VmValue::dict(options),
+        ])
+    }
+
+    // The `mock` provider needs no API key and resolves its capability row by
+    // spoofing the real provider family of the model-id shape: a Claude-shaped
+    // id lands on the Anthropic row (prompt_caching = true), while a bare,
+    // unrecognised id falls through to defaults (prompt_caching = false). This
+    // lets us exercise both default branches against the real capability
+    // lookup, offline.
+    fn caching_route() -> DictMap {
+        let mut options = DictMap::new();
+        options.put_str("provider", "mock");
+        options.put_str("model", "claude-sonnet-4.6");
+        options
+    }
+
+    fn non_caching_route() -> DictMap {
+        let mut options = DictMap::new();
+        options.put_str("provider", "mock");
+        options.put_str("model", "no-cache-model");
+        options
+    }
+
+    #[test]
+    fn cache_defaults_off_for_non_supporting_route() {
+        // A route whose capability matrix says `prompt_caching = false` must
+        // resolve the default to OFF so the outgoing request stays byte-
+        // identical and the strict capability gate never trips on a default.
+        assert!(
+            !crate::llm::capabilities::lookup("mock", "no-cache-model").prompt_caching,
+            "precondition: route must not support caching"
+        );
+        assert!(
+            !opts_with(non_caching_route()).cache,
+            "cache default must be OFF when the route does not support caching"
+        );
+    }
+
+    #[test]
+    fn cache_defaults_on_for_supporting_route() {
+        // When the route supports prompt caching, the stable system+tools+
+        // history prefix is marked cacheable by default so multi-turn loops
+        // and the rubric grader pay the discounted cached-input rate.
+        assert!(
+            crate::llm::capabilities::lookup("mock", "claude-sonnet-4.6").prompt_caching,
+            "precondition: route must support caching"
+        );
+        assert!(
+            opts_with(caching_route()).cache,
+            "cache must default ON for a caching-capable route"
+        );
+    }
+
+    #[test]
+    fn explicit_cache_false_opts_out_on_supporting_route() {
+        let mut options = caching_route();
+        options.insert("cache".to_string(), VmValue::Bool(false));
+        assert!(
+            !opts_with(options).cache,
+            "explicit `cache: false` must opt out"
+        );
+    }
+
+    #[test]
+    fn explicit_cache_true_errors_on_non_supporting_route() {
+        // The strict capability gate is preserved: an explicit `cache: true`
+        // on a route that cannot cache surfaces a loud error rather than a
+        // silent no-op (unchanged behavior).
+        let mut options = non_caching_route();
+        options.insert("cache".to_string(), VmValue::Bool(true));
+        assert!(
+            try_opts_with(options).is_err(),
+            "explicit `cache: true` on a non-supporting route must error"
+        );
     }
 }
 


### PR DESCRIPTION
## What

Every multi-turn agent loop re-sends a large, **byte-stable** prefix (system prompt + tool definitions) on every turn; the rubric grader does the same across turns × trials × cells. This PR turns on provider-side prompt caching for that prefix so supporting providers discount the re-sent tokens heavily.

## The gap this closes

The full caching machinery **already existed** in Harn but was dormant:

- Capability matrix already carries `prompt_caching` + `cache_breakpoint_style` per (provider, model) (`capabilities.toml`).
- Anthropic provider already emits top-level `cache_control: {type:"ephemeral"}` when `opts.cache` (`providers/anthropic.rs:240`).
- `openai_compat` already applies `top_level` / `last_block` breakpoints gated on `caps.prompt_caching` (`providers/openai_compat.rs:336,672`).
- Response parsing already surfaces `cache_read_input_tokens` / `cache_creation_input_tokens` (`api/response.rs`).

…but the `cache` request option **defaulted to `false` and the live agent loop + grader never set it**, so none of this fired in production.

## Change

Default the resolved `cache` flag **ON for routes that advertise `prompt_caching`**, at the single `extract_llm_options` seam every `llm_call` flows through (so it covers the agent loop *and* the grader in one DRY place):

```rust
let cache = match options.as_ref().and_then(|o| o.get("cache")) {
    Some(value) => value.is_truthy(),   // explicit value honoured verbatim
    None => caps.prompt_caching,        // default ON only where supported
};
```

- **Non-supporting routes are byte-identical** — the default resolves to `false`, so no `cache_control` is emitted and the strict capability gate never trips on a default.
- **Explicit `cache:` is honoured verbatim** — `cache: false` opts out anywhere; an explicit `cache: true` on a non-caching route still errors loudly (unchanged behavior).

## Why it's safe / correct

The stable system + tools prefix is byte-stable turn-to-turn in the common case: the iteration number is not injected into the system prompt, and per-turn-varying content (timestamps, reminders, budget warnings, tool-search results) is appended as later **messages**, not folded into the system prompt. The growing conversation is itself a stable-growing prefix, so the `last_block` breakpoint correctly enables incremental caching on subsequent turns. Tool-surface narrowing / tool-search promotion can change the tools prefix mid-loop, but that self-heals (re-caches the new prefix next turn).

## Impact

The win is largest for the cheap value models the product steers toward: Anthropic ephemeral caching (~90% off cached input), OpenRouter `cache_control` passthrough, implicit DeepSeek / gpt-oss caching.

## Tests

Added `cache_default_tests` in `extract.rs`:
- default OFF for a non-supporting route (byte-identical guarantee)
- default ON for a caching-capable route
- explicit `cache: false` opts out
- explicit `cache: true` on a non-supporting route errors loudly

`cargo test -p harn-vm --lib cache` → 114 passed; `llm::helpers::options` → 71 passed; `providers::` → 148 passed. `cargo check -p harn-vm` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)