### PR TITLE
perf(vm): intern dict keys — DictMap keys become shared HarnStr

### DIFF
--- a/changelog.d/dictmap-harnstr-keys.changed.md
+++ b/changelog.d/dictmap-harnstr-keys.changed.md
@@ -1,0 +1,13 @@
+- **Dict keys are now interned, refcounted strings instead of owned `String`s.**
+  The map backing every `VmValue::Dict` changed from `OrdMap<String, VmValue>` to
+  `OrdMap<HarnStr, VmValue>` (the thin one-word `arcstr::ArcStr` from the value
+  shrink), and keys flow through a bounded interner (`harn_vm::value::intern_key`).
+  Agent workloads are dict-heavy — the same field names (`role`, `content`,
+  `arguments`, …) recur across thousands of message/JSON dicts — so each recurring
+  key now shares a single allocation (a refcount bump) instead of allocating a
+  fresh `String` per key, and dict tree nodes hold an 8-byte key instead of a
+  24-byte one. The interner is bounded (keys up to 64 bytes, at most 8192 distinct
+  entries) so high-cardinality or adversarial keys fall back to a plain allocation
+  and can never grow it without bound. `VmValue::dict(...)` still accepts the
+  `BTreeMap<String, _>` / `DictMap` maps callers already build (it interns on the
+  way in). No `harn` language behavior changes.

--- a/crates/harn-cli/src/commands/eval_prompt.rs
+++ b/crates/harn-cli/src/commands/eval_prompt.rs
@@ -562,7 +562,7 @@ fn vm_value_to_json(value: &VmValue) -> JsonValue {
         VmValue::Dict(d) => {
             let mut map = serde_json::Map::new();
             for (k, v) in d.iter() {
-                map.insert(k.clone(), vm_value_to_json(v));
+                map.insert(k.to_string(), vm_value_to_json(v));
             }
             JsonValue::Object(map)
         }

--- a/crates/harn-cli/src/commands/eval_prompt_context.rs
+++ b/crates/harn-cli/src/commands/eval_prompt_context.rs
@@ -529,32 +529,35 @@ fn context_case_bindings(
             .as_object()
             .ok_or_else(|| "context fixture case bindings must be a JSON object".to_string())?;
         for (key, value) in object {
-            bindings.insert(key.clone(), harn_vm::json_to_vm_value(value));
+            bindings.insert(
+                harn_vm::value::intern_key(key),
+                harn_vm::json_to_vm_value(value),
+            );
         }
     }
 
     let context_text = render_assembled_chunks(assembled);
     bindings.insert(
-        "candidate_artifacts".to_string(),
+        harn_vm::value::intern_key("candidate_artifacts"),
         harn_vm::json_to_vm_value(
             &serde_json::to_value(artifacts)
                 .map_err(|error| format!("failed to serialize candidate artifacts: {error}"))?,
         ),
     );
     bindings.insert(
-        "assembled_context".to_string(),
+        harn_vm::value::intern_key("assembled_context"),
         harn_vm::json_to_vm_value(&assembled_context_to_json(assembled)),
     );
     bindings.insert(
-        "context".to_string(),
+        harn_vm::value::intern_key("context"),
         harn_vm::json_to_vm_value(&JsonValue::String(context_text)),
     );
     bindings.insert(
-        "selected_artifact_ids".to_string(),
+        harn_vm::value::intern_key("selected_artifact_ids"),
         harn_vm::json_to_vm_value(&json!(selected_artifact_ids)),
     );
     bindings.insert(
-        "dropped_artifact_ids".to_string(),
+        harn_vm::value::intern_key("dropped_artifact_ids"),
         harn_vm::json_to_vm_value(&json!(dropped_artifact_ids)),
     );
     Ok(bindings)

--- a/crates/harn-cli/src/skill_loader.rs
+++ b/crates/harn-cli/src/skill_loader.rs
@@ -138,7 +138,10 @@ pub fn load_skills(inputs: &SkillLoaderInputs) -> LoadedSkills {
         };
         let strip_hooks = should_strip_executable_frontmatter(provenance.as_ref());
         if let Some(report) = provenance.as_ref() {
-            entry.insert("provenance".to_string(), provenance_to_vm(report));
+            entry.insert(
+                harn_vm::value::intern_key("provenance"),
+                provenance_to_vm(report),
+            );
             if strip_hooks && strip_untrusted_command_frontmatter(&mut entry) {
                 loader_warnings.push(format!(
                     "skills: {} command frontmatter omitted because provenance check did not verify: {}",
@@ -181,7 +184,7 @@ pub fn load_skills(inputs: &SkillLoaderInputs) -> LoadedSkills {
     let mut registry: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
     registry.put_str("_type", "skill_registry");
     registry.insert(
-        "skills".to_string(),
+        harn_vm::value::intern_key("skills"),
         VmValue::List(std::sync::Arc::new(entries)),
     );
     let registry_value = VmValue::dict(registry);
@@ -393,7 +396,10 @@ fn provenance_to_vm(report: &VerificationReport) -> VmValue {
                 VmValue::Dict(map) => (*map).clone(),
                 _ => harn_vm::value::DictMap::new(),
             };
-            item.insert("trusted".to_string(), VmValue::Bool(endorsement.trusted));
+            item.insert(
+                harn_vm::value::intern_key("trusted"),
+                VmValue::Bool(endorsement.trusted),
+            );
             item.put_str("status", status_label(endorsement.status));
             if let Some(error) = endorsement.error.as_deref() {
                 item.put_str("error", error);

--- a/crates/harn-dap/src/debugger/tests.rs
+++ b/crates/harn-dap/src/debugger/tests.rs
@@ -325,9 +325,12 @@ pipeline test(task) {
 #[test]
 fn test_scopes_and_variables() {
     let mut dbg = Debugger::new();
-    dbg.variables.insert("x".to_string(), VmValue::Int(42));
     dbg.variables
-        .insert("name".to_string(), VmValue::String("hello".into()));
+        .insert(harn_vm::value::intern_key("x"), VmValue::Int(42));
+    dbg.variables.insert(
+        harn_vm::value::intern_key("name"),
+        VmValue::String("hello".into()),
+    );
 
     let responses = dbg.handle_message(make_request(
         1,
@@ -343,7 +346,8 @@ fn test_scopes_and_variables() {
 #[test]
 fn test_evaluate() {
     let mut dbg = Debugger::new();
-    dbg.variables.insert("x".to_string(), VmValue::Int(42));
+    dbg.variables
+        .insert(harn_vm::value::intern_key("x"), VmValue::Int(42));
 
     let responses = dbg.handle_message(make_request(
         1,
@@ -362,7 +366,7 @@ fn test_evaluate_dot_access() {
     let mut inner = BTreeMap::new();
     inner.insert("bar".to_string(), VmValue::Int(99));
     dbg.variables
-        .insert("foo".to_string(), VmValue::dict(inner));
+        .insert(harn_vm::value::intern_key("foo"), VmValue::dict(inner));
 
     let responses = dbg.handle_message(make_request(
         1,
@@ -382,7 +386,8 @@ fn test_evaluate_nested_dot_access() {
     inner.insert("c".to_string(), VmValue::String("deep".into()));
     let mut outer = BTreeMap::new();
     outer.insert("b".to_string(), VmValue::dict(inner));
-    dbg.variables.insert("a".to_string(), VmValue::dict(outer));
+    dbg.variables
+        .insert(harn_vm::value::intern_key("a"), VmValue::dict(outer));
 
     let responses = dbg.handle_message(make_request(
         1,
@@ -399,7 +404,8 @@ fn test_evaluate_complex_value_has_var_ref() {
     let mut dbg = Debugger::new();
     let mut map = BTreeMap::new();
     map.insert("key".to_string(), VmValue::Int(1));
-    dbg.variables.insert("d".to_string(), VmValue::dict(map));
+    dbg.variables
+        .insert(harn_vm::value::intern_key("d"), VmValue::dict(map));
 
     let responses = dbg.handle_message(make_request(
         1,
@@ -432,7 +438,8 @@ fn test_evaluate_undefined_returns_error() {
 #[test]
 fn test_evaluate_with_context() {
     let mut dbg = Debugger::new();
-    dbg.variables.insert("x".to_string(), VmValue::Int(7));
+    dbg.variables
+        .insert(harn_vm::value::intern_key("x"), VmValue::Int(7));
 
     for ctx in &["watch", "repl", "hover"] {
         let responses = dbg.handle_message(make_request(
@@ -1419,7 +1426,7 @@ fn test_hit_condition_matches_parses_all_forms() {
     assert_eq!(hit_condition_matches("= =1", 1), None);
 
     let mut vars = harn_vm::value::DictMap::new();
-    vars.insert("count".to_string(), VmValue::Int(5));
+    vars.insert(harn_vm::value::intern_key("count"), VmValue::Int(5));
     vars.put_str("label", "ready");
 
     assert_eq!(check_condition_literal("count >= 5", &vars), Ok(true));

--- a/crates/harn-dap/src/debugger/variables.rs
+++ b/crates/harn-dap/src/debugger/variables.rs
@@ -86,8 +86,10 @@ impl Debugger {
                 }
             }
             VmValue::Dict(map) => {
-                let children: Vec<(String, VmValue)> =
-                    map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                let children: Vec<(String, VmValue)> = map
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.clone()))
+                    .collect();
                 let display = format!("dict<{}>", map.len());
                 if children.is_empty() {
                     (0, display)
@@ -98,8 +100,10 @@ impl Debugger {
             VmValue::StructInstance(si) => {
                 let layout = &si.layout;
                 let fields = val.struct_fields_map().unwrap_or_default();
-                let children: Vec<(String, VmValue)> =
-                    fields.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+                let children: Vec<(String, VmValue)> = fields
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.clone()))
+                    .collect();
                 let display = layout.struct_name().to_string();
                 if children.is_empty() {
                     (0, display)
@@ -218,7 +222,12 @@ impl Debugger {
         }
 
         // Fallback: scope 1 is the locals map.
-        let variable_list: Vec<(String, VmValue)> = self.variables.clone().into_iter().collect();
+        let variable_list: Vec<(String, VmValue)> = self
+            .variables
+            .clone()
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect();
         let vars: Vec<Variable> = variable_list
             .iter()
             .map(|(name, val)| self.make_variable(name.clone(), val))
@@ -551,7 +560,7 @@ impl Debugger {
                         };
                         list.get(idx)?.clone()
                     }
-                    VmValue::Dict(map) => map.get(&i.to_string())?.clone(),
+                    VmValue::Dict(map) => map.get(i.to_string().as_str())?.clone(),
                     _ => return None,
                 },
             };

--- a/crates/harn-dap/src/host_bridge.rs
+++ b/crates/harn-dap/src/host_bridge.rs
@@ -337,7 +337,7 @@ pub fn deliver_reply(pending: &PendingMap, request_seq: i64, reply: DapHostCallR
 fn vm_dict_to_json(params: &harn_vm::value::DictMap) -> Value {
     let mut map = serde_json::Map::with_capacity(params.len());
     for (k, v) in params.iter() {
-        map.insert(k.clone(), vm_value_to_json(v));
+        map.insert(k.to_string(), vm_value_to_json(v));
     }
     Value::Object(map)
 }
@@ -355,7 +355,7 @@ fn vm_value_to_json(value: &VmValue) -> Value {
         VmValue::Dict(map) => {
             let mut obj = serde_json::Map::with_capacity(map.len());
             for (k, v) in map.iter() {
-                obj.insert(k.clone(), vm_value_to_json(v));
+                obj.insert(k.to_string(), vm_value_to_json(v));
             }
             Value::Object(obj)
         }

--- a/crates/harn-hostlib/benches/code_index_cypher.rs
+++ b/crates/harn-hostlib/benches/code_index_cypher.rs
@@ -32,7 +32,7 @@ const LINES_PER_FILE: usize = 500;
 fn dict(entries: &[(&str, VmValue)]) -> VmValue {
     let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
-        map.insert((*k).to_string(), v.clone());
+        map.insert(harn_vm::value::intern_key(k), v.clone());
     }
     VmValue::dict(map)
 }

--- a/crates/harn-hostlib/src/ast/apply_node.rs
+++ b/crates/harn-hostlib/src/ast/apply_node.rs
@@ -361,7 +361,7 @@ mod tests {
     fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
         let mut map: harn_vm::value::DictMap = Default::default();
         for (k, v) in pairs {
-            map.insert((*k).to_string(), v.clone());
+            map.insert(harn_vm::value::intern_key(k), v.clone());
         }
         VmValue::dict(map)
     }

--- a/crates/harn-hostlib/src/ast/batch_apply.rs
+++ b/crates/harn-hostlib/src/ast/batch_apply.rs
@@ -462,7 +462,7 @@ mod tests {
     fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
         let mut map: harn_vm::value::DictMap = Default::default();
         for (k, v) in pairs {
-            map.insert((*k).to_string(), v.clone());
+            map.insert(harn_vm::value::intern_key(k), v.clone());
         }
         VmValue::dict(map)
     }

--- a/crates/harn-hostlib/src/ast/capabilities.rs
+++ b/crates/harn-hostlib/src/ast/capabilities.rs
@@ -93,7 +93,7 @@ mod tests {
     fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
         let mut map: harn_vm::value::DictMap = Default::default();
         for (k, v) in pairs {
-            map.insert((*k).to_string(), v.clone());
+            map.insert(harn_vm::value::intern_key(k), v.clone());
         }
         VmValue::dict(map)
     }

--- a/crates/harn-hostlib/src/ast/dry_run.rs
+++ b/crates/harn-hostlib/src/ast/dry_run.rs
@@ -302,8 +302,11 @@ fn delegate_to_builtin(
 ) -> OpOutcome {
     let mut forwarded: harn_vm::value::DictMap = (**raw).clone();
     forwarded.remove("op");
-    forwarded.insert("session_id".to_string(), str_value(session_id));
-    forwarded.insert("dry_run".to_string(), VmValue::Bool(false));
+    forwarded.insert(
+        harn_vm::value::intern_key("session_id"),
+        str_value(session_id),
+    );
+    forwarded.insert(harn_vm::value::intern_key("dry_run"), VmValue::Bool(false));
     let request = VmValue::dict(forwarded);
     match runner(&[request]) {
         Ok(VmValue::Dict(result)) => parse_builtin_outcome(&result, op_label),
@@ -388,10 +391,13 @@ fn run_rename_symbol(
     };
     let mut forwarded: harn_vm::value::DictMap = (**raw).clone();
     forwarded.remove("op");
-    forwarded.insert("session_id".to_string(), str_value(session_id));
-    forwarded.insert("dry_run".to_string(), VmValue::Bool(false));
+    forwarded.insert(
+        harn_vm::value::intern_key("session_id"),
+        str_value(session_id),
+    );
+    forwarded.insert(harn_vm::value::intern_key("dry_run"), VmValue::Bool(false));
     forwarded
-        .entry("scope".to_string())
+        .entry(harn_vm::value::intern_key("scope"))
         .or_insert_with(|| str_value("workspace"));
 
     let request = VmValue::dict(forwarded);
@@ -827,7 +833,7 @@ mod tests {
     fn vm_dict(pairs: &[(&str, VmValue)]) -> VmValue {
         let mut map: harn_vm::value::DictMap = Default::default();
         for (k, v) in pairs {
-            map.insert((*k).to_string(), v.clone());
+            map.insert(harn_vm::value::intern_key(k), v.clone());
         }
         VmValue::dict(map)
     }

--- a/crates/harn-hostlib/src/ast/function_body.rs
+++ b/crates/harn-hostlib/src/ast/function_body.rs
@@ -51,13 +51,22 @@ pub(super) struct ExtractedBody {
 impl ExtractedBody {
     fn to_vm_value(&self) -> VmValue {
         let mut dict: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
-        dict.insert("name".into(), str_value(&self.name));
-        dict.insert("body_text".into(), str_value(&self.body_text));
-        dict.insert("start_line".into(), VmValue::Int(self.start_line as i64));
-        dict.insert("end_line".into(), VmValue::Int(self.end_line as i64));
+        dict.insert(harn_vm::value::intern_key("name"), str_value(&self.name));
+        dict.insert(
+            harn_vm::value::intern_key("body_text"),
+            str_value(&self.body_text),
+        );
+        dict.insert(
+            harn_vm::value::intern_key("start_line"),
+            VmValue::Int(self.start_line as i64),
+        );
+        dict.insert(
+            harn_vm::value::intern_key("end_line"),
+            VmValue::Int(self.end_line as i64),
+        );
         let fields: Vec<VmValue> = self.return_object_fields.iter().map(str_value).collect();
         dict.insert(
-            "return_object_fields".into(),
+            harn_vm::value::intern_key("return_object_fields"),
             VmValue::List(Arc::new(fields)),
         );
         VmValue::dict(dict)
@@ -84,32 +93,50 @@ pub(super) fn run_single(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 
     let mut response: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
     response.insert(
-        "path".into(),
+        harn_vm::value::intern_key("path"),
         match path_for_response {
             Some(ref p) => str_value(p),
             None => VmValue::Nil,
         },
     );
-    response.insert("language".into(), str_value(language.name()));
-    response.insert("name".into(), str_value(&function_name));
-    response.insert("brace_based".into(), VmValue::Bool(brace_based));
+    response.insert(
+        harn_vm::value::intern_key("language"),
+        str_value(language.name()),
+    );
+    response.insert(
+        harn_vm::value::intern_key("name"),
+        str_value(&function_name),
+    );
+    response.insert(
+        harn_vm::value::intern_key("brace_based"),
+        VmValue::Bool(brace_based),
+    );
     if let Some(body) = body {
-        response.insert("found".into(), VmValue::Bool(true));
-        response.insert("body_text".into(), str_value(&body.body_text));
-        response.insert("start_line".into(), VmValue::Int(body.start_line as i64));
-        response.insert("end_line".into(), VmValue::Int(body.end_line as i64));
+        response.insert(harn_vm::value::intern_key("found"), VmValue::Bool(true));
+        response.insert(
+            harn_vm::value::intern_key("body_text"),
+            str_value(&body.body_text),
+        );
+        response.insert(
+            harn_vm::value::intern_key("start_line"),
+            VmValue::Int(body.start_line as i64),
+        );
+        response.insert(
+            harn_vm::value::intern_key("end_line"),
+            VmValue::Int(body.end_line as i64),
+        );
         let fields: Vec<VmValue> = body.return_object_fields.iter().map(str_value).collect();
         response.insert(
-            "return_object_fields".into(),
+            harn_vm::value::intern_key("return_object_fields"),
             VmValue::List(Arc::new(fields)),
         );
     } else {
-        response.insert("found".into(), VmValue::Bool(false));
-        response.insert("body_text".into(), str_value(""));
-        response.insert("start_line".into(), VmValue::Int(0));
-        response.insert("end_line".into(), VmValue::Int(0));
+        response.insert(harn_vm::value::intern_key("found"), VmValue::Bool(false));
+        response.insert(harn_vm::value::intern_key("body_text"), str_value(""));
+        response.insert(harn_vm::value::intern_key("start_line"), VmValue::Int(0));
+        response.insert(harn_vm::value::intern_key("end_line"), VmValue::Int(0));
         response.insert(
-            "return_object_fields".into(),
+            harn_vm::value::intern_key("return_object_fields"),
             VmValue::List(Arc::new(Vec::new())),
         );
     }
@@ -129,7 +156,7 @@ pub(super) fn run_bulk(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let mut bodies_dict: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
     for name in &unique {
         if let Some(body) = extract_body(&tree, &source, language, name, container.as_deref()) {
-            bodies_dict.insert(name.clone(), body.to_vm_value());
+            bodies_dict.insert(harn_vm::value::intern_key(name), body.to_vm_value());
         }
     }
 
@@ -137,23 +164,35 @@ pub(super) fn run_bulk(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 
     let mut missing: Vec<VmValue> = Vec::new();
     for name in &unique {
-        if !bodies_dict.contains_key(name) {
+        if !bodies_dict.contains_key(name.as_str()) {
             missing.push(str_value(name));
         }
     }
 
     let mut response: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
     response.insert(
-        "path".into(),
+        harn_vm::value::intern_key("path"),
         match path_for_response {
             Some(ref p) => str_value(p),
             None => VmValue::Nil,
         },
     );
-    response.insert("language".into(), str_value(language.name()));
-    response.insert("brace_based".into(), VmValue::Bool(brace_based));
-    response.insert("bodies".into(), VmValue::dict(bodies_dict));
-    response.insert("missing".into(), VmValue::List(Arc::new(missing)));
+    response.insert(
+        harn_vm::value::intern_key("language"),
+        str_value(language.name()),
+    );
+    response.insert(
+        harn_vm::value::intern_key("brace_based"),
+        VmValue::Bool(brace_based),
+    );
+    response.insert(
+        harn_vm::value::intern_key("bodies"),
+        VmValue::dict(bodies_dict),
+    );
+    response.insert(
+        harn_vm::value::intern_key("missing"),
+        VmValue::List(Arc::new(missing)),
+    );
     Ok(VmValue::dict(response))
 }
 

--- a/crates/harn-hostlib/src/ast/insert_at_anchor.rs
+++ b/crates/harn-hostlib/src/ast/insert_at_anchor.rs
@@ -749,7 +749,7 @@ mod tests {
     fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
         let mut map: harn_vm::value::DictMap = Default::default();
         for (k, v) in pairs {
-            map.insert((*k).to_string(), v.clone());
+            map.insert(harn_vm::value::intern_key(k), v.clone());
         }
         VmValue::dict(map)
     }

--- a/crates/harn-hostlib/src/ast/mutation.rs
+++ b/crates/harn-hostlib/src/ast/mutation.rs
@@ -441,7 +441,7 @@ mod tests {
     fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
         let mut map: harn_vm::value::DictMap = Default::default();
         for (k, v) in pairs {
-            map.insert((*k).to_string(), v.clone());
+            map.insert(harn_vm::value::intern_key(k), v.clone());
         }
         VmValue::dict(map)
     }

--- a/crates/harn-hostlib/src/ast/search.rs
+++ b/crates/harn-hostlib/src/ast/search.rs
@@ -391,7 +391,7 @@ mod tests {
     fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
         let mut map: harn_vm::value::DictMap = Default::default();
         for (k, v) in pairs {
-            map.insert((*k).to_string(), v.clone());
+            map.insert(harn_vm::value::intern_key(k), v.clone());
         }
         VmValue::dict(map)
     }

--- a/crates/harn-hostlib/src/code_index/builtins.rs
+++ b/crates/harn-hostlib/src/code_index/builtins.rs
@@ -924,7 +924,7 @@ pub(super) fn run_cypher(index: &SharedIndex, args: &[VmValue]) -> Result<VmValu
         .map(|row| {
             let mut map: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
             for (k, v) in row {
-                map.insert(k, v.to_vm());
+                map.insert(harn_vm::value::intern_key(&k), v.to_vm());
             }
             VmValue::dict(map)
         })
@@ -1316,15 +1316,15 @@ fn hit_to_value(hit: Hit) -> VmValue {
 
 fn import_entry(module: &str, resolved: Option<&str>, kind: &str) -> VmValue {
     let mut map: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
-    map.insert("module".into(), str_value(module));
+    map.insert(harn_vm::value::intern_key("module"), str_value(module));
     map.insert(
-        "resolved_path".into(),
+        harn_vm::value::intern_key("resolved_path"),
         match resolved {
             Some(p) => str_value(p),
             None => VmValue::Nil,
         },
     );
-    map.insert("kind".into(), str_value(kind));
+    map.insert(harn_vm::value::intern_key("kind"), str_value(kind));
     VmValue::dict(map)
 }
 

--- a/crates/harn-hostlib/src/code_index/rename.rs
+++ b/crates/harn-hostlib/src/code_index/rename.rs
@@ -932,7 +932,7 @@ mod tests {
     fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
         let mut map: harn_vm::value::DictMap = Default::default();
         for (k, v) in pairs {
-            map.insert((*k).to_string(), v.clone());
+            map.insert(harn_vm::value::intern_key(k), v.clone());
         }
         VmValue::dict(map)
     }

--- a/crates/harn-hostlib/src/fs_watch/mod.rs
+++ b/crates/harn-hostlib/src/fs_watch/mod.rs
@@ -642,7 +642,7 @@ mod tests {
         let root = std::env::current_dir().unwrap();
         let mut config = harn_vm::value::DictMap::new();
         config.insert(
-            "kinds".to_string(),
+            harn_vm::value::intern_key("kinds"),
             VmValue::List(std::sync::Arc::new(vec![
                 VmValue::String(arcstr::ArcStr::from("access")),
                 VmValue::String(arcstr::ArcStr::from("other")),

--- a/crates/harn-hostlib/src/tools/args.rs
+++ b/crates/harn-hostlib/src/tools/args.rs
@@ -124,7 +124,7 @@ where
 {
     let mut map: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
     for (k, v) in entries {
-        map.insert(k.into(), v);
+        map.insert(harn_vm::value::intern_key(&k.into()), v);
     }
     VmValue::dict(map)
 }
@@ -141,7 +141,7 @@ mod tests {
     fn dict(entries: [(&'static str, VmValue); 1]) -> harn_vm::value::DictMap {
         entries
             .into_iter()
-            .map(|(key, value)| (key.to_string(), value))
+            .map(|(key, value)| (harn_vm::value::intern_key(key), value))
             .collect()
     }
 

--- a/crates/harn-hostlib/src/tools/inspect_test_results.rs
+++ b/crates/harn-hostlib/src/tools/inspect_test_results.rs
@@ -157,39 +157,39 @@ fn record_to_map(record: test_parsers::TestRecord) -> harn_vm::value::DictMap {
     map.put_str("name", record.name);
     map.put_str("status", record.status.as_str());
     map.insert(
-        "duration_ms".to_string(),
+        harn_vm::value::intern_key("duration_ms"),
         VmValue::Int(record.duration_ms as i64),
     );
     map.insert(
-        "message".to_string(),
+        harn_vm::value::intern_key("message"),
         record
             .message
             .map(|m| VmValue::String(arcstr::ArcStr::from(m)))
             .unwrap_or(VmValue::Nil),
     );
     map.insert(
-        "stdout".to_string(),
+        harn_vm::value::intern_key("stdout"),
         record
             .stdout
             .map(|s| VmValue::String(arcstr::ArcStr::from(s)))
             .unwrap_or(VmValue::Nil),
     );
     map.insert(
-        "stderr".to_string(),
+        harn_vm::value::intern_key("stderr"),
         record
             .stderr
             .map(|s| VmValue::String(arcstr::ArcStr::from(s)))
             .unwrap_or(VmValue::Nil),
     );
     map.insert(
-        "path".to_string(),
+        harn_vm::value::intern_key("path"),
         record
             .path
             .map(|p| VmValue::String(arcstr::ArcStr::from(p)))
             .unwrap_or(VmValue::Nil),
     );
     map.insert(
-        "line".to_string(),
+        harn_vm::value::intern_key("line"),
         record.line.map(VmValue::Int).unwrap_or(VmValue::Nil),
     );
     map

--- a/crates/harn-hostlib/src/tools/mod.rs
+++ b/crates/harn-hostlib/src/tools/mod.rs
@@ -219,8 +219,11 @@ fn handle_enable(args: &[VmValue]) -> Result<VmValue, HostlibError> {
             let newly_enabled = permissions::enable(&feature);
             let mut map: harn_vm::value::DictMap = harn_vm::value::DictMap::new();
             map.put_str("feature", feature);
-            map.insert("enabled".to_string(), VmValue::Bool(true));
-            map.insert("newly_enabled".to_string(), VmValue::Bool(newly_enabled));
+            map.insert(harn_vm::value::intern_key("enabled"), VmValue::Bool(true));
+            map.insert(
+                harn_vm::value::intern_key("newly_enabled"),
+                VmValue::Bool(newly_enabled),
+            );
             Ok(VmValue::dict(map))
         }
         other => Err(HostlibError::InvalidParameter {

--- a/crates/harn-hostlib/src/tools/payload.rs
+++ b/crates/harn-hostlib/src/tools/payload.rs
@@ -109,7 +109,7 @@ pub(crate) fn optional_string_map(
                         message: format!("value for {k:?} must be string, got {}", describe(v)),
                     });
                 };
-                out.insert(k.clone(), s.to_string());
+                out.insert(k.to_string(), s.to_string());
             }
             Ok(Some(out))
         }

--- a/crates/harn-hostlib/src/tools/proc.rs
+++ b/crates/harn-hostlib/src/tools/proc.rs
@@ -321,7 +321,10 @@ pub(crate) fn build_response(
     };
     let mut sandbox = harn_vm::value::DictMap::new();
     sandbox.put_str("kind", sandbox_kind());
-    sandbox.insert("enforced".to_string(), VmValue::Bool(sandbox_enforced()));
+    sandbox.insert(
+        harn_vm::value::intern_key("enforced"),
+        VmValue::Bool(sandbox_enforced()),
+    );
     builder = builder.dict("sandbox", sandbox);
     if let Some(policy_context) = policy_context {
         builder = builder.dict("policy_context", policy_context);
@@ -340,7 +343,10 @@ pub(crate) fn running_response(
     let artifacts = planned_artifact_paths(&command_id);
     let mut sandbox = harn_vm::value::DictMap::new();
     sandbox.put_str("kind", sandbox_kind());
-    sandbox.insert("enforced".to_string(), VmValue::Bool(sandbox_enforced()));
+    sandbox.insert(
+        harn_vm::value::intern_key("enforced"),
+        VmValue::Bool(sandbox_enforced()),
+    );
     let mut builder = ResponseBuilder::new()
         .str("command_id", command_id.clone())
         .str("status", CommandStatus::Running.as_str())

--- a/crates/harn-hostlib/src/tools/response.rs
+++ b/crates/harn-hostlib/src/tools/response.rs
@@ -20,19 +20,21 @@ impl ResponseBuilder {
 
     pub(crate) fn str(mut self, key: &str, value: impl Into<String>) -> Self {
         self.inner.insert(
-            key.to_string(),
+            harn_vm::value::intern_key(key),
             VmValue::String(arcstr::ArcStr::from(value.into())),
         );
         self
     }
 
     pub(crate) fn int(mut self, key: &str, value: i64) -> Self {
-        self.inner.insert(key.to_string(), VmValue::Int(value));
+        self.inner
+            .insert(harn_vm::value::intern_key(key), VmValue::Int(value));
         self
     }
 
     pub(crate) fn bool(mut self, key: &str, value: bool) -> Self {
-        self.inner.insert(key.to_string(), VmValue::Bool(value));
+        self.inner
+            .insert(harn_vm::value::intern_key(key), VmValue::Bool(value));
         self
     }
 
@@ -40,30 +42,35 @@ impl ResponseBuilder {
         match value {
             Some(v) => {
                 self.inner.insert(
-                    key.to_string(),
+                    harn_vm::value::intern_key(key),
                     VmValue::String(arcstr::ArcStr::from(v.into())),
                 );
             }
             None => {
-                self.inner.insert(key.to_string(), VmValue::Nil);
+                self.inner
+                    .insert(harn_vm::value::intern_key(key), VmValue::Nil);
             }
         }
         self
     }
 
     pub(crate) fn nil(mut self, key: &str) -> Self {
-        self.inner.insert(key.to_string(), VmValue::Nil);
+        self.inner
+            .insert(harn_vm::value::intern_key(key), VmValue::Nil);
         self
     }
 
     pub(crate) fn dict(mut self, key: &str, value: harn_vm::value::DictMap) -> Self {
-        self.inner.insert(key.to_string(), VmValue::dict(value));
+        self.inner
+            .insert(harn_vm::value::intern_key(key), VmValue::dict(value));
         self
     }
 
     pub(crate) fn list(mut self, key: &str, value: Vec<VmValue>) -> Self {
-        self.inner
-            .insert(key.to_string(), VmValue::List(Arc::new(value)));
+        self.inner.insert(
+            harn_vm::value::intern_key(key),
+            VmValue::List(Arc::new(value)),
+        );
         self
     }
 

--- a/crates/harn-hostlib/src/tools/run_build_command.rs
+++ b/crates/harn-hostlib/src/tools/run_build_command.rs
@@ -97,17 +97,17 @@ pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
             entry.put_str("severity", d.severity.as_str());
             entry.put_str("message", d.message);
             entry.insert(
-                "path".to_string(),
+                harn_vm::value::intern_key("path"),
                 d.path
                     .map(|p| VmValue::String(arcstr::ArcStr::from(p)))
                     .unwrap_or(VmValue::Nil),
             );
             entry.insert(
-                "line".to_string(),
+                harn_vm::value::intern_key("line"),
                 d.line.map(VmValue::Int).unwrap_or(VmValue::Nil),
             );
             entry.insert(
-                "column".to_string(),
+                harn_vm::value::intern_key("column"),
                 d.column.map(VmValue::Int).unwrap_or(VmValue::Nil),
             );
             VmValue::dict(entry)

--- a/crates/harn-hostlib/src/tools/run_command.rs
+++ b/crates/harn-hostlib/src/tools/run_command.rs
@@ -175,11 +175,20 @@ fn initial_background_snapshot(
         _ => harn_vm::value::DictMap::new(),
     };
     response.put_str("feedback_kind", "tool_progress");
-    response.insert("duration_ms".to_string(), VmValue::Int(wait_ms as i64));
+    response.insert(
+        harn_vm::value::intern_key("duration_ms"),
+        VmValue::Int(wait_ms as i64),
+    );
     response.put_str("stdout", inline_stdout);
     response.put_str("stderr", inline_stderr);
-    response.insert("byte_count".to_string(), VmValue::Int(byte_count as i64));
-    response.insert("line_count".to_string(), VmValue::Int(line_count as i64));
+    response.insert(
+        harn_vm::value::intern_key("byte_count"),
+        VmValue::Int(byte_count as i64),
+    );
+    response.insert(
+        harn_vm::value::intern_key("line_count"),
+        VmValue::Int(line_count as i64),
+    );
     VmValue::dict(response)
 }
 
@@ -210,7 +219,7 @@ fn parse_command(map: &harn_vm::value::DictMap) -> Result<(String, Vec<String>),
             if let Some(shell) = map.get("shell") {
                 match shell {
                     VmValue::Dict(_) => {
-                        invocation.insert("shell".to_string(), shell.clone());
+                        invocation.insert(harn_vm::value::intern_key("shell"), shell.clone());
                     }
                     VmValue::Nil => {}
                     other => {
@@ -223,10 +232,13 @@ fn parse_command(map: &harn_vm::value::DictMap) -> Result<(String, Vec<String>),
                 }
             }
             if let Some(login) = optional_bool(NAME, map, "login")? {
-                invocation.insert("login".to_string(), VmValue::Bool(login));
+                invocation.insert(harn_vm::value::intern_key("login"), VmValue::Bool(login));
             }
             if let Some(interactive) = optional_bool(NAME, map, "interactive")? {
-                invocation.insert("interactive".to_string(), VmValue::Bool(interactive));
+                invocation.insert(
+                    harn_vm::value::intern_key("interactive"),
+                    VmValue::Bool(interactive),
+                );
             }
             let resolved = harn_vm::shells::resolve_invocation_from_vm_params(&invocation)
                 .map_err(|message| HostlibError::InvalidParameter {

--- a/crates/harn-hostlib/src/tools/run_test.rs
+++ b/crates/harn-hostlib/src/tools/run_test.rs
@@ -121,9 +121,18 @@ pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
 
 fn summary_to_dict(summary: TestSummaryData) -> harn_vm::value::DictMap {
     let mut map = harn_vm::value::DictMap::new();
-    map.insert("passed".to_string(), VmValue::Int(summary.passed as i64));
-    map.insert("failed".to_string(), VmValue::Int(summary.failed as i64));
-    map.insert("skipped".to_string(), VmValue::Int(summary.skipped as i64));
+    map.insert(
+        harn_vm::value::intern_key("passed"),
+        VmValue::Int(summary.passed as i64),
+    );
+    map.insert(
+        harn_vm::value::intern_key("failed"),
+        VmValue::Int(summary.failed as i64),
+    );
+    map.insert(
+        harn_vm::value::intern_key("skipped"),
+        VmValue::Int(summary.skipped as i64),
+    );
     map
 }
 

--- a/crates/harn-hostlib/tests/code_index.rs
+++ b/crates/harn-hostlib/tests/code_index.rs
@@ -24,7 +24,7 @@ fn build_registry() -> (BuiltinRegistry, CodeIndexCapability) {
 fn dict(entries: &[(&str, VmValue)]) -> VmValue {
     let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
-        map.insert((*k).to_string(), v.clone());
+        map.insert(harn_vm::value::intern_key(k), v.clone());
     }
     VmValue::dict(map)
 }

--- a/crates/harn-hostlib/tests/code_index_cypher_recall.rs
+++ b/crates/harn-hostlib/tests/code_index_cypher_recall.rs
@@ -21,7 +21,7 @@ fn fixture_root() -> PathBuf {
 fn dict(entries: &[(&str, VmValue)]) -> VmValue {
     let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
-        map.insert((*k).to_string(), v.clone());
+        map.insert(harn_vm::value::intern_key(k), v.clone());
     }
     VmValue::dict(map)
 }

--- a/crates/harn-hostlib/tests/code_index_graph_surface.rs
+++ b/crates/harn-hostlib/tests/code_index_graph_surface.rs
@@ -14,7 +14,7 @@ use harn_vm::VmValue;
 fn dict(entries: &[(&str, VmValue)]) -> VmValue {
     let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
-        map.insert((*k).to_string(), v.clone());
+        map.insert(harn_vm::value::intern_key(k), v.clone());
     }
     VmValue::dict(map)
 }

--- a/crates/harn-hostlib/tests/code_index_live_state.rs
+++ b/crates/harn-hostlib/tests/code_index_live_state.rs
@@ -26,7 +26,7 @@ fn build() -> (BuiltinRegistry, CodeIndexCapability) {
 fn dict(entries: &[(&str, VmValue)]) -> VmValue {
     let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
-        map.insert((*k).to_string(), v.clone());
+        map.insert(harn_vm::value::intern_key(k), v.clone());
     }
     VmValue::dict(map)
 }

--- a/crates/harn-hostlib/tests/code_index_scenario.rs
+++ b/crates/harn-hostlib/tests/code_index_scenario.rs
@@ -27,7 +27,7 @@ use harn_vm::VmValue;
 fn dict(entries: &[(&str, VmValue)]) -> VmValue {
     let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
-        map.insert((*k).to_string(), v.clone());
+        map.insert(harn_vm::value::intern_key(k), v.clone());
     }
     VmValue::dict(map)
 }

--- a/crates/harn-hostlib/tests/fs_path_scope.rs
+++ b/crates/harn-hostlib/tests/fs_path_scope.rs
@@ -66,7 +66,7 @@ impl Drop for PolicyGuard {
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
     let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
-        map.insert(k.to_string(), v.clone());
+        map.insert(harn_vm::value::intern_key(k), v.clone());
     }
     vec![VmValue::dict(map)]
 }

--- a/crates/harn-hostlib/tests/fs_snapshot.rs
+++ b/crates/harn-hostlib/tests/fs_snapshot.rs
@@ -32,7 +32,7 @@ fn registry() -> BuiltinRegistry {
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
     let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
-        map.insert(k.to_string(), v.clone());
+        map.insert(harn_vm::value::intern_key(k), v.clone());
     }
     vec![VmValue::dict(map)]
 }

--- a/crates/harn-hostlib/tests/fs_staging.rs
+++ b/crates/harn-hostlib/tests/fs_staging.rs
@@ -23,7 +23,7 @@ fn registry() -> BuiltinRegistry {
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
     let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
-        map.insert(k.to_string(), v.clone());
+        map.insert(harn_vm::value::intern_key(k), v.clone());
     }
     vec![VmValue::dict(map)]
 }

--- a/crates/harn-hostlib/tests/process_tools.rs
+++ b/crates/harn-hostlib/tests/process_tools.rs
@@ -439,7 +439,7 @@ fn run_command_argv_must_be_strings() {
 
 #[test]
 fn run_command_rejects_out_of_range_capture_limit() {
-    let mut capture = BTreeMap::new();
+    let mut capture: BTreeMap<String, VmValue> = BTreeMap::new();
     capture.insert("max_inline_bytes".into(), VmValue::Float(1.0e100));
 
     let mut req = dict();
@@ -998,7 +998,7 @@ fn cancel_handle_can_wait_for_timed_out_result() {
     start_req.insert("argv".into(), vlist_str(&["sleep", "30"]));
     start_req.insert("background".into(), VmValue::Bool(true));
     start_req.insert("capture".into(), {
-        let mut capture = BTreeMap::new();
+        let mut capture: BTreeMap<String, VmValue> = BTreeMap::new();
         capture.insert("max_inline_bytes".into(), VmValue::Int(200));
         VmValue::dict(capture)
     });

--- a/crates/harn-hostlib/tests/secret_store.rs
+++ b/crates/harn-hostlib/tests/secret_store.rs
@@ -71,7 +71,7 @@ fn registry() -> BuiltinRegistry {
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
     let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
-        map.insert(k.to_string(), v.clone());
+        map.insert(harn_vm::value::intern_key(k), v.clone());
     }
     vec![VmValue::dict(map)]
 }

--- a/crates/harn-hostlib/tests/secret_store_os_native.rs
+++ b/crates/harn-hostlib/tests/secret_store_os_native.rs
@@ -30,7 +30,7 @@ fn registry() -> BuiltinRegistry {
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
     let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
-        map.insert(k.to_string(), v.clone());
+        map.insert(harn_vm::value::intern_key(k), v.clone());
     }
     vec![VmValue::dict(map)]
 }

--- a/crates/harn-hostlib/tests/tools_file_io.rs
+++ b/crates/harn-hostlib/tests/tools_file_io.rs
@@ -19,7 +19,7 @@ fn registry() -> BuiltinRegistry {
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
     let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
-        map.insert(k.to_string(), v.clone());
+        map.insert(harn_vm::value::intern_key(k), v.clone());
     }
     vec![VmValue::dict(map)]
 }

--- a/crates/harn-hostlib/tests/tools_git.rs
+++ b/crates/harn-hostlib/tests/tools_git.rs
@@ -32,7 +32,7 @@ fn registry() -> BuiltinRegistry {
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
     let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
-        map.insert(k.to_string(), v.clone());
+        map.insert(harn_vm::value::intern_key(k), v.clone());
     }
     vec![VmValue::dict(map)]
 }

--- a/crates/harn-hostlib/tests/tools_outline.rs
+++ b/crates/harn-hostlib/tests/tools_outline.rs
@@ -18,7 +18,7 @@ fn registry() -> BuiltinRegistry {
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
     let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
-        map.insert(k.to_string(), v.clone());
+        map.insert(harn_vm::value::intern_key(k), v.clone());
     }
     vec![VmValue::dict(map)]
 }

--- a/crates/harn-hostlib/tests/tools_search.rs
+++ b/crates/harn-hostlib/tests/tools_search.rs
@@ -20,7 +20,7 @@ fn registry() -> BuiltinRegistry {
 fn dict_arg(entries: &[(&str, VmValue)]) -> Vec<VmValue> {
     let mut map: harn_vm::value::DictMap = Default::default();
     for (k, v) in entries {
-        map.insert(k.to_string(), v.clone());
+        map.insert(harn_vm::value::intern_key(k), v.clone());
     }
     vec![VmValue::dict(map)]
 }

--- a/crates/harn-rules-hostlib/src/lib.rs
+++ b/crates/harn-rules-hostlib/src/lib.rs
@@ -409,7 +409,7 @@ fn parse_severity_overrides(
                     _ => None,
                 };
                 if let Some(severity) = severity {
-                    out.insert(rule.clone(), severity);
+                    out.insert(rule.to_string(), severity);
                 }
             }
         }
@@ -578,7 +578,7 @@ fn capture_metadata_vm(m: &RuleMatch) -> VmValue {
 }
 
 fn binding_metadata_vm(metadata: &BindingMetadata) -> VmValue {
-    let mut entries = BTreeMap::new();
+    let mut entries: BTreeMap<String, harn_vm::VmValue> = BTreeMap::new();
     if let Some(ty) = &metadata.ty {
         entries.insert("type".into(), str_vm(ty));
     }

--- a/crates/harn-serve/src/adapters/acp/builtins.rs
+++ b/crates/harn-serve/src/adapters/acp/builtins.rs
@@ -22,7 +22,7 @@ pub(super) async fn register_acp_builtins(vm: &mut harn_vm::Vm, bridge: Arc<AcpB
         .map(|result| {
             normalize_host_capability_manifest(harn_vm::bridge::json_result_to_vm_value(&result))
         })
-        .unwrap_or_else(|_| harn_vm::VmValue::dict(std::collections::BTreeMap::new()));
+        .unwrap_or_else(|_| harn_vm::VmValue::dict_map(Default::default()));
     let selected_shell =
         if manifest_has_operation(&host_capability_manifest, "process", "get_default_shell") {
             bridge
@@ -93,7 +93,7 @@ pub(super) async fn register_acp_builtins(vm: &mut harn_vm::Vm, bridge: Arc<AcpB
         let capability = args.first().map(|a| a.display()).unwrap_or_default();
         let op = args.get(1).map(|a| a.display());
         let valid = if let Some(manifest) = host_has_cache.as_dict() {
-            if let Some(value) = manifest.get(&capability) {
+            if let Some(value) = manifest.get(capability.as_str()) {
                 if let Some(cap) = value.as_dict() {
                     if let Some(op) = op {
                         cap.get("ops")
@@ -333,7 +333,7 @@ pub(super) async fn acp_terminal_exec(
             .unwrap_or_default();
         if !normalized.contains_key("combined") {
             normalized.insert(
-                "combined".to_string(),
+                harn_vm::value::intern_key("combined"),
                 harn_vm::VmValue::String(arcstr::ArcStr::from(format!("{stdout}{stderr}"))),
             );
         }
@@ -343,14 +343,20 @@ pub(super) async fn acp_terminal_exec(
                 .or_else(|| normalized.get("exitCode"))
                 .and_then(|v| v.as_int())
                 .unwrap_or(-1);
-            normalized.insert("status".to_string(), harn_vm::VmValue::Int(status));
+            normalized.insert(
+                harn_vm::value::intern_key("status"),
+                harn_vm::VmValue::Int(status),
+            );
         }
         if !normalized.contains_key("success") {
             let success = normalized
                 .get("status")
                 .and_then(|v| v.as_int())
                 .is_some_and(|code| code == 0);
-            normalized.insert("success".to_string(), harn_vm::VmValue::Bool(success));
+            normalized.insert(
+                harn_vm::value::intern_key("success"),
+                harn_vm::VmValue::Bool(success),
+            );
         }
         return Ok(harn_vm::VmValue::dict(normalized));
     }
@@ -379,7 +385,7 @@ async fn kill_and_release_terminal(bridge: &AcpBridge, terminal_id: &str) {
 
 pub(super) fn normalize_host_capability_manifest(value: harn_vm::VmValue) -> harn_vm::VmValue {
     let Some(root) = value.as_dict() else {
-        return harn_vm::VmValue::dict(BTreeMap::new());
+        return harn_vm::VmValue::dict_map(Default::default());
     };
 
     let mut normalized = BTreeMap::new();
@@ -391,7 +397,10 @@ pub(super) fn normalize_host_capability_manifest(value: harn_vm::VmValue) -> har
                     if let Some(ops) =
                         operation_names_from_value(normalized_entry.get("operations"))
                     {
-                        normalized_entry.insert("ops".to_string(), harn_vm::VmValue::List(ops));
+                        normalized_entry.insert(
+                            harn_vm::value::intern_key("ops"),
+                            harn_vm::VmValue::List(ops),
+                        );
                     }
                 }
                 normalized.insert(capability.clone(), harn_vm::VmValue::dict(normalized_entry));
@@ -416,7 +425,7 @@ fn operation_names_from_value(
         harn_vm::VmValue::List(list) => Some(list.clone()),
         harn_vm::VmValue::Dict(dict) => Some(Arc::new(
             dict.keys()
-                .map(|name| harn_vm::VmValue::String(arcstr::ArcStr::from(name.clone())))
+                .map(|name| harn_vm::VmValue::String(name.clone()))
                 .collect(),
         )),
         _ => None,
@@ -442,10 +451,10 @@ fn manifest_has_operation(manifest: &harn_vm::VmValue, capability: &str, op: &st
 fn local_shell_exec(cmd: &str, shell: &harn_vm::VmValue) -> std::io::Result<std::process::Output> {
     let mut params = harn_vm::value::DictMap::new();
     params.insert(
-        "command".to_string(),
+        harn_vm::value::intern_key("command"),
         harn_vm::VmValue::String(arcstr::ArcStr::from(cmd.to_string())),
     );
-    params.insert("shell".to_string(), shell.clone());
+    params.insert(harn_vm::value::intern_key("shell"), shell.clone());
     let invocation =
         harn_vm::shells::resolve_invocation_from_vm_params(&params).map_err(|error| {
             std::io::Error::new(

--- a/crates/harn-serve/src/adapters/acp/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/tests.rs
@@ -1416,7 +1416,7 @@ fn normalize_host_capabilities_derives_ops_from_operation_metadata() {
     let mut operations = BTreeMap::new();
     operations.insert(
         "get_default_shell".to_string(),
-        VmValue::dict(BTreeMap::new()),
+        VmValue::dict_map(Default::default()),
     );
     let mut process = BTreeMap::new();
     process.insert("operations".to_string(), VmValue::dict(operations));

--- a/crates/harn-serve/src/core.rs
+++ b/crates/harn-serve/src/core.rs
@@ -825,7 +825,10 @@ fn build_pipeline_globals(
             for (index, param) in function.params.iter().enumerate() {
                 match values.get(index) {
                     Some(value) => {
-                        globals.insert(param.name.clone(), json_to_vm_value(value));
+                        globals.insert(
+                            harn_vm::value::intern_key(&param.name),
+                            json_to_vm_value(value),
+                        );
                     }
                     None if param.has_default => {}
                     None => {
@@ -841,7 +844,10 @@ fn build_pipeline_globals(
             for param in &function.params {
                 match values.get(&param.name) {
                     Some(value) => {
-                        globals.insert(param.name.clone(), json_to_vm_value(value));
+                        globals.insert(
+                            harn_vm::value::intern_key(&param.name),
+                            json_to_vm_value(value),
+                        );
                     }
                     None if param.has_default => {}
                     None => {

--- a/crates/harn-serve/src/mcp_prompts.rs
+++ b/crates/harn-serve/src/mcp_prompts.rs
@@ -213,7 +213,10 @@ impl FilePrompt {
 
         let mut bindings = harn_vm::value::DictMap::new();
         for (key, value) in object {
-            bindings.insert(key.clone(), harn_vm::json_to_vm_value(value));
+            bindings.insert(
+                harn_vm::value::intern_key(key),
+                harn_vm::json_to_vm_value(value),
+            );
         }
 
         let rendered = harn_vm::stdlib::template::render_template_to_string(

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -1428,11 +1428,11 @@ fn truncate_state(state: &mut SessionState, keep_first: usize) -> Option<Session
         new_tip_turn_id = turn_event_id_for_count(&retained_events, kept_turn_count);
         let mut next = dict;
         next.insert(
-            "events".to_string(),
+            crate::value::intern_key("events"),
             VmValue::List(std::sync::Arc::new(retained_events)),
         );
         next.insert(
-            "messages".to_string(),
+            crate::value::intern_key("messages"),
             VmValue::List(std::sync::Arc::new(retained)),
         );
         next.remove("summary");
@@ -1501,13 +1501,13 @@ pub fn trim(id: &str, keep_last: usize) -> Option<usize> {
         let kept = retained.len();
         let mut next = dict;
         next.insert(
-            "events".to_string(),
+            crate::value::intern_key("events"),
             VmValue::List(std::sync::Arc::new(
                 crate::llm::helpers::transcript_events_from_messages(&retained),
             )),
         );
         next.insert(
-            "messages".to_string(),
+            crate::value::intern_key("messages"),
             VmValue::List(std::sync::Arc::new(retained)),
         );
         apply_transcript_with_budget(state, VmValue::dict(next), "trim").ok()?;
@@ -1554,11 +1554,11 @@ pub fn inject_message(id: &str, message: VmValue) -> Result<(), String> {
         messages.push(new_message);
         let mut next = dict;
         next.insert(
-            "events".to_string(),
+            crate::value::intern_key("events"),
             VmValue::List(std::sync::Arc::new(events)),
         );
         next.insert(
-            "messages".to_string(),
+            crate::value::intern_key("messages"),
             VmValue::List(std::sync::Arc::new(messages)),
         );
         let persisted_message = next
@@ -1787,7 +1787,7 @@ fn append_event_to_transcript(transcript: VmValue, event: VmValue) -> VmValue {
     let mut events = transcript_events_from_dict(&next);
     events.push(event);
     next.insert(
-        "events".to_string(),
+        crate::value::intern_key("events"),
         VmValue::List(std::sync::Arc::new(events)),
     );
     VmValue::dict(next)
@@ -1820,13 +1820,13 @@ fn trim_transcript_for_budget(
     let retained: Vec<VmValue> = messages.into_iter().skip(start).collect();
     let mut next = dict;
     next.insert(
-        "events".to_string(),
+        crate::value::intern_key("events"),
         VmValue::List(std::sync::Arc::new(
             crate::llm::helpers::transcript_events_from_messages(&retained),
         )),
     );
     next.insert(
-        "messages".to_string(),
+        crate::value::intern_key("messages"),
         VmValue::List(std::sync::Arc::new(retained)),
     );
     next.remove("summary");
@@ -1926,11 +1926,11 @@ fn compact_transcript_for_budget(
 
     let mut next = dict;
     next.insert(
-        "events".to_string(),
+        crate::value::intern_key("events"),
         VmValue::List(std::sync::Arc::new(events)),
     );
     next.insert(
-        "messages".to_string(),
+        crate::value::intern_key("messages"),
         VmValue::List(std::sync::Arc::new(retained)),
     );
     if let Some(summary) = summary {
@@ -2468,7 +2468,7 @@ pub fn prune_invalid_reminder_events(id: &str) -> usize {
         if pruned > 0 {
             let mut next = dict;
             next.insert(
-                "events".to_string(),
+                crate::value::intern_key("events"),
                 VmValue::List(std::sync::Arc::new(kept)),
             );
             let _ = apply_transcript_with_budget(
@@ -2584,7 +2584,7 @@ pub fn inject_reminder(
         events.push(crate::llm::helpers::transcript_reminder_event(&reminder));
         let mut next = dict;
         next.insert(
-            "events".to_string(),
+            crate::value::intern_key("events"),
             VmValue::List(std::sync::Arc::new(events)),
         );
         apply_transcript_with_budget(state, VmValue::dict(next), "inject_reminder")?;
@@ -2670,7 +2670,7 @@ fn append_event_to_state(
     events.push(event);
     let mut next = dict;
     next.insert(
-        "events".to_string(),
+        crate::value::intern_key("events"),
         VmValue::List(std::sync::Arc::new(events)),
     );
     apply_transcript_with_budget(state, VmValue::dict(next), action)
@@ -2709,13 +2709,13 @@ pub fn replace_messages_with_summary(
             .collect();
         let mut next = dict;
         next.insert(
-            "events".to_string(),
+            crate::value::intern_key("events"),
             VmValue::List(std::sync::Arc::new(
                 crate::llm::helpers::transcript_events_from_messages(&vm_messages),
             )),
         );
         next.insert(
-            "messages".to_string(),
+            crate::value::intern_key("messages"),
             VmValue::List(std::sync::Arc::new(vm_messages)),
         );
         if let Some(summary) = summary {
@@ -2855,7 +2855,7 @@ pub fn record_system_prompt(id: &str, system_prompt: &str) -> Result<(), String>
                 )),
             ));
             next.insert(
-                "events".to_string(),
+                crate::value::intern_key("events"),
                 VmValue::List(std::sync::Arc::new(events)),
             );
         }
@@ -3232,7 +3232,7 @@ fn clone_transcript_with_parent(transcript: &VmValue, parent_id: &str) -> VmValu
             VmValue::String(arcstr::ArcStr::from(parent_id.to_string())),
         )])),
     };
-    next.insert("metadata".to_string(), metadata);
+    next.insert(crate::value::intern_key("metadata"), metadata);
     VmValue::dict(next)
 }
 
@@ -3242,12 +3242,15 @@ fn apply_system_prompt_metadata(next: &mut crate::value::DictMap, system_prompt:
         _ => crate::value::DictMap::new(),
     };
     metadata.insert(
-        "system_prompt".to_string(),
+        crate::value::intern_key("system_prompt"),
         crate::stdlib::json_to_vm_value(&crate::llm::helpers::system_prompt_metadata(
             system_prompt,
         )),
     );
-    next.insert("metadata".to_string(), VmValue::dict(metadata));
+    next.insert(
+        crate::value::intern_key("metadata"),
+        VmValue::dict(metadata),
+    );
 }
 
 fn transcript_with_session_metadata(transcript: VmValue, state: &SessionState) -> VmValue {
@@ -3261,33 +3264,42 @@ fn transcript_with_session_metadata(transcript: VmValue, state: &SessionState) -
     };
     if let Some(tool_format) = state.tool_format.as_ref() {
         metadata.put_str("tool_format", tool_format.clone());
-        metadata.insert("tool_mode_locked".to_string(), VmValue::Bool(true));
+        metadata.insert(
+            crate::value::intern_key("tool_mode_locked"),
+            VmValue::Bool(true),
+        );
     }
     if let Some(system_prompt) = state.system_prompt.as_ref() {
         metadata.insert(
-            "system_prompt".to_string(),
+            crate::value::intern_key("system_prompt"),
             crate::stdlib::json_to_vm_value(&crate::llm::helpers::system_prompt_metadata(
                 system_prompt,
             )),
         );
     }
     if let Some(actor_chain) = state.actor_chain.as_ref() {
-        metadata.insert("actor_chain".to_string(), actor_chain.to_vm_value());
+        metadata.insert(
+            crate::value::intern_key("actor_chain"),
+            actor_chain.to_vm_value(),
+        );
     } else {
         metadata.remove("actor_chain");
     }
     if let Some(anchor) = state.workspace_anchor.as_ref() {
         metadata.insert(
-            WORKSPACE_ANCHOR_METADATA_KEY.to_string(),
+            crate::value::intern_key(WORKSPACE_ANCHOR_METADATA_KEY),
             anchor.to_vm_value(),
         );
     } else {
         metadata.remove(WORKSPACE_ANCHOR_METADATA_KEY);
     }
     if let Some(scratchpad) = state.scratchpad.as_ref() {
-        metadata.insert("agent_scratchpad".to_string(), scratchpad.clone());
         metadata.insert(
-            "agent_scratchpad_version".to_string(),
+            crate::value::intern_key("agent_scratchpad"),
+            scratchpad.clone(),
+        );
+        metadata.insert(
+            crate::value::intern_key("agent_scratchpad_version"),
             VmValue::Int(state.scratchpad_version as i64),
         );
     } else {
@@ -3300,7 +3312,7 @@ fn transcript_with_session_metadata(transcript: VmValue, state: &SessionState) -
             state.transcript_budget_policy.max_approx_bytes.is_some(),
         );
         metadata.insert(
-            "transcript_budget".to_string(),
+            crate::value::intern_key("transcript_budget"),
             crate::stdlib::json_to_vm_value(&serde_json::json!({
                 "policy": transcript_budget_policy_json(&state.transcript_budget_policy.normalized()),
                 "usage": transcript_budget_usage_json(&usage),
@@ -3309,7 +3321,10 @@ fn transcript_with_session_metadata(transcript: VmValue, state: &SessionState) -
         );
     }
     if !metadata.is_empty() {
-        next.insert("metadata".to_string(), VmValue::dict(metadata));
+        next.insert(
+            crate::value::intern_key("metadata"),
+            VmValue::dict(metadata),
+        );
     }
     VmValue::dict(next)
 }
@@ -3327,10 +3342,10 @@ fn session_snapshot(state: &SessionState) -> VmValue {
             _ => None,
         })
         .unwrap_or(0);
-    next.insert("length".to_string(), VmValue::Int(length));
+    next.insert(crate::value::intern_key("length"), VmValue::Int(length));
     next.put_str("created_at", state.created_at.clone());
     next.insert(
-        "parent_id".to_string(),
+        crate::value::intern_key("parent_id"),
         state
             .parent_id
             .as_ref()
@@ -3338,7 +3353,7 @@ fn session_snapshot(state: &SessionState) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     next.insert(
-        "child_ids".to_string(),
+        crate::value::intern_key("child_ids"),
         VmValue::List(std::sync::Arc::new(
             state
                 .child_ids
@@ -3349,14 +3364,14 @@ fn session_snapshot(state: &SessionState) -> VmValue {
         )),
     );
     next.insert(
-        "branched_at_event_index".to_string(),
+        crate::value::intern_key("branched_at_event_index"),
         state
             .branched_at_event_index
             .map(|index| VmValue::Int(index as i64))
             .unwrap_or(VmValue::Nil),
     );
     next.insert(
-        "system_prompt".to_string(),
+        crate::value::intern_key("system_prompt"),
         state
             .system_prompt
             .as_ref()
@@ -3364,7 +3379,7 @@ fn session_snapshot(state: &SessionState) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     next.insert(
-        "tool_format".to_string(),
+        crate::value::intern_key("tool_format"),
         state
             .tool_format
             .as_ref()
@@ -3372,7 +3387,7 @@ fn session_snapshot(state: &SessionState) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     next.insert(
-        "pinned_model".to_string(),
+        crate::value::intern_key("pinned_model"),
         state
             .pinned_model
             .as_ref()
@@ -3380,7 +3395,7 @@ fn session_snapshot(state: &SessionState) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     next.insert(
-        "pinned_reasoning_policy".to_string(),
+        crate::value::intern_key("pinned_reasoning_policy"),
         state
             .pinned_reasoning_policy
             .as_ref()
@@ -3388,7 +3403,7 @@ fn session_snapshot(state: &SessionState) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     next.insert(
-        "actor_chain".to_string(),
+        crate::value::intern_key("actor_chain"),
         state
             .actor_chain
             .as_ref()
@@ -3396,15 +3411,15 @@ fn session_snapshot(state: &SessionState) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     next.insert(
-        "scratchpad".to_string(),
+        crate::value::intern_key("scratchpad"),
         state.scratchpad.clone().unwrap_or(VmValue::Nil),
     );
     next.insert(
-        "scratchpad_version".to_string(),
+        crate::value::intern_key("scratchpad_version"),
         VmValue::Int(state.scratchpad_version as i64),
     );
     next.insert(
-        "workspace_anchor".to_string(),
+        crate::value::intern_key("workspace_anchor"),
         state
             .workspace_anchor
             .as_ref()
@@ -3412,17 +3427,17 @@ fn session_snapshot(state: &SessionState) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     next.insert(
-        "workspace_policy".to_string(),
+        crate::value::intern_key("workspace_policy"),
         state.workspace_policy.to_vm_value(),
     );
     next.insert(
-        "live_clients".to_string(),
+        crate::value::intern_key("live_clients"),
         crate::stdlib::json_to_vm_value(&serde_json::Value::Array(
             state.live_clients.values().map(live_client_json).collect(),
         )),
     );
     next.insert(
-        "live_controller_id".to_string(),
+        crate::value::intern_key("live_controller_id"),
         state
             .live_controller_id
             .as_ref()
@@ -3430,11 +3445,11 @@ fn session_snapshot(state: &SessionState) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     next.insert(
-        "completed_turn_checkpoint_count".to_string(),
+        crate::value::intern_key("completed_turn_checkpoint_count"),
         VmValue::Int(state.completed_turn_checkpoints.len() as i64),
     );
     next.insert(
-        "redo_checkpoint_count".to_string(),
+        crate::value::intern_key("redo_checkpoint_count"),
         VmValue::Int(state.redo_stack.len() as i64),
     );
     VmValue::dict(next)

--- a/crates/harn-vm/src/compiler/closures.rs
+++ b/crates/harn-vm/src/compiler/closures.rs
@@ -150,7 +150,7 @@ impl Compiler {
             };
 
             if p.default_value.is_some() {
-                param_schema.insert("required".to_string(), VmValue::Bool(false));
+                param_schema.insert(crate::value::intern_key("required"), VmValue::Bool(false));
             }
 
             self.emit_vm_value_literal(&VmValue::dict(param_schema));

--- a/crates/harn-vm/src/compiler/optimizer.rs
+++ b/crates/harn-vm/src/compiler/optimizer.rs
@@ -261,7 +261,7 @@ fn fold_pow(left: VmValue, right: VmValue) -> Option<VmValue> {
 fn contains_value(item: &VmValue, collection: &VmValue) -> bool {
     match collection {
         VmValue::List(items) => items.iter().any(|value| values_equal(value, item)),
-        VmValue::Dict(entries) => entries.contains_key(&item.display()),
+        VmValue::Dict(entries) => entries.contains_key(item.display().as_str()),
         VmValue::String(text) => match item {
             VmValue::String(substr) => text.contains(&**substr),
             other => text.contains(&other.display()),
@@ -292,7 +292,7 @@ fn value_to_snode(value: VmValue, span: harn_lexer::Span) -> Option<SNode> {
                 .map(|(key, value)| {
                     Some(DictEntry {
                         key: SNode {
-                            node: Node::StringLiteral(key.clone()),
+                            node: Node::StringLiteral(key.to_string()),
                             span,
                         },
                         value: value_to_snode(value.clone(), span)?,

--- a/crates/harn-vm/src/flow/predicates/result.rs
+++ b/crates/harn-vm/src/flow/predicates/result.rs
@@ -143,7 +143,7 @@ fn vm_value_to_json(value: &VmValue) -> serde_json::Value {
         VmValue::Dict(map) => {
             let mut object = serde_json::Map::new();
             for (key, item) in map.iter() {
-                object.insert(key.clone(), vm_value_to_json(item));
+                object.insert(key.to_string(), vm_value_to_json(item));
             }
             serde_json::Value::Object(object)
         }

--- a/crates/harn-vm/src/http/client.rs
+++ b/crates/harn-vm/src/http/client.rs
@@ -136,12 +136,12 @@ fn build_http_response(
     final_url: &str,
 ) -> VmValue {
     let mut result = crate::value::DictMap::new();
-    result.insert("status".to_string(), VmValue::Int(status));
-    result.insert("headers".to_string(), VmValue::dict(headers));
+    result.insert(crate::value::intern_key("status"), VmValue::Int(status));
+    result.insert(crate::value::intern_key("headers"), VmValue::dict(headers));
     result.put_str("body", body);
     result.put_str("final_url", final_url);
     result.insert(
-        "ok".to_string(),
+        crate::value::intern_key("ok"),
         VmValue::Bool((200..300).contains(&(status as u16))),
     );
     VmValue::dict(result)
@@ -153,14 +153,14 @@ fn build_http_download_response(
     bytes_written: u64,
 ) -> VmValue {
     let mut result = crate::value::DictMap::new();
-    result.insert("status".to_string(), VmValue::Int(status));
-    result.insert("headers".to_string(), VmValue::dict(headers));
+    result.insert(crate::value::intern_key("status"), VmValue::Int(status));
+    result.insert(crate::value::intern_key("headers"), VmValue::dict(headers));
     result.insert(
-        "bytes_written".to_string(),
+        crate::value::intern_key("bytes_written"),
         VmValue::Int(u64_to_vm_int(bytes_written)),
     );
     result.insert(
-        "ok".to_string(),
+        crate::value::intern_key("ok"),
         VmValue::Bool((200..300).contains(&(status as u16))),
     );
     VmValue::dict(result)
@@ -175,7 +175,7 @@ fn response_headers(headers: &reqwest::header::HeaderMap) -> crate::value::DictM
     for (name, value) in headers {
         if let Ok(v) = value.to_str() {
             resp_headers.insert(
-                name.as_str().to_string(),
+                crate::value::intern_key(name.as_str()),
                 VmValue::String(arcstr::ArcStr::from(v)),
             );
         }
@@ -831,7 +831,7 @@ pub(super) fn parse_http_request_parts(
                 .map_err(|e| vm_error(format!("http: invalid header value for '{k}': {e}")))?;
             header_map.insert(name, val);
             recorded_headers.insert(
-                k.to_ascii_lowercase(),
+                crate::value::intern_key(&k.to_ascii_lowercase()),
                 VmValue::String(arcstr::ArcStr::from(v.display())),
             );
         }
@@ -1574,10 +1574,16 @@ pub(super) fn vm_http_stream_info(stream_id: &str) -> Result<VmValue, VmError> {
             .get(stream_id)
             .ok_or_else(|| vm_error(format!("http_stream_info: unknown stream '{stream_id}'")))?;
         let mut dict = crate::value::DictMap::new();
-        dict.insert("status".to_string(), VmValue::Int(handle.status));
-        dict.insert("headers".to_string(), VmValue::dict(handle.headers.clone()));
         dict.insert(
-            "ok".to_string(),
+            crate::value::intern_key("status"),
+            VmValue::Int(handle.status),
+        );
+        dict.insert(
+            crate::value::intern_key("headers"),
+            VmValue::dict(handle.headers.clone()),
+        );
+        dict.insert(
+            crate::value::intern_key("ok"),
             VmValue::Bool((200..300).contains(&(handle.status as u16))),
         );
         Ok(VmValue::dict(dict))
@@ -1733,18 +1739,18 @@ mod tests {
     fn proxy_options(password: &str) -> crate::value::DictMap {
         crate::value::DictMap::from_iter([
             (
-                "proxy".to_string(),
+                crate::value::intern_key("proxy"),
                 VmValue::String(arcstr::ArcStr::from("http://proxy.local:8080")),
             ),
             (
-                "proxy_auth".to_string(),
+                crate::value::intern_key("proxy_auth"),
                 VmValue::dict(crate::value::DictMap::from_iter([
                     (
-                        "user".to_string(),
+                        crate::value::intern_key("user"),
                         VmValue::String(arcstr::ArcStr::from("alice")),
                     ),
                     (
-                        "pass".to_string(),
+                        crate::value::intern_key("pass"),
                         VmValue::String(arcstr::ArcStr::from(password)),
                     ),
                 ])),

--- a/crates/harn-vm/src/http/mock.rs
+++ b/crates/harn-vm/src/http/mock.rs
@@ -41,7 +41,12 @@ impl From<HttpMockResponse> for MockResponse {
             headers: value
                 .headers
                 .into_iter()
-                .map(|(key, value)| (key, VmValue::String(arcstr::ArcStr::from(value))))
+                .map(|(key, value)| {
+                    (
+                        crate::value::intern_key(&key),
+                        VmValue::String(arcstr::ArcStr::from(value)),
+                    )
+                })
                 .collect(),
         }
     }
@@ -131,7 +136,7 @@ pub fn http_mock_calls_snapshot() -> Vec<HttpMockCallSnapshot> {
                 headers: call
                     .headers
                     .iter()
-                    .map(|(key, value)| (key.clone(), value.display()))
+                    .map(|(key, value)| (key.to_string(), value.display()))
                     .collect(),
                 body: call.body.clone(),
             })

--- a/crates/harn-vm/src/http/mod.rs
+++ b/crates/harn-vm/src/http/mod.rs
@@ -179,8 +179,11 @@ fn closure_arg(args: &[VmValue], index: usize, builtin: &str) -> Result<Arc<VmCl
 
 fn http_server_handle_value(id: &str) -> VmValue {
     let mut dict = crate::value::DictMap::new();
-    dict.insert("id".to_string(), VmValue::string(id));
-    dict.insert("kind".to_string(), VmValue::string("http_server"));
+    dict.insert(crate::value::intern_key("id"), VmValue::string(id));
+    dict.insert(
+        crate::value::intern_key("kind"),
+        VmValue::string("http_server"),
+    );
     dict_value(dict)
 }
 
@@ -201,14 +204,20 @@ fn headers_from_value(value: &VmValue) -> crate::value::DictMap {
                 headers
                     .iter()
                     .map(|(key, value)| {
-                        (key.to_ascii_lowercase(), VmValue::string(value.display()))
+                        (
+                            crate::value::intern_key(&key.to_ascii_lowercase()),
+                            VmValue::string(value.display()),
+                        )
                     })
                     .collect()
             })
             .unwrap_or_else(|| {
                 dict.iter()
                     .map(|(key, value)| {
-                        (key.to_ascii_lowercase(), VmValue::string(value.display()))
+                        (
+                            crate::value::intern_key(&key.to_ascii_lowercase()),
+                            VmValue::string(value.display()),
+                        )
                     })
                     .collect()
             }),
@@ -220,7 +229,12 @@ fn normalize_headers(value: Option<&VmValue>) -> crate::value::DictMap {
     match value.and_then(VmValue::as_dict) {
         Some(headers) => headers
             .iter()
-            .map(|(key, value)| (key.to_ascii_lowercase(), VmValue::string(value.display())))
+            .map(|(key, value)| {
+                (
+                    crate::value::intern_key(&key.to_ascii_lowercase()),
+                    VmValue::string(value.display()),
+                )
+            })
             .collect(),
         None => crate::value::DictMap::new(),
     }
@@ -263,7 +277,10 @@ fn split_path_and_query(raw_path: &str) -> (String, crate::value::DictMap) {
     let mut query_map = crate::value::DictMap::new();
     for pair in query.split('&').filter(|part| !part.is_empty()) {
         let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
-        query_map.insert(percent_decode(key), VmValue::string(percent_decode(value)));
+        query_map.insert(
+            crate::value::intern_key(&percent_decode(key)),
+            VmValue::string(percent_decode(value)),
+        );
     }
     (
         if path.is_empty() { "/" } else { path }.to_string(),
@@ -299,16 +316,16 @@ fn request_value(
     let headers = normalize_headers(input.get("headers"));
     let body = String::from_utf8_lossy(body_bytes).into_owned();
     let mut request = crate::value::DictMap::new();
-    request.insert("method".to_string(), VmValue::string(method));
-    request.insert("path".to_string(), VmValue::string(path));
+    request.insert(crate::value::intern_key("method"), VmValue::string(method));
+    request.insert(crate::value::intern_key("path"), VmValue::string(path));
     let path_params = dict_value(path_params);
-    request.insert("path_params".to_string(), path_params.clone());
-    request.insert("params".to_string(), path_params);
-    request.insert("query".to_string(), dict_value(query));
-    request.insert("headers".to_string(), dict_value(headers));
-    request.insert("body".to_string(), VmValue::string(body));
+    request.insert(crate::value::intern_key("path_params"), path_params.clone());
+    request.insert(crate::value::intern_key("params"), path_params);
+    request.insert(crate::value::intern_key("query"), dict_value(query));
+    request.insert(crate::value::intern_key("headers"), dict_value(headers));
+    request.insert(crate::value::intern_key("body"), VmValue::string(body));
     request.insert(
-        "raw_body".to_string(),
+        crate::value::intern_key("raw_body"),
         if retain_raw_body {
             VmValue::Bytes(std::sync::Arc::new(body_bytes.to_vec()))
         } else {
@@ -316,11 +333,11 @@ fn request_value(
         },
     );
     request.insert(
-        "body_bytes".to_string(),
+        crate::value::intern_key("body_bytes"),
         VmValue::Int(body_bytes.len() as i64),
     );
     request.insert(
-        "remote_addr".to_string(),
+        crate::value::intern_key("remote_addr"),
         input
             .get("remote_addr")
             .or_else(|| input.get("remote"))
@@ -328,7 +345,7 @@ fn request_value(
             .unwrap_or(VmValue::Nil),
     );
     request.insert(
-        "client_ip".to_string(),
+        crate::value::intern_key("client_ip"),
         input
             .get("client_ip")
             .or_else(|| input.get("remote_ip"))
@@ -358,36 +375,42 @@ fn response_with_kind(
     if body_kind == "json" && matches!(header_lookup_value(&headers, "content-type"), VmValue::Nil)
     {
         headers.insert(
-            "content-type".to_string(),
+            crate::value::intern_key("content-type"),
             VmValue::string("application/json; charset=utf-8"),
         );
     } else if body_kind == "text"
         && matches!(header_lookup_value(&headers, "content-type"), VmValue::Nil)
     {
         headers.insert(
-            "content-type".to_string(),
+            crate::value::intern_key("content-type"),
             VmValue::string("text/plain; charset=utf-8"),
         );
     }
-    response.insert("status".to_string(), VmValue::Int(status));
-    response.insert("headers".to_string(), dict_value(headers));
+    response.insert(crate::value::intern_key("status"), VmValue::Int(status));
+    response.insert(crate::value::intern_key("headers"), dict_value(headers));
     response.insert(
-        "ok".to_string(),
+        crate::value::intern_key("ok"),
         VmValue::Bool((200..300).contains(&status)),
     );
-    response.insert("body_kind".to_string(), VmValue::string(body_kind));
+    response.insert(
+        crate::value::intern_key("body_kind"),
+        VmValue::string(body_kind),
+    );
     match body {
         VmValue::Bytes(bytes) => {
             response.insert(
-                "body".to_string(),
+                crate::value::intern_key("body"),
                 VmValue::string(String::from_utf8_lossy(&bytes)),
             );
-            response.insert("raw_body".to_string(), VmValue::Bytes(bytes));
+            response.insert(crate::value::intern_key("raw_body"), VmValue::Bytes(bytes));
         }
         other => {
-            response.insert("body".to_string(), VmValue::string(other.display()));
             response.insert(
-                "raw_body".to_string(),
+                crate::value::intern_key("body"),
+                VmValue::string(other.display()),
+            );
+            response.insert(
+                crate::value::intern_key("raw_body"),
                 VmValue::Bytes(std::sync::Arc::new(other.display().into_bytes())),
             );
         }
@@ -425,12 +448,15 @@ fn normalize_response(value: VmValue) -> VmValue {
 fn body_limit_response(limit: usize, actual: usize) -> VmValue {
     let mut headers = crate::value::DictMap::new();
     headers.insert(
-        "content-type".to_string(),
+        crate::value::intern_key("content-type"),
         VmValue::string("text/plain; charset=utf-8"),
     );
-    headers.insert("connection".to_string(), VmValue::string("close"));
     headers.insert(
-        "x-harn-body-limit".to_string(),
+        crate::value::intern_key("connection"),
+        VmValue::string("close"),
+    );
+    headers.insert(
+        crate::value::intern_key("x-harn-body-limit"),
         VmValue::string(limit.to_string()),
     );
     response_with_kind(
@@ -472,12 +498,12 @@ fn route_template_match(template: &str, path: &str) -> Option<crate::value::Dict
     for (tmpl, actual) in template_segments.iter().zip(path_segments.iter()) {
         if tmpl.starts_with('{') && tmpl.ends_with('}') && tmpl.len() > 2 {
             params.insert(
-                tmpl[1..tmpl.len() - 1].to_string(),
+                crate::value::intern_key(&tmpl[1..tmpl.len() - 1]),
                 VmValue::string(percent_decode(actual)),
             );
         } else if tmpl.starts_with(':') && tmpl.len() > 1 {
             params.insert(
-                tmpl[1..].to_string(),
+                crate::value::intern_key(&tmpl[1..]),
                 VmValue::string(percent_decode(actual)),
             );
         } else if tmpl != actual {
@@ -675,7 +701,7 @@ fn register_http_tls_builtins(vm: &mut Vm) {
         })?;
         let mut extra = crate::value::DictMap::new();
         extra.insert(
-            "hosts".to_string(),
+            crate::value::intern_key("hosts"),
             VmValue::List(std::sync::Arc::new(
                 hosts
                     .into_iter()
@@ -1073,9 +1099,12 @@ fn http_server_tls_config_value(
 ) -> VmValue {
     let mut dict = crate::value::DictMap::new();
     dict.put_str("mode", mode);
-    dict.insert("terminate_tls".to_string(), VmValue::Bool(terminate_tls));
+    dict.insert(
+        crate::value::intern_key("terminate_tls"),
+        VmValue::Bool(terminate_tls),
+    );
     dict.put_str("scheme", scheme);
-    dict.insert("hsts".to_string(), VmValue::Bool(hsts));
+    dict.insert(crate::value::intern_key("hsts"), VmValue::Bool(hsts));
     for (key, value) in extra {
         dict.insert(key, value);
     }
@@ -1085,7 +1114,7 @@ fn http_server_tls_config_value(
 fn hsts_options(options: &crate::value::DictMap) -> crate::value::DictMap {
     let mut hsts = crate::value::DictMap::new();
     hsts.insert(
-        "hsts_max_age_seconds".to_string(),
+        crate::value::intern_key("hsts_max_age_seconds"),
         VmValue::Int(vm_get_int_option(
             options,
             "hsts_max_age_seconds",
@@ -1093,7 +1122,7 @@ fn hsts_options(options: &crate::value::DictMap) -> crate::value::DictMap {
         )),
     );
     hsts.insert(
-        "hsts_include_subdomains".to_string(),
+        crate::value::intern_key("hsts_include_subdomains"),
         VmValue::Bool(vm_get_bool_option(
             options,
             "hsts_include_subdomains",
@@ -1101,7 +1130,7 @@ fn hsts_options(options: &crate::value::DictMap) -> crate::value::DictMap {
         )),
     );
     hsts.insert(
-        "hsts_preload".to_string(),
+        crate::value::intern_key("hsts_preload"),
         VmValue::Bool(vm_get_bool_option(options, "hsts_preload", false)),
     );
     hsts
@@ -1123,7 +1152,7 @@ fn http_server_security_headers(config: &crate::value::DictMap) -> crate::value:
         value.push_str("; preload");
     }
     crate::value::DictMap::from_iter([(
-        "strict-transport-security".to_string(),
+        crate::value::intern_key("strict-transport-security"),
         VmValue::String(arcstr::ArcStr::from(value)),
     )])
 }

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -528,7 +528,7 @@ mod reset_leak_tests {
         llm::routing::clear_policy_registry();
         let mut config: crate::value::DictMap = crate::value::DictMap::new();
         config.insert(
-            "chain".to_string(),
+            crate::value::intern_key("chain"),
             VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                 arcstr::ArcStr::from("mock:mock"),
             )])),

--- a/crates/harn-vm/src/llm/agent_host_primitives.rs
+++ b/crates/harn-vm/src/llm/agent_host_primitives.rs
@@ -89,9 +89,9 @@ async fn host_agent_capture_events_impl(
         })
         .unwrap_or_default();
     let mut envelope = crate::value::DictMap::new();
-    envelope.insert("result".to_string(), result);
+    envelope.insert(crate::value::intern_key("result"), result);
     envelope.insert(
-        "events".to_string(),
+        crate::value::intern_key("events"),
         json_to_vm_value(&serde_json::Value::Array(events)),
     );
     Ok(VmValue::dict(envelope))
@@ -1962,14 +1962,20 @@ mod security_gate_tests {
     #[test]
     fn tool_descriptor_extracts_description_and_schema_changed() {
         let mut tool = crate::value::DictMap::new();
-        tool.insert("name".to_string(), vm_str("linear__create"));
-        tool.insert("description".to_string(), vm_str("Create an issue"));
-        tool.insert("_mcp_server".to_string(), vm_str("linear"));
-        tool.insert("_schema_changed".to_string(), VmValue::Bool(true));
+        tool.insert(crate::value::intern_key("name"), vm_str("linear__create"));
+        tool.insert(
+            crate::value::intern_key("description"),
+            vm_str("Create an issue"),
+        );
+        tool.insert(crate::value::intern_key("_mcp_server"), vm_str("linear"));
+        tool.insert(
+            crate::value::intern_key("_schema_changed"),
+            VmValue::Bool(true),
+        );
         let catalog = {
             let mut dict = crate::value::DictMap::new();
             dict.insert(
-                "tools".to_string(),
+                crate::value::intern_key("tools"),
                 VmValue::List(Arc::new(vec![VmValue::dict(tool)])),
             );
             VmValue::dict(dict)

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -649,7 +649,7 @@ fn vm_value_to_json(value: &crate::value::VmValue) -> serde_json::Value {
         }
         VmValue::Dict(d) => serde_json::Value::Object(
             d.iter()
-                .map(|(k, v)| (k.clone(), vm_value_to_json(v)))
+                .map(|(k, v)| (k.to_string(), vm_value_to_json(v)))
                 .collect(),
         ),
         other => serde_json::Value::String(other.display()),
@@ -1667,7 +1667,7 @@ mod retry_tests {
                 VmValue::dict(
                     pairs
                         .iter()
-                        .map(|(k, v)| ((*k).to_string(), v.clone()))
+                        .map(|(k, v)| (crate::value::intern_key(k), v.clone()))
                         .collect::<crate::value::DictMap>(),
                 )
             };

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -410,17 +410,20 @@ async fn host_agent_session_init(
     control.put_str("session_id", resolved);
     control.put_str("task", message);
     control.insert(
-        "system".to_string(),
+        crate::value::intern_key("system"),
         system
             .map(|s| VmValue::String(arcstr::ArcStr::from(s)))
             .unwrap_or(VmValue::Nil),
     );
-    control.insert("max_iterations".to_string(), VmValue::Int(max_iterations));
     control.insert(
-        "max_verify_attempts".to_string(),
+        crate::value::intern_key("max_iterations"),
+        VmValue::Int(max_iterations),
+    );
+    control.insert(
+        crate::value::intern_key("max_verify_attempts"),
         VmValue::Int(max_verify_attempts),
     );
-    control.insert("done".to_string(), VmValue::Bool(false));
+    control.insert(crate::value::intern_key("done"), VmValue::Bool(false));
     Ok(VmValue::dict(control))
 }
 
@@ -527,15 +530,18 @@ fn agent_init_control_done(
     control.put_str("session_id", session_id);
     control.put_str("task", task);
     control.insert(
-        "system".to_string(),
+        crate::value::intern_key("system"),
         system
             .map(|s| VmValue::String(arcstr::ArcStr::from(s.to_string())))
             .unwrap_or(VmValue::Nil),
     );
-    control.insert("max_iterations".to_string(), VmValue::Int(0));
-    control.insert("max_verify_attempts".to_string(), VmValue::Int(0));
-    control.insert("done".to_string(), VmValue::Bool(true));
-    control.insert("result".to_string(), result);
+    control.insert(crate::value::intern_key("max_iterations"), VmValue::Int(0));
+    control.insert(
+        crate::value::intern_key("max_verify_attempts"),
+        VmValue::Int(0),
+    );
+    control.insert(crate::value::intern_key("done"), VmValue::Bool(true));
+    control.insert(crate::value::intern_key("result"), result);
     VmValue::dict(control)
 }
 
@@ -1345,8 +1351,14 @@ fn host_agent_session_record_usage_builtin(
     )
     .map_err(VmError::Runtime)?;
     let mut out = crate::value::DictMap::new();
-    out.insert("tokens_used".to_string(), VmValue::Int(totals.0));
-    out.insert("cost_usd".to_string(), VmValue::Float(totals.1));
+    out.insert(
+        crate::value::intern_key("tokens_used"),
+        VmValue::Int(totals.0),
+    );
+    out.insert(
+        crate::value::intern_key("cost_usd"),
+        VmValue::Float(totals.1),
+    );
     Ok(VmValue::dict(out))
 }
 
@@ -1410,8 +1422,11 @@ fn host_agent_session_drain_feedback_builtin(
             item.put_str("kind", entry.kind);
             item.put_str("content", entry.content);
             item.put_str("source", entry.source);
-            item.insert("sequence".to_string(), VmValue::Int(entry.sequence as i64));
-            item.insert("ts_ms".to_string(), VmValue::Int(entry.ts_ms));
+            item.insert(
+                crate::value::intern_key("sequence"),
+                VmValue::Int(entry.sequence as i64),
+            );
+            item.insert(crate::value::intern_key("ts_ms"), VmValue::Int(entry.ts_ms));
             VmValue::dict(item)
         })
         .collect::<Vec<_>>();
@@ -1433,8 +1448,14 @@ fn host_agent_session_totals_builtin(
         Ok((session.tokens_used, session.cost_used))
     })?;
     let mut out = crate::value::DictMap::new();
-    out.insert("tokens_used".to_string(), VmValue::Int(totals.0));
-    out.insert("cost_usd".to_string(), VmValue::Float(totals.1));
+    out.insert(
+        crate::value::intern_key("tokens_used"),
+        VmValue::Int(totals.0),
+    );
+    out.insert(
+        crate::value::intern_key("cost_usd"),
+        VmValue::Float(totals.1),
+    );
     Ok(VmValue::dict(out))
 }
 
@@ -3057,18 +3078,18 @@ async fn host_autonomy_budget_check(
         .unwrap_or_else(|| format!("agent_session_{}", now_id()));
     let mut opts = crate::value::DictMap::new();
     if let Some(config) = args.get(1) {
-        opts.insert("autonomy_budget".to_string(), config.clone());
+        opts.insert(crate::value::intern_key("autonomy_budget"), config.clone());
     }
     match check_autonomy_budget(&opts, &session_id).await? {
         AutonomyCheck::Denied(result) => {
             let mut out = crate::value::DictMap::new();
-            out.insert("approved".to_string(), VmValue::Bool(false));
-            out.insert("denial_result".to_string(), result);
+            out.insert(crate::value::intern_key("approved"), VmValue::Bool(false));
+            out.insert(crate::value::intern_key("denial_result"), result);
             Ok(VmValue::dict(out))
         }
         AutonomyCheck::Approved(_) | AutonomyCheck::NoBudget => {
             let mut out = crate::value::DictMap::new();
-            out.insert("approved".to_string(), VmValue::Bool(true));
+            out.insert(crate::value::intern_key("approved"), VmValue::Bool(true));
             Ok(VmValue::dict(out))
         }
     }

--- a/crates/harn-vm/src/llm/agent_session_host_tests.rs
+++ b/crates/harn-vm/src/llm/agent_session_host_tests.rs
@@ -112,7 +112,7 @@ fn gpt_oss_harmony_leak_persists_clean_reasoning_and_tool_calls() {
 fn initial_user_content_preserves_multimodal_blocks() {
     let mut opts = crate::value::DictMap::new();
     opts.insert(
-        "initial_user_content".to_string(),
+        crate::value::intern_key("initial_user_content"),
         crate::stdlib::json_to_vm_value(&json!([
             {"type": "text", "text": "Describe this image."},
             {
@@ -500,7 +500,7 @@ mod nested_budget_tests {
 
         let mut opts_map = crate::value::DictMap::new();
         opts_map.insert(
-            "policy".to_string(),
+            crate::value::intern_key("policy"),
             policy_value(&CapabilityPolicy {
                 recursion_limit: Some(1),
                 ..Default::default()

--- a/crates/harn-vm/src/llm/agent_tools.rs
+++ b/crates/harn-vm/src/llm/agent_tools.rs
@@ -773,14 +773,14 @@ mod tests {
             .into_iter()
             .map(|(name, mut entry)| {
                 entry
-                    .entry("name".to_string())
+                    .entry(crate::value::intern_key("name"))
                     .or_insert_with(|| VmValue::String(arcstr::ArcStr::from(name.to_string())));
                 VmValue::dict(entry)
             })
             .collect();
         let mut dict = crate::value::DictMap::new();
         dict.insert(
-            "tools".to_string(),
+            crate::value::intern_key("tools"),
             VmValue::List(std::sync::Arc::new(list)),
         );
         VmValue::dict(dict)
@@ -890,11 +890,14 @@ mod tests {
         function.put_str("name", "create_issue");
         function.put_str("_mcp_server", "linear");
         let mut entry = crate::value::DictMap::new();
-        entry.insert("function".to_string(), VmValue::dict(function));
+        entry.insert(
+            crate::value::intern_key("function"),
+            VmValue::dict(function),
+        );
         // The outer entry has no `name` — fall back to function.name.
         let mut dict = crate::value::DictMap::new();
         dict.insert(
-            "tools".to_string(),
+            crate::value::intern_key("tools"),
             VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
                 std::sync::Arc::new(entry),
             )])),

--- a/crates/harn-vm/src/llm/api/completion.rs
+++ b/crates/harn-vm/src/llm/api/completion.rs
@@ -274,7 +274,10 @@ async fn vm_call_completion_fallback(
     let has_suffix = suffix.is_some_and(|s| !s.is_empty());
     let mut bindings = crate::value::DictMap::new();
     bindings.put_str("prefix", prefix);
-    bindings.insert("has_suffix".to_string(), VmValue::Bool(has_suffix));
+    bindings.insert(
+        crate::value::intern_key("has_suffix"),
+        VmValue::Bool(has_suffix),
+    );
     bindings.put_str("suffix", suffix.unwrap_or_default());
     let instruction = crate::stdlib::template::render_stdlib_prompt_asset(
         "llm/prompts/completion_fallback_system.harn.prompt",

--- a/crates/harn-vm/src/llm/api/result.rs
+++ b/crates/harn-vm/src/llm/api/result.rs
@@ -80,43 +80,46 @@ fn build_usage_dict(result: &LlmResult) -> crate::value::DictMap {
 
     let mut usage = crate::value::DictMap::new();
     usage.insert(
-        "input_tokens".to_string(),
+        crate::value::intern_key("input_tokens"),
         VmValue::Int(result.input_tokens),
     );
     usage.insert(
-        "output_tokens".to_string(),
+        crate::value::intern_key("output_tokens"),
         VmValue::Int(result.output_tokens),
     );
     usage.insert(
-        "cache_read_tokens".to_string(),
+        crate::value::intern_key("cache_read_tokens"),
         VmValue::Int(result.cache_read_tokens),
     );
     usage.insert(
-        "cache_write_tokens".to_string(),
+        crate::value::intern_key("cache_write_tokens"),
         VmValue::Int(result.cache_write_tokens),
     );
     usage.insert(
-        "cache_creation_input_tokens".to_string(),
+        crate::value::intern_key("cache_creation_input_tokens"),
         VmValue::Int(result.cache_write_tokens),
     );
     if result.cache_supported {
         usage.insert(
-            "cache_hit_ratio".to_string(),
+            crate::value::intern_key("cache_hit_ratio"),
             VmValue::Float(cache_hit_ratio),
         );
-        usage.insert("cache_visibility".to_string(), VmValue::Nil);
+        usage.insert(crate::value::intern_key("cache_visibility"), VmValue::Nil);
     } else {
         // Native local runtimes report no cache field; a 0.0 ratio here would
         // mislabel a local model as a 100% cache miss. Surface the unknown
         // explicitly instead of fabricating a number.
-        usage.insert("cache_hit_ratio".to_string(), VmValue::Nil);
+        usage.insert(crate::value::intern_key("cache_hit_ratio"), VmValue::Nil);
         usage.put_str("cache_visibility", "unsupported");
     }
     usage.insert(
-        "cache_savings_usd".to_string(),
+        crate::value::intern_key("cache_savings_usd"),
         VmValue::Float(cache_savings_usd),
     );
-    usage.insert("served_fast".to_string(), VmValue::Bool(result.served_fast));
+    usage.insert(
+        crate::value::intern_key("served_fast"),
+        VmValue::Bool(result.served_fast),
+    );
     usage
 }
 
@@ -133,36 +136,39 @@ pub(crate) fn vm_build_llm_result(
     dict.put_str("model", result.model.as_str());
     dict.put_str("provider", result.provider.as_str());
     dict.insert(
-        "input_tokens".to_string(),
+        crate::value::intern_key("input_tokens"),
         VmValue::Int(result.input_tokens),
     );
     dict.insert(
-        "output_tokens".to_string(),
+        crate::value::intern_key("output_tokens"),
         VmValue::Int(result.output_tokens),
     );
     // Cache accounting (0 when provider doesn't report cache info).
     dict.insert(
-        "cache_read_tokens".to_string(),
+        crate::value::intern_key("cache_read_tokens"),
         VmValue::Int(result.cache_read_tokens),
     );
     dict.insert(
-        "cache_write_tokens".to_string(),
+        crate::value::intern_key("cache_write_tokens"),
         VmValue::Int(result.cache_write_tokens),
     );
     dict.insert(
-        "cache_creation_input_tokens".to_string(),
+        crate::value::intern_key("cache_creation_input_tokens"),
         VmValue::Int(result.cache_write_tokens),
     );
-    dict.insert("served_fast".to_string(), VmValue::Bool(result.served_fast));
+    dict.insert(
+        crate::value::intern_key("served_fast"),
+        VmValue::Bool(result.served_fast),
+    );
     let usage = build_usage_dict(result);
     if let Some(value) = usage.get("cache_hit_ratio") {
-        dict.insert("cache_hit_ratio".to_string(), value.clone());
+        dict.insert(crate::value::intern_key("cache_hit_ratio"), value.clone());
     }
     if let Some(value) = usage.get("cache_visibility") {
-        dict.insert("cache_visibility".to_string(), value.clone());
+        dict.insert(crate::value::intern_key("cache_visibility"), value.clone());
     }
     if let Some(value) = usage.get("cache_savings_usd") {
-        dict.insert("cache_savings_usd".to_string(), value.clone());
+        dict.insert(crate::value::intern_key("cache_savings_usd"), value.clone());
     }
     // Surface provider-side timings (Ollama load_duration, prompt_eval_duration,
     // eval_duration; OpenAI usage; llama.cpp `timings`). Evals key off
@@ -171,15 +177,21 @@ pub(crate) fn vm_build_llm_result(
     let telemetry_dict = result.telemetry.as_vm_dict();
     let mut usage = usage;
     if let Some(ref telemetry_dict) = telemetry_dict {
-        usage.insert("provider_telemetry".to_string(), telemetry_dict.clone());
+        usage.insert(
+            crate::value::intern_key("provider_telemetry"),
+            telemetry_dict.clone(),
+        );
     }
-    dict.insert("usage".to_string(), VmValue::dict(usage));
+    dict.insert(crate::value::intern_key("usage"), VmValue::dict(usage));
     if let Some(telemetry_dict) = telemetry_dict {
-        dict.insert("provider_telemetry".to_string(), telemetry_dict);
+        dict.insert(
+            crate::value::intern_key("provider_telemetry"),
+            telemetry_dict,
+        );
     }
 
     if let Some(json_val) = parsed_json {
-        dict.insert("data".to_string(), json_val);
+        dict.insert(crate::value::intern_key("data"), json_val);
     }
 
     let has_tagged_blocks = [
@@ -208,7 +220,7 @@ pub(crate) fn vm_build_llm_result(
     if !merged_tool_calls.is_empty() {
         let calls: Vec<VmValue> = merged_tool_calls.iter().map(json_to_vm_value).collect();
         dict.insert(
-            "tool_calls".to_string(),
+            crate::value::intern_key("tool_calls"),
             VmValue::List(std::sync::Arc::new(calls)),
         );
     }
@@ -218,7 +230,7 @@ pub(crate) fn vm_build_llm_result(
     // just want the unified view.
     let native_calls: Vec<VmValue> = result.tool_calls.iter().map(json_to_vm_value).collect();
     dict.insert(
-        "native_tool_calls".to_string(),
+        crate::value::intern_key("native_tool_calls"),
         VmValue::List(std::sync::Arc::new(native_calls)),
     );
 
@@ -230,7 +242,7 @@ pub(crate) fn vm_build_llm_result(
                 .map(|v| VmValue::String(arcstr::ArcStr::from(v.as_str())))
                 .collect();
             dict.insert(
-                "protocol_violations".to_string(),
+                crate::value::intern_key("protocol_violations"),
                 VmValue::List(std::sync::Arc::new(violations)),
             );
         }
@@ -241,7 +253,7 @@ pub(crate) fn vm_build_llm_result(
                 .map(|e| VmValue::String(arcstr::ArcStr::from(e.as_str())))
                 .collect();
             dict.insert(
-                "tool_parse_errors".to_string(),
+                crate::value::intern_key("tool_parse_errors"),
                 VmValue::List(std::sync::Arc::new(errors)),
             );
         }
@@ -280,7 +292,7 @@ pub(crate) fn vm_build_llm_result(
     }
 
     if let Some(transcript) = transcript {
-        dict.insert("transcript".to_string(), transcript);
+        dict.insert(crate::value::intern_key("transcript"), transcript);
     }
 
     // Prose with fenceless TS tool-call expressions stripped. Agent_loop
@@ -294,7 +306,7 @@ pub(crate) fn vm_build_llm_result(
     };
     dict.put_str("visible_text", visible_text.as_str());
     dict.insert(
-        "blocks".to_string(),
+        crate::value::intern_key("blocks"),
         VmValue::List(std::sync::Arc::new(
             result
                 .blocks
@@ -305,7 +317,7 @@ pub(crate) fn vm_build_llm_result(
     );
     if !result.logprobs.is_empty() {
         dict.insert(
-            "logprobs".to_string(),
+            crate::value::intern_key("logprobs"),
             VmValue::List(std::sync::Arc::new(
                 result
                     .logprobs

--- a/crates/harn-vm/src/llm/api/telemetry.rs
+++ b/crates/harn-vm/src/llm/api/telemetry.rs
@@ -392,13 +392,13 @@ fn ms_or_round(value: Option<&serde_json::Value>) -> Option<u64> {
 
 fn insert_opt_u64(dict: &mut crate::value::DictMap, key: &str, value: Option<u64>) {
     if let Some(value) = value {
-        dict.insert(key.to_string(), VmValue::Int(value as i64));
+        dict.insert(crate::value::intern_key(key), VmValue::Int(value as i64));
     }
 }
 
 fn insert_opt_i64(dict: &mut crate::value::DictMap, key: &str, value: Option<i64>) {
     if let Some(value) = value {
-        dict.insert(key.to_string(), VmValue::Int(value));
+        dict.insert(crate::value::intern_key(key), VmValue::Int(value));
     }
 }
 

--- a/crates/harn-vm/src/llm/autonomy_budget.rs
+++ b/crates/harn-vm/src/llm/autonomy_budget.rs
@@ -358,7 +358,7 @@ mod tests {
     fn missing_caps_returns_none() {
         let mut opts = crate::value::DictMap::new();
         opts.insert(
-            "autonomy_budget".to_string(),
+            crate::value::intern_key("autonomy_budget"),
             VmValue::dict(crate::value::DictMap::new()),
         );
         let parsed = parse_autonomy_budget(Some(&opts), "session-1", "agent_loop").expect("parse");

--- a/crates/harn-vm/src/llm/cache.rs
+++ b/crates/harn-vm/src/llm/cache.rs
@@ -119,9 +119,15 @@ fn cache_get_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
     record_lookup(&options, hit.is_some());
 
     let mut envelope = cache_envelope_base(&options);
-    envelope.insert("hit".to_string(), VmValue::Bool(hit.is_some()));
+    envelope.insert(
+        crate::value::intern_key("hit"),
+        VmValue::Bool(hit.is_some()),
+    );
     if let Some(value) = hit {
-        envelope.insert("value".to_string(), crate::stdlib::json_to_vm_value(&value));
+        envelope.insert(
+            crate::value::intern_key("value"),
+            crate::stdlib::json_to_vm_value(&value),
+        );
     }
     Ok(VmValue::dict(envelope))
 }
@@ -145,7 +151,7 @@ fn cache_put_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
     )?;
 
     let mut envelope = cache_envelope_base(&options);
-    envelope.insert("stored".to_string(), VmValue::Bool(true));
+    envelope.insert(crate::value::intern_key("stored"), VmValue::Bool(true));
     envelope.put_str("key", key);
     Ok(VmValue::dict(envelope))
 }
@@ -171,15 +177,15 @@ fn cache_stats_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
     let total = snapshot.hits.saturating_add(snapshot.misses);
     let mut dict = cache_envelope_base(&options);
     dict.insert(
-        "hits".to_string(),
+        crate::value::intern_key("hits"),
         VmValue::Int(saturating_u64_to_i64(snapshot.hits)),
     );
     dict.insert(
-        "misses".to_string(),
+        crate::value::intern_key("misses"),
         VmValue::Int(saturating_u64_to_i64(snapshot.misses)),
     );
     dict.insert(
-        "lookups".to_string(),
+        crate::value::intern_key("lookups"),
         VmValue::Int(saturating_u64_to_i64(total)),
     );
     let hit_rate = if total == 0 {
@@ -187,7 +193,10 @@ fn cache_stats_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
     } else {
         snapshot.hits as f64 / total as f64
     };
-    dict.insert("hit_rate".to_string(), VmValue::Float(hit_rate));
+    dict.insert(
+        crate::value::intern_key("hit_rate"),
+        VmValue::Float(hit_rate),
+    );
     Ok(VmValue::dict(dict))
 }
 

--- a/crates/harn-vm/src/llm/cache_tests.rs
+++ b/crates/harn-vm/src/llm/cache_tests.rs
@@ -284,11 +284,11 @@ mod cache_key_identity_tests {
     fn base_options() -> crate::value::DictMap {
         let mut map = crate::value::DictMap::new();
         map.insert(
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("mock")),
         );
         map.insert(
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("mock")),
         );
         map
@@ -310,7 +310,7 @@ mod cache_key_identity_tests {
         let without = key("hello", dict(base_options()));
         let mut with_tools = base_options();
         with_tools.insert(
-            "tools".to_string(),
+            crate::value::intern_key("tools"),
             VmValue::List(Arc::new(vec![VmValue::String(arcstr::ArcStr::from(
                 "read_file",
             ))])),
@@ -324,7 +324,7 @@ mod cache_key_identity_tests {
         let without = key("hello", dict(base_options()));
         let mut with_schema = base_options();
         with_schema.insert(
-            "json_schema".to_string(),
+            crate::value::intern_key("json_schema"),
             VmValue::String(arcstr::ArcStr::from(r#"{"type":"object"}"#)),
         );
         let with = key("hello", dict(with_schema));
@@ -336,7 +336,7 @@ mod cache_key_identity_tests {
         let without = key("hello", dict(base_options()));
         let mut with_stop = base_options();
         with_stop.insert(
-            "stop".to_string(),
+            crate::value::intern_key("stop"),
             VmValue::List(Arc::new(vec![VmValue::String(arcstr::ArcStr::from(
                 "\n\n",
             ))])),

--- a/crates/harn-vm/src/llm/call.rs
+++ b/crates/harn-vm/src/llm/call.rs
@@ -400,13 +400,13 @@ pub(crate) fn build_llm_error_dict(err: &VmError, provider: &str, model: &str) -
     let llm_error = api::classify_llm_error(category.clone(), &message);
     if let VmError::Thrown(VmValue::Dict(existing)) = err {
         let mut dict = existing.as_ref().clone();
-        dict.entry("category".to_string())
+        dict.entry(crate::value::intern_key("category"))
             .or_insert_with(|| VmValue::String(arcstr::ArcStr::from(category.as_str())));
-        dict.entry("kind".to_string())
+        dict.entry(crate::value::intern_key("kind"))
             .or_insert_with(|| VmValue::String(arcstr::ArcStr::from(llm_error.kind.as_str())));
-        dict.entry("reason".to_string())
+        dict.entry(crate::value::intern_key("reason"))
             .or_insert_with(|| VmValue::String(arcstr::ArcStr::from(llm_error.reason.as_str())));
-        dict.entry("message".to_string())
+        dict.entry(crate::value::intern_key("message"))
             .or_insert_with(|| VmValue::String(arcstr::ArcStr::from(message.as_str())));
         dict.put_str("provider", provider);
         dict.put_str("model", model);
@@ -604,7 +604,10 @@ fn attach_routing_block(
         "session_cost_usd".to_string(),
         VmValue::Float(trace.session_cost_usd),
     );
-    dict.insert("routing".to_string(), VmValue::dict(routing_dict));
+    dict.insert(
+        crate::value::intern_key("routing"),
+        VmValue::dict(routing_dict),
+    );
     VmValue::dict(dict)
 }
 
@@ -862,22 +865,22 @@ pub(crate) fn rewrite_structured_args(args: Vec<VmValue>) -> Result<Vec<VmValue>
     let retries_alias = options.remove("retries").and_then(|v| v.as_int());
     if let Some(n) = retries_alias {
         options
-            .entry("schema_retries".to_string())
+            .entry(crate::value::intern_key("schema_retries"))
             .or_insert(VmValue::Int(n));
     } else {
         options
-            .entry("schema_retries".to_string())
+            .entry(crate::value::intern_key("schema_retries"))
             .or_insert(VmValue::Int(3));
     }
 
     options
-        .entry("output_schema".to_string())
+        .entry(crate::value::intern_key("output_schema"))
         .or_insert(schema.clone());
     options
-        .entry("json_schema".to_string())
+        .entry(crate::value::intern_key("json_schema"))
         .or_insert(schema.clone());
     options
-        .entry("output_format".to_string())
+        .entry(crate::value::intern_key("output_format"))
         .or_insert_with(|| {
             let mut fmt = std::collections::BTreeMap::new();
             fmt.put_str("kind", "json_schema");
@@ -886,10 +889,10 @@ pub(crate) fn rewrite_structured_args(args: Vec<VmValue>) -> Result<Vec<VmValue>
             VmValue::dict(fmt)
         });
     options
-        .entry("response_format".to_string())
+        .entry(crate::value::intern_key("response_format"))
         .or_insert(VmValue::String(arcstr::ArcStr::from("json")));
     options
-        .entry("output_validation".to_string())
+        .entry(crate::value::intern_key("output_validation"))
         .or_insert(VmValue::String(arcstr::ArcStr::from("error")));
 
     Ok(vec![
@@ -967,7 +970,10 @@ mod schema_stream_abort_retry_tests {
 
     fn options_with_retries(retries: i64) -> crate::value::DictMap {
         let mut opts = crate::value::DictMap::new();
-        opts.insert("schema_retries".to_string(), VmValue::Int(retries));
+        opts.insert(
+            crate::value::intern_key("schema_retries"),
+            VmValue::Int(retries),
+        );
         opts
     }
 
@@ -1003,21 +1009,22 @@ mod schema_stream_abort_retry_tests {
         let chain = VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
             std::sync::Arc::new(crate::value::DictMap::from_iter([
                 (
-                    "provider".to_string(),
+                    crate::value::intern_key("provider"),
                     VmValue::String(arcstr::ArcStr::from("fake")),
                 ),
                 (
-                    "model".to_string(),
+                    crate::value::intern_key("model"),
                     VmValue::String(arcstr::ArcStr::from("fake-stream")),
                 ),
             ])),
         )]));
         let tagged = routing::build_routing_policy(&crate::value::DictMap::from_iter([(
-            "chain".to_string(),
+            crate::value::intern_key("chain"),
             chain,
         )]))
         .expect("routing policy validates");
-        let options = crate::value::DictMap::from_iter([("routing".to_string(), tagged)]);
+        let options =
+            crate::value::DictMap::from_iter([(crate::value::intern_key("routing"), tagged)]);
         routing::extract_routing_policy(Some(&options))
             .expect("routing policy extracts")
             .expect("routing policy present")
@@ -1033,7 +1040,7 @@ mod schema_stream_abort_retry_tests {
         let opts = api::options::base_opts("fake");
         for spelling in ["max_tokens", "MAX_TOKENS", "length", "LENGTH"] {
             let dict = VmValue::dict(crate::value::DictMap::from_iter([(
-                "stop_reason".to_string(),
+                crate::value::intern_key("stop_reason"),
                 VmValue::String(arcstr::ArcStr::from(spelling)),
             )]));
             let errors = structured_output_errors(&dict, &opts);
@@ -1044,7 +1051,7 @@ mod schema_stream_abort_retry_tests {
         }
         // A non-truncation stop_reason must NOT add the token-limit error.
         let dict = VmValue::dict(crate::value::DictMap::from_iter([(
-            "stop_reason".to_string(),
+            crate::value::intern_key("stop_reason"),
             VmValue::String(arcstr::ArcStr::from("stop")),
         )]));
         let errors = structured_output_errors(&dict, &opts);

--- a/crates/harn-vm/src/llm/compass_router.rs
+++ b/crates/harn-vm/src/llm/compass_router.rs
@@ -657,7 +657,12 @@ pub(crate) fn options_to_json(options: &crate::value::DictMap) -> JsonValue {
     JsonValue::Object(
         options
             .iter()
-            .map(|(key, value)| (key.clone(), crate::llm::helpers::vm_value_to_json(value)))
+            .map(|(key, value)| {
+                (
+                    key.to_string(),
+                    crate::llm::helpers::vm_value_to_json(value),
+                )
+            })
             .collect(),
     )
 }

--- a/crates/harn-vm/src/llm/config_builtins.rs
+++ b/crates/harn-vm/src/llm/config_builtins.rs
@@ -185,7 +185,7 @@ fn llm_model_defaults_builtin(args: &[VmValue], _out: &mut String) -> Result<VmV
     let params = llm_config::model_params(&model_id);
     let mut dict = crate::value::DictMap::new();
     for (k, v) in &params {
-        dict.insert(k.clone(), toml_value_to_vm_value(v));
+        dict.insert(crate::value::intern_key(k), toml_value_to_vm_value(v));
     }
     Ok(VmValue::dict(dict))
 }
@@ -223,8 +223,8 @@ fn llm_resolved_options_builtin(args: &[VmValue], _out: &mut String) -> Result<V
 
     let mut out = opts.clone();
     for (k, v) in &defaults {
-        if !out.contains_key(k) {
-            out.insert(k.clone(), toml_value_to_vm_value(v));
+        if !out.contains_key(k.as_str()) {
+            out.insert(crate::value::intern_key(k), toml_value_to_vm_value(v));
         }
     }
     out.put_str("provider", final_provider);
@@ -262,7 +262,7 @@ fn toml_value_to_vm_value(value: &toml::Value) -> VmValue {
         toml::Value::Table(table) => {
             let mut dict = crate::value::DictMap::new();
             for (k, v) in table {
-                dict.insert(k.clone(), toml_value_to_vm_value(v));
+                dict.insert(crate::value::intern_key(k), toml_value_to_vm_value(v));
             }
             VmValue::dict(dict)
         }
@@ -459,7 +459,10 @@ pub(crate) fn llm_provider_status_value() -> VmValue {
                 Err(_) => (false, "missing"),
             }
         };
-        entry.insert("available".to_string(), VmValue::Bool(available));
+        entry.insert(
+            crate::value::intern_key("available"),
+            VmValue::Bool(available),
+        );
         entry.put_str("credential_status", credential_status);
         entries.push(VmValue::dict(entry));
     }
@@ -583,7 +586,10 @@ fn llm_config_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
             let mut dict = crate::value::DictMap::new();
             for name in llm_config::provider_names() {
                 if let Some(pdef) = llm_config::provider_config(&name) {
-                    dict.insert(name.clone(), provider_def_to_vm_value(Some(&name), &pdef));
+                    dict.insert(
+                        crate::value::intern_key(&name),
+                        provider_def_to_vm_value(Some(&name), &pdef),
+                    );
                 }
             }
             Ok(VmValue::dict(dict))
@@ -871,11 +877,11 @@ fn provider_region_value(provider_name: Option<&str>) -> Option<VmValue> {
     let mut region = crate::value::DictMap::new();
     region.put_str("override_key", "region");
     region.insert(
-        "envs".to_string(),
+        crate::value::intern_key("envs"),
         string_list_to_vm_value(envs.iter().map(|s| s.to_string()).collect()),
     );
     region.insert(
-        "resolved".to_string(),
+        crate::value::intern_key("resolved"),
         match resolved {
             Some(value) => VmValue::String(arcstr::ArcStr::from(value)),
             None => VmValue::Nil,
@@ -897,14 +903,14 @@ fn provider_def_to_vm_value(
     dict.put_opt_str("base_url_env", pdef.base_url_env.as_deref());
     dict.put_str("auth_style", pdef.auth_style.as_str());
     dict.insert(
-        "auth_envs".to_string(),
+        crate::value::intern_key("auth_envs"),
         string_list_to_vm_value(llm_config::auth_env_names(&pdef.auth_env)),
     );
     if let Some(region) = provider_region_value(provider_name) {
-        dict.insert("region".to_string(), region);
+        dict.insert(crate::value::intern_key("region"), region);
     }
     dict.insert(
-        "auth_available".to_string(),
+        crate::value::intern_key("auth_available"),
         VmValue::Bool(
             provider_name
                 .map(llm_config::provider_key_available)
@@ -916,20 +922,20 @@ fn provider_def_to_vm_value(
     dict.put_opt_str("command", pdef.command.as_deref());
     if !pdef.args.is_empty() {
         dict.insert(
-            "args".to_string(),
+            crate::value::intern_key("args"),
             string_list_to_vm_value(pdef.args.clone()),
         );
     }
     if !pdef.env.is_empty() {
         dict.insert(
-            "env".to_string(),
+            crate::value::intern_key("env"),
             json_to_vm_value(&serde_json::json!(pdef.env)),
         );
     }
     dict.put_opt_str("cwd", pdef.cwd.as_deref());
     if !pdef.mcp_servers.is_empty() {
         dict.insert(
-            "mcp_servers".to_string(),
+            crate::value::intern_key("mcp_servers"),
             json_to_vm_value(&serde_json::Value::Array(pdef.mcp_servers.clone())),
         );
     }
@@ -937,9 +943,15 @@ fn provider_def_to_vm_value(
     if !pdef.extra_headers.is_empty() {
         let mut headers = crate::value::DictMap::new();
         for (k, v) in &pdef.extra_headers {
-            headers.insert(k.clone(), VmValue::String(arcstr::ArcStr::from(v.as_str())));
+            headers.insert(
+                crate::value::intern_key(k),
+                VmValue::String(arcstr::ArcStr::from(v.as_str())),
+            );
         }
-        dict.insert("extra_headers".to_string(), VmValue::dict(headers));
+        dict.insert(
+            crate::value::intern_key("extra_headers"),
+            VmValue::dict(headers),
+        );
     }
     if !pdef.features.is_empty() {
         let features: Vec<VmValue> = pdef
@@ -948,12 +960,12 @@ fn provider_def_to_vm_value(
             .map(|f| VmValue::String(arcstr::ArcStr::from(f.as_str())))
             .collect();
         dict.insert(
-            "features".to_string(),
+            crate::value::intern_key("features"),
             VmValue::List(std::sync::Arc::new(features)),
         );
     }
     if let Some(rpm) = pdef.rpm {
-        dict.insert("rpm".to_string(), VmValue::Int(rpm as i64));
+        dict.insert(crate::value::intern_key("rpm"), VmValue::Int(rpm as i64));
     }
     let rate_limits = pdef
         .rate_limits
@@ -962,18 +974,27 @@ fn provider_def_to_vm_value(
         .with_rpm_fallback(pdef.rpm);
     if let Some(rate_limits) = rate_limits {
         dict.insert(
-            "rate_limits".to_string(),
+            crate::value::intern_key("rate_limits"),
             rate_limits_to_vm_value(&rate_limits),
         );
     }
     if let Some(cost) = pdef.cost_per_1k_in {
-        dict.insert("cost_per_1k_in".to_string(), VmValue::Float(cost));
+        dict.insert(
+            crate::value::intern_key("cost_per_1k_in"),
+            VmValue::Float(cost),
+        );
     }
     if let Some(cost) = pdef.cost_per_1k_out {
-        dict.insert("cost_per_1k_out".to_string(), VmValue::Float(cost));
+        dict.insert(
+            crate::value::intern_key("cost_per_1k_out"),
+            VmValue::Float(cost),
+        );
     }
     if let Some(latency) = pdef.latency_p50_ms {
-        dict.insert("latency_p50_ms".to_string(), VmValue::Int(latency as i64));
+        dict.insert(
+            crate::value::intern_key("latency_p50_ms"),
+            VmValue::Int(latency as i64),
+        );
     }
     VmValue::dict(dict)
 }
@@ -992,7 +1013,7 @@ fn resolved_model_to_vm_value(resolved: &llm_config::ResolvedModel) -> VmValue {
     dict.put_str("id", resolved.id.as_str());
     dict.put_str("provider", resolved.provider.as_str());
     dict.insert(
-        "alias".to_string(),
+        crate::value::intern_key("alias"),
         resolved
             .alias
             .as_deref()
@@ -1013,23 +1034,23 @@ fn model_info_to_vm_value(resolved: &llm_config::ResolvedModel) -> VmValue {
     };
     let caps = super::capabilities::lookup(&resolved.provider, &resolved.id);
     dict.insert(
-        "capabilities".to_string(),
+        crate::value::intern_key("capabilities"),
         capabilities_to_vm_value(&resolved.provider, &resolved.id, &caps),
     );
     dict.insert(
-        "catalog".to_string(),
+        crate::value::intern_key("catalog"),
         llm_config::model_catalog_entry(&resolved.id)
             .map(|entry| model_def_to_vm_value(&resolved.id, &entry))
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "qc_default_model".to_string(),
+        crate::value::intern_key("qc_default_model"),
         llm_config::qc_default_model(&resolved.provider)
             .map(|model| VmValue::String(arcstr::ArcStr::from(model)))
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "auth_available".to_string(),
+        crate::value::intern_key("auth_available"),
         VmValue::Bool(llm_config::provider_key_available(&resolved.provider)),
     );
     VmValue::dict(dict)
@@ -1043,32 +1064,35 @@ pub(crate) fn capabilities_to_vm_value(
     let mut dict = crate::value::DictMap::new();
     dict.put_str("provider", provider);
     dict.put_str("model", model);
-    dict.insert("native_tools".to_string(), VmValue::Bool(caps.native_tools));
+    dict.insert(
+        crate::value::intern_key("native_tools"),
+        VmValue::Bool(caps.native_tools),
+    );
     dict.put_str("message_wire_format", caps.message_wire_format.clone());
     dict.put_str(
         "native_tool_wire_format",
         caps.native_tool_wire_format.clone(),
     );
     dict.insert(
-        "text_tool_wire_format_supported".to_string(),
+        crate::value::intern_key("text_tool_wire_format_supported"),
         VmValue::Bool(caps.text_tool_wire_format_supported),
     );
     dict.insert(
-        "preferred_tool_format".to_string(),
+        crate::value::intern_key("preferred_tool_format"),
         caps.preferred_tool_format
             .as_deref()
             .map(|format| VmValue::String(arcstr::ArcStr::from(format)))
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "tool_mode_parity".to_string(),
+        crate::value::intern_key("tool_mode_parity"),
         caps.tool_mode_parity
             .as_deref()
             .map(|status| VmValue::String(arcstr::ArcStr::from(status)))
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "tool_mode_parity_notes".to_string(),
+        crate::value::intern_key("tool_mode_parity_notes"),
         caps.tool_mode_parity_notes
             .as_deref()
             .map(|notes| VmValue::String(arcstr::ArcStr::from(notes)))
@@ -1077,50 +1101,56 @@ pub(crate) fn capabilities_to_vm_value(
     // Mirrors the VM's tool-capability gate at llm_config::effective_model_capability_tags:
     // either native or text-format tool calling counts as tool-capable.
     dict.insert(
-        "tools".to_string(),
+        crate::value::intern_key("tools"),
         VmValue::Bool(caps.native_tools || caps.text_tool_wire_format_supported),
     );
     dict.insert(
-        "defer_loading".to_string(),
+        crate::value::intern_key("defer_loading"),
         VmValue::Bool(caps.defer_loading),
     );
     dict.insert(
-        "tool_search".to_string(),
+        crate::value::intern_key("tool_search"),
         string_list_to_vm_value(caps.tool_search.clone()),
     );
     dict.insert(
-        "responses_api".to_string(),
+        crate::value::intern_key("responses_api"),
         VmValue::Bool(caps.responses_api),
     );
     dict.insert(
-        "hosted_tools".to_string(),
+        crate::value::intern_key("hosted_tools"),
         string_list_to_vm_value(caps.hosted_tools.clone()),
     );
-    dict.insert("remote_mcp".to_string(), VmValue::Bool(caps.remote_mcp));
     dict.insert(
-        "conversation_state".to_string(),
+        crate::value::intern_key("remote_mcp"),
+        VmValue::Bool(caps.remote_mcp),
+    );
+    dict.insert(
+        crate::value::intern_key("conversation_state"),
         VmValue::Bool(caps.conversation_state),
     );
-    dict.insert("compaction".to_string(), VmValue::Bool(caps.compaction));
     dict.insert(
-        "background_mode".to_string(),
+        crate::value::intern_key("compaction"),
+        VmValue::Bool(caps.compaction),
+    );
+    dict.insert(
+        crate::value::intern_key("background_mode"),
         VmValue::Bool(caps.background_mode),
     );
     dict.insert(
-        "tool_approval_policy".to_string(),
+        crate::value::intern_key("tool_approval_policy"),
         caps.tool_approval_policy
             .as_deref()
             .map(|value| VmValue::String(arcstr::ArcStr::from(value)))
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "max_tools".to_string(),
+        crate::value::intern_key("max_tools"),
         caps.max_tools
             .map(|n| VmValue::Int(n as i64))
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "prompt_caching".to_string(),
+        crate::value::intern_key("prompt_caching"),
         VmValue::Bool(caps.prompt_caching),
     );
     dict.put_str(
@@ -1128,11 +1158,11 @@ pub(crate) fn capabilities_to_vm_value(
         caps.cache_breakpoint_style.as_str(),
     );
     dict.insert(
-        "prefers_xml_scaffolding".to_string(),
+        crate::value::intern_key("prefers_xml_scaffolding"),
         VmValue::Bool(caps.prefers_xml_scaffolding),
     );
     dict.insert(
-        "prefers_markdown_scaffolding".to_string(),
+        crate::value::intern_key("prefers_markdown_scaffolding"),
         VmValue::Bool(caps.prefers_markdown_scaffolding),
     );
     dict.put_str(
@@ -1140,72 +1170,72 @@ pub(crate) fn capabilities_to_vm_value(
         caps.structured_output_mode.as_str(),
     );
     dict.insert(
-        "supports_assistant_prefill".to_string(),
+        crate::value::intern_key("supports_assistant_prefill"),
         VmValue::Bool(caps.supports_assistant_prefill),
     );
     dict.insert(
-        "prefers_role_developer".to_string(),
+        crate::value::intern_key("prefers_role_developer"),
         VmValue::Bool(caps.prefers_role_developer),
     );
     dict.insert(
-        "prefers_xml_tools".to_string(),
+        crate::value::intern_key("prefers_xml_tools"),
         VmValue::Bool(caps.prefers_xml_tools),
     );
     dict.insert(
-        "thinking".to_string(),
+        crate::value::intern_key("thinking"),
         VmValue::Bool(!caps.thinking_modes.is_empty()),
     );
     dict.put_str("thinking_block_style", caps.thinking_block_style.as_str());
     dict.insert(
-        "thinking_modes".to_string(),
+        crate::value::intern_key("thinking_modes"),
         string_list_to_vm_value(caps.thinking_modes.clone()),
     );
     dict.insert(
-        "interleaved_thinking_supported".to_string(),
+        crate::value::intern_key("interleaved_thinking_supported"),
         VmValue::Bool(caps.interleaved_thinking_supported),
     );
     dict.insert(
-        "anthropic_beta_features".to_string(),
+        crate::value::intern_key("anthropic_beta_features"),
         string_list_to_vm_value(caps.anthropic_beta_features.clone()),
     );
     dict.insert(
-        "vision_supported".to_string(),
+        crate::value::intern_key("vision_supported"),
         VmValue::Bool(caps.vision_supported),
     );
-    dict.insert("audio".to_string(), VmValue::Bool(caps.audio));
-    dict.insert("pdf".to_string(), VmValue::Bool(caps.pdf));
-    dict.insert("video".to_string(), VmValue::Bool(caps.video));
+    dict.insert(crate::value::intern_key("audio"), VmValue::Bool(caps.audio));
+    dict.insert(crate::value::intern_key("pdf"), VmValue::Bool(caps.pdf));
+    dict.insert(crate::value::intern_key("video"), VmValue::Bool(caps.video));
     dict.insert(
-        "files_api_supported".to_string(),
+        crate::value::intern_key("files_api_supported"),
         VmValue::Bool(caps.files_api_supported),
     );
     dict.insert(
-        "file_upload_wire_format".to_string(),
+        crate::value::intern_key("file_upload_wire_format"),
         caps.file_upload_wire_format
             .as_ref()
             .map(|value| VmValue::String(arcstr::ArcStr::from(value.clone())))
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "structured_output".to_string(),
+        crate::value::intern_key("structured_output"),
         caps.structured_output
             .as_deref()
             .map(|value| VmValue::String(arcstr::ArcStr::from(value)))
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "json_schema".to_string(),
+        crate::value::intern_key("json_schema"),
         caps.json_schema
             .as_deref()
             .map(|value| VmValue::String(arcstr::ArcStr::from(value)))
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "prefers_xml_scaffolding".to_string(),
+        crate::value::intern_key("prefers_xml_scaffolding"),
         VmValue::Bool(caps.prefers_xml_scaffolding),
     );
     dict.insert(
-        "prefers_markdown_scaffolding".to_string(),
+        crate::value::intern_key("prefers_markdown_scaffolding"),
         VmValue::Bool(caps.prefers_markdown_scaffolding),
     );
     dict.put_str(
@@ -1213,79 +1243,79 @@ pub(crate) fn capabilities_to_vm_value(
         caps.structured_output_mode.as_str(),
     );
     dict.insert(
-        "supports_assistant_prefill".to_string(),
+        crate::value::intern_key("supports_assistant_prefill"),
         VmValue::Bool(caps.supports_assistant_prefill),
     );
     dict.insert(
-        "prefers_role_developer".to_string(),
+        crate::value::intern_key("prefers_role_developer"),
         VmValue::Bool(caps.prefers_role_developer),
     );
     dict.insert(
-        "prefers_xml_tools".to_string(),
+        crate::value::intern_key("prefers_xml_tools"),
         VmValue::Bool(caps.prefers_xml_tools),
     );
     dict.put_str("thinking_block_style", caps.thinking_block_style.as_str());
     dict.insert(
-        "preserve_thinking".to_string(),
+        crate::value::intern_key("preserve_thinking"),
         VmValue::Bool(caps.preserve_thinking),
     );
     dict.insert(
-        "requires_completion_tokens".to_string(),
+        crate::value::intern_key("requires_completion_tokens"),
         VmValue::Bool(caps.requires_completion_tokens),
     );
     dict.insert(
-        "requires_streaming".to_string(),
+        crate::value::intern_key("requires_streaming"),
         VmValue::Bool(caps.requires_streaming),
     );
     dict.insert(
-        "reasoning_effort_supported".to_string(),
+        crate::value::intern_key("reasoning_effort_supported"),
         VmValue::Bool(caps.reasoning_effort_supported),
     );
     dict.insert(
-        "reasoning_none_supported".to_string(),
+        crate::value::intern_key("reasoning_none_supported"),
         VmValue::Bool(caps.reasoning_none_supported),
     );
     dict.insert(
-        "reasoning_disable_supported".to_string(),
+        crate::value::intern_key("reasoning_disable_supported"),
         VmValue::Bool(caps.reasoning_disable_supported),
     );
     dict.insert(
-        "reasoning_text_promotable".to_string(),
+        crate::value::intern_key("reasoning_text_promotable"),
         VmValue::Bool(caps.reasoning_text_promotable),
     );
     dict.insert(
-        "reasoning_wire_format".to_string(),
+        crate::value::intern_key("reasoning_wire_format"),
         caps.reasoning_wire_format
             .as_ref()
             .map(|value| VmValue::String(arcstr::ArcStr::from(value.clone())))
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "seed_supported".to_string(),
+        crate::value::intern_key("seed_supported"),
         VmValue::Bool(caps.seed_supported),
     );
     dict.insert(
-        "top_k_supported".to_string(),
+        crate::value::intern_key("top_k_supported"),
         VmValue::Bool(caps.top_k_supported),
     );
     dict.insert(
-        "temperature_supported".to_string(),
+        crate::value::intern_key("temperature_supported"),
         VmValue::Bool(caps.temperature_supported),
     );
     dict.insert(
-        "top_p_supported".to_string(),
+        crate::value::intern_key("top_p_supported"),
         VmValue::Bool(caps.top_p_supported),
     );
     dict.insert(
-        "frequency_penalty_supported".to_string(),
+        crate::value::intern_key("frequency_penalty_supported"),
         VmValue::Bool(caps.frequency_penalty_supported),
     );
     dict.insert(
-        "presence_penalty_supported".to_string(),
+        crate::value::intern_key("presence_penalty_supported"),
         VmValue::Bool(caps.presence_penalty_supported),
     );
     dict.insert(
-        "allowed_tool_choice_modes".to_string(),
+        crate::value::intern_key("allowed_tool_choice_modes"),
         VmValue::List(std::sync::Arc::new(
             caps.allowed_tool_choice_modes
                 .iter()
@@ -1294,13 +1324,13 @@ pub(crate) fn capabilities_to_vm_value(
         )),
     );
     dict.insert(
-        "auto_reasoning_overrides".to_string(),
+        crate::value::intern_key("auto_reasoning_overrides"),
         VmValue::dict(
             caps.auto_reasoning_overrides
                 .iter()
                 .map(|(task, mode)| {
                     (
-                        task.clone(),
+                        crate::value::intern_key(task),
                         VmValue::String(arcstr::ArcStr::from(mode.clone())),
                     )
                 })
@@ -1314,7 +1344,7 @@ pub(crate) fn capabilities_to_vm_value(
     // catalog metadata when any tier is declared.
     let fast_mode = super::fast_mode::lookup(model);
     dict.insert(
-        "fast_mode_supported".to_string(),
+        crate::value::intern_key("fast_mode_supported"),
         VmValue::Bool(
             fast_mode
                 .as_ref()
@@ -1327,7 +1357,7 @@ pub(crate) fn capabilities_to_vm_value(
         fast.put_str("param", fast_mode.param.as_str());
         fast.put_str("value", fast_mode.value.as_str());
         fast.insert(
-            "status".to_string(),
+            crate::value::intern_key("status"),
             fast_mode
                 .status
                 .as_deref()
@@ -1335,7 +1365,7 @@ pub(crate) fn capabilities_to_vm_value(
                 .unwrap_or(VmValue::Nil),
         );
         fast.insert(
-            "beta_header".to_string(),
+            crate::value::intern_key("beta_header"),
             fast_mode
                 .beta_header
                 .as_deref()
@@ -1343,13 +1373,13 @@ pub(crate) fn capabilities_to_vm_value(
                 .unwrap_or(VmValue::Nil),
         );
         fast.insert(
-            "otps_speedup".to_string(),
+            crate::value::intern_key("otps_speedup"),
             fast_mode
                 .otps_speedup
                 .map(VmValue::Float)
                 .unwrap_or(VmValue::Nil),
         );
-        dict.insert("fast_mode".to_string(), VmValue::dict(fast));
+        dict.insert(crate::value::intern_key("fast_mode"), VmValue::dict(fast));
     }
     VmValue::dict(dict)
 }
@@ -1360,11 +1390,11 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
     dict.put_str("name", model.name.as_str());
     dict.put_str("provider", model.provider.as_str());
     dict.insert(
-        "context_window".to_string(),
+        crate::value::intern_key("context_window"),
         VmValue::Int(model.context_window as i64),
     );
     dict.insert(
-        "logical_model".to_string(),
+        crate::value::intern_key("logical_model"),
         model
             .logical_model
             .as_deref()
@@ -1372,7 +1402,7 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "equivalence_group".to_string(),
+        crate::value::intern_key("equivalence_group"),
         model
             .equivalence_group
             .as_deref()
@@ -1380,7 +1410,7 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "served_variant".to_string(),
+        crate::value::intern_key("served_variant"),
         model
             .served_variant
             .as_deref()
@@ -1388,7 +1418,7 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "wire_model".to_string(),
+        crate::value::intern_key("wire_model"),
         model
             .wire_model
             .as_deref()
@@ -1396,7 +1426,7 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "api_dialect".to_string(),
+        crate::value::intern_key("api_dialect"),
         model
             .api_dialect
             .as_deref()
@@ -1404,7 +1434,7 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "rate_limits".to_string(),
+        crate::value::intern_key("rate_limits"),
         model
             .rate_limits
             .as_ref()
@@ -1413,7 +1443,7 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "architecture".to_string(),
+        crate::value::intern_key("architecture"),
         model
             .architecture
             .as_ref()
@@ -1422,34 +1452,37 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "runtime_context_window".to_string(),
+        crate::value::intern_key("runtime_context_window"),
         model
             .runtime_context_window
             .map(|window| VmValue::Int(window as i64))
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "stream_timeout".to_string(),
+        crate::value::intern_key("stream_timeout"),
         model
             .stream_timeout
             .map(VmValue::Float)
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "capabilities".to_string(),
+        crate::value::intern_key("capabilities"),
         string_list_to_vm_value(model.capabilities.clone()),
     );
     dict.insert(
-        "pricing".to_string(),
+        crate::value::intern_key("pricing"),
         model
             .pricing
             .as_ref()
             .map(pricing_to_vm_value)
             .unwrap_or(VmValue::Nil),
     );
-    dict.insert("deprecated".to_string(), VmValue::Bool(model.deprecated));
     dict.insert(
-        "deprecation_note".to_string(),
+        crate::value::intern_key("deprecated"),
+        VmValue::Bool(model.deprecated),
+    );
+    dict.insert(
+        crate::value::intern_key("deprecation_note"),
         model
             .deprecation_note
             .as_deref()
@@ -1457,7 +1490,7 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "superseded_by".to_string(),
+        crate::value::intern_key("superseded_by"),
         model
             .superseded_by
             .as_deref()
@@ -1465,37 +1498,40 @@ fn model_def_to_vm_value(id: &str, model: &llm_config::ModelDef) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "quality_tags".to_string(),
+        crate::value::intern_key("quality_tags"),
         string_list_to_vm_value(model.quality_tags.clone()),
     );
     dict.put_str("family", llm_config::model_family(&model.provider, id));
     dict.put_str("lineage", llm_config::model_lineage(&model.provider, id));
     dict.insert(
-        "complementary_with".to_string(),
+        crate::value::intern_key("complementary_with"),
         string_list_to_vm_value(model.complementary_with.clone()),
     );
     dict.insert(
-        "avoid_as_reviewer_for".to_string(),
+        crate::value::intern_key("avoid_as_reviewer_for"),
         string_list_to_vm_value(model.avoid_as_reviewer_for.clone()),
     );
     dict.put_str("availability", model.availability.as_str());
     dict.put_str("tier", llm_config::model_tier(id));
     dict.insert(
-        "open_weight".to_string(),
+        crate::value::intern_key("open_weight"),
         model.open_weight.map(VmValue::Bool).unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "strengths".to_string(),
+        crate::value::intern_key("strengths"),
         string_list_to_vm_value(model.strengths.clone()),
     );
     let benchmarks: crate::value::DictMap = model
         .benchmarks
         .iter()
-        .map(|(key, value)| (key.clone(), VmValue::Float(*value)))
+        .map(|(key, value)| (crate::value::intern_key(key), VmValue::Float(*value)))
         .collect();
-    dict.insert("benchmarks".to_string(), VmValue::dict(benchmarks));
     dict.insert(
-        "fast_mode".to_string(),
+        crate::value::intern_key("benchmarks"),
+        VmValue::dict(benchmarks),
+    );
+    dict.insert(
+        crate::value::intern_key("fast_mode"),
         model
             .fast_mode
             .as_ref()
@@ -1516,22 +1552,22 @@ fn architecture_to_vm_value(architecture: &llm_config::ModelArchitectureDef) -> 
 fn pricing_to_vm_value(pricing: &llm_config::ModelPricing) -> VmValue {
     let mut dict = crate::value::DictMap::new();
     dict.insert(
-        "input_per_mtok".to_string(),
+        crate::value::intern_key("input_per_mtok"),
         VmValue::Float(pricing.input_per_mtok),
     );
     dict.insert(
-        "output_per_mtok".to_string(),
+        crate::value::intern_key("output_per_mtok"),
         VmValue::Float(pricing.output_per_mtok),
     );
     dict.insert(
-        "cache_read_per_mtok".to_string(),
+        crate::value::intern_key("cache_read_per_mtok"),
         pricing
             .cache_read_per_mtok
             .map(VmValue::Float)
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "cache_write_per_mtok".to_string(),
+        crate::value::intern_key("cache_write_per_mtok"),
         pricing
             .cache_write_per_mtok
             .map(VmValue::Float)
@@ -1545,34 +1581,34 @@ fn fast_mode_to_vm_value(fast: &llm_config::FastModeDef) -> VmValue {
     dict.put_str("param", fast.param.as_str());
     dict.put_str("value", fast.value.as_str());
     dict.insert(
-        "beta_header".to_string(),
+        crate::value::intern_key("beta_header"),
         fast.beta_header
             .as_deref()
             .map(|header| VmValue::String(arcstr::ArcStr::from(header)))
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "otps_speedup".to_string(),
+        crate::value::intern_key("otps_speedup"),
         fast.otps_speedup
             .map(VmValue::Float)
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "status".to_string(),
+        crate::value::intern_key("status"),
         fast.status
             .as_deref()
             .map(|status| VmValue::String(arcstr::ArcStr::from(status)))
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "pricing".to_string(),
+        crate::value::intern_key("pricing"),
         fast.pricing
             .as_ref()
             .map(pricing_to_vm_value)
             .unwrap_or(VmValue::Nil),
     );
     dict.insert(
-        "note".to_string(),
+        crate::value::intern_key("note"),
         fast.note
             .as_deref()
             .map(|note| VmValue::String(arcstr::ArcStr::from(note)))
@@ -1596,15 +1632,15 @@ fn provider_catalog_to_vm_value() -> VmValue {
         }
     }
     dict.insert(
-        "providers".to_string(),
+        crate::value::intern_key("providers"),
         VmValue::List(std::sync::Arc::new(providers)),
     );
     dict.insert(
-        "known_model_names".to_string(),
+        crate::value::intern_key("known_model_names"),
         string_list_to_vm_value(llm_config::known_model_names()),
     );
     dict.insert(
-        "available_providers".to_string(),
+        crate::value::intern_key("available_providers"),
         string_list_to_vm_value(llm_config::available_provider_names()),
     );
     let aliases = llm_config::alias_entries()
@@ -1612,7 +1648,7 @@ fn provider_catalog_to_vm_value() -> VmValue {
         .map(|(name, alias)| alias_def_to_vm_value(&name, &alias))
         .collect();
     dict.insert(
-        "aliases".to_string(),
+        crate::value::intern_key("aliases"),
         VmValue::List(std::sync::Arc::new(aliases)),
     );
     let models = llm_config::model_catalog_entries()
@@ -1620,14 +1656,22 @@ fn provider_catalog_to_vm_value() -> VmValue {
         .map(|(id, model)| model_def_to_vm_value(&id, &model))
         .collect();
     dict.insert(
-        "models".to_string(),
+        crate::value::intern_key("models"),
         VmValue::List(std::sync::Arc::new(models)),
     );
     let qc_defaults = llm_config::qc_defaults()
         .into_iter()
-        .map(|(provider, model)| (provider, VmValue::String(arcstr::ArcStr::from(model))))
+        .map(|(provider, model)| {
+            (
+                crate::value::intern_key(&provider),
+                VmValue::String(arcstr::ArcStr::from(model)),
+            )
+        })
         .collect::<crate::value::DictMap>();
-    dict.insert("qc_defaults".to_string(), VmValue::dict(qc_defaults));
+    dict.insert(
+        crate::value::intern_key("qc_defaults"),
+        VmValue::dict(qc_defaults),
+    );
 
     VmValue::dict(dict)
 }
@@ -1638,7 +1682,7 @@ fn alias_def_to_vm_value(name: &str, alias: &llm_config::AliasDef) -> VmValue {
     dict.put_str("id", alias.id.as_str());
     dict.put_str("provider", alias.provider.as_str());
     dict.insert(
-        "tool_format".to_string(),
+        crate::value::intern_key("tool_format"),
         alias
             .tool_format
             .as_deref()
@@ -1676,7 +1720,7 @@ fn readiness_result(readiness: &super::ModelReadiness) -> VmValue {
     meta.put_str("provider", readiness.provider.as_str());
     meta.put_str("model", readiness.model.as_str());
     meta.insert(
-        "url".to_string(),
+        crate::value::intern_key("url"),
         readiness
             .url
             .as_ref()
@@ -1684,14 +1728,14 @@ fn readiness_result(readiness: &super::ModelReadiness) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     meta.insert(
-        "status".to_string(),
+        crate::value::intern_key("status"),
         readiness
             .status
             .map(|status| VmValue::Int(status as i64))
             .unwrap_or(VmValue::Nil),
     );
     meta.insert(
-        "available_models".to_string(),
+        crate::value::intern_key("available_models"),
         VmValue::List(std::sync::Arc::new(
             readiness
                 .available_models
@@ -1710,9 +1754,9 @@ fn healthcheck_result_with_meta(
     meta: crate::value::DictMap,
 ) -> VmValue {
     let mut dict = crate::value::DictMap::new();
-    dict.insert("valid".to_string(), VmValue::Bool(valid));
+    dict.insert(crate::value::intern_key("valid"), VmValue::Bool(valid));
     dict.put_str("message", message);
-    dict.insert("metadata".to_string(), VmValue::dict(meta));
+    dict.insert(crate::value::intern_key("metadata"), VmValue::dict(meta));
     VmValue::dict(dict)
 }
 
@@ -1723,7 +1767,7 @@ mod tests {
     fn build_dict(entries: Vec<(&str, VmValue)>) -> VmValue {
         let mut map = crate::value::DictMap::new();
         for (k, v) in entries {
-            map.insert(k.to_string(), v);
+            map.insert(crate::value::intern_key(k), v);
         }
         VmValue::dict(map)
     }

--- a/crates/harn-vm/src/llm/conversation.rs
+++ b/crates/harn-vm/src/llm/conversation.rs
@@ -455,7 +455,7 @@ pub(crate) fn register_conversation_builtins(vm: &mut Vm) {
             _ => crate::value::DictMap::new(),
         };
         compacted.insert(
-            "archived_messages".to_string(),
+            crate::value::intern_key("archived_messages"),
             VmValue::Int(archived_count as i64),
         );
         Ok(VmValue::dict(compacted))
@@ -680,13 +680,13 @@ fn transcript_inject_reminder_builtin(args: &[VmValue]) -> Result<VmValue, VmErr
     );
 
     Ok(VmValue::dict(crate::value::DictMap::from_iter([
-        ("transcript".to_string(), next),
+        (crate::value::intern_key("transcript"), next),
         (
-            "reminder_id".to_string(),
+            crate::value::intern_key("reminder_id"),
             VmValue::String(arcstr::ArcStr::from(reminder_id)),
         ),
         (
-            "deduped_count".to_string(),
+            crate::value::intern_key("deduped_count"),
             VmValue::Int(deduped_reminder_ids.len() as i64),
         ),
     ])))
@@ -736,8 +736,11 @@ fn transcript_clear_reminders_builtin(args: &[VmValue]) -> Result<VmValue, VmErr
     }
 
     Ok(VmValue::dict(crate::value::DictMap::from_iter([
-        ("transcript".to_string(), next),
-        ("removed_count".to_string(), VmValue::Int(removed_count)),
+        (crate::value::intern_key("transcript"), next),
+        (
+            crate::value::intern_key("removed_count"),
+            VmValue::Int(removed_count),
+        ),
     ])))
 }
 
@@ -769,7 +772,7 @@ fn ensure_known_reminder_keys(
     let unknown = options
         .keys()
         .filter(|key| !allowed.contains(&key.as_str()))
-        .map(String::as_str)
+        .map(|key| key.as_str())
         .collect::<Vec<_>>();
     if unknown.is_empty() {
         Ok(())
@@ -1047,7 +1050,7 @@ mod tests {
         VmValue::dict(
             entries
                 .into_iter()
-                .map(|(key, value)| (key.to_string(), value))
+                .map(|(key, value)| (crate::value::intern_key(key), value))
                 .collect::<crate::value::DictMap>(),
         )
     }

--- a/crates/harn-vm/src/llm/cost_route.rs
+++ b/crates/harn-vm/src/llm/cost_route.rs
@@ -35,7 +35,7 @@ fn route_policy_dict(
         dict.put_str("target", target);
     }
     if let Some(prefer) = prefer {
-        dict.insert("prefer".to_string(), prefer);
+        dict.insert(crate::value::intern_key("prefer"), prefer);
     }
     if let Some(strategy) = strategy {
         dict.put_str("strategy", strategy);
@@ -52,12 +52,12 @@ fn merge_budget_aliases(options: &mut crate::value::DictMap) {
         _ => crate::value::DictMap::new(),
     };
     budget
-        .entry("max_cost_usd".to_string())
+        .entry(crate::value::intern_key("max_cost_usd"))
         .or_insert(budget_usd.clone());
     options
-        .entry("max_cost_usd".to_string())
+        .entry(crate::value::intern_key("max_cost_usd"))
         .or_insert(budget_usd);
-    options.insert("budget".to_string(), VmValue::dict(budget));
+    options.insert(crate::value::intern_key("budget"), VmValue::dict(budget));
 }
 
 fn normalize_config(mut config: crate::value::DictMap) -> crate::value::DictMap {
@@ -69,7 +69,7 @@ fn normalize_config(mut config: crate::value::DictMap) -> crate::value::DictMap 
     if let Some(prefer) = config.get("prefer").cloned() {
         let strategy = strategy_text(&config).unwrap_or_else(|| "prefer_order".to_string());
         config.insert(
-            "route_policy".to_string(),
+            crate::value::intern_key("route_policy"),
             route_policy_dict("preference_list", None, Some(prefer), Some(strategy)),
         );
         return config;
@@ -84,7 +84,7 @@ fn normalize_config(mut config: crate::value::DictMap) -> crate::value::DictMap 
         };
         if let Some(mode) = mode {
             config.insert(
-                "route_policy".to_string(),
+                crate::value::intern_key("route_policy"),
                 route_policy_dict(mode, Some(quality_text(&config)), None, None),
             );
         }
@@ -98,7 +98,7 @@ fn merge_budget(inherited: Option<&VmValue>, explicit: Option<&VmValue>) -> Opti
         Some(VmValue::Dict(dict)) => dict.as_ref().clone(),
         Some(value) => {
             let mut dict = crate::value::DictMap::new();
-            dict.insert("max_cost_usd".to_string(), value.clone());
+            dict.insert(crate::value::intern_key("max_cost_usd"), value.clone());
             dict
         }
         None => crate::value::DictMap::new(),
@@ -108,7 +108,7 @@ fn merge_budget(inherited: Option<&VmValue>, explicit: Option<&VmValue>) -> Opti
             merged.insert(key.clone(), value.clone());
         }
     } else if let Some(value) = explicit {
-        merged.insert("max_cost_usd".to_string(), value.clone());
+        merged.insert(crate::value::intern_key("max_cost_usd"), value.clone());
     }
     (!merged.is_empty()).then(|| VmValue::dict(merged))
 }
@@ -139,7 +139,7 @@ pub(crate) fn merge_context_options(
             merged.insert(key, value);
         }
         if let Some(budget) = budget {
-            merged.insert("budget".to_string(), budget);
+            merged.insert(crate::value::intern_key("budget"), budget);
         }
     }
     Some(merged)

--- a/crates/harn-vm/src/llm/helpers/mod.rs
+++ b/crates/harn-vm/src/llm/helpers/mod.rs
@@ -60,7 +60,7 @@ pub(super) const TRANSCRIPT_VERSION: i64 = 2;
 pub(crate) fn vm_value_dict_to_json(dict: &crate::value::DictMap) -> serde_json::Value {
     let mut map = serde_json::Map::new();
     for (k, v) in dict {
-        map.insert(k.clone(), vm_value_to_json(v));
+        map.insert(k.to_string(), vm_value_to_json(v));
     }
     serde_json::Value::Object(map)
 }
@@ -166,7 +166,7 @@ mod tests {
         // to the openrouter provider. With LOCAL_LLM_BASE_URL set the
         // pre-fix code would have returned "local".
         let opts = Some(crate::value::DictMap::from_iter([(
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("anthropic/claude-sonnet-4-6")),
         )]));
         assert_eq!(vm_resolve_provider(&opts), "openrouter");
@@ -174,7 +174,7 @@ mod tests {
         // An unknown id with no catalog hit still falls into "local"
         // so users with a custom local server keep working.
         let opts_unknown = Some(crate::value::DictMap::from_iter([(
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("my-custom-local-tag")),
         )]));
         assert_eq!(vm_resolve_provider(&opts_unknown), "local");
@@ -204,15 +204,15 @@ mod tests {
     fn vm_messages_to_json_preserves_tool_message_fields() {
         let message = VmValue::dict(crate::value::DictMap::from_iter([
             (
-                "role".to_string(),
+                crate::value::intern_key("role"),
                 VmValue::String(arcstr::ArcStr::from("tool")),
             ),
             (
-                "tool_call_id".to_string(),
+                crate::value::intern_key("tool_call_id"),
                 VmValue::String(arcstr::ArcStr::from("call_123")),
             ),
             (
-                "content".to_string(),
+                crate::value::intern_key("content"),
                 VmValue::String(arcstr::ArcStr::from("ok")),
             ),
         ]));
@@ -235,7 +235,7 @@ mod tests {
 
         let transcript = new_transcript_with(None, Vec::new(), None, None);
         let options = VmValue::dict(crate::value::DictMap::from_iter([(
-            "transcript".to_string(),
+            crate::value::intern_key("transcript"),
             transcript,
         )]));
         let err = extract_llm_options(&[
@@ -283,7 +283,7 @@ mod tests {
         reset_provider_key_cache();
 
         let options = Some(crate::value::DictMap::from_iter([(
-            "model_tier".to_string(),
+            crate::value::intern_key("model_tier"),
             VmValue::String(arcstr::ArcStr::from("small")),
         )]));
         let provider = vm_resolve_provider(&options);
@@ -328,7 +328,7 @@ mod tests {
         reset_provider_key_cache();
 
         let options = Some(crate::value::DictMap::from_iter([(
-            "model_tier".to_string(),
+            crate::value::intern_key("model_tier"),
             VmValue::String(arcstr::ArcStr::from("small")),
         )]));
         let provider = vm_resolve_provider(&options);
@@ -455,11 +455,11 @@ mod tests {
 
         let opts = crate::value::DictMap::from_iter([
             (
-                "provider".to_string(),
+                crate::value::intern_key("provider"),
                 VmValue::String(arcstr::ArcStr::from("auto")),
             ),
             (
-                "model".to_string(),
+                crate::value::intern_key("model"),
                 VmValue::String(arcstr::ArcStr::from("unclassified-provider-model-for-test")),
             ),
         ]);

--- a/crates/harn-vm/src/llm/helpers/opt_get.rs
+++ b/crates/harn-vm/src/llm/helpers/opt_get.rs
@@ -38,7 +38,7 @@ mod tests {
     #[test]
     fn opt_str_treats_nil_as_unset() {
         let mut options = crate::value::DictMap::new();
-        options.insert("path".to_string(), VmValue::Nil);
+        options.insert(crate::value::intern_key("path"), VmValue::Nil);
 
         assert_eq!(opt_str(&Some(options), "path"), None);
     }

--- a/crates/harn-vm/src/llm/helpers/options/defaults.rs
+++ b/crates/harn-vm/src/llm/helpers/options/defaults.rs
@@ -37,15 +37,18 @@ pub(super) fn apply_active_step_defaults(options: &mut Option<crate::value::Dict
             };
             if let Some(max_tokens) = max_tokens {
                 step_budget_dict
-                    .entry("max_output_tokens".to_string())
+                    .entry(crate::value::intern_key("max_output_tokens"))
                     .or_insert_with(|| VmValue::Int(max_tokens as i64));
             }
             if let Some(max_usd) = max_usd {
                 step_budget_dict
-                    .entry("max_cost_usd".to_string())
+                    .entry(crate::value::intern_key("max_cost_usd"))
                     .or_insert_with(|| VmValue::Float(max_usd));
             }
-            opts.insert("budget".to_string(), VmValue::dict(step_budget_dict));
+            opts.insert(
+                crate::value::intern_key("budget"),
+                VmValue::dict(step_budget_dict),
+            );
         }
     }
 }
@@ -63,7 +66,7 @@ pub(super) fn toml_value_to_vm_value(value: &toml::Value) -> VmValue {
         toml::Value::Table(table) => VmValue::dict(
             table
                 .iter()
-                .map(|(key, value)| (key.clone(), toml_value_to_vm_value(value)))
+                .map(|(key, value)| (crate::value::intern_key(key), toml_value_to_vm_value(value)))
                 .collect::<crate::value::DictMap>(),
         ),
     }
@@ -92,7 +95,7 @@ pub(super) fn apply_model_role_defaults(options: &mut Option<crate::value::DictM
         if key == "model_role" || key == "role" {
             continue;
         }
-        opts.entry(key)
+        opts.entry(crate::value::intern_key(&key))
             .or_insert_with(|| toml_value_to_vm_value(&value));
     }
 }

--- a/crates/harn-vm/src/llm/helpers/options/extract.rs
+++ b/crates/harn-vm/src/llm/helpers/options/extract.rs
@@ -558,7 +558,7 @@ pub(crate) fn extract_llm_options(
 
     let provider_overrides = options
         .as_ref()
-        .and_then(|o| o.get(&provider))
+        .and_then(|o| o.get(provider.as_str()))
         .and_then(|v| v.as_dict())
         .map(vm_value_dict_to_json);
     let previous_response_id =
@@ -849,7 +849,7 @@ mod cache_default_tests {
     #[test]
     fn explicit_cache_false_opts_out_on_supporting_route() {
         let mut options = caching_route();
-        options.insert("cache".to_string(), VmValue::Bool(false));
+        options.put("cache", VmValue::Bool(false));
         assert!(
             !opts_with(options).cache,
             "explicit `cache: false` must opt out"
@@ -862,7 +862,7 @@ mod cache_default_tests {
         // on a route that cannot cache surfaces a loud error rather than a
         // silent no-op (unchanged behavior).
         let mut options = non_caching_route();
-        options.insert("cache".to_string(), VmValue::Bool(true));
+        options.put("cache", VmValue::Bool(true));
         assert!(
             try_opts_with(options).is_err(),
             "explicit `cache: true` on a non-supporting route must error"

--- a/crates/harn-vm/src/llm/helpers/options/output_format_tests.rs
+++ b/crates/harn-vm/src/llm/helpers/options/output_format_tests.rs
@@ -7,15 +7,17 @@ fn parses_explicit_json_schema_output_format() {
     let mut fmt = crate::value::DictMap::new();
     fmt.put_str("kind", "json_schema");
     fmt.insert(
-        "schema".to_string(),
+        crate::value::intern_key("schema"),
         VmValue::dict(crate::value::DictMap::from_iter([(
-            "type".to_string(),
+            crate::value::intern_key("type"),
             VmValue::String(arcstr::ArcStr::from("object")),
         )])),
     );
-    fmt.insert("strict".to_string(), VmValue::Bool(false));
-    let options =
-        crate::value::DictMap::from_iter([("output_format".to_string(), VmValue::dict(fmt))]);
+    fmt.insert(crate::value::intern_key("strict"), VmValue::Bool(false));
+    let options = crate::value::DictMap::from_iter([(
+        crate::value::intern_key("output_format"),
+        VmValue::dict(fmt),
+    )]);
 
     let parsed = parse_output_format_option(Some(&options), None, None).expect("output_format");
 

--- a/crates/harn-vm/src/llm/helpers/options/routing_tests.rs
+++ b/crates/harn-vm/src/llm/helpers/options/routing_tests.rs
@@ -151,7 +151,7 @@ fn extract_with_policy(policy: &str) -> crate::llm::api::LlmCallOptions {
     let mut options = crate::value::DictMap::new();
     options.put_str("route_policy", policy);
     options.insert(
-        "fallback_chain".to_string(),
+        crate::value::intern_key("fallback_chain"),
         VmValue::List(std::sync::Arc::new(vec![VmValue::String(
             arcstr::ArcStr::from("fast".to_string()),
         )])),
@@ -193,7 +193,7 @@ fn extract_with_options(
 
 fn model_role_options(role: &str) -> crate::value::DictMap {
     crate::value::DictMap::from_iter([(
-        "model_role".to_string(),
+        crate::value::intern_key("model_role"),
         VmValue::String(arcstr::ArcStr::from(role.to_string())),
     )])
 }
@@ -272,7 +272,7 @@ fn explicit_options_win_over_model_role_defaults() {
 
     let mut options = model_role_options("merge");
     options.put_str("model", "mock-explicit");
-    options.insert("max_tokens".to_string(), VmValue::Int(512));
+    options.insert(crate::value::intern_key("max_tokens"), VmValue::Int(512));
     let opts = extract_with_options(options).expect("options");
 
     assert_eq!(opts.provider, "mock");
@@ -406,7 +406,7 @@ fn model_role_config_keys_normalize_like_call_options() {
 fn fast_options(model: &str) -> crate::value::DictMap {
     let mut options = crate::value::DictMap::new();
     options.put_str("model", model);
-    options.insert("fast".to_string(), VmValue::Bool(true));
+    options.insert(crate::value::intern_key("fast"), VmValue::Bool(true));
     options
 }
 
@@ -465,14 +465,17 @@ fn preference_list_cheapest_first_sets_route_fallbacks() {
     policy.put_str("mode", "preference_list");
     policy.put_str("strategy", "cheapest_first");
     policy.insert(
-        "prefer".to_string(),
+        crate::value::intern_key("prefer"),
         VmValue::List(std::sync::Arc::new(vec![
             VmValue::String(arcstr::ArcStr::from("fast-mid")),
             VmValue::String(arcstr::ArcStr::from("cheap-mid")),
         ])),
     );
     let mut options = crate::value::DictMap::new();
-    options.insert("route_policy".to_string(), VmValue::dict(policy));
+    options.insert(
+        crate::value::intern_key("route_policy"),
+        VmValue::dict(policy),
+    );
     let opts = extract_llm_options(&[
         VmValue::String(arcstr::ArcStr::from("hello".to_string())),
         VmValue::Nil,
@@ -493,17 +496,20 @@ fn preference_list_cheapest_first_sets_route_fallbacks() {
 fn equivalent_failover_builds_catalog_backed_routing_policy() {
     install_equivalent_routes();
     let mut failover = crate::value::DictMap::new();
-    failover.insert("max_routes".to_string(), VmValue::Int(2));
+    failover.insert(crate::value::intern_key("max_routes"), VmValue::Int(2));
     let opts = extract_with_options(crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("primary")),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("primary-model")),
         ),
-        ("equivalent_failover".to_string(), VmValue::dict(failover)),
+        (
+            crate::value::intern_key("equivalent_failover"),
+            VmValue::dict(failover),
+        ),
     ]))
     .expect("options");
 
@@ -531,18 +537,24 @@ fn equivalent_failover_builds_catalog_backed_routing_policy() {
 fn equivalent_failover_enables_no_dispatch_failover_when_requested() {
     install_equivalent_routes();
     let mut failover = crate::value::DictMap::new();
-    failover.insert("max_routes".to_string(), VmValue::Int(2));
-    failover.insert("on_no_dispatch".to_string(), VmValue::Bool(true));
+    failover.insert(crate::value::intern_key("max_routes"), VmValue::Int(2));
+    failover.insert(
+        crate::value::intern_key("on_no_dispatch"),
+        VmValue::Bool(true),
+    );
     let opts = extract_with_options(crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("primary")),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("primary-model")),
         ),
-        ("equivalent_failover".to_string(), VmValue::dict(failover)),
+        (
+            crate::value::intern_key("equivalent_failover"),
+            VmValue::dict(failover),
+        ),
     ]))
     .expect("options");
 
@@ -559,20 +571,23 @@ fn equivalent_failover_rejects_non_bool_no_dispatch_option() {
     install_equivalent_routes();
     let mut failover = crate::value::DictMap::new();
     failover.insert(
-        "on_no_dispatch".to_string(),
+        crate::value::intern_key("on_no_dispatch"),
         VmValue::String(arcstr::ArcStr::from("yes")),
     );
 
     let err = match extract_with_options(crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("primary")),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("primary-model")),
         ),
-        ("equivalent_failover".to_string(), VmValue::dict(failover)),
+        (
+            crate::value::intern_key("equivalent_failover"),
+            VmValue::dict(failover),
+        ),
     ])) {
         Ok(_) => panic!("non-bool on_no_dispatch should fail"),
         Err(err) => err,
@@ -598,32 +613,35 @@ fn equivalent_failover_rejects_explicit_routing_policy() {
     let chain = VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
         std::sync::Arc::new(crate::value::DictMap::from_iter([
             (
-                "provider".to_string(),
+                crate::value::intern_key("provider"),
                 VmValue::String(arcstr::ArcStr::from("primary")),
             ),
             (
-                "model".to_string(),
+                crate::value::intern_key("model"),
                 VmValue::String(arcstr::ArcStr::from("primary-model")),
             ),
         ])),
     )]));
     let routing = crate::llm::routing::build_routing_policy(&crate::value::DictMap::from_iter([(
-        "chain".to_string(),
+        crate::value::intern_key("chain"),
         chain,
     )]))
     .expect("routing policy");
 
     let err = match extract_with_options(crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("primary")),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("primary-model")),
         ),
-        ("routing".to_string(), routing),
-        ("equivalent_failover".to_string(), VmValue::Bool(true)),
+        (crate::value::intern_key("routing"), routing),
+        (
+            crate::value::intern_key("equivalent_failover"),
+            VmValue::Bool(true),
+        ),
     ])) {
         Ok(_) => panic!("ambiguous routing should fail"),
         Err(err) => err,
@@ -656,9 +674,9 @@ fn thinking_dict_enabled_false_disables_thinking() {
     options.put_str("provider", "mock");
     options.put_str("model", "gpt-5.4");
     options.insert(
-        "thinking".to_string(),
+        crate::value::intern_key("thinking"),
         VmValue::dict(crate::value::DictMap::from_iter([(
-            "enabled".to_string(),
+            crate::value::intern_key("enabled"),
             VmValue::Bool(false),
         )])),
     );
@@ -677,13 +695,16 @@ fn thinking_dict_enabled_budget_parses_typed_config() {
     options.put_str("provider", "mock");
     options.put_str("model", "claude-opus-4-6");
     options.insert(
-        "thinking".to_string(),
+        crate::value::intern_key("thinking"),
         VmValue::dict(crate::value::DictMap::from_iter([
             (
-                "mode".to_string(),
+                crate::value::intern_key("mode"),
                 VmValue::String(arcstr::ArcStr::from("enabled".to_string())),
             ),
-            ("budget_tokens".to_string(), VmValue::Int(8000)),
+            (
+                crate::value::intern_key("budget_tokens"),
+                VmValue::Int(8000),
+            ),
         ])),
     );
     let opts = extract_llm_options(&[
@@ -710,7 +731,7 @@ fn anthropic_beta_features_parse_and_dedupe_with_interleaved_flag() {
     options.put_str("provider", "mock");
     options.put_str("model", "claude-opus-4-6");
     options.insert(
-        "anthropic_beta_features".to_string(),
+        crate::value::intern_key("anthropic_beta_features"),
         VmValue::List(std::sync::Arc::new(vec![
             VmValue::String(arcstr::ArcStr::from(
                 "fine-grained-tool-streaming-2025-05-14",
@@ -720,7 +741,10 @@ fn anthropic_beta_features_parse_and_dedupe_with_interleaved_flag() {
             )),
         ])),
     );
-    options.insert("interleaved_thinking".to_string(), VmValue::Bool(true));
+    options.insert(
+        crate::value::intern_key("interleaved_thinking"),
+        VmValue::Bool(true),
+    );
 
     let opts = extract_llm_options(&[
         VmValue::String(arcstr::ArcStr::from("hello".to_string())),
@@ -741,15 +765,15 @@ fn anthropic_beta_features_parse_and_dedupe_with_interleaved_flag() {
 fn anthropic_beta_features_reject_invalid_header_names() {
     let options = crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("mock".to_string())),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("claude-opus-4-6".to_string())),
         ),
         (
-            "anthropic_beta_features".to_string(),
+            crate::value::intern_key("anthropic_beta_features"),
             VmValue::String(arcstr::ArcStr::from("bad\r\nheader".to_string())),
         ),
     ]);
@@ -771,14 +795,14 @@ fn thinking_effort_parses_typed_level() {
     options.put_str("provider", "mock");
     options.put_str("model", "o3");
     options.insert(
-        "thinking".to_string(),
+        crate::value::intern_key("thinking"),
         VmValue::dict(crate::value::DictMap::from_iter([
             (
-                "mode".to_string(),
+                crate::value::intern_key("mode"),
                 VmValue::String(arcstr::ArcStr::from("effort".to_string())),
             ),
             (
-                "level".to_string(),
+                crate::value::intern_key("level"),
                 VmValue::String(arcstr::ArcStr::from("high".to_string())),
             ),
         ])),
@@ -800,16 +824,16 @@ fn thinking_effort_parses_typed_level() {
 fn unsupported_local_options(extra: Vec<(&str, VmValue)>) -> VmError {
     let mut options = crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("local".to_string())),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("unsupported-model".to_string())),
         ),
     ]);
     for (key, value) in extra {
-        options.insert(key.to_string(), value);
+        options.insert(crate::value::intern_key(key), value);
     }
     match extract_llm_options(&[
         VmValue::String(arcstr::ArcStr::from("hello".to_string())),
@@ -840,15 +864,15 @@ fn one_tool_list() -> VmValue {
     VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
         std::sync::Arc::new(crate::value::DictMap::from_iter([
             (
-                "name".to_string(),
+                crate::value::intern_key("name"),
                 VmValue::String(arcstr::ArcStr::from("lookup")),
             ),
             (
-                "description".to_string(),
+                crate::value::intern_key("description"),
                 VmValue::String(arcstr::ArcStr::from("Look something up")),
             ),
             (
-                "parameters".to_string(),
+                crate::value::intern_key("parameters"),
                 VmValue::dict(crate::value::DictMap::new()),
             ),
         ])),
@@ -929,15 +953,15 @@ fn tool_choice_accepted_on_text_tool_routes() {
 
     let options = crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("ollama".to_string())),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("devstral-small-2:24b".to_string())),
         ),
         (
-            "tool_choice".to_string(),
+            crate::value::intern_key("tool_choice"),
             VmValue::String(arcstr::ArcStr::from("none".to_string())),
         ),
     ]);
@@ -957,18 +981,18 @@ fn text_tool_format_does_not_emit_native_provider_tools() {
 
     let options = crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("ollama".to_string())),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("devstral-small-2:24b".to_string())),
         ),
         (
-            "tool_format".to_string(),
+            crate::value::intern_key("tool_format"),
             VmValue::String(arcstr::ArcStr::from("text".to_string())),
         ),
-        ("tools".to_string(), one_tool_list()),
+        (crate::value::intern_key("tools"), one_tool_list()),
     ]);
     let opts = extract_llm_options(&[
         VmValue::String(arcstr::ArcStr::from("hello".to_string())),
@@ -985,15 +1009,15 @@ fn text_tool_format_does_not_emit_native_provider_tools() {
 fn standalone_reasoning_effort_maps_to_thinking_effort_when_supported() {
     let options = crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("mock".to_string())),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("o3".to_string())),
         ),
         (
-            "reasoning_effort".to_string(),
+            crate::value::intern_key("reasoning_effort"),
             VmValue::String(arcstr::ArcStr::from("high".to_string())),
         ),
     ]);
@@ -1017,15 +1041,15 @@ fn standalone_reasoning_effort_maps_to_thinking_effort_when_supported() {
 fn standalone_reasoning_effort_accepts_minimal_when_supported() {
     let options = crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("mock".to_string())),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("o3".to_string())),
         ),
         (
-            "reasoning_effort".to_string(),
+            crate::value::intern_key("reasoning_effort"),
             VmValue::String(arcstr::ArcStr::from("minimal".to_string())),
         ),
     ]);
@@ -1049,15 +1073,15 @@ fn standalone_reasoning_effort_accepts_minimal_when_supported() {
 fn reasoning_policy_maps_to_provider_aware_thinking_when_explicit() {
     let options = crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("mock".to_string())),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("gpt-5.5".to_string())),
         ),
         (
-            "reasoning_policy".to_string(),
+            crate::value::intern_key("reasoning_policy"),
             VmValue::String(arcstr::ArcStr::from("off".to_string())),
         ),
     ]);
@@ -1087,11 +1111,11 @@ fn session_pinned_reasoning_policy_is_llm_call_default() {
     let _session_guard = crate::agent_sessions::enter_current_session(session_id);
     let options = crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("mock".to_string())),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("o3".to_string())),
         ),
     ]);
@@ -1125,14 +1149,14 @@ fn explicit_thinking_wins_over_session_pinned_reasoning_policy() {
     let _session_guard = crate::agent_sessions::enter_current_session(session_id);
     let options = crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("mock".to_string())),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("o3".to_string())),
         ),
-        ("thinking".to_string(), VmValue::Bool(false)),
+        (crate::value::intern_key("thinking"), VmValue::Bool(false)),
     ]);
 
     let opts = extract_llm_options(&[
@@ -1156,15 +1180,15 @@ fn standalone_reasoning_effort_accepts_none_and_xhigh_when_supported() {
     ] {
         let options = crate::value::DictMap::from_iter([
             (
-                "provider".to_string(),
+                crate::value::intern_key("provider"),
                 VmValue::String(arcstr::ArcStr::from("mock".to_string())),
             ),
             (
-                "model".to_string(),
+                crate::value::intern_key("model"),
                 VmValue::String(arcstr::ArcStr::from("gpt-5.5".to_string())),
             ),
             (
-                "reasoning_effort".to_string(),
+                crate::value::intern_key("reasoning_effort"),
                 VmValue::String(arcstr::ArcStr::from(raw.to_string())),
             ),
         ]);
@@ -1195,11 +1219,11 @@ fn standalone_reasoning_effort_rejects_cerebras_gpt_oss_unsupported_levels() {
             "thinking",
             VmValue::dict(crate::value::DictMap::from_iter([
                 (
-                    "mode".to_string(),
+                    crate::value::intern_key("mode"),
                     VmValue::String(arcstr::ArcStr::from("effort".to_string())),
                 ),
                 (
-                    "level".to_string(),
+                    crate::value::intern_key("level"),
                     VmValue::String(arcstr::ArcStr::from("minimal".to_string())),
                 ),
             ])),
@@ -1207,14 +1231,14 @@ fn standalone_reasoning_effort_rejects_cerebras_gpt_oss_unsupported_levels() {
     ] {
         let options = crate::value::DictMap::from_iter([
             (
-                "provider".to_string(),
+                crate::value::intern_key("provider"),
                 VmValue::String(arcstr::ArcStr::from("cerebras".to_string())),
             ),
             (
-                "model".to_string(),
+                crate::value::intern_key("model"),
                 VmValue::String(arcstr::ArcStr::from("gpt-oss-120b".to_string())),
             ),
-            (key.to_string(), value),
+            (crate::value::intern_key(key), value),
         ]);
 
         let err = match extract_with_options(options) {
@@ -1234,15 +1258,15 @@ fn standalone_reasoning_effort_rejects_cerebras_gpt_oss_unsupported_levels() {
 fn standalone_reasoning_effort_none_disables_thinking_without_effort_capability() {
     let options = crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("local".to_string())),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("no-effort-model".to_string())),
         ),
         (
-            "reasoning_effort".to_string(),
+            crate::value::intern_key("reasoning_effort"),
             VmValue::String(arcstr::ArcStr::from("none".to_string())),
         ),
     ]);
@@ -1297,39 +1321,39 @@ thinking_modes = ["effort"]
 fn image_content_sets_vision_and_requires_capability() {
     let image_block = VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "type".to_string(),
+            crate::value::intern_key("type"),
             VmValue::String(arcstr::ArcStr::from("image")),
         ),
         (
-            "base64".to_string(),
+            crate::value::intern_key("base64"),
             VmValue::String(arcstr::ArcStr::from("iVBORw0KGgo=")),
         ),
         (
-            "media_type".to_string(),
+            crate::value::intern_key("media_type"),
             VmValue::String(arcstr::ArcStr::from("image/png")),
         ),
     ]));
     let message = VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "role".to_string(),
+            crate::value::intern_key("role"),
             VmValue::String(arcstr::ArcStr::from("user")),
         ),
         (
-            "content".to_string(),
+            crate::value::intern_key("content"),
             VmValue::List(std::sync::Arc::new(vec![image_block])),
         ),
     ]));
     let options = VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("mock")),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("gpt-4o")),
         ),
         (
-            "messages".to_string(),
+            crate::value::intern_key("messages"),
             VmValue::List(std::sync::Arc::new(vec![message.clone()])),
         ),
     ]));
@@ -1343,15 +1367,15 @@ fn image_content_sets_vision_and_requires_capability() {
 
     let bad_options = VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("mock")),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("gpt-3.5-turbo")),
         ),
         (
-            "messages".to_string(),
+            crate::value::intern_key("messages"),
             VmValue::List(std::sync::Arc::new(vec![message])),
         ),
     ]));
@@ -1366,39 +1390,39 @@ fn image_content_sets_vision_and_requires_capability() {
 
     let url_image = VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "type".to_string(),
+            crate::value::intern_key("type"),
             VmValue::String(arcstr::ArcStr::from("image")),
         ),
         (
-            "url".to_string(),
+            crate::value::intern_key("url"),
             VmValue::String(arcstr::ArcStr::from("https://example.com/image.png")),
         ),
         (
-            "media_type".to_string(),
+            crate::value::intern_key("media_type"),
             VmValue::String(arcstr::ArcStr::from("image/png")),
         ),
     ]));
     let url_message = VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "role".to_string(),
+            crate::value::intern_key("role"),
             VmValue::String(arcstr::ArcStr::from("user")),
         ),
         (
-            "content".to_string(),
+            crate::value::intern_key("content"),
             VmValue::List(std::sync::Arc::new(vec![url_image])),
         ),
     ]));
     let ollama_options = VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("ollama")),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("llava:latest")),
         ),
         (
-            "messages".to_string(),
+            crate::value::intern_key("messages"),
             VmValue::List(std::sync::Arc::new(vec![url_message])),
         ),
     ]));
@@ -1416,49 +1440,49 @@ fn image_content_sets_vision_and_requires_capability() {
 fn pdf_and_audio_content_require_capabilities() {
     let pdf_block = VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "type".to_string(),
+            crate::value::intern_key("type"),
             VmValue::String(arcstr::ArcStr::from("pdf")),
         ),
         (
-            "file_id".to_string(),
+            crate::value::intern_key("file_id"),
             VmValue::String(arcstr::ArcStr::from("file_123")),
         ),
     ]));
     let audio_block = VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "type".to_string(),
+            crate::value::intern_key("type"),
             VmValue::String(arcstr::ArcStr::from("audio")),
         ),
         (
-            "base64".to_string(),
+            crate::value::intern_key("base64"),
             VmValue::String(arcstr::ArcStr::from("UklGRg==")),
         ),
         (
-            "media_type".to_string(),
+            crate::value::intern_key("media_type"),
             VmValue::String(arcstr::ArcStr::from("audio/wav")),
         ),
     ]));
     let message = VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "role".to_string(),
+            crate::value::intern_key("role"),
             VmValue::String(arcstr::ArcStr::from("user")),
         ),
         (
-            "content".to_string(),
+            crate::value::intern_key("content"),
             VmValue::List(std::sync::Arc::new(vec![pdf_block, audio_block])),
         ),
     ]));
     let options = VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("mock")),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("claude-sonnet-4-7")),
         ),
         (
-            "messages".to_string(),
+            crate::value::intern_key("messages"),
             VmValue::List(std::sync::Arc::new(vec![message.clone()])),
         ),
     ]));
@@ -1474,15 +1498,15 @@ fn pdf_and_audio_content_require_capabilities() {
 
     let bad_options = VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("mock")),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("gpt-3.5-turbo")),
         ),
         (
-            "messages".to_string(),
+            crate::value::intern_key("messages"),
             VmValue::List(std::sync::Arc::new(vec![message])),
         ),
     ]));
@@ -1508,39 +1532,39 @@ video_supported = true
     .expect("capability override");
     let video_block = VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "type".to_string(),
+            crate::value::intern_key("type"),
             VmValue::String(arcstr::ArcStr::from("video")),
         ),
         (
-            "base64".to_string(),
+            crate::value::intern_key("base64"),
             VmValue::String(arcstr::ArcStr::from("AAAA")),
         ),
         (
-            "media_type".to_string(),
+            crate::value::intern_key("media_type"),
             VmValue::String(arcstr::ArcStr::from("video/mp4")),
         ),
     ]));
     let message = VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "role".to_string(),
+            crate::value::intern_key("role"),
             VmValue::String(arcstr::ArcStr::from("user")),
         ),
         (
-            "content".to_string(),
+            crate::value::intern_key("content"),
             VmValue::List(std::sync::Arc::new(vec![video_block])),
         ),
     ]));
     let options = VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("local")),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("video-model")),
         ),
         (
-            "messages".to_string(),
+            crate::value::intern_key("messages"),
             VmValue::List(std::sync::Arc::new(vec![message.clone()])),
         ),
     ]));
@@ -1554,15 +1578,15 @@ video_supported = true
 
     let bad_options = VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from("mock")),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from("gpt-4o")),
         ),
         (
-            "messages".to_string(),
+            crate::value::intern_key("messages"),
             VmValue::List(std::sync::Arc::new(vec![message])),
         ),
     ]));

--- a/crates/harn-vm/src/llm/helpers/options/system_prompt.rs
+++ b/crates/harn-vm/src/llm/helpers/options/system_prompt.rs
@@ -529,7 +529,7 @@ pub(super) fn collect_caps(value: Option<&VmValue>, out: &mut std::collections::
         Some(VmValue::Dict(dict)) => {
             for (key, value) in dict.iter() {
                 if !matches!(value, VmValue::Bool(false) | VmValue::Nil) {
-                    out.insert(key.clone());
+                    out.insert(key.to_string());
                 }
             }
         }

--- a/crates/harn-vm/src/llm/helpers/transcript.rs
+++ b/crates/harn-vm/src/llm/helpers/transcript.rs
@@ -505,15 +505,15 @@ pub(crate) fn transcript_event(
         VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
             std::sync::Arc::new(crate::value::DictMap::from_iter([
                 (
-                    "type".to_string(),
+                    crate::value::intern_key("type"),
                     VmValue::String(arcstr::ArcStr::from("text")),
                 ),
                 (
-                    "text".to_string(),
+                    crate::value::intern_key("text"),
                     VmValue::String(arcstr::ArcStr::from(text)),
                 ),
                 (
-                    "visibility".to_string(),
+                    crate::value::intern_key("visibility"),
                     VmValue::String(arcstr::ArcStr::from(visibility)),
                 ),
             ])),
@@ -542,7 +542,7 @@ pub(crate) fn normalize_transcript_asset(value: &VmValue) -> VmValue {
     }
     if value.as_dict().is_none() {
         asset.insert(
-            "storage".to_string(),
+            crate::value::intern_key("storage"),
             VmValue::dict(BTreeMap::from([(
                 "path".to_string(),
                 VmValue::String(arcstr::ArcStr::from(value.display())),
@@ -585,7 +585,7 @@ pub(crate) fn transcript_reminder_event(reminder: &SystemReminder) -> VmValue {
     // home for the lifecycle payload; `metadata` is the back-compat
     // mirror observers already key off.
     event.insert(
-        "reminder".to_string(),
+        crate::value::intern_key("reminder"),
         crate::stdlib::json_to_vm_value(&reminder_json),
     );
     VmValue::dict(event)
@@ -657,13 +657,16 @@ pub(crate) fn apply_reminder_post_turn(transcript: &VmValue, turn: i64) -> Remin
 
     let mut next = dict.clone();
     next.insert(
-        "events".to_string(),
+        crate::value::intern_key("events"),
         VmValue::List(std::sync::Arc::new(next_events)),
     );
     if !expired.is_empty() {
         let mut lifecycle = BTreeMap::new();
         lifecycle.insert("last_post_turn".to_string(), VmValue::Int(turn));
-        next.insert("reminder_lifecycle".to_string(), VmValue::dict(lifecycle));
+        next.insert(
+            crate::value::intern_key("reminder_lifecycle"),
+            VmValue::dict(lifecycle),
+        );
     }
     ReminderPostTurnReport {
         transcript: Some(VmValue::dict(next)),
@@ -848,7 +851,7 @@ fn lifecycle_transcript_event(
     let envelope = transcript_event(kind, "system", "public", text, Some(payload.clone()));
     let mut event = envelope.as_dict().cloned().unwrap_or_default();
     event.insert(
-        payload_key.to_string(),
+        crate::value::intern_key(payload_key),
         crate::stdlib::json_to_vm_value(payload),
     );
     VmValue::dict(event)
@@ -995,8 +998,8 @@ pub(crate) fn replace_reminder_payload(event: &VmValue, reminder: &SystemReminde
     let reminder_json = serde_json::to_value(reminder).unwrap_or(JsonValue::Null);
     let reminder_value = crate::stdlib::json_to_vm_value(&reminder_json);
     let mut dict = event.as_dict().cloned().unwrap_or_default();
-    dict.insert("reminder".to_string(), reminder_value.clone());
-    dict.insert("metadata".to_string(), reminder_value);
+    dict.insert(crate::value::intern_key("reminder"), reminder_value.clone());
+    dict.insert(crate::value::intern_key("metadata"), reminder_value);
     VmValue::dict(dict)
 }
 

--- a/crates/harn-vm/src/llm/permissions.rs
+++ b/crates/harn-vm/src/llm/permissions.rs
@@ -252,7 +252,7 @@ fn parse_rule_set(value: Option<&VmValue>, label: &str) -> Result<Vec<Permission
                     continue;
                 }
                 rules.push(PermissionRule {
-                    tool_pattern: tool_pattern.clone(),
+                    tool_pattern: tool_pattern.to_string(),
                     matcher: parse_matcher(matcher, &format!("{label}.{tool_pattern}"))?,
                 });
             }

--- a/crates/harn-vm/src/llm/reasoning_policy.rs
+++ b/crates/harn-vm/src/llm/reasoning_policy.rs
@@ -67,11 +67,11 @@ pub(crate) fn apply_policy_to_vm_options(
     };
     let mut out = opts.clone();
     out.insert(
-        "thinking".to_string(),
+        crate::value::intern_key("thinking"),
         thinking_to_vm_value(&application.thinking),
     );
     out.insert(
-        "_agent_reasoning_policy_applied".to_string(),
+        crate::value::intern_key("_agent_reasoning_policy_applied"),
         application_metadata_to_vm_value(&application),
     );
     Ok(out)
@@ -415,33 +415,33 @@ fn resolved_route_from_options(opts: &crate::value::DictMap) -> Option<(String, 
 fn thinking_to_vm_value(thinking: &ThinkingConfig) -> VmValue {
     match thinking {
         ThinkingConfig::Disabled => VmValue::dict(crate::value::DictMap::from_iter([(
-            "mode".to_string(),
+            crate::value::intern_key("mode"),
             VmValue::String(arcstr::ArcStr::from("disabled")),
         )])),
         ThinkingConfig::Enabled { budget_tokens } => {
             let mut dict = crate::value::DictMap::from_iter([(
-                "mode".to_string(),
+                crate::value::intern_key("mode"),
                 VmValue::String(arcstr::ArcStr::from("enabled")),
             )]);
             if let Some(budget_tokens) = budget_tokens {
                 dict.insert(
-                    "budget_tokens".to_string(),
+                    crate::value::intern_key("budget_tokens"),
                     VmValue::Int(*budget_tokens as i64),
                 );
             }
             VmValue::dict(dict)
         }
         ThinkingConfig::Adaptive => VmValue::dict(crate::value::DictMap::from_iter([(
-            "mode".to_string(),
+            crate::value::intern_key("mode"),
             VmValue::String(arcstr::ArcStr::from("adaptive")),
         )])),
         ThinkingConfig::Effort { level } => VmValue::dict(crate::value::DictMap::from_iter([
             (
-                "mode".to_string(),
+                crate::value::intern_key("mode"),
                 VmValue::String(arcstr::ArcStr::from("effort")),
             ),
             (
-                "level".to_string(),
+                crate::value::intern_key("level"),
                 VmValue::String(arcstr::ArcStr::from(level.as_str())),
             ),
         ])),
@@ -451,27 +451,27 @@ fn thinking_to_vm_value(thinking: &ThinkingConfig) -> VmValue {
 fn application_metadata_to_vm_value(application: &ReasoningPolicyApplication) -> VmValue {
     VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "policy".to_string(),
+            crate::value::intern_key("policy"),
             VmValue::String(arcstr::ArcStr::from(application.policy.clone())),
         ),
         (
-            "task".to_string(),
+            crate::value::intern_key("task"),
             VmValue::String(arcstr::ArcStr::from(application.task.clone())),
         ),
         (
-            "scale".to_string(),
+            crate::value::intern_key("scale"),
             VmValue::String(arcstr::ArcStr::from(application.scale.clone())),
         ),
         (
-            "level".to_string(),
+            crate::value::intern_key("level"),
             VmValue::String(arcstr::ArcStr::from(application.level.clone())),
         ),
         (
-            "provider".to_string(),
+            crate::value::intern_key("provider"),
             VmValue::String(arcstr::ArcStr::from(application.provider.clone())),
         ),
         (
-            "model".to_string(),
+            crate::value::intern_key("model"),
             VmValue::String(arcstr::ArcStr::from(application.model.clone())),
         ),
     ]))
@@ -489,15 +489,15 @@ mod tests {
     fn high_policy_maps_to_effort_for_openai_reasoning_models() {
         let opts = crate::value::DictMap::from_iter([
             (
-                "provider".to_string(),
+                crate::value::intern_key("provider"),
                 VmValue::String(arcstr::ArcStr::from("openai")),
             ),
             (
-                "model".to_string(),
+                crate::value::intern_key("model"),
                 VmValue::String(arcstr::ArcStr::from("gpt-5")),
             ),
             (
-                "reasoning_policy".to_string(),
+                crate::value::intern_key("reasoning_policy"),
                 VmValue::String(arcstr::ArcStr::from("high")),
             ),
         ]);
@@ -520,15 +520,15 @@ mod tests {
     fn off_policy_floors_to_low_for_cerebras_gpt_oss() {
         let opts = crate::value::DictMap::from_iter([
             (
-                "provider".to_string(),
+                crate::value::intern_key("provider"),
                 VmValue::String(arcstr::ArcStr::from("cerebras")),
             ),
             (
-                "model".to_string(),
+                crate::value::intern_key("model"),
                 VmValue::String(arcstr::ArcStr::from("gpt-oss-120b")),
             ),
             (
-                "reasoning_policy".to_string(),
+                crate::value::intern_key("reasoning_policy"),
                 VmValue::String(arcstr::ArcStr::from("off")),
             ),
         ]);
@@ -568,19 +568,19 @@ mod tests {
         // `local_qwen_route` branch in resolve_policy.
         let opts = crate::value::DictMap::from_iter([
             (
-                "provider".to_string(),
+                crate::value::intern_key("provider"),
                 VmValue::String(arcstr::ArcStr::from("ollama")),
             ),
             (
-                "model".to_string(),
+                crate::value::intern_key("model"),
                 VmValue::String(arcstr::ArcStr::from("qwen3.6:35b-a3b-coding-nvfp4")),
             ),
             (
-                "reasoning_policy".to_string(),
+                crate::value::intern_key("reasoning_policy"),
                 VmValue::String(arcstr::ArcStr::from("auto")),
             ),
             (
-                "reasoning_task".to_string(),
+                crate::value::intern_key("reasoning_task"),
                 VmValue::String(arcstr::ArcStr::from("agent")),
             ),
         ]);
@@ -613,19 +613,19 @@ mod tests {
         // motivated this work).
         let opts = crate::value::DictMap::from_iter([
             (
-                "provider".to_string(),
+                crate::value::intern_key("provider"),
                 VmValue::String(arcstr::ArcStr::from("openrouter")),
             ),
             (
-                "model".to_string(),
+                crate::value::intern_key("model"),
                 VmValue::String(arcstr::ArcStr::from("qwen/qwen3.6-35b-a3b")),
             ),
             (
-                "reasoning_policy".to_string(),
+                crate::value::intern_key("reasoning_policy"),
                 VmValue::String(arcstr::ArcStr::from("auto")),
             ),
             (
-                "reasoning_task".to_string(),
+                crate::value::intern_key("reasoning_task"),
                 VmValue::String(arcstr::ArcStr::from("agent")),
             ),
         ]);
@@ -648,19 +648,19 @@ mod tests {
         // override declares the auto default, not a ceiling.
         let opts = crate::value::DictMap::from_iter([
             (
-                "provider".to_string(),
+                crate::value::intern_key("provider"),
                 VmValue::String(arcstr::ArcStr::from("openrouter")),
             ),
             (
-                "model".to_string(),
+                crate::value::intern_key("model"),
                 VmValue::String(arcstr::ArcStr::from("qwen/qwen3.6-35b-a3b")),
             ),
             (
-                "reasoning_policy".to_string(),
+                crate::value::intern_key("reasoning_policy"),
                 VmValue::String(arcstr::ArcStr::from("high")),
             ),
             (
-                "reasoning_task".to_string(),
+                crate::value::intern_key("reasoning_task"),
                 VmValue::String(arcstr::ArcStr::from("agent")),
             ),
         ]);
@@ -695,19 +695,19 @@ auto_reasoning_overrides = { agent = "off" }
         .expect("override toml");
         let opts = crate::value::DictMap::from_iter([
             (
-                "provider".to_string(),
+                crate::value::intern_key("provider"),
                 VmValue::String(arcstr::ArcStr::from("acme")),
             ),
             (
-                "model".to_string(),
+                crate::value::intern_key("model"),
                 VmValue::String(arcstr::ArcStr::from("custom-thinker")),
             ),
             (
-                "reasoning_policy".to_string(),
+                crate::value::intern_key("reasoning_policy"),
                 VmValue::String(arcstr::ArcStr::from("auto")),
             ),
             (
-                "reasoning_task".to_string(),
+                crate::value::intern_key("reasoning_task"),
                 VmValue::String(arcstr::ArcStr::from("agent")),
             ),
         ]);
@@ -726,19 +726,19 @@ auto_reasoning_overrides = { agent = "off" }
     fn agent_opts(provider: &str, model: &str, task: &str, policy: &str) -> crate::value::DictMap {
         crate::value::DictMap::from_iter([
             (
-                "provider".to_string(),
+                crate::value::intern_key("provider"),
                 VmValue::String(arcstr::ArcStr::from(provider)),
             ),
             (
-                "model".to_string(),
+                crate::value::intern_key("model"),
                 VmValue::String(arcstr::ArcStr::from(model)),
             ),
             (
-                "reasoning_policy".to_string(),
+                crate::value::intern_key("reasoning_policy"),
                 VmValue::String(arcstr::ArcStr::from(policy)),
             ),
             (
-                "reasoning_task".to_string(),
+                crate::value::intern_key("reasoning_task"),
                 VmValue::String(arcstr::ArcStr::from(task)),
             ),
         ])
@@ -850,18 +850,18 @@ auto_reasoning_overrides = { agent = "off" }
     fn explicit_thinking_wins_over_policy() {
         let opts = crate::value::DictMap::from_iter([
             (
-                "provider".to_string(),
+                crate::value::intern_key("provider"),
                 VmValue::String(arcstr::ArcStr::from("openai")),
             ),
             (
-                "model".to_string(),
+                crate::value::intern_key("model"),
                 VmValue::String(arcstr::ArcStr::from("gpt-5")),
             ),
             (
-                "reasoning_policy".to_string(),
+                crate::value::intern_key("reasoning_policy"),
                 VmValue::String(arcstr::ArcStr::from("high")),
             ),
-            ("thinking".to_string(), VmValue::Bool(true)),
+            (crate::value::intern_key("thinking"), VmValue::Bool(true)),
         ]);
         let out = apply_policy_to_vm_options(&opts).expect("policy");
         assert!(matches!(out.get("thinking"), Some(VmValue::Bool(true))));

--- a/crates/harn-vm/src/llm/reminder_providers.rs
+++ b/crates/harn-vm/src/llm/reminder_providers.rs
@@ -1640,7 +1640,12 @@ pub(crate) fn options_map_to_json(options: &crate::value::DictMap) -> JsonValue 
     JsonValue::Object(
         options
             .iter()
-            .map(|(key, value)| (key.clone(), crate::llm::helpers::vm_value_to_json(value)))
+            .map(|(key, value)| {
+                (
+                    key.to_string(),
+                    crate::llm::helpers::vm_value_to_json(value),
+                )
+            })
             .collect(),
     )
 }

--- a/crates/harn-vm/src/llm/rerank.rs
+++ b/crates/harn-vm/src/llm/rerank.rs
@@ -61,15 +61,15 @@ async fn self_certainty_builtin(
     }
 
     let mut call_options = options;
-    call_options.insert("logprobs".to_string(), VmValue::Bool(true));
+    call_options.insert(crate::value::intern_key("logprobs"), VmValue::Bool(true));
     call_options
-        .entry("stream".to_string())
+        .entry(crate::value::intern_key("stream"))
         .or_insert(VmValue::Bool(false));
     call_options
-        .entry("temperature".to_string())
+        .entry(crate::value::intern_key("temperature"))
         .or_insert(VmValue::Float(0.0));
     call_options
-        .entry("max_tokens".to_string())
+        .entry(crate::value::intern_key("max_tokens"))
         .or_insert(VmValue::Int(estimate_echo_tokens(&text)));
 
     let prompt = format!("{SELF_CERTAINTY_PROMPT_PREFIX}{text}{SELF_CERTAINTY_PROMPT_SUFFIX}");
@@ -101,7 +101,7 @@ fn vm_logprobs(value: &VmValue) -> Result<Vec<serde_json::Value>, VmError> {
             }
             Ok(vec![serde_json::Value::Object(
                 dict.iter()
-                    .map(|(key, value)| (key.clone(), super::helpers::vm_value_to_json(value)))
+                    .map(|(key, value)| (key.to_string(), super::helpers::vm_value_to_json(value)))
                     .collect(),
             )])
         }

--- a/crates/harn-vm/src/llm/schema_recover.rs
+++ b/crates/harn-vm/src/llm/schema_recover.rs
@@ -607,29 +607,29 @@ fn merge_repair_options(
     // burning the caller's `schema_retries` budget here would amplify
     // cost and the outer recovery cascade has already done what it
     // can. Set explicitly rather than relying on defaults.
-    merged.insert("schema_retries".to_string(), VmValue::Int(0));
+    merged.insert(crate::value::intern_key("schema_retries"), VmValue::Int(0));
     // Strip schema_recover-specific keys so they don't leak into
     // `extract_llm_options` as unknown provider params.
     merged.remove("llm_repair");
     merged.remove("apply_defaults");
     // Install the schema on the call so providers can use their
     // native JSON-mode and so the schema-retry loop's validation runs.
-    merged.insert("output_schema".to_string(), schema.clone());
-    merged.insert("json_schema".to_string(), schema.clone());
+    merged.insert(crate::value::intern_key("output_schema"), schema.clone());
+    merged.insert(crate::value::intern_key("json_schema"), schema.clone());
     merged
-        .entry("output_format".to_string())
+        .entry(crate::value::intern_key("output_format"))
         .or_insert_with(|| {
             let mut fmt = crate::value::DictMap::new();
             fmt.put_str("kind", "json_schema");
-            fmt.insert("schema".to_string(), schema.clone());
-            fmt.insert("strict".to_string(), VmValue::Bool(true));
+            fmt.insert(crate::value::intern_key("schema"), schema.clone());
+            fmt.insert(crate::value::intern_key("strict"), VmValue::Bool(true));
             VmValue::dict(fmt)
         });
     merged
-        .entry("output_validation".to_string())
+        .entry(crate::value::intern_key("output_validation"))
         .or_insert(VmValue::String(arcstr::ArcStr::from("error")));
     merged
-        .entry("response_format".to_string())
+        .entry(crate::value::intern_key("response_format"))
         .or_insert(VmValue::String(arcstr::ArcStr::from("json")));
     for (k, v) in overrides {
         merged.insert(k.clone(), v.clone());
@@ -645,14 +645,20 @@ fn envelope_success(
     repaired: bool,
 ) -> VmValue {
     let mut env = crate::value::DictMap::new();
-    env.insert("ok".to_string(), VmValue::Bool(true));
-    env.insert("data".to_string(), data);
+    env.insert(crate::value::intern_key("ok"), VmValue::Bool(true));
+    env.insert(crate::value::intern_key("data"), data);
     env.put_str("raw_text", raw_text);
     env.put_str("error", "");
-    env.insert("error_category".to_string(), VmValue::Nil);
-    env.insert("attempts".to_string(), VmValue::Int(attempts as i64));
+    env.insert(crate::value::intern_key("error_category"), VmValue::Nil);
+    env.insert(
+        crate::value::intern_key("attempts"),
+        VmValue::Int(attempts as i64),
+    );
     env.put_str("stage", stage);
-    env.insert("repaired".to_string(), VmValue::Bool(repaired));
+    env.insert(
+        crate::value::intern_key("repaired"),
+        VmValue::Bool(repaired),
+    );
     VmValue::dict(env)
 }
 
@@ -664,14 +670,17 @@ fn envelope_failure(
     attempts: usize,
 ) -> VmValue {
     let mut env = crate::value::DictMap::new();
-    env.insert("ok".to_string(), VmValue::Bool(false));
-    env.insert("data".to_string(), VmValue::Nil);
+    env.insert(crate::value::intern_key("ok"), VmValue::Bool(false));
+    env.insert(crate::value::intern_key("data"), VmValue::Nil);
     env.put_str("raw_text", raw_text);
     env.put_str("error", error_message);
     env.put_str("error_category", error_category);
-    env.insert("attempts".to_string(), VmValue::Int(attempts as i64));
+    env.insert(
+        crate::value::intern_key("attempts"),
+        VmValue::Int(attempts as i64),
+    );
     env.put_str("stage", stage);
-    env.insert("repaired".to_string(), VmValue::Bool(false));
+    env.insert(crate::value::intern_key("repaired"), VmValue::Bool(false));
     VmValue::dict(env)
 }
 
@@ -688,17 +697,17 @@ mod tests {
         let mut active = crate::value::DictMap::new();
         active.put_str("type", "boolean");
         let mut props = crate::value::DictMap::new();
-        props.insert("name".to_string(), VmValue::dict(name));
-        props.insert("age".to_string(), VmValue::dict(age));
-        props.insert("active".to_string(), VmValue::dict(active));
+        props.insert(crate::value::intern_key("name"), VmValue::dict(name));
+        props.insert(crate::value::intern_key("age"), VmValue::dict(age));
+        props.insert(crate::value::intern_key("active"), VmValue::dict(active));
         let required = VmValue::List(std::sync::Arc::new(vec![
             VmValue::String(arcstr::ArcStr::from("name")),
             VmValue::String(arcstr::ArcStr::from("age")),
         ]));
         let mut schema = crate::value::DictMap::new();
         schema.put_str("type", "object");
-        schema.insert("properties".to_string(), VmValue::dict(props));
-        schema.insert("required".to_string(), required);
+        schema.insert(crate::value::intern_key("properties"), VmValue::dict(props));
+        schema.insert(crate::value::intern_key("required"), required);
         VmValue::dict(schema)
     }
 
@@ -842,7 +851,7 @@ mod tests {
     #[test]
     fn parse_repair_config_disable_via_bool() {
         let mut opts = crate::value::DictMap::new();
-        opts.insert("llm_repair".to_string(), VmValue::Bool(false));
+        opts.insert(crate::value::intern_key("llm_repair"), VmValue::Bool(false));
         let cfg = parse_llm_repair_config(&Some(opts));
         assert!(!cfg.enabled);
     }
@@ -857,9 +866,12 @@ mod tests {
     fn parse_repair_config_dict_extracts_overrides() {
         let mut repair = crate::value::DictMap::new();
         repair.put_str("model", "local:fix");
-        repair.insert("max_tokens".to_string(), VmValue::Int(400));
+        repair.insert(crate::value::intern_key("max_tokens"), VmValue::Int(400));
         let mut opts = crate::value::DictMap::new();
-        opts.insert("llm_repair".to_string(), VmValue::dict(repair));
+        opts.insert(
+            crate::value::intern_key("llm_repair"),
+            VmValue::dict(repair),
+        );
         let cfg = parse_llm_repair_config(&Some(opts));
         assert!(cfg.enabled);
         assert_eq!(
@@ -876,9 +888,12 @@ mod tests {
     fn merge_repair_caps_schema_retries_and_installs_schema() {
         let schema = person_schema();
         let mut base = crate::value::DictMap::new();
-        base.insert("schema_retries".to_string(), VmValue::Int(7));
-        base.insert("llm_repair".to_string(), VmValue::Bool(true));
-        base.insert("apply_defaults".to_string(), VmValue::Bool(true));
+        base.insert(crate::value::intern_key("schema_retries"), VmValue::Int(7));
+        base.insert(crate::value::intern_key("llm_repair"), VmValue::Bool(true));
+        base.insert(
+            crate::value::intern_key("apply_defaults"),
+            VmValue::Bool(true),
+        );
         let merged = merge_repair_options(Some(&base), &crate::value::DictMap::new(), &schema);
         assert_eq!(
             merged.get("schema_retries").and_then(VmValue::as_int),
@@ -982,7 +997,7 @@ mod tests {
     async fn schema_recover_failure_when_repair_disabled_and_unrecoverable() {
         let schema = person_schema();
         let mut opts = crate::value::DictMap::new();
-        opts.insert("llm_repair".to_string(), VmValue::Bool(false));
+        opts.insert(crate::value::intern_key("llm_repair"), VmValue::Bool(false));
         let args = vec![
             VmValue::String(arcstr::ArcStr::from("nothing useful here at all")),
             schema,

--- a/crates/harn-vm/src/llm/structural_experiments.rs
+++ b/crates/harn-vm/src/llm/structural_experiments.rs
@@ -85,7 +85,10 @@ fn parse_structural_experiment_dict(
                 ) {
                     continue;
                 }
-                args.insert(key.clone(), crate::llm::helpers::vm_value_to_json(value));
+                args.insert(
+                    key.to_string(),
+                    crate::llm::helpers::vm_value_to_json(value),
+                );
             }
             serde_json::Value::Object(args)
         });
@@ -297,20 +300,20 @@ pub(crate) async fn apply_structural_experiment(
                 })?;
             let mut ctx = crate::value::DictMap::new();
             ctx.insert(
-                "messages".to_string(),
+                crate::value::intern_key("messages"),
                 VmValue::List(std::sync::Arc::new(
                     crate::llm::helpers::json_messages_to_vm(&current_messages),
                 )),
             );
             ctx.insert(
-                "system".to_string(),
+                crate::value::intern_key("system"),
                 current_system
                     .as_ref()
                     .map(|value| VmValue::String(arcstr::ArcStr::from(value.as_str())))
                     .unwrap_or(VmValue::Nil),
             );
             ctx.insert(
-                "iteration".to_string(),
+                crate::value::intern_key("iteration"),
                 iteration
                     .map(|value| VmValue::Int(value as i64))
                     .unwrap_or(VmValue::Nil),
@@ -318,7 +321,7 @@ pub(crate) async fn apply_structural_experiment(
             ctx.put_str("label", config.label.as_str());
             ctx.put_str("name", config.name.as_str());
             ctx.insert(
-                "args".to_string(),
+                crate::value::intern_key("args"),
                 crate::stdlib::json_to_vm_value(&config.args),
             );
             interpret_closure_result(

--- a/crates/harn-vm/src/llm/structured_envelope.rs
+++ b/crates/harn-vm/src/llm/structured_envelope.rs
@@ -373,7 +373,7 @@ fn merge_repair_options(
     // retries from the main call (cost amplification) and do not let
     // the main call's transient retry budget propagate either —
     // repair is best-effort and should fail fast.
-    merged.insert("schema_retries".to_string(), VmValue::Int(0));
+    merged.insert(crate::value::intern_key("schema_retries"), VmValue::Int(0));
     // Drop any nested `repair` key from the base options so a repair
     // call cannot recursively trigger another repair pass.
     merged.remove("repair");
@@ -420,18 +420,24 @@ fn envelope_success(outcome: &SchemaLoopOutcome, repaired: bool) -> VmValue {
     let (model, provider) = result_model_provider(outcome);
 
     let mut env = crate::value::DictMap::new();
-    env.insert("ok".to_string(), VmValue::Bool(true));
-    env.insert("data".to_string(), data);
+    env.insert(crate::value::intern_key("ok"), VmValue::Bool(true));
+    env.insert(crate::value::intern_key("data"), data);
     env.put_str("raw_text", outcome.raw_text.as_str());
     env.put_str("error", "");
-    env.insert("error_category".to_string(), VmValue::Nil);
+    env.insert(crate::value::intern_key("error_category"), VmValue::Nil);
     env.insert(
-        "attempts".to_string(),
+        crate::value::intern_key("attempts"),
         VmValue::Int(outcome.attempts as i64),
     );
-    env.insert("repaired".to_string(), VmValue::Bool(repaired));
-    env.insert("extracted_json".to_string(), VmValue::Bool(extracted_json));
-    env.insert("usage".to_string(), usage);
+    env.insert(
+        crate::value::intern_key("repaired"),
+        VmValue::Bool(repaired),
+    );
+    env.insert(
+        crate::value::intern_key("extracted_json"),
+        VmValue::Bool(extracted_json),
+    );
+    env.insert(crate::value::intern_key("usage"), usage);
     env.put_str("model", model.as_str());
     env.put_str("provider", provider.as_str());
     VmValue::dict(env)
@@ -452,18 +458,24 @@ fn envelope_failure(
     };
 
     let mut env = crate::value::DictMap::new();
-    env.insert("ok".to_string(), VmValue::Bool(false));
-    env.insert("data".to_string(), VmValue::Nil);
+    env.insert(crate::value::intern_key("ok"), VmValue::Bool(false));
+    env.insert(crate::value::intern_key("data"), VmValue::Nil);
     env.put_str("raw_text", outcome.raw_text.as_str());
     env.put_str("error", message.as_str());
     env.put_str("error_category", kind.category());
     env.insert(
-        "attempts".to_string(),
+        crate::value::intern_key("attempts"),
         VmValue::Int(outcome.attempts as i64),
     );
-    env.insert("repaired".to_string(), VmValue::Bool(repaired));
-    env.insert("extracted_json".to_string(), VmValue::Bool(extracted_json));
-    env.insert("usage".to_string(), usage);
+    env.insert(
+        crate::value::intern_key("repaired"),
+        VmValue::Bool(repaired),
+    );
+    env.insert(
+        crate::value::intern_key("extracted_json"),
+        VmValue::Bool(extracted_json),
+    );
+    env.insert(crate::value::intern_key("usage"), usage);
     env.put_str("model", model.as_str());
     env.put_str("provider", provider.as_str());
     VmValue::dict(env)
@@ -481,15 +493,21 @@ fn envelope_from_transport_error(err: &VmError, provider: &str, model: &str) -> 
         _ => err.to_string(),
     };
     let mut env = crate::value::DictMap::new();
-    env.insert("ok".to_string(), VmValue::Bool(false));
-    env.insert("data".to_string(), VmValue::Nil);
+    env.insert(crate::value::intern_key("ok"), VmValue::Bool(false));
+    env.insert(crate::value::intern_key("data"), VmValue::Nil);
     env.put_str("raw_text", "");
     env.put_str("error", message.as_str());
     env.put_str("error_category", category.as_str());
-    env.insert("attempts".to_string(), VmValue::Int(0));
-    env.insert("repaired".to_string(), VmValue::Bool(false));
-    env.insert("extracted_json".to_string(), VmValue::Bool(false));
-    env.insert("usage".to_string(), VmValue::dict(empty_usage_dict()));
+    env.insert(crate::value::intern_key("attempts"), VmValue::Int(0));
+    env.insert(crate::value::intern_key("repaired"), VmValue::Bool(false));
+    env.insert(
+        crate::value::intern_key("extracted_json"),
+        VmValue::Bool(false),
+    );
+    env.insert(
+        crate::value::intern_key("usage"),
+        VmValue::dict(empty_usage_dict()),
+    );
     env.put_str("model", model);
     env.put_str("provider", provider);
     VmValue::dict(env)
@@ -504,13 +522,28 @@ fn envelope_from_arg_error(err: &VmError) -> VmValue {
 
 fn empty_usage_dict() -> crate::value::DictMap {
     let mut usage = crate::value::DictMap::new();
-    usage.insert("input_tokens".to_string(), VmValue::Int(0));
-    usage.insert("output_tokens".to_string(), VmValue::Int(0));
-    usage.insert("cache_read_tokens".to_string(), VmValue::Int(0));
-    usage.insert("cache_write_tokens".to_string(), VmValue::Int(0));
-    usage.insert("cache_creation_input_tokens".to_string(), VmValue::Int(0));
-    usage.insert("cache_hit_ratio".to_string(), VmValue::Float(0.0));
-    usage.insert("cache_savings_usd".to_string(), VmValue::Float(0.0));
+    usage.insert(crate::value::intern_key("input_tokens"), VmValue::Int(0));
+    usage.insert(crate::value::intern_key("output_tokens"), VmValue::Int(0));
+    usage.insert(
+        crate::value::intern_key("cache_read_tokens"),
+        VmValue::Int(0),
+    );
+    usage.insert(
+        crate::value::intern_key("cache_write_tokens"),
+        VmValue::Int(0),
+    );
+    usage.insert(
+        crate::value::intern_key("cache_creation_input_tokens"),
+        VmValue::Int(0),
+    );
+    usage.insert(
+        crate::value::intern_key("cache_hit_ratio"),
+        VmValue::Float(0.0),
+    );
+    usage.insert(
+        crate::value::intern_key("cache_savings_usd"),
+        VmValue::Float(0.0),
+    );
     usage
 }
 
@@ -533,7 +566,7 @@ fn build_usage_dict(outcome: &SchemaLoopOutcome) -> VmValue {
         "cache_savings_usd",
     ] {
         if let Some(v) = dict.get(key) {
-            usage.insert(key.to_string(), v.clone());
+            usage.insert(crate::value::intern_key(key), v.clone());
         }
     }
     VmValue::dict(usage)
@@ -679,9 +712,9 @@ mod tests {
     fn merge_repair_caps_schema_retries_and_drops_nested_repair() {
         let mut base = crate::value::DictMap::new();
         base.put_str("provider", "auto");
-        base.insert("schema_retries".to_string(), VmValue::Int(5));
+        base.insert(crate::value::intern_key("schema_retries"), VmValue::Int(5));
         base.insert(
-            "repair".to_string(),
+            crate::value::intern_key("repair"),
             VmValue::dict(crate::value::DictMap::new()),
         );
         let overrides = {
@@ -716,7 +749,7 @@ mod tests {
             parse_repair_value(&VmValue::dict(crate::value::DictMap::new())).unwrap();
         assert!(dict_no_enabled.enabled);
         let mut disabled = crate::value::DictMap::new();
-        disabled.insert("enabled".to_string(), VmValue::Bool(false));
+        disabled.insert(crate::value::intern_key("enabled"), VmValue::Bool(false));
         let dict_disabled = parse_repair_value(&VmValue::dict(disabled)).unwrap();
         assert!(!dict_disabled.enabled);
     }
@@ -725,15 +758,15 @@ mod tests {
     fn prompt_mode_structured_transport_keeps_harn_side_validation() {
         let schema = VmValue::dict(crate::value::DictMap::from_iter([
             (
-                "type".to_string(),
+                crate::value::intern_key("type"),
                 VmValue::String(arcstr::ArcStr::from("object")),
             ),
             (
-                "properties".to_string(),
+                crate::value::intern_key("properties"),
                 VmValue::dict(crate::value::DictMap::from_iter([(
-                    "pass".to_string(),
+                    crate::value::intern_key("pass"),
                     VmValue::dict(crate::value::DictMap::from_iter([(
-                        "type".to_string(),
+                        crate::value::intern_key("type"),
                         VmValue::String(arcstr::ArcStr::from("boolean")),
                     )])),
                 )])),
@@ -741,11 +774,11 @@ mod tests {
         ]));
         let options = VmValue::dict(crate::value::DictMap::from_iter([
             (
-                "provider".to_string(),
+                crate::value::intern_key("provider"),
                 VmValue::String(arcstr::ArcStr::from("ollama")),
             ),
             (
-                "model".to_string(),
+                crate::value::intern_key("model"),
                 // A capability rule with no structured_output transport, so native
                 // structured transport is unsupported and the loop must fall back to
                 // prompt-mode. (ollama gemma4/devstral now declare format_kw support.)

--- a/crates/harn-vm/src/llm/tools/json_schema.rs
+++ b/crates/harn-vm/src/llm/tools/json_schema.rs
@@ -169,9 +169,9 @@ pub(super) fn vm_build_json_schema(params: Option<&crate::value::DictMap>) -> se
                     obj.remove("required");
                 }
             }
-            properties.insert(name.clone(), schema);
+            properties.insert(name.to_string(), schema);
             if is_required {
-                required.push(serde_json::Value::String(name.clone()));
+                required.push(serde_json::Value::String(name.to_string()));
             }
         }
     }

--- a/crates/harn-vm/src/llm/tools/params.rs
+++ b/crates/harn-vm/src/llm/tools/params.rs
@@ -43,7 +43,7 @@ pub(super) fn extract_params_from_vm_dict(
                 )
             };
             params.push(ToolParamSchema {
-                name: pname.clone(),
+                name: pname.to_string(),
                 ty,
                 description: desc,
                 required,

--- a/crates/harn-vm/src/mcp/builtins.rs
+++ b/crates/harn-vm/src/mcp/builtins.rs
@@ -16,7 +16,7 @@ pub(crate) fn vm_value_to_serde(val: &VmValue) -> serde_json::Value {
         VmValue::Dict(map) => {
             let obj: serde_json::Map<String, serde_json::Value> = map
                 .iter()
-                .map(|(k, v)| (k.clone(), vm_value_to_serde(v)))
+                .map(|(k, v)| (k.to_string(), vm_value_to_serde(v)))
                 .collect();
             serde_json::Value::Object(obj)
         }
@@ -420,7 +420,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
             Some(VmValue::Dict(d)) => {
                 let obj: serde_json::Map<String, serde_json::Value> = d
                     .iter()
-                    .map(|(k, v)| (k.clone(), vm_value_to_serde(v)))
+                    .map(|(k, v)| (k.to_string(), vm_value_to_serde(v)))
                     .collect();
                 serde_json::Value::Object(obj)
             }
@@ -632,7 +632,7 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
             Some(VmValue::Dict(d)) => {
                 let obj: serde_json::Map<String, serde_json::Value> = d
                     .iter()
-                    .map(|(k, v)| (k.clone(), vm_value_to_serde(v)))
+                    .map(|(k, v)| (k.to_string(), vm_value_to_serde(v)))
                     .collect();
                 serde_json::Value::Object(obj)
             }
@@ -799,7 +799,7 @@ pub(crate) fn register_supervised_mcp_host_builtins(vm: &mut Vm) {
             Some(VmValue::Dict(d)) => {
                 let obj: serde_json::Map<String, serde_json::Value> = d
                     .iter()
-                    .map(|(k, v)| (k.clone(), vm_value_to_serde(v)))
+                    .map(|(k, v)| (k.to_string(), vm_value_to_serde(v)))
                     .collect();
                 serde_json::Value::Object(obj)
             }

--- a/crates/harn-vm/src/mcp_elicit.rs
+++ b/crates/harn-vm/src/mcp_elicit.rs
@@ -227,7 +227,7 @@ pub(crate) fn envelope_from_response(
             .cloned()
             .unwrap_or(JsonValue::Object(Default::default()));
         let validated = validate_accepted_content(&content, requested_schema)?;
-        envelope.insert("content".to_string(), validated);
+        envelope.insert(crate::value::intern_key("content"), validated);
     }
 
     Ok(VmValue::dict(envelope))
@@ -318,7 +318,7 @@ pub(crate) async fn dispatch_inbound_elicitation(
     bridge_params.put_str("server", server_name);
     bridge_params.put_str("message", message.as_str());
     bridge_params.insert(
-        "requestedSchema".to_string(),
+        crate::value::intern_key("requestedSchema"),
         json_to_vm_value(&requested_schema),
     );
 

--- a/crates/harn-vm/src/mcp_sampling.rs
+++ b/crates/harn-vm/src/mcp_sampling.rs
@@ -261,7 +261,7 @@ fn parse_sampling_request(params: &JsonValue) -> Result<SamplingRequest, String>
 async fn ask_host_approval(server_name: &str, params: &JsonValue) -> ApprovalDecision {
     let mut bridge_params: crate::value::DictMap = crate::value::DictMap::new();
     bridge_params.put_str("server", server_name);
-    bridge_params.insert("params".to_string(), json_to_vm_value(params));
+    bridge_params.insert(crate::value::intern_key("params"), json_to_vm_value(params));
 
     let result = dispatch_mock_host_call("mcp", "sample", &bridge_params)
         .or_else(|| dispatch_host_call_bridge("mcp", "sample", &bridge_params));
@@ -398,14 +398,20 @@ fn build_llm_call_args(
     // `extract_llm_options` accepts (a list of `{role, content}` dicts).
     let messages_vm: Vec<VmValue> = parsed.messages.iter().map(json_to_vm_value).collect();
     options.insert(
-        "messages".to_string(),
+        crate::value::intern_key("messages"),
         VmValue::List(std::sync::Arc::new(messages_vm)),
     );
 
-    options.insert("max_tokens".to_string(), VmValue::Int(parsed.max_tokens));
+    options.insert(
+        crate::value::intern_key("max_tokens"),
+        VmValue::Int(parsed.max_tokens),
+    );
 
     if let Some(temperature) = parsed.temperature {
-        options.insert("temperature".to_string(), VmValue::Float(temperature));
+        options.insert(
+            crate::value::intern_key("temperature"),
+            VmValue::Float(temperature),
+        );
     }
 
     if let Some(stop) = parsed.stop_sequences.as_ref() {
@@ -414,7 +420,7 @@ fn build_llm_call_args(
             .map(|s| VmValue::String(arcstr::ArcStr::from(s.as_str())))
             .collect();
         options.insert(
-            "stop".to_string(),
+            crate::value::intern_key("stop"),
             VmValue::List(std::sync::Arc::new(stop_vm)),
         );
     }
@@ -424,19 +430,28 @@ fn build_llm_call_args(
     }
 
     if let Some(tools) = parsed.tools.as_ref() {
-        options.insert("tools".to_string(), json_to_vm_value(tools));
+        options.insert(crate::value::intern_key("tools"), json_to_vm_value(tools));
     }
     if let Some(tool_choice) = parsed.tool_choice.as_ref() {
-        options.insert("tool_choice".to_string(), json_to_vm_value(tool_choice));
+        options.insert(
+            crate::value::intern_key("tool_choice"),
+            json_to_vm_value(tool_choice),
+        );
     }
     if let Some(thinking) = parsed.thinking.as_ref() {
-        options.insert("thinking".to_string(), json_to_vm_value(thinking));
+        options.insert(
+            crate::value::intern_key("thinking"),
+            json_to_vm_value(thinking),
+        );
     }
 
     // Pass-through fields kept on the options map so transcripts and
     // mocks see the original server's intent.
     if let Some(metadata) = parsed.metadata.as_ref() {
-        options.insert("metadata".to_string(), json_to_vm_value(metadata));
+        options.insert(
+            crate::value::intern_key("metadata"),
+            json_to_vm_value(metadata),
+        );
     }
     if let Some(include_context) = parsed.include_context.as_ref() {
         options.put_str("include_context", include_context.as_str());
@@ -629,7 +644,7 @@ mod tests {
         dict.put_str("action", "accept");
         let mut options = crate::value::DictMap::new();
         options.put_str("provider", "mock");
-        dict.insert("options".to_string(), VmValue::dict(options));
+        dict.insert(crate::value::intern_key("options"), VmValue::dict(options));
         match coerce_bridge_response(VmValue::dict(dict)) {
             ApprovalDecision::Accept(map) => {
                 assert_eq!(
@@ -758,7 +773,10 @@ mod tests {
             if capability == "mcp" && operation == "sample" {
                 let mut envelope: crate::value::DictMap = crate::value::DictMap::new();
                 envelope.put_str("action", "accept");
-                envelope.insert("options".to_string(), VmValue::dict(self.overrides.clone()));
+                envelope.insert(
+                    crate::value::intern_key("options"),
+                    VmValue::dict(self.overrides.clone()),
+                );
                 Ok(Some(VmValue::dict(envelope)))
             } else {
                 Ok(None)

--- a/crates/harn-vm/src/mcp_server/convert.rs
+++ b/crates/harn-vm/src/mcp_server/convert.rs
@@ -183,14 +183,14 @@ pub(super) fn vm_value_to_json(value: &VmValue) -> serde_json::Value {
         VmValue::Dict(d) => {
             let mut map = serde_json::Map::new();
             for (k, v) in d.iter() {
-                map.insert(k.clone(), vm_value_to_json(v));
+                map.insert(k.to_string(), vm_value_to_json(v));
             }
             serde_json::Value::Object(map)
         }
         VmValue::StructInstance { .. } => {
             let mut map = serde_json::Map::new();
             for (k, v) in value.struct_fields_map().unwrap_or_default().iter() {
-                map.insert(k.clone(), vm_value_to_json(v));
+                map.insert(k.to_string(), vm_value_to_json(v));
             }
             serde_json::Value::Object(map)
         }

--- a/crates/harn-vm/src/mcp_server/register.rs
+++ b/crates/harn-vm/src/mcp_server/register.rs
@@ -350,7 +350,7 @@ fn completion_sources_from_dict(value: Option<&VmValue>) -> BTreeMap<String, Mcp
     sources
         .iter()
         .filter_map(|(name, value)| {
-            completion_source_from_value(value).map(|source| (name.clone(), source))
+            completion_source_from_value(value).map(|source| (name.to_string(), source))
         })
         .collect()
 }

--- a/crates/harn-vm/src/mcp_server/tests.rs
+++ b/crates/harn-vm/src/mcp_server/tests.rs
@@ -49,8 +49,8 @@ fn test_params_to_json_schema_with_params() {
     let mut param_def = crate::value::DictMap::new();
     param_def.put_str("type", "string");
     param_def.put_str("description", "A file path");
-    param_def.insert("required".to_string(), VmValue::Bool(true));
-    params.insert("path".to_string(), VmValue::dict(param_def));
+    param_def.insert(crate::value::intern_key("required"), VmValue::Bool(true));
+    params.insert(crate::value::intern_key("path"), VmValue::dict(param_def));
 
     let schema = params_to_json_schema(Some(&VmValue::dict(params)));
     assert_eq!(
@@ -67,21 +67,24 @@ fn test_params_to_json_schema_with_params() {
 fn test_params_to_json_schema_preserves_file_input_descriptor() {
     let mut file_descriptor = crate::value::DictMap::new();
     file_descriptor.insert(
-        "accept".to_string(),
+        crate::value::intern_key("accept"),
         VmValue::List(std::sync::Arc::new(vec![VmValue::String(
             arcstr::ArcStr::from("text/*"),
         )])),
     );
-    file_descriptor.insert("maxSize".to_string(), VmValue::Int(64));
+    file_descriptor.insert(crate::value::intern_key("maxSize"), VmValue::Int(64));
 
     let mut param_def = crate::value::DictMap::new();
     param_def.put_str("type", "string");
     param_def.put_str("format", "uri");
-    param_def.insert("x-mcp-file".to_string(), VmValue::dict(file_descriptor));
-    param_def.insert("required".to_string(), VmValue::Bool(true));
+    param_def.insert(
+        crate::value::intern_key("x-mcp-file"),
+        VmValue::dict(file_descriptor),
+    );
+    param_def.insert(crate::value::intern_key("required"), VmValue::Bool(true));
 
     let mut params = crate::value::DictMap::new();
-    params.insert("upload".to_string(), VmValue::dict(param_def));
+    params.insert(crate::value::intern_key("upload"), VmValue::dict(param_def));
 
     let schema = params_to_json_schema(Some(&VmValue::dict(params)));
     assert_eq!(schema["properties"]["upload"]["type"], "string");

--- a/crates/harn-vm/src/mcp_server/tools_schema.rs
+++ b/crates/harn-vm/src/mcp_server/tools_schema.rs
@@ -102,10 +102,10 @@ pub(super) fn params_to_json_schema(params: Option<&VmValue>) -> serde_json::Val
             } else {
                 def.iter()
                     .filter_map(|(key, value)| {
-                        if key == "required" {
+                        if key.as_str() == "required" {
                             return None;
                         }
-                        Some((key.clone(), vm_value_to_json(value)))
+                        Some((key.to_string(), vm_value_to_json(value)))
                     })
                     .collect::<serde_json::Map<_, _>>()
             };
@@ -114,16 +114,16 @@ pub(super) fn params_to_json_schema(params: Option<&VmValue>) -> serde_json::Val
                     .or_insert_with(|| serde_json::Value::String(d.to_string()));
             }
             if matches!(def.get("required"), Some(VmValue::Bool(true))) {
-                required.push(serde_json::Value::String(param_name.clone()));
+                required.push(serde_json::Value::String(param_name.to_string()));
             }
-            properties.insert(param_name.clone(), serde_json::Value::Object(prop));
+            properties.insert(param_name.to_string(), serde_json::Value::Object(prop));
         } else if let VmValue::String(type_str) = param_def {
             let mut prop = serde_json::Map::new();
             prop.insert(
                 "type".into(),
                 serde_json::Value::String(type_str.to_string()),
             );
-            properties.insert(param_name.clone(), serde_json::Value::Object(prop));
+            properties.insert(param_name.to_string(), serde_json::Value::Object(prop));
         }
     }
 

--- a/crates/harn-vm/src/metadata.rs
+++ b/crates/harn-vm/src/metadata.rs
@@ -844,7 +844,7 @@ fn metadata_set_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
     let mut data = BTreeMap::new();
     if let VmValue::Dict(dict) = &data_val {
         for (k, v) in dict.iter() {
-            data.insert(k.clone(), vm_to_json(v));
+            data.insert(k.to_string(), vm_to_json(v));
         }
     }
 
@@ -1132,7 +1132,7 @@ fn path_metadata_set_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue
     let mut data = BTreeMap::new();
     if let VmValue::Dict(dict) = &data_val {
         for (k, v) in dict.iter() {
-            data.insert(k.clone(), vm_to_json(v));
+            data.insert(k.to_string(), vm_to_json(v));
         }
     }
     if data.is_empty() {

--- a/crates/harn-vm/src/orchestration/command_policy.rs
+++ b/crates/harn-vm/src/orchestration/command_policy.rs
@@ -134,19 +134,19 @@ pub fn normalize_command_policy_value(config: &VmValue) -> Result<VmValue, VmErr
     };
     let mut normalized = (*map).clone();
     normalized
-        .entry("_type".to_string())
+        .entry(crate::value::intern_key("_type"))
         .or_insert_with(|| VmValue::String(arcstr::ArcStr::from("command_policy")));
     normalized
-        .entry("default_shell_mode".to_string())
+        .entry(crate::value::intern_key("default_shell_mode"))
         .or_insert_with(|| VmValue::String(arcstr::ArcStr::from(DEFAULT_SHELL_MODE)));
     normalized
-        .entry("workspace_roots".to_string())
+        .entry(crate::value::intern_key("workspace_roots"))
         .or_insert_with(|| VmValue::List(std::sync::Arc::new(Vec::new())));
     normalized
-        .entry("deny_patterns".to_string())
+        .entry(crate::value::intern_key("deny_patterns"))
         .or_insert_with(|| VmValue::List(std::sync::Arc::new(Vec::new())));
     normalized
-        .entry("require_approval".to_string())
+        .entry(crate::value::intern_key("require_approval"))
         .or_insert_with(|| VmValue::List(std::sync::Arc::new(Vec::new())));
     parse_command_policy_value(Some(&VmValue::dict(normalized.clone())), "command_policy")?;
     Ok(VmValue::dict(normalized))
@@ -540,7 +540,7 @@ fn attach_policy_audit(
         audit["annotation"] = annotation;
     }
     out.insert(
-        "command_policy".to_string(),
+        crate::value::intern_key("command_policy"),
         crate::stdlib::json_to_vm_value(&audit),
     );
     VmValue::dict(out)
@@ -805,7 +805,7 @@ fn command_request_json(params: &crate::value::DictMap) -> JsonValue {
     if let Some(env) = params.get("env").and_then(|value| value.as_dict()) {
         for (key, value) in env.iter() {
             env_diff.insert(
-                key.clone(),
+                key.to_string(),
                 serde_json::json!({
                     "present": true,
                     "redacted": true,
@@ -1161,7 +1161,7 @@ fn redacted_vm_request(params: &crate::value::DictMap) -> crate::value::DictMap 
     params
         .iter()
         .map(|(key, value)| {
-            if key == "env" || key == "stdin" {
+            if key.as_str() == "env" || key.as_str() == "stdin" {
                 (
                     key.clone(),
                     VmValue::String(arcstr::ArcStr::from("<redacted>")),

--- a/crates/harn-vm/src/orchestration/compaction.rs
+++ b/crates/harn-vm/src/orchestration/compaction.rs
@@ -205,7 +205,7 @@ pub fn compaction_policy_to_vm_value(policy: &CompactionPolicy) -> VmValue {
         map.put_str("scope", scope.clone());
     }
     map.insert(
-        "preserve".to_string(),
+        crate::value::intern_key("preserve"),
         VmValue::List(std::sync::Arc::new(
             policy
                 .preserve
@@ -215,7 +215,7 @@ pub fn compaction_policy_to_vm_value(policy: &CompactionPolicy) -> VmValue {
         )),
     );
     map.insert(
-        "drop".to_string(),
+        crate::value::intern_key("drop"),
         VmValue::List(std::sync::Arc::new(
             policy
                 .drop_items
@@ -226,7 +226,7 @@ pub fn compaction_policy_to_vm_value(policy: &CompactionPolicy) -> VmValue {
     );
     if let Some(extend_default_instructions) = policy.extend_default_instructions {
         map.insert(
-            "extend_default_instructions".to_string(),
+            crate::value::intern_key("extend_default_instructions"),
             VmValue::Bool(extend_default_instructions),
         );
     }
@@ -852,7 +852,7 @@ fn render_llm_compaction_prompt(
     let mut bindings = crate::value::DictMap::new();
     bindings.put_str("formatted_messages", formatted);
     bindings.insert(
-        "archived_count".to_string(),
+        crate::value::intern_key("archived_count"),
         VmValue::Int(archived_count as i64),
     );
     let Some(path) = summarize_prompt.filter(|path| !path.trim().is_empty()) else {
@@ -880,7 +880,7 @@ fn render_replacement_compaction_prompt(
     bindings.put_str("directives", directives);
     bindings.put_str("formatted_messages", formatted);
     bindings.insert(
-        "archived_count".to_string(),
+        crate::value::intern_key("archived_count"),
         VmValue::Int(archived_count as i64),
     );
     crate::stdlib::template::render_stdlib_prompt_asset(

--- a/crates/harn-vm/src/orchestration/hooks.rs
+++ b/crates/harn-vm/src/orchestration/hooks.rs
@@ -1103,7 +1103,7 @@ fn parse_reminder_spec(value: &VmValue, context: &str) -> Result<ReminderSpec, V
     let unknown = options
         .keys()
         .filter(|key| !ALLOWED.contains(&key.as_str()))
-        .map(String::as_str)
+        .map(|key| key.as_str())
         .collect::<Vec<_>>();
     if !unknown.is_empty() {
         return Err(reminder_code_error(
@@ -1914,7 +1914,7 @@ mod tests {
         VmValue::dict(
             entries
                 .into_iter()
-                .map(|(key, value)| (key.to_string(), value))
+                .map(|(key, value)| (crate::value::intern_key(key), value))
                 .collect::<crate::value::DictMap>(),
         )
     }

--- a/crates/harn-vm/src/orchestration/policy/mod.rs
+++ b/crates/harn-vm/src/orchestration/policy/mod.rs
@@ -559,11 +559,11 @@ pub fn redact_transcript_visibility(
     };
     let mut redacted = dict.clone();
     redacted.insert(
-        "messages".to_string(),
+        crate::value::intern_key("messages"),
         VmValue::List(std::sync::Arc::new(public_messages)),
     );
     redacted.insert(
-        "events".to_string(),
+        crate::value::intern_key("events"),
         VmValue::List(std::sync::Arc::new(public_events)),
     );
     Some(VmValue::dict(redacted))
@@ -598,7 +598,7 @@ fn redact_public_message(message: &VmValue) -> Option<VmValue> {
                 public_text = text_fragments_from_blocks(&public_blocks);
             }
             redacted.insert(
-                key.to_string(),
+                crate::value::intern_key(key),
                 VmValue::List(std::sync::Arc::new(public_blocks)),
             );
         }

--- a/crates/harn-vm/src/orchestration/policy/nested_budget.rs
+++ b/crates/harn-vm/src/orchestration/policy/nested_budget.rs
@@ -176,11 +176,11 @@ pub fn annotate_nested_execution_options(
     label: &str,
 ) {
     options.insert(
-        NESTED_KIND_OPTION_KEY.to_string(),
+        crate::value::intern_key(NESTED_KIND_OPTION_KEY),
         VmValue::String(arcstr::ArcStr::from(kind.as_str().to_string())),
     );
     options.insert(
-        NESTED_LABEL_OPTION_KEY.to_string(),
+        crate::value::intern_key(NESTED_LABEL_OPTION_KEY),
         VmValue::String(arcstr::ArcStr::from(label.to_string())),
     );
 }

--- a/crates/harn-vm/src/orchestration/workflow.rs
+++ b/crates/harn-vm/src/orchestration/workflow.rs
@@ -654,7 +654,7 @@ pub fn normalize_workflow_value(value: &VmValue) -> Result<WorkflowGraph, VmErro
             node.raw_tools = as_dict
                 .get("nodes")
                 .and_then(|nodes| nodes.as_dict())
-                .and_then(|nodes| nodes.get(node_id))
+                .and_then(|nodes| nodes.get(node_id.as_str()))
                 .and_then(|node_value| node_value.as_dict())
                 .and_then(|raw_node| raw_node.get("tools"))
                 .cloned();
@@ -892,7 +892,10 @@ fn insert_json_vm_option<T: Serialize>(
     let json = serde_json::to_value(value).map_err(|error| {
         VmError::Runtime(format!("workflow stage option encode error: {error}"))
     })?;
-    options.insert(key.to_string(), crate::stdlib::json_to_vm_value(&json));
+    options.insert(
+        crate::value::intern_key(key),
+        crate::stdlib::json_to_vm_value(&json),
+    );
     Ok(())
 }
 
@@ -917,7 +920,10 @@ fn preserve_nested_command_policy(options: &mut crate::value::DictMap, node: &Wo
     else {
         return;
     };
-    options.insert("command_policy".to_string(), command_policy.clone());
+    options.insert(
+        crate::value::intern_key("command_policy"),
+        command_policy.clone(),
+    );
 }
 
 fn stage_tools_value(node: &WorkflowNode) -> Option<VmValue> {
@@ -937,7 +943,7 @@ fn add_stage_tools_option(
 ) {
     if !tool_names.is_empty() {
         if let Some(value) = tools_value.clone() {
-            options.insert("tools".to_string(), value);
+            options.insert(crate::value::intern_key("tools"), value);
         }
     }
 }
@@ -959,21 +965,33 @@ fn workflow_stage_llm_options(
 
 fn add_workflow_agent_compaction_options(options: &mut crate::value::DictMap, node: &WorkflowNode) {
     if !node.auto_compact.enabled {
-        options.insert("auto_compact".to_string(), VmValue::Bool(false));
+        options.insert(
+            crate::value::intern_key("auto_compact"),
+            VmValue::Bool(false),
+        );
         return;
     }
-    options.insert("auto_compact".to_string(), VmValue::Bool(true));
+    options.insert(
+        crate::value::intern_key("auto_compact"),
+        VmValue::Bool(true),
+    );
     if let Some(value) = node.auto_compact.token_threshold {
-        options.insert("compact_threshold".to_string(), VmValue::Int(value as i64));
+        options.insert(
+            crate::value::intern_key("compact_threshold"),
+            VmValue::Int(value as i64),
+        );
     }
     if let Some(value) = node.auto_compact.tool_output_max_chars {
         options.insert(
-            "tool_output_max_chars".to_string(),
+            crate::value::intern_key("tool_output_max_chars"),
             VmValue::Int(value as i64),
         );
     }
     if let Some(value) = node.auto_compact.hard_limit_tokens {
-        options.insert("hard_limit_tokens".to_string(), VmValue::Int(value as i64));
+        options.insert(
+            crate::value::intern_key("hard_limit_tokens"),
+            VmValue::Int(value as i64),
+        );
     }
     if let Some(strategy) = node.auto_compact.compact_strategy.as_ref() {
         options.put_str("compact_strategy", strategy.clone());
@@ -984,7 +1002,10 @@ fn add_workflow_agent_compaction_options(options: &mut crate::value::DictMap, no
     if let Some(value) = raw_auto_compact_int(node, "compact_keep_last")
         .or_else(|| raw_auto_compact_int(node, "keep_last"))
     {
-        options.insert("compact_keep_last".to_string(), VmValue::Int(value as i64));
+        options.insert(
+            crate::value::intern_key("compact_keep_last"),
+            VmValue::Int(value as i64),
+        );
     }
     if let Some(prompt) = raw_auto_compact_string(node, "summarize_prompt") {
         options.put_str("summarize_prompt", prompt);
@@ -992,11 +1013,14 @@ fn add_workflow_agent_compaction_options(options: &mut crate::value::DictMap, no
     if let Some(dict) = raw_auto_compact_dict(node) {
         for key in ["compress_callback", "mask_callback"] {
             if let Some(callback) = dict.get(key) {
-                options.insert(key.to_string(), callback.clone());
+                options.insert(crate::value::intern_key(key), callback.clone());
             }
         }
         if let Some(callback) = dict.get("custom_compactor") {
-            options.insert("compact_callback".to_string(), callback.clone());
+            options.insert(
+                crate::value::intern_key("compact_callback"),
+                callback.clone(),
+            );
         }
     }
 }
@@ -1013,12 +1037,12 @@ fn workflow_stage_agent_loop_options(
     if let Some(context) = crate::orchestration::current_workflow_skill_context() {
         if !options.contains_key("skills") {
             if let Some(registry) = context.registry {
-                options.insert("skills".to_string(), registry);
+                options.insert(crate::value::intern_key("skills"), registry);
             }
         }
         if !options.contains_key("skill_match") {
             if let Some(match_config) = context.match_config {
-                options.insert("skill_match".to_string(), match_config);
+                options.insert(crate::value::intern_key("skill_match"), match_config);
             }
         }
     }

--- a/crates/harn-vm/src/runtime_context.rs
+++ b/crates/harn-vm/src/runtime_context.rs
@@ -138,7 +138,7 @@ fn runtime_context_get(vm: &crate::vm::Vm, args: &[VmValue]) -> Result<VmValue, 
     Ok(vm
         .runtime_context
         .values
-        .get(&key)
+        .get(key.as_str())
         .cloned()
         .or_else(|| args.get(1).cloned())
         .unwrap_or(VmValue::Nil))
@@ -150,7 +150,7 @@ fn runtime_context_set(vm: &mut crate::vm::Vm, args: &[VmValue]) -> Result<VmVal
     Ok(vm
         .runtime_context
         .values
-        .insert(key, value)
+        .insert(crate::value::intern_key(&key), value)
         .unwrap_or(VmValue::Nil))
 }
 
@@ -159,7 +159,7 @@ fn runtime_context_clear(vm: &mut crate::vm::Vm, args: &[VmValue]) -> Result<VmV
     Ok(vm
         .runtime_context
         .values
-        .remove(&key)
+        .remove(key.as_str())
         .unwrap_or(VmValue::Nil))
 }
 
@@ -309,20 +309,29 @@ pub(crate) fn runtime_context_value(vm: &crate::vm::Vm) -> VmValue {
     insert_string(&mut values, "runner", None);
     insert_string(&mut values, "capacity_class", None);
     values.insert(
-        "context_values".to_string(),
+        crate::value::intern_key("context_values"),
         VmValue::dict(vm.runtime_context.values.clone()),
     );
-    values.insert("cancelled".to_string(), VmValue::Bool(cancelled));
-    values.insert("debug".to_string(), debug_context_value(vm, cancelled));
+    values.insert(
+        crate::value::intern_key("cancelled"),
+        VmValue::Bool(cancelled),
+    );
+    values.insert(
+        crate::value::intern_key("debug"),
+        debug_context_value(vm, cancelled),
+    );
     VmValue::dict(values)
 }
 
 fn debug_context_value(vm: &crate::vm::Vm, cancelled: bool) -> VmValue {
     let mut debug = crate::value::DictMap::new();
-    debug.insert("cancelled".to_string(), VmValue::Bool(cancelled));
-    debug.insert("waiting_reason".to_string(), VmValue::Nil);
     debug.insert(
-        "active_task_ids".to_string(),
+        crate::value::intern_key("cancelled"),
+        VmValue::Bool(cancelled),
+    );
+    debug.insert(crate::value::intern_key("waiting_reason"), VmValue::Nil);
+    debug.insert(
+        crate::value::intern_key("active_task_ids"),
         VmValue::List(std::sync::Arc::new(
             vm.spawned_tasks
                 .keys()
@@ -331,11 +340,11 @@ fn debug_context_value(vm: &crate::vm::Vm, cancelled: bool) -> VmValue {
         )),
     );
     debug.insert(
-        "held_synchronization".to_string(),
+        crate::value::intern_key("held_synchronization"),
         VmValue::List(std::sync::Arc::new(Vec::new())),
     );
     debug.insert(
-        "supervisors".to_string(),
+        crate::value::intern_key("supervisors"),
         crate::stdlib::supervisor::supervisor_debug_values(),
     );
     VmValue::dict(debug)
@@ -343,7 +352,7 @@ fn debug_context_value(vm: &crate::vm::Vm, cancelled: bool) -> VmValue {
 
 fn insert_string(values: &mut crate::value::DictMap, key: &str, value: Option<String>) {
     values.insert(
-        key.to_string(),
+        crate::value::intern_key(key),
         value
             .map(|value| VmValue::String(arcstr::ArcStr::from(value)))
             .unwrap_or(VmValue::Nil),

--- a/crates/harn-vm/src/schema/canonicalize.rs
+++ b/crates/harn-vm/src/schema/canonicalize.rs
@@ -25,7 +25,7 @@ pub(super) fn resolve_canonical_ref_with_path(
         let decoded = segment.replace("~1", "/").replace("~0", "~");
         normalized_segments.push(encode_json_pointer_segment(&decoded));
         current = match current {
-            VmValue::Dict(ref map) => map.get(&decoded)?.clone(),
+            VmValue::Dict(ref map) => map.get(decoded.as_str())?.clone(),
             VmValue::List(ref list) => {
                 let idx = decoded.parse::<usize>().ok()?;
                 list.get(idx)?.clone()
@@ -88,13 +88,13 @@ fn canonicalize_schema_dict(
         "x-harn-type",
     ] {
         if let Some(value) = schema.get(key) {
-            out.insert(key.to_string(), value.clone());
+            out.insert(crate::value::intern_key(key), value.clone());
         }
     }
 
     if let Some(reference) = schema.get("$ref") {
         traversal.mark_ref();
-        out.insert("$ref".to_string(), reference.clone());
+        out.insert(crate::value::intern_key("$ref"), reference.clone());
     }
 
     if let Some(properties) = schema.get("properties").and_then(VmValue::as_dict) {
@@ -105,12 +105,12 @@ fn canonicalize_schema_dict(
                 canonicalize_schema_value_with(value, traversal)?,
             );
         }
-        out.insert("properties".to_string(), VmValue::dict(next));
+        out.insert(crate::value::intern_key("properties"), VmValue::dict(next));
     }
 
     if let Some(items) = schema.get("items") {
         out.insert(
-            "items".to_string(),
+            crate::value::intern_key("items"),
             canonicalize_schema_value_with(items, traversal)?,
         );
     }
@@ -121,11 +121,14 @@ fn canonicalize_schema_dict(
     {
         match additional {
             VmValue::Bool(value) => {
-                out.insert("additional_properties".to_string(), VmValue::Bool(*value));
+                out.insert(
+                    crate::value::intern_key("additional_properties"),
+                    VmValue::Bool(*value),
+                );
             }
             VmValue::Dict(_) => {
                 out.insert(
-                    "additional_properties".to_string(),
+                    crate::value::intern_key("additional_properties"),
                     canonicalize_schema_value_with(additional, traversal)?,
                 );
             }
@@ -134,51 +137,57 @@ fn canonicalize_schema_dict(
     }
 
     if let Some(required) = schema.get("required") {
-        out.insert("required".to_string(), normalize_string_list(required));
+        out.insert(
+            crate::value::intern_key("required"),
+            normalize_string_list(required),
+        );
     }
 
     if let Some(default) = schema.get("default") {
-        out.insert("default".to_string(), default.clone());
+        out.insert(crate::value::intern_key("default"), default.clone());
     }
     if let Some(const_value) = schema.get("const") {
-        out.insert("const".to_string(), const_value.clone());
+        out.insert(crate::value::intern_key("const"), const_value.clone());
     }
     if let Some(enum_values) = schema.get("enum") {
-        out.insert("enum".to_string(), enum_values.clone());
+        out.insert(crate::value::intern_key("enum"), enum_values.clone());
     }
 
     if let Some(min) = schema.get("min").or_else(|| schema.get("minimum")) {
-        out.insert("min".to_string(), min.clone());
+        out.insert(crate::value::intern_key("min"), min.clone());
     }
     if let Some(max) = schema.get("max").or_else(|| schema.get("maximum")) {
-        out.insert("max".to_string(), max.clone());
+        out.insert(crate::value::intern_key("max"), max.clone());
     }
     if let Some(min_length) = schema.get("min_length").or_else(|| schema.get("minLength")) {
-        out.insert("min_length".to_string(), min_length.clone());
+        out.insert(crate::value::intern_key("min_length"), min_length.clone());
     }
     if let Some(max_length) = schema.get("max_length").or_else(|| schema.get("maxLength")) {
-        out.insert("max_length".to_string(), max_length.clone());
+        out.insert(crate::value::intern_key("max_length"), max_length.clone());
     }
     if let Some(min_items) = schema.get("min_items").or_else(|| schema.get("minItems")) {
-        out.insert("min_items".to_string(), min_items.clone());
+        out.insert(crate::value::intern_key("min_items"), min_items.clone());
     }
     if let Some(max_items) = schema.get("max_items").or_else(|| schema.get("maxItems")) {
-        out.insert("max_items".to_string(), max_items.clone());
+        out.insert(crate::value::intern_key("max_items"), max_items.clone());
     }
     if schema_bool(schema, "unique_items") || schema_bool(schema, "uniqueItems") {
-        out.insert("unique_items".to_string(), VmValue::Bool(true));
+        out.insert(
+            crate::value::intern_key("unique_items"),
+            VmValue::Bool(true),
+        );
     }
     if let Some(pattern) = schema.get("pattern") {
-        out.insert("pattern".to_string(), pattern.clone());
+        out.insert(crate::value::intern_key("pattern"), pattern.clone());
     }
 
     if schema_bool(schema, "nullable") {
-        out.insert("nullable".to_string(), VmValue::Bool(true));
+        out.insert(crate::value::intern_key("nullable"), VmValue::Bool(true));
     }
 
     if let Some(definitions) = schema.get("definitions").and_then(VmValue::as_dict) {
         out.insert(
-            "definitions".to_string(),
+            crate::value::intern_key("definitions"),
             VmValue::dict(canonicalize_schema_map(definitions, traversal)?),
         );
     }
@@ -187,11 +196,14 @@ fn canonicalize_schema_dict(
         let mut next_components = components.clone();
         if let Some(schemas) = components.get("schemas").and_then(VmValue::as_dict) {
             next_components.insert(
-                "schemas".to_string(),
+                crate::value::intern_key("schemas"),
                 VmValue::dict(canonicalize_schema_map(schemas, traversal)?),
             );
         }
-        out.insert("components".to_string(), VmValue::dict(next_components));
+        out.insert(
+            crate::value::intern_key("components"),
+            VmValue::dict(next_components),
+        );
     }
 
     if let Some(union) = schema
@@ -200,14 +212,14 @@ fn canonicalize_schema_dict(
         .or_else(|| schema.get("anyOf"))
     {
         out.insert(
-            "union".to_string(),
+            crate::value::intern_key("union"),
             canonicalize_schema_list(union, traversal)?,
         );
     }
 
     if let Some(all_of) = schema.get("all_of").or_else(|| schema.get("allOf")) {
         out.insert(
-            "all_of".to_string(),
+            crate::value::intern_key("all_of"),
             canonicalize_schema_list(all_of, traversal)?,
         );
     }
@@ -228,7 +240,7 @@ fn canonicalize_schema_dict(
                 })
                 .collect::<Vec<_>>();
             out.insert(
-                "union".to_string(),
+                crate::value::intern_key("union"),
                 VmValue::List(std::sync::Arc::new(union)),
             );
         }
@@ -582,7 +594,7 @@ fn canonical_to_json_schema_with(
             let mut props = serde_json::Map::new();
             for (name, child) in properties.iter() {
                 props.insert(
-                    name.clone(),
+                    name.to_string(),
                     canonical_to_json_schema_with(child, openapi_style, traversal)?,
                 );
             }
@@ -654,7 +666,7 @@ fn canonical_to_json_schema_with(
             let mut exported = serde_json::Map::new();
             for (name, child) in definitions.iter() {
                 exported.insert(
-                    name.clone(),
+                    name.to_string(),
                     canonical_to_json_schema_with(child, openapi_style, traversal)?,
                 );
             }
@@ -666,12 +678,12 @@ fn canonical_to_json_schema_with(
         if let Some(VmValue::Dict(components)) = schema_dict.get("components") {
             let mut next_components = serde_json::Map::new();
             for (key, value) in components.iter() {
-                if key == "schemas" {
+                if key.as_str() == "schemas" {
                     let schema_map = value.as_dict().cloned().unwrap_or_default();
                     let mut exported_schemas = serde_json::Map::new();
                     for (name, child) in schema_map.iter() {
                         exported_schemas.insert(
-                            name.clone(),
+                            name.to_string(),
                             canonical_to_json_schema_with(child, openapi_style, traversal)?,
                         );
                     }
@@ -680,7 +692,7 @@ fn canonical_to_json_schema_with(
                         serde_json::Value::Object(exported_schemas),
                     );
                 } else {
-                    next_components.insert(key.clone(), vm_value_to_serde_json(value));
+                    next_components.insert(key.to_string(), vm_value_to_serde_json(value));
                 }
             }
             out.insert(
@@ -748,7 +760,7 @@ pub fn json_to_vm_value(jv: &serde_json::Value) -> VmValue {
         serde_json::Value::Object(map) => {
             let mut m = crate::value::DictMap::new();
             for (k, v) in map {
-                m.insert(k.clone(), json_to_vm_value(v));
+                m.insert(crate::value::intern_key(k), json_to_vm_value(v));
             }
             VmValue::dict(m)
         }

--- a/crates/harn-vm/src/schema/mod.rs
+++ b/crates/harn-vm/src/schema/mod.rs
@@ -62,7 +62,7 @@ fn vm_value_to_serde_json(value: &VmValue) -> serde_json::Value {
         VmValue::Dict(items) => serde_json::Value::Object(
             items
                 .iter()
-                .map(|(key, value)| (key.clone(), vm_value_to_serde_json(value)))
+                .map(|(key, value)| (key.to_string(), vm_value_to_serde_json(value)))
                 .collect(),
         ),
         _ => serde_json::Value::String(value.display()),

--- a/crates/harn-vm/src/schema/transform.rs
+++ b/crates/harn-vm/src/schema/transform.rs
@@ -25,11 +25,14 @@ pub(crate) fn schema_partial_dict(schema: &crate::value::DictMap) -> crate::valu
                 next_props.insert(key.clone(), value.clone());
             }
         }
-        partial.insert("properties".to_string(), VmValue::dict(next_props));
+        partial.insert(
+            crate::value::intern_key("properties"),
+            VmValue::dict(next_props),
+        );
     }
     if let Some(VmValue::List(branches)) = schema.get("union") {
         partial.insert(
-            "union".to_string(),
+            crate::value::intern_key("union"),
             VmValue::List(std::sync::Arc::new(
                 branches
                     .iter()
@@ -45,7 +48,7 @@ pub(crate) fn schema_partial_dict(schema: &crate::value::DictMap) -> crate::valu
     }
     if let Some(VmValue::List(branches)) = schema.get("all_of") {
         partial.insert(
-            "all_of".to_string(),
+            crate::value::intern_key("all_of"),
             VmValue::List(std::sync::Arc::new(
                 branches
                     .iter()
@@ -61,13 +64,13 @@ pub(crate) fn schema_partial_dict(schema: &crate::value::DictMap) -> crate::valu
     }
     if let Some(VmValue::Dict(item_schema)) = schema.get("items") {
         partial.insert(
-            "items".to_string(),
+            crate::value::intern_key("items"),
             VmValue::dict(schema_partial_dict(item_schema)),
         );
     }
     if let Some(VmValue::Dict(extra_schema)) = schema.get("additional_properties") {
         partial.insert(
-            "additional_properties".to_string(),
+            crate::value::intern_key("additional_properties"),
             VmValue::dict(schema_partial_dict(extra_schema)),
         );
     }
@@ -82,14 +85,17 @@ pub(crate) fn schema_pick_dict(
     if let Some(VmValue::Dict(properties)) = schema.get("properties") {
         let filtered: crate::value::DictMap = properties
             .iter()
-            .filter(|(key, _)| keys.contains(*key))
+            .filter(|(key, _)| keys.iter().any(|k| k.as_str() == key.as_str()))
             .map(|(key, value)| (key.clone(), value.clone()))
             .collect();
-        picked.insert("properties".to_string(), VmValue::dict(filtered));
+        picked.insert(
+            crate::value::intern_key("properties"),
+            VmValue::dict(filtered),
+        );
     }
     if let Some(VmValue::List(required)) = schema.get("required") {
         picked.insert(
-            "required".to_string(),
+            crate::value::intern_key("required"),
             VmValue::List(std::sync::Arc::new(
                 required
                     .iter()
@@ -110,14 +116,17 @@ pub(crate) fn schema_omit_dict(
     if let Some(VmValue::Dict(properties)) = schema.get("properties") {
         let filtered: crate::value::DictMap = properties
             .iter()
-            .filter(|(key, _)| !keys.contains(*key))
+            .filter(|(key, _)| !keys.iter().any(|k| k.as_str() == key.as_str()))
             .map(|(key, value)| (key.clone(), value.clone()))
             .collect();
-        kept.insert("properties".to_string(), VmValue::dict(filtered));
+        kept.insert(
+            crate::value::intern_key("properties"),
+            VmValue::dict(filtered),
+        );
     }
     if let Some(VmValue::List(required)) = schema.get("required") {
         kept.insert(
-            "required".to_string(),
+            crate::value::intern_key("required"),
             VmValue::List(std::sync::Arc::new(
                 required
                     .iter()

--- a/crates/harn-vm/src/schema/validate.rs
+++ b/crates/harn-vm/src/schema/validate.rs
@@ -400,11 +400,11 @@ fn validate_object_fields(
     if let Some(VmValue::List(required_keys)) = schema.get("required") {
         for key_val in required_keys.iter() {
             let key = key_val.display();
-            if !fields.contains_key(&key) {
+            if !fields.contains_key(key.as_str()) {
                 let has_default = schema
                     .get("properties")
                     .and_then(VmValue::as_dict)
-                    .and_then(|props| props.get(&key))
+                    .and_then(|props| props.get(key.as_str()))
                     .and_then(VmValue::as_dict)
                     .is_some_and(|prop_schema| prop_schema.contains_key("default"));
                 if options.apply_defaults && has_default {
@@ -503,7 +503,7 @@ fn validate_object_fields(
         let mut field_names = layout.field_names().to_vec();
         for key in merged.keys() {
             if layout.field_index(key).is_none() {
-                field_names.push(key.clone());
+                field_names.push(key.to_string());
             }
         }
         VmValue::struct_instance_with_layout(layout.struct_name().to_string(), field_names, merged)
@@ -777,23 +777,23 @@ fn first_object_param_error(
     if let Some(VmValue::List(required_keys)) = schema.get("required") {
         for key_value in required_keys.iter() {
             let key = key_value.display();
-            if !fields.contains_key(&key) {
+            if !fields.contains_key(key.as_str()) {
                 let key_initial = key.chars().next();
                 let suggestion = crate::value::closest_match(
                     &key,
                     fields
                         .keys()
-                        .map(String::as_str)
+                        .map(|key| key.as_str())
                         .filter(|candidate| candidate.chars().next() == key_initial),
                 );
                 let expected = schema
                     .get("properties")
                     .and_then(VmValue::as_dict)
-                    .and_then(|props| props.get(&key))
+                    .and_then(|props| props.get(key.as_str()))
                     .and_then(VmValue::as_dict)
                     .map(schema_expected_label)
                     .unwrap_or_else(|| "value".to_string());
-                let actual_keys: Vec<&str> = fields.keys().map(String::as_str).collect();
+                let actual_keys: Vec<&str> = fields.keys().map(|key| key.as_str()).collect();
                 let actual_summary = crate::stdlib::shapes::format_available_fields(&actual_keys);
                 if let Some(suggestion) = suggestion {
                     return Some(format!(

--- a/crates/harn-vm/src/shared_state.rs
+++ b/crates/harn-vm/src/shared_state.rs
@@ -159,7 +159,10 @@ impl VmSharedStateRuntime {
     pub(crate) fn map_set(&self, scoped: &ScopedKey, key: String, value: VmValue) -> VmValue {
         let mut maps = self.maps.lock();
         let map = maps.entry(scoped.clone()).or_default();
-        let old = map.entries.insert(key, value).unwrap_or(VmValue::Nil);
+        let old = map
+            .entries
+            .insert(crate::value::intern_key(&key), value)
+            .unwrap_or(VmValue::Nil);
         map.version = map.version.saturating_add(1);
         map.metrics.write_count += 1;
         old
@@ -185,15 +188,20 @@ impl VmSharedStateRuntime {
     ) -> bool {
         let mut maps = self.maps.lock();
         let map = maps.entry(scoped.clone()).or_default();
-        let current = map.entries.get(&key).cloned().unwrap_or(VmValue::Nil);
+        let current = map
+            .entries
+            .get(key.as_str())
+            .cloned()
+            .unwrap_or(VmValue::Nil);
         let (expected_value, expected_version) = snapshot_expected(expected);
         let version_matches = expected_version.is_none_or(|version| version == map.version);
         let value_matches = values_equal(&current, &expected_value);
         if version_matches && value_matches {
             if matches!(new_value, VmValue::Nil) {
-                map.entries.remove(&key);
+                map.entries.remove(key.as_str());
             } else {
-                map.entries.insert(key, new_value);
+                map.entries
+                    .insert(crate::value::intern_key(&key), new_value);
             }
             map.version = map.version.saturating_add(1);
             map.metrics.write_count += 1;

--- a/crates/harn-vm/src/shells.rs
+++ b/crates/harn-vm/src/shells.rs
@@ -169,35 +169,53 @@ pub fn resolve_shell_from_vm_params(
 
 pub fn shell_descriptor_to_vm_value(shell: &ShellDescriptor) -> VmValue {
     let mut map = crate::value::DictMap::new();
-    map.insert("id".to_string(), string(&shell.id));
-    map.insert("label".to_string(), string(&shell.label));
-    map.insert("path".to_string(), string(&shell.path));
-    map.insert("platform".to_string(), string(&shell.platform));
-    map.insert("available".to_string(), VmValue::Bool(shell.available));
+    map.insert(crate::value::intern_key("id"), string(&shell.id));
+    map.insert(crate::value::intern_key("label"), string(&shell.label));
+    map.insert(crate::value::intern_key("path"), string(&shell.path));
     map.insert(
-        "supports_login".to_string(),
+        crate::value::intern_key("platform"),
+        string(&shell.platform),
+    );
+    map.insert(
+        crate::value::intern_key("available"),
+        VmValue::Bool(shell.available),
+    );
+    map.insert(
+        crate::value::intern_key("supports_login"),
         VmValue::Bool(shell.supports_login),
     );
     map.insert(
-        "supports_interactive".to_string(),
+        crate::value::intern_key("supports_interactive"),
         VmValue::Bool(shell.supports_interactive),
     );
-    map.insert("default_args".to_string(), string_list(&shell.default_args));
-    map.insert("login_args".to_string(), string_list(&shell.login_args));
-    map.insert("source".to_string(), string(&shell.source));
+    map.insert(
+        crate::value::intern_key("default_args"),
+        string_list(&shell.default_args),
+    );
+    map.insert(
+        crate::value::intern_key("login_args"),
+        string_list(&shell.login_args),
+    );
+    map.insert(crate::value::intern_key("source"), string(&shell.source));
     VmValue::dict(map)
 }
 
 pub fn shell_invocation_to_vm_value(invocation: &ShellInvocation) -> VmValue {
     let mut map = crate::value::DictMap::new();
-    map.insert("program".to_string(), string(&invocation.program));
-    map.insert("args".to_string(), string_list(&invocation.args));
     map.insert(
-        "command_arg_index".to_string(),
+        crate::value::intern_key("program"),
+        string(&invocation.program),
+    );
+    map.insert(
+        crate::value::intern_key("args"),
+        string_list(&invocation.args),
+    );
+    map.insert(
+        crate::value::intern_key("command_arg_index"),
         VmValue::Int(invocation.command_arg_index as i64),
     );
     map.insert(
-        "shell".to_string(),
+        crate::value::intern_key("shell"),
         shell_descriptor_to_vm_value(&invocation.shell),
     );
     VmValue::dict(map)
@@ -206,7 +224,7 @@ pub fn shell_invocation_to_vm_value(invocation: &ShellInvocation) -> VmValue {
 fn shell_catalog_to_vm_value(catalog: &ShellCatalog) -> VmValue {
     let mut map = crate::value::DictMap::new();
     map.insert(
-        "shells".to_string(),
+        crate::value::intern_key("shells"),
         VmValue::List(std::sync::Arc::new(
             catalog
                 .shells
@@ -216,7 +234,7 @@ fn shell_catalog_to_vm_value(catalog: &ShellCatalog) -> VmValue {
         )),
     );
     map.insert(
-        "default_shell_id".to_string(),
+        crate::value::intern_key("default_shell_id"),
         catalog
             .default_shell_id
             .as_ref()
@@ -630,7 +648,10 @@ mod tests {
         let default_shell = get_default_shell().expect("test host should expose a default shell");
 
         let mut params = crate::value::DictMap::new();
-        params.insert("command".to_string(), string("echo default-shell"));
+        params.insert(
+            crate::value::intern_key("command"),
+            string("echo default-shell"),
+        );
 
         let invocation = resolve_invocation_from_vm_params(&params).unwrap();
         assert_eq!(invocation.shell, default_shell);
@@ -644,14 +665,14 @@ mod tests {
     #[test]
     fn malformed_explicit_shell_fields_do_not_fall_back_to_default() {
         let mut params = crate::value::DictMap::new();
-        params.insert("shell".to_string(), VmValue::Int(1));
+        params.insert(crate::value::intern_key("shell"), VmValue::Int(1));
         assert_eq!(
             resolve_shell_from_vm_params(&params).unwrap_err(),
             "shell must be a dict, got int"
         );
 
         let mut params = crate::value::DictMap::new();
-        params.insert("shell_id".to_string(), VmValue::Int(1));
+        params.insert(crate::value::intern_key("shell_id"), VmValue::Int(1));
         assert_eq!(
             resolve_shell_from_vm_params(&params).unwrap_err(),
             "shell_id must be a string, got int"

--- a/crates/harn-vm/src/skills/source.rs
+++ b/crates/harn-vm/src/skills/source.rs
@@ -417,11 +417,14 @@ pub fn skill_entry_to_vm(skill: &Skill) -> crate::value::VmValue {
     );
     entry.put_opt_str("when_to_use", skill.manifest.when_to_use.as_deref());
     if skill.manifest.disable_model_invocation {
-        entry.insert("disable_model_invocation".to_string(), VmValue::Bool(true));
+        entry.insert(
+            crate::value::intern_key("disable_model_invocation"),
+            VmValue::Bool(true),
+        );
     }
     if !skill.manifest.allowed_tools.is_empty() {
         entry.insert(
-            "allowed_tools".to_string(),
+            crate::value::intern_key("allowed_tools"),
             VmValue::List(std::sync::Arc::new(
                 skill
                     .manifest
@@ -433,11 +436,14 @@ pub fn skill_entry_to_vm(skill: &Skill) -> crate::value::VmValue {
         );
     }
     if skill.manifest.user_invocable {
-        entry.insert("user_invocable".to_string(), VmValue::Bool(true));
+        entry.insert(
+            crate::value::intern_key("user_invocable"),
+            VmValue::Bool(true),
+        );
     }
     if !skill.manifest.paths.is_empty() {
         entry.insert(
-            "paths".to_string(),
+            crate::value::intern_key("paths"),
             VmValue::List(std::sync::Arc::new(
                 skill
                     .manifest
@@ -453,18 +459,24 @@ pub fn skill_entry_to_vm(skill: &Skill) -> crate::value::VmValue {
     if !skill.manifest.hooks.is_empty() {
         let mut hooks: crate::value::DictMap = crate::value::DictMap::new();
         for (k, v) in &skill.manifest.hooks {
-            hooks.insert(k.clone(), VmValue::String(arcstr::ArcStr::from(v.as_str())));
+            hooks.insert(
+                crate::value::intern_key(k),
+                VmValue::String(arcstr::ArcStr::from(v.as_str())),
+            );
         }
-        entry.insert("hooks".to_string(), VmValue::dict(hooks));
+        entry.insert(crate::value::intern_key("hooks"), VmValue::dict(hooks));
     }
     entry.put_opt_str("model", skill.manifest.model.as_deref());
     entry.put_opt_str("effort", skill.manifest.effort.as_deref());
     if skill.manifest.require_signature {
-        entry.insert("require_signature".to_string(), VmValue::Bool(true));
+        entry.insert(
+            crate::value::intern_key("require_signature"),
+            VmValue::Bool(true),
+        );
     }
     if !skill.manifest.trusted_signers.is_empty() {
         entry.insert(
-            "trusted_signers".to_string(),
+            crate::value::intern_key("trusted_signers"),
             VmValue::List(std::sync::Arc::new(
                 skill
                     .manifest
@@ -502,11 +514,14 @@ pub fn skill_manifest_ref_to_vm(skill: &SkillManifestRef) -> crate::value::VmVal
     );
     entry.put_opt_str("when_to_use", skill.manifest.when_to_use.as_deref());
     if skill.manifest.disable_model_invocation {
-        entry.insert("disable_model_invocation".to_string(), VmValue::Bool(true));
+        entry.insert(
+            crate::value::intern_key("disable_model_invocation"),
+            VmValue::Bool(true),
+        );
     }
     if !skill.manifest.allowed_tools.is_empty() {
         entry.insert(
-            "allowed_tools".to_string(),
+            crate::value::intern_key("allowed_tools"),
             VmValue::List(std::sync::Arc::new(
                 skill
                     .manifest
@@ -518,11 +533,14 @@ pub fn skill_manifest_ref_to_vm(skill: &SkillManifestRef) -> crate::value::VmVal
         );
     }
     if skill.manifest.user_invocable {
-        entry.insert("user_invocable".to_string(), VmValue::Bool(true));
+        entry.insert(
+            crate::value::intern_key("user_invocable"),
+            VmValue::Bool(true),
+        );
     }
     if !skill.manifest.paths.is_empty() {
         entry.insert(
-            "paths".to_string(),
+            crate::value::intern_key("paths"),
             VmValue::List(std::sync::Arc::new(
                 skill
                     .manifest
@@ -539,11 +557,11 @@ pub fn skill_manifest_ref_to_vm(skill: &SkillManifestRef) -> crate::value::VmVal
         let mut hooks: crate::value::DictMap = crate::value::DictMap::new();
         for (key, value) in &skill.manifest.hooks {
             hooks.insert(
-                key.clone(),
+                crate::value::intern_key(key),
                 VmValue::String(arcstr::ArcStr::from(value.as_str())),
             );
         }
-        entry.insert("hooks".to_string(), VmValue::dict(hooks));
+        entry.insert(crate::value::intern_key("hooks"), VmValue::dict(hooks));
     }
     entry.put_opt_str("model", skill.manifest.model.as_deref());
     entry.put_opt_str("effort", skill.manifest.effort.as_deref());

--- a/crates/harn-vm/src/stdlib/agent_sessions.rs
+++ b/crates/harn-vm/src/stdlib/agent_sessions.rs
@@ -572,14 +572,14 @@ fn agent_session_ancestry_builtin(args: &[VmValue], _out: &mut String) -> Result
     };
     Ok(VmValue::dict(crate::value::DictMap::from_iter([
         (
-            "parent_id".to_string(),
+            crate::value::intern_key("parent_id"),
             ancestry
                 .parent_id
                 .map(|value| VmValue::String(arcstr::ArcStr::from(value)))
                 .unwrap_or(VmValue::Nil),
         ),
         (
-            "child_ids".to_string(),
+            crate::value::intern_key("child_ids"),
             VmValue::List(std::sync::Arc::new(
                 ancestry
                     .child_ids
@@ -589,7 +589,7 @@ fn agent_session_ancestry_builtin(args: &[VmValue], _out: &mut String) -> Result
             )),
         ),
         (
-            "root_id".to_string(),
+            crate::value::intern_key("root_id"),
             VmValue::String(arcstr::ArcStr::from(ancestry.root_id)),
         ),
     ])))
@@ -1296,11 +1296,14 @@ fn agent_session_drain_inbox_builtin(
         .into_iter()
         .map(|entry| {
             let mut dict = crate::value::DictMap::new();
-            dict.insert("sequence".to_string(), VmValue::Int(entry.sequence as i64));
+            dict.insert(
+                crate::value::intern_key("sequence"),
+                VmValue::Int(entry.sequence as i64),
+            );
             dict.put_str("kind", entry.kind);
             dict.put_str("content", entry.content);
             dict.put_str("source", entry.source);
-            dict.insert("ts_ms".to_string(), VmValue::Int(entry.ts_ms));
+            dict.insert(crate::value::intern_key("ts_ms"), VmValue::Int(entry.ts_ms));
             VmValue::dict(dict)
         })
         .collect::<Vec<_>>();
@@ -1800,7 +1803,7 @@ async fn cancel_in_flight_tool_call_builtin(
     result.put_str("status", final_status);
     result.put_str("call_id", call_id);
     result.insert(
-        "tool".to_string(),
+        crate::value::intern_key("tool"),
         outcome
             .tool_name
             .map(|name| VmValue::String(arcstr::ArcStr::from(name)))
@@ -1931,7 +1934,7 @@ mod tests {
             "hard_limit_tokens",
         ] {
             let mut opts = crate::value::DictMap::new();
-            opts.insert(key.to_string(), VmValue::Int(-1));
+            opts.insert(crate::value::intern_key(key), VmValue::Int(-1));
             let err = build_compact_config(&opts).expect_err("negative option must fail");
             assert!(err.to_string().contains(key), "{err}");
         }

--- a/crates/harn-vm/src/stdlib/agents/replay.rs
+++ b/crates/harn-vm/src/stdlib/agents/replay.rs
@@ -259,7 +259,7 @@ pub(super) fn apply_workflow_replay_config(
     }
     options.put_str("parent_worker_id", carry.parent_worker_id);
     if let Some(transcript) = carry.transcript {
-        options.insert("transcript".to_string(), transcript);
+        options.insert(crate::value::intern_key("transcript"), transcript);
     } else {
         options.remove("transcript");
     }

--- a/crates/harn-vm/src/stdlib/agents/resume.rs
+++ b/crates/harn-vm/src/stdlib/agents/resume.rs
@@ -388,7 +388,7 @@ pub(super) fn install_resume_continuity_payload(
     });
     if let WorkerConfig::SubAgent { spec } = &mut worker.config {
         spec.options.insert(
-            "_resume_continuity".to_string(),
+            crate::value::intern_key("_resume_continuity"),
             crate::stdlib::json_to_vm_value(&payload),
         );
     }

--- a/crates/harn-vm/src/stdlib/agents_daemon.rs
+++ b/crates/harn-vm/src/stdlib/agents_daemon.rs
@@ -359,22 +359,25 @@ async fn daemon_resume_builtin(
     let spec = parse_spawn_spec(
         &crate::value::DictMap::from_iter([
             (
-                "name".to_string(),
+                crate::value::intern_key("name"),
                 VmValue::String(arcstr::ArcStr::from(meta.name.clone())),
             ),
             (
-                "task".to_string(),
+                crate::value::intern_key("task"),
                 VmValue::String(arcstr::ArcStr::from(meta.prompt.clone())),
             ),
             (
-                "persist_path".to_string(),
+                crate::value::intern_key("persist_path"),
                 VmValue::String(arcstr::ArcStr::from(persist_root.clone())),
             ),
             (
-                "session_id".to_string(),
+                crate::value::intern_key("session_id"),
                 VmValue::String(arcstr::ArcStr::from(meta.session_id.clone())),
             ),
-            ("options".to_string(), VmValue::dict(options.clone())),
+            (
+                crate::value::intern_key("options"),
+                VmValue::dict(options.clone()),
+            ),
         ]),
         Some(meta.id.clone()),
         meta.system.clone(),
@@ -399,10 +402,11 @@ async fn daemon_resume_builtin(
             daemon.options = options.clone();
             daemon
                 .options
-                .insert("daemon".to_string(), VmValue::Bool(true));
-            daemon
-                .options
-                .insert("loop_until_done".to_string(), VmValue::Bool(false));
+                .insert(crate::value::intern_key("daemon"), VmValue::Bool(true));
+            daemon.options.insert(
+                crate::value::intern_key("loop_until_done"),
+                VmValue::Bool(false),
+            );
             daemon
                 .options
                 .put_str("session_id", spec.session_id.clone());
@@ -446,8 +450,11 @@ async fn daemon_resume_builtin(
     }
 
     let mut resume_options = options;
-    resume_options.insert("daemon".to_string(), VmValue::Bool(true));
-    resume_options.insert("loop_until_done".to_string(), VmValue::Bool(false));
+    resume_options.insert(crate::value::intern_key("daemon"), VmValue::Bool(true));
+    resume_options.insert(
+        crate::value::intern_key("loop_until_done"),
+        VmValue::Bool(false),
+    );
     resume_options.put_str("session_id", spec.session_id.clone());
     resume_options.put_str("persist_path", spec.snapshot_path.clone());
     resume_options.put_str("resume_path", spec.snapshot_path.clone());
@@ -562,8 +569,11 @@ fn parse_spawn_spec(
         .filter(|value| *value > 0)
         .unwrap_or(DEFAULT_EVENT_QUEUE_CAPACITY);
 
-    options.insert("daemon".to_string(), VmValue::Bool(true));
-    options.insert("loop_until_done".to_string(), VmValue::Bool(false));
+    options.insert(crate::value::intern_key("daemon"), VmValue::Bool(true));
+    options.insert(
+        crate::value::intern_key("loop_until_done"),
+        VmValue::Bool(false),
+    );
     options.put_str("session_id", session_id.clone());
     options.put_str("persist_path", paths.snapshot_path.clone());
     options.remove("resume_path");

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -266,7 +266,7 @@ fn prepare_sub_agent_options(
     options.put_str("session_id", session_id);
     match requested_policy {
         Some(policy) => {
-            options.insert("policy".to_string(), super::to_vm(policy)?);
+            options.insert(crate::value::intern_key("policy"), super::to_vm(policy)?);
         }
         None => {
             options.remove("policy");
@@ -281,12 +281,12 @@ fn inject_sub_agent_skill_context(options: &mut crate::value::DictMap) {
     };
     if !options.contains_key("skills") {
         if let Some(registry) = context.registry {
-            options.insert("skills".to_string(), registry);
+            options.insert(crate::value::intern_key("skills"), registry);
         }
     }
     if !options.contains_key("skill_match") {
         if let Some(match_config) = context.match_config {
-            options.insert("skill_match".to_string(), match_config);
+            options.insert(crate::value::intern_key("skill_match"), match_config);
         }
     }
 }
@@ -314,17 +314,23 @@ fn sub_agent_base_envelope(
     session_id: &str,
 ) -> crate::value::DictMap {
     let mut envelope = crate::value::DictMap::new();
-    envelope.insert("ok".to_string(), VmValue::Bool(true));
+    envelope.insert(crate::value::intern_key("ok"), VmValue::Bool(true));
     envelope.put_str("summary", summary);
-    envelope.insert("artifacts".to_string(), artifacts);
-    envelope.insert("evidence_added".to_string(), VmValue::Int(evidence_added));
-    envelope.insert("tokens_used".to_string(), VmValue::Int(tokens_used));
+    envelope.insert(crate::value::intern_key("artifacts"), artifacts);
     envelope.insert(
-        "budget_exceeded".to_string(),
+        crate::value::intern_key("evidence_added"),
+        VmValue::Int(evidence_added),
+    );
+    envelope.insert(
+        crate::value::intern_key("tokens_used"),
+        VmValue::Int(tokens_used),
+    );
+    envelope.insert(
+        crate::value::intern_key("budget_exceeded"),
         VmValue::Bool(budget_exceeded),
     );
-    envelope.insert("data".to_string(), VmValue::Nil);
-    envelope.insert("error".to_string(), VmValue::Nil);
+    envelope.insert(crate::value::intern_key("data"), VmValue::Nil);
+    envelope.insert(crate::value::intern_key("error"), VmValue::Nil);
     envelope.put_str("session_id", session_id);
     envelope
 }
@@ -347,10 +353,10 @@ fn wrap_sub_agent_error(
         budget_exceeded,
         session_id,
     );
-    envelope.insert("ok".to_string(), VmValue::Bool(false));
-    envelope.insert("error".to_string(), error);
+    envelope.insert(crate::value::intern_key("ok"), VmValue::Bool(false));
+    envelope.insert(crate::value::intern_key("error"), error);
     if let Some(transcript) = transcript {
-        envelope.insert("transcript".to_string(), transcript);
+        envelope.insert(crate::value::intern_key("transcript"), transcript);
     }
     VmValue::dict(envelope)
 }
@@ -872,12 +878,12 @@ pub(super) async fn execute_sub_agent(
         budget_exceeded,
         &spec.session_id,
     );
-    envelope.insert("transcript".to_string(), transcript.clone());
+    envelope.insert(crate::value::intern_key("transcript"), transcript.clone());
 
     if spec.returns_schema.is_none() && option_requests_structured_output(&spec.options) {
         if let Some(candidate) = synthesized.structured_json.as_ref() {
             envelope.insert(
-                "data".to_string(),
+                crate::value::intern_key("data"),
                 crate::stdlib::json_to_vm_value(&candidate.value),
             );
         }
@@ -886,7 +892,7 @@ pub(super) async fn execute_sub_agent(
     if let Some(schema) = spec.returns_schema.as_ref() {
         match parse_structured_sub_agent_data(synthesized.structured_json.as_ref(), schema) {
             Ok(data) => {
-                envelope.insert("data".to_string(), data);
+                envelope.insert(crate::value::intern_key("data"), data);
             }
             Err(error) => {
                 let message = error.to_string();
@@ -1000,11 +1006,11 @@ mod tests {
     fn assistant_message(text: &str) -> VmValue {
         VmValue::dict(crate::value::DictMap::from_iter([
             (
-                "role".to_string(),
+                crate::value::intern_key("role"),
                 VmValue::String(arcstr::ArcStr::from("assistant")),
             ),
             (
-                "content".to_string(),
+                crate::value::intern_key("content"),
                 VmValue::String(arcstr::ArcStr::from(text)),
             ),
         ]))
@@ -1013,16 +1019,16 @@ mod tests {
     fn normalized_request(extra: Vec<(&str, VmValue)>) -> VmValue {
         let mut request = crate::value::DictMap::from_iter([
             (
-                "_type".to_string(),
+                crate::value::intern_key("_type"),
                 VmValue::String(arcstr::ArcStr::from("sub_agent_request")),
             ),
             (
-                "task".to_string(),
+                crate::value::intern_key("task"),
                 VmValue::String(arcstr::ArcStr::from("summarize")),
             ),
         ]);
         for (key, value) in extra {
-            request.insert(key.to_string(), value);
+            request.insert(crate::value::intern_key(key), value);
         }
         VmValue::dict(request)
     }
@@ -1059,32 +1065,32 @@ mod tests {
         for (path, mount_mode) in additional {
             roots.push(VmValue::dict(crate::value::DictMap::from_iter([
                 (
-                    "path".to_string(),
+                    crate::value::intern_key("path"),
                     VmValue::String(arcstr::ArcStr::from(path)),
                 ),
                 (
-                    "mount_mode".to_string(),
+                    crate::value::intern_key("mount_mode"),
                     VmValue::String(arcstr::ArcStr::from(mount_mode)),
                 ),
                 (
-                    "mounted_at".to_string(),
+                    crate::value::intern_key("mounted_at"),
                     VmValue::String(arcstr::ArcStr::from("2026-05-24T00:00:00Z")),
                 ),
             ])));
         }
         let mut anchor = crate::value::DictMap::from_iter([
             (
-                "primary".to_string(),
+                crate::value::intern_key("primary"),
                 VmValue::String(arcstr::ArcStr::from(primary)),
             ),
             (
-                "anchored_at".to_string(),
+                crate::value::intern_key("anchored_at"),
                 VmValue::String(arcstr::ArcStr::from("2026-05-24T00:00:00Z")),
             ),
         ]);
         if !roots.is_empty() {
             anchor.insert(
-                "additional_roots".to_string(),
+                crate::value::intern_key("additional_roots"),
                 VmValue::List(std::sync::Arc::new(roots)),
             );
         }
@@ -1280,14 +1286,14 @@ mod tests {
             system: None,
             options: crate::value::DictMap::from_iter([
                 (
-                    "provider".to_string(),
+                    crate::value::intern_key("provider"),
                     VmValue::String(arcstr::ArcStr::from("mock")),
                 ),
                 (
-                    "model".to_string(),
+                    crate::value::intern_key("model"),
                     VmValue::String(arcstr::ArcStr::from("mock")),
                 ),
-                ("max_iterations".to_string(), VmValue::Int(1)),
+                (crate::value::intern_key("max_iterations"), VmValue::Int(1)),
             ]),
             returns_schema: None,
             session_id: "child-subagent".to_string(),
@@ -1356,14 +1362,14 @@ mod tests {
         let parent = crate::agent_sessions::open_or_create(Some("parent-budget".into()));
         let mut options = crate::value::DictMap::from_iter([
             (
-                "provider".to_string(),
+                crate::value::intern_key("provider"),
                 VmValue::String(arcstr::ArcStr::from("mock")),
             ),
             (
-                "model".to_string(),
+                crate::value::intern_key("model"),
                 VmValue::String(arcstr::ArcStr::from("mock")),
             ),
-            ("max_iterations".to_string(), VmValue::Int(1)),
+            (crate::value::intern_key("max_iterations"), VmValue::Int(1)),
         ]);
         annotate_nested_execution_options(
             &mut options,

--- a/crates/harn-vm/src/stdlib/agents_workers/audit.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/audit.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use crate::orchestration::MutationSessionRecord;
 use crate::value::{VmError, VmValue};
 
@@ -9,7 +7,7 @@ pub(super) fn parse_worker_audit(
     let audit_value = dict
         .get("audit")
         .cloned()
-        .unwrap_or_else(|| VmValue::dict(BTreeMap::new()));
+        .unwrap_or_else(|| VmValue::dict_map(Default::default()));
     let parent_session = crate::orchestration::current_mutation_session();
     let mut audit: MutationSessionRecord =
         serde_json::from_value(crate::llm::vm_value_to_json(&audit_value))

--- a/crates/harn-vm/src/stdlib/agents_workers/config.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/config.rs
@@ -79,7 +79,12 @@ fn sub_agent_spec_from_json(value: &serde_json::Value) -> Result<SubAgentRunSpec
         .map(|options| {
             options
                 .iter()
-                .map(|(key, value)| (key.clone(), crate::stdlib::json_to_vm_value(value)))
+                .map(|(key, value)| {
+                    (
+                        crate::value::intern_key(key),
+                        crate::stdlib::json_to_vm_value(value),
+                    )
+                })
                 .collect::<crate::value::DictMap>()
         })
         .unwrap_or_default();
@@ -148,7 +153,12 @@ fn worker_config_from_json(value: &serde_json::Value) -> Result<WorkerConfig, Vm
         .map(|object| {
             object
                 .iter()
-                .map(|(key, value)| (key.clone(), crate::stdlib::json_to_vm_value(value)))
+                .map(|(key, value)| {
+                    (
+                        crate::value::intern_key(key),
+                        crate::stdlib::json_to_vm_value(value),
+                    )
+                })
                 .collect::<crate::value::DictMap>()
         })
         .unwrap_or_default();
@@ -500,7 +510,7 @@ pub(in super::super) fn parse_worker_config(value: &VmValue) -> Result<WorkerIni
                 .and_then(|value| value.as_dict())
                 .cloned()
                 .unwrap_or_default();
-            raw_model_policy.insert("permissions".to_string(), permissions);
+            raw_model_policy.insert(crate::value::intern_key("permissions"), permissions);
             node.raw_model_policy = Some(VmValue::dict(raw_model_policy));
         }
         let artifacts = parse_artifact_list(artifacts_value)?;

--- a/crates/harn-vm/src/stdlib/agents_workers/execution.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/execution.rs
@@ -195,12 +195,12 @@ async fn execute_worker_config(
                 );
             }
             options.insert(
-                "execution".to_string(),
+                crate::value::intern_key("execution"),
                 crate::stdlib::json_to_vm_value(
                     &serde_json::to_value(&execution_record).unwrap_or_default(),
                 ),
             );
-            options.insert("delegated".to_string(), VmValue::Bool(true));
+            options.insert(crate::value::intern_key("delegated"), VmValue::Bool(true));
             let result = call_worker_harn_export(
                 ctx,
                 "std/workflow/execute",

--- a/crates/harn-vm/src/stdlib/agents_workers/policy.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/policy.rs
@@ -231,7 +231,7 @@ fn fork_worker_transcript(transcript: VmValue) -> VmValue {
                 VmValue::String(arcstr::ArcStr::from(parent_id)),
             )])),
         };
-        next.insert("metadata".to_string(), metadata);
+        next.insert(crate::value::intern_key("metadata"), metadata);
     }
     VmValue::dict(next)
 }
@@ -286,11 +286,11 @@ pub(in super::super) async fn compact_worker_transcript(
     events.extend(outcome.reminder_report.preserved_events);
     let mut next = dict.clone();
     next.insert(
-        "messages".to_string(),
+        crate::value::intern_key("messages"),
         VmValue::List(std::sync::Arc::new(vm_messages)),
     );
     next.insert(
-        "events".to_string(),
+        crate::value::intern_key("events"),
         VmValue::List(std::sync::Arc::new(events)),
     );
     next.put_str("summary", outcome.summary);

--- a/crates/harn-vm/src/stdlib/collections.rs
+++ b/crates/harn-vm/src/stdlib/collections.rs
@@ -134,7 +134,12 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
         Ok(VmValue::dict(
             groups
                 .into_iter()
-                .map(|(key, values)| (key, VmValue::List(std::sync::Arc::new(values))))
+                .map(|(key, values)| {
+                    (
+                        crate::value::intern_key(&key),
+                        VmValue::List(std::sync::Arc::new(values)),
+                    )
+                })
                 .collect::<crate::value::DictMap>(),
         ))
     });
@@ -289,7 +294,7 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
         Ok(VmValue::dict(
             counts
                 .into_iter()
-                .map(|(key, count)| (key, VmValue::Int(count)))
+                .map(|(key, count)| (crate::value::intern_key(&key), VmValue::Int(count)))
                 .collect::<crate::value::DictMap>(),
         ))
     });
@@ -477,7 +482,7 @@ fn deep_merge_value(a: &VmValue, b: &VmValue) -> Result<VmValue, VmError> {
         return Ok(VmValue::Dict(right));
     }
     let mut merged = Arc::try_unwrap(left).unwrap_or_else(|d| (*d).clone());
-    let right_entries: Vec<(String, VmValue)> = match Arc::try_unwrap(right) {
+    let right_entries: Vec<(crate::value::HarnStr, VmValue)> = match Arc::try_unwrap(right) {
         Ok(map) => map.into_iter().collect(),
         Err(rc) => rc.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
     };
@@ -535,7 +540,7 @@ fn dict_from_pairs(value: &VmValue) -> Result<VmValue, VmError> {
     let pairs: &[VmValue] = match value {
         VmValue::List(items) => items,
         VmValue::Set(set) => set.items(),
-        VmValue::Nil => return Ok(VmValue::dict(BTreeMap::new())),
+        VmValue::Nil => return Ok(VmValue::dict_map(Default::default())),
         other => {
             return Err(VmError::TypeError(format!(
                 "dict_from_pairs: expected a list of [key, value] pairs, got {}",
@@ -599,7 +604,7 @@ fn dict_pick(data: &VmValue, keys: &VmValue) -> Result<VmValue, VmError> {
     let mut out = BTreeMap::new();
     for key in keys {
         let key = key.display();
-        if let Some(value) = dict.get(&key) {
+        if let Some(value) = dict.get(key.as_str()) {
             if !matches!(value, VmValue::Nil) {
                 out.insert(key, value.clone());
             }
@@ -614,7 +619,7 @@ fn dict_pick_keys(data: &VmValue, keys: &VmValue, drop_nil: bool) -> Result<VmVa
     let mut out = BTreeMap::new();
     for key in keys {
         let key = key.display();
-        if let Some(value) = dict.get(&key) {
+        if let Some(value) = dict.get(key.as_str()) {
             if drop_nil && matches!(value, VmValue::Nil) {
                 continue;
             }
@@ -630,11 +635,11 @@ fn dict_omit(data: &VmValue, keys: &VmValue) -> Result<VmValue, VmError> {
         .iter()
         .map(VmValue::display)
         .collect();
-    if exclude.is_empty() || dict.keys().all(|k| !exclude.contains(k)) {
+    if exclude.is_empty() || dict.keys().all(|k| !exclude.contains(k.as_str())) {
         return Ok(VmValue::Dict(dict));
     }
     let mut out = Arc::try_unwrap(dict).unwrap_or_else(|d| (*d).clone());
-    out.retain(|key, _| !exclude.contains(key));
+    out.retain(|key, _| !exclude.contains(key.as_str()));
     Ok(VmValue::dict(out))
 }
 
@@ -739,7 +744,7 @@ mod tests {
 
     #[test]
     fn shallow_clone_decouples_dict_from_source() {
-        let inner = VmValue::dict(BTreeMap::new());
+        let inner = VmValue::dict_map(Default::default());
         let source = dict(&[("inner", inner)]);
         let copy = shallow_clone(&source);
         match (&source, &copy) {

--- a/crates/harn-vm/src/stdlib/compression.rs
+++ b/crates/harn-vm/src/stdlib/compression.rs
@@ -446,8 +446,8 @@ fn tar_extract_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
         total_extracted = total_extracted.saturating_add(content.len() as u64);
 
         let mut fields = crate::value::DictMap::new();
-        fields.insert("content".to_string(), bytes_value(content));
-        fields.insert("mode".to_string(), VmValue::Int(mode));
+        fields.insert(crate::value::intern_key("content"), bytes_value(content));
+        fields.insert(crate::value::intern_key("mode"), VmValue::Int(mode));
         fields.put_str("path", path);
         output.push(entry_value(fields));
     }
@@ -519,7 +519,7 @@ fn zip_extract_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
         total_extracted = total_extracted.saturating_add(content.len() as u64);
 
         let mut fields = crate::value::DictMap::new();
-        fields.insert("content".to_string(), bytes_value(content));
+        fields.insert(crate::value::intern_key("content"), bytes_value(content));
         fields.put_str("path", path);
         output.push(entry_value(fields));
     }
@@ -591,7 +591,10 @@ mod tests {
         )
         .unwrap();
         let mut options = crate::value::DictMap::new();
-        options.insert("max_decompressed_bytes".to_string(), VmValue::Int(1024));
+        options.insert(
+            crate::value::intern_key("max_decompressed_bytes"),
+            VmValue::Int(1024),
+        );
         let result = call(
             &mut vm,
             "gzip_decode",
@@ -622,7 +625,10 @@ mod tests {
         )
         .unwrap();
         let mut options = crate::value::DictMap::new();
-        options.insert("max_decompressed_bytes".to_string(), VmValue::Int(1024));
+        options.insert(
+            crate::value::intern_key("max_decompressed_bytes"),
+            VmValue::Int(1024),
+        );
         let result = call(
             &mut vm,
             "zstd_decode",
@@ -634,9 +640,9 @@ mod tests {
     #[test]
     fn tar_round_trip_preserves_mode() {
         let mut fields = crate::value::DictMap::new();
-        fields.insert("path".to_string(), text("bin/run"));
-        fields.insert("content".to_string(), text("echo hi"));
-        fields.insert("mode".to_string(), VmValue::Int(0o755));
+        fields.insert(crate::value::intern_key("path"), text("bin/run"));
+        fields.insert(crate::value::intern_key("content"), text("echo hi"));
+        fields.insert(crate::value::intern_key("mode"), VmValue::Int(0o755));
 
         let mut vm = vm();
         let archive = call(

--- a/crates/harn-vm/src/stdlib/connectors.rs
+++ b/crates/harn-vm/src/stdlib/connectors.rs
@@ -47,7 +47,7 @@ async fn connector_call_impl(
                 "connector_call: params must be a dict when provided",
             ))));
         }
-        _ => vm_value_to_json(&VmValue::dict(BTreeMap::new())),
+        _ => vm_value_to_json(&VmValue::dict_map(Default::default())),
     };
 
     let client = active_connector_client(&provider).ok_or_else(|| {
@@ -242,7 +242,7 @@ fn optional_headers_arg(
         None | Some(VmValue::Nil) => Ok(BTreeMap::new()),
         Some(VmValue::Dict(dict)) => Ok(dict
             .iter()
-            .map(|(key, value)| (key.clone(), value.display()))
+            .map(|(key, value)| (key.to_string(), value.display()))
             .collect()),
         Some(_other) => Err(VmError::Thrown(VmValue::String(arcstr::ArcStr::from(
             format!("{builtin}: headers must be a dict when provided"),

--- a/crates/harn-vm/src/stdlib/cookies.rs
+++ b/crates/harn-vm/src/stdlib/cookies.rs
@@ -201,8 +201,14 @@ fn raw_cookie_headers(value: &VmValue) -> Result<Vec<String>, VmError> {
 
 fn invalid_segment(segment: &str, reason: &str) -> VmValue {
     dict(crate::value::DictMap::from_iter([
-        ("segment".to_string(), string(segment.to_string())),
-        ("reason".to_string(), string(reason.to_string())),
+        (
+            crate::value::intern_key("segment"),
+            string(segment.to_string()),
+        ),
+        (
+            crate::value::intern_key("reason"),
+            string(reason.to_string()),
+        ),
     ]))
 }
 
@@ -245,15 +251,15 @@ fn parse_cookie_header_value(raw: &str) -> ParsedCookieHeader {
             continue;
         }
         cookies
-            .entry(name.to_string())
+            .entry(crate::value::intern_key(name))
             .or_insert_with(|| string(value.clone()));
         all_values
             .entry(name.to_string())
             .or_default()
             .push(value.clone());
         pairs.push(dict(crate::value::DictMap::from_iter([
-            ("name".to_string(), string(name.to_string())),
-            ("value".to_string(), string(value)),
+            (crate::value::intern_key("name"), string(name.to_string())),
+            (crate::value::intern_key("value"), string(value)),
         ])));
     }
 
@@ -289,7 +295,7 @@ fn parse_cookie_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
         .filter_map(|(name, values)| {
             if values.len() > 1 {
                 Some((
-                    name,
+                    crate::value::intern_key(&name),
                     list(values.into_iter().map(string).collect::<Vec<_>>()),
                 ))
             } else {
@@ -299,10 +305,10 @@ fn parse_cookie_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
         .collect();
 
     Ok(dict(crate::value::DictMap::from_iter([
-        ("cookies".to_string(), dict(cookies)),
-        ("pairs".to_string(), list(pairs)),
-        ("duplicates".to_string(), dict(duplicates)),
-        ("invalid".to_string(), list(invalid)),
+        (crate::value::intern_key("cookies"), dict(cookies)),
+        (crate::value::intern_key("pairs"), list(pairs)),
+        (crate::value::intern_key("duplicates"), dict(duplicates)),
+        (crate::value::intern_key("invalid"), list(invalid)),
     ])))
 }
 
@@ -465,9 +471,15 @@ fn cookie_sign_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
 
 fn cookie_verify_result(ok: bool, value: Option<String>, error: Option<&str>) -> VmValue {
     let mut result = crate::value::DictMap::new();
-    result.insert("ok".to_string(), bool_value(ok));
-    result.insert("value".to_string(), value.map(string).unwrap_or_else(nil));
-    result.insert("error".to_string(), error.map(string).unwrap_or_else(nil));
+    result.insert(crate::value::intern_key("ok"), bool_value(ok));
+    result.insert(
+        crate::value::intern_key("value"),
+        value.map(string).unwrap_or_else(nil),
+    );
+    result.insert(
+        crate::value::intern_key("error"),
+        error.map(string).unwrap_or_else(nil),
+    );
     dict(result)
 }
 
@@ -497,9 +509,12 @@ fn session_sign_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
 
 fn session_verify_result(ok: bool, payload: VmValue, error: Option<&str>) -> VmValue {
     dict(crate::value::DictMap::from_iter([
-        ("ok".to_string(), bool_value(ok)),
-        ("payload".to_string(), payload),
-        ("error".to_string(), error.map(string).unwrap_or_else(nil)),
+        (crate::value::intern_key("ok"), bool_value(ok)),
+        (crate::value::intern_key("payload"), payload),
+        (
+            crate::value::intern_key("error"),
+            error.map(string).unwrap_or_else(nil),
+        ),
     ]))
 }
 
@@ -557,7 +572,7 @@ fn session_from_cookies_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
     let secret = args[2].display();
     let token = match &parsed {
         VmValue::Dict(result) => match result.get("cookies") {
-            Some(VmValue::Dict(cookies)) => cookies.get(&name).map(VmValue::display),
+            Some(VmValue::Dict(cookies)) => cookies.get(name.as_str()).map(VmValue::display),
             _ => None,
         },
         _ => None,
@@ -652,7 +667,7 @@ fn cookie_round_trip_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
     if let VmValue::Dict(result) = parsed_request {
         if let Some(VmValue::Dict(parsed)) = result.get("cookies") {
             for (name, value) in parsed.iter() {
-                cookies.insert(name.clone(), value.display());
+                cookies.insert(name.to_string(), value.display());
             }
         }
     }
@@ -670,11 +685,11 @@ fn cookie_round_trip_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
     let header = cookie_header_from_map(&cookies);
     let cookie_values = cookies
         .iter()
-        .map(|(name, value)| (name.clone(), string(value.clone())))
+        .map(|(name, value)| (crate::value::intern_key(name), string(value.clone())))
         .collect::<crate::value::DictMap>();
     Ok(dict(crate::value::DictMap::from_iter([
-        ("cookie_header".to_string(), string(header)),
-        ("cookies".to_string(), dict(cookie_values)),
+        (crate::value::intern_key("cookie_header"), string(header)),
+        (crate::value::intern_key("cookies"), dict(cookie_values)),
     ])))
 }
 

--- a/crates/harn-vm/src/stdlib/crypto.rs
+++ b/crates/harn-vm/src/stdlib/crypto.rs
@@ -340,7 +340,7 @@ fn claims_arg<'a>(
         &options.expires_param,
         &options.kid_param,
     ] {
-        if dict.contains_key(reserved) {
+        if dict.contains_key(reserved.as_str()) {
             return Err(signed_url_error(format!(
                 "claims cannot contain reserved parameter `{reserved}`"
             )));
@@ -368,7 +368,7 @@ fn signed_url_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
             && key != &options.kid_param
     });
     for (key, value) in claims.iter() {
-        parts.query_pairs.push((key.clone(), value.display()));
+        parts.query_pairs.push((key.to_string(), value.display()));
     }
     parts
         .query_pairs
@@ -401,23 +401,23 @@ fn verification_result(
     claims: crate::value::DictMap,
 ) -> VmValue {
     let mut result = crate::value::DictMap::new();
-    result.insert("valid".to_string(), VmValue::Bool(valid));
+    result.insert(crate::value::intern_key("valid"), VmValue::Bool(valid));
     result.put_str("reason", reason);
     result.insert(
-        "signature_valid".to_string(),
+        crate::value::intern_key("signature_valid"),
         VmValue::Bool(signature_valid),
     );
-    result.insert("expired".to_string(), VmValue::Bool(expired));
+    result.insert(crate::value::intern_key("expired"), VmValue::Bool(expired));
     result.insert(
-        "expires_at".to_string(),
+        crate::value::intern_key("expires_at"),
         expires_at.map(VmValue::Int).unwrap_or(VmValue::Nil),
     );
     result.insert(
-        "kid".to_string(),
+        crate::value::intern_key("kid"),
         kid.map(|kid| VmValue::String(arcstr::ArcStr::from(kid)))
             .unwrap_or(VmValue::Nil),
     );
-    result.insert("claims".to_string(), VmValue::dict(claims));
+    result.insert(crate::value::intern_key("claims"), VmValue::dict(claims));
     VmValue::dict(result)
 }
 
@@ -543,7 +543,7 @@ fn verify_signed_url_builtin(args: &[VmValue]) -> Result<VmValue, VmError> {
             && key != &options.kid_param
         {
             claims.insert(
-                key.clone(),
+                crate::value::intern_key(key),
                 VmValue::String(arcstr::ArcStr::from(value.as_str())),
             );
         }
@@ -628,7 +628,7 @@ fn aws_sigv4_headers_arg(
         None | Some(VmValue::Nil) => Ok(std::collections::BTreeMap::new()),
         Some(VmValue::Dict(headers)) => Ok(headers
             .iter()
-            .map(|(key, value)| (key.clone(), value.display()))
+            .map(|(key, value)| (key.to_string(), value.display()))
             .collect()),
         Some(value) => Err(aws_sigv4_error(format!(
             "headers must be a dict when provided, got {}",
@@ -1343,8 +1343,8 @@ fn jwt_verify_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
     })?;
     let claims_value = crate::schema::json_to_vm_value(&decoded.claims);
     let mut dict = crate::value::DictMap::new();
-    dict.insert("valid".to_string(), VmValue::Bool(true));
-    dict.insert("claims".to_string(), claims_value);
+    dict.insert(crate::value::intern_key("valid"), VmValue::Bool(true));
+    dict.insert(crate::value::intern_key("claims"), claims_value);
     Ok(VmValue::dict(dict))
 }
 
@@ -1423,9 +1423,9 @@ C/edCMRM78P8eQTBCDUTK1ywSYaszvQZvneiW6gNtWEJndSreEcyyUdVvg==\n\
 
     fn jwt_claims() -> VmValue {
         VmValue::dict(crate::value::DictMap::from_iter([
-            ("exp".to_string(), VmValue::Int(4_102_444_800)),
-            ("iat".to_string(), VmValue::Int(1_700_000_000)),
-            ("iss".to_string(), s("12345")),
+            (crate::value::intern_key("exp"), VmValue::Int(4_102_444_800)),
+            (crate::value::intern_key("iat"), VmValue::Int(1_700_000_000)),
+            (crate::value::intern_key("iss"), s("12345")),
         ]))
     }
 
@@ -1433,7 +1433,7 @@ C/edCMRM78P8eQTBCDUTK1ywSYaszvQZvneiW6gNtWEJndSreEcyyUdVvg==\n\
         VmValue::dict(
             items
                 .iter()
-                .map(|(key, value)| (key.to_string(), value.clone()))
+                .map(|(key, value)| (crate::value::intern_key(key), value.clone()))
                 .collect::<crate::value::DictMap>(),
         )
     }

--- a/crates/harn-vm/src/stdlib/csv.rs
+++ b/crates/harn-vm/src/stdlib/csv.rs
@@ -143,7 +143,7 @@ fn csv_stringify_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
         for row in rows.iter() {
             if let VmValue::Dict(d) = row {
                 for k in d.keys() {
-                    keys.insert(k.clone());
+                    keys.insert(k.to_string());
                 }
             }
         }
@@ -163,7 +163,7 @@ fn csv_stringify_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, Vm
             };
             let cells: Vec<String> = header
                 .iter()
-                .map(|k| d.get(k).map(|v| v.display()).unwrap_or_default())
+                .map(|k| d.get(k.as_str()).map(|v| v.display()).unwrap_or_default())
                 .collect();
             wtr.write_record(&cells).map_err(|e| {
                 VmError::Thrown(VmValue::String(arcstr::ArcStr::from(format!(
@@ -229,7 +229,7 @@ mod tests {
         VmValue::dict(
             items
                 .into_iter()
-                .map(|(key, value)| (key.to_string(), value))
+                .map(|(key, value)| (crate::value::intern_key(key), value))
                 .collect::<crate::value::DictMap>(),
         )
     }

--- a/crates/harn-vm/src/stdlib/datetime.rs
+++ b/crates/harn-vm/src/stdlib/datetime.rs
@@ -22,7 +22,7 @@ fn date_now_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
     let now = Utc::now();
     let mut result = utc_datetime_dict(now);
     result.insert(
-        "timestamp".to_string(),
+        crate::value::intern_key("timestamp"),
         VmValue::Float(now.timestamp_millis() as f64 / 1000.0),
     );
     result.put_str(
@@ -283,14 +283,32 @@ pub(crate) fn vm_error(message: impl Into<String>) -> VmError {
 
 fn utc_datetime_dict(dt: DateTime<Utc>) -> crate::value::DictMap {
     let mut result = crate::value::DictMap::new();
-    result.insert("year".to_string(), VmValue::Int(dt.year() as i64));
-    result.insert("month".to_string(), VmValue::Int(dt.month() as i64));
-    result.insert("day".to_string(), VmValue::Int(dt.day() as i64));
-    result.insert("hour".to_string(), VmValue::Int(dt.hour() as i64));
-    result.insert("minute".to_string(), VmValue::Int(dt.minute() as i64));
-    result.insert("second".to_string(), VmValue::Int(dt.second() as i64));
     result.insert(
-        "weekday".to_string(),
+        crate::value::intern_key("year"),
+        VmValue::Int(dt.year() as i64),
+    );
+    result.insert(
+        crate::value::intern_key("month"),
+        VmValue::Int(dt.month() as i64),
+    );
+    result.insert(
+        crate::value::intern_key("day"),
+        VmValue::Int(dt.day() as i64),
+    );
+    result.insert(
+        crate::value::intern_key("hour"),
+        VmValue::Int(dt.hour() as i64),
+    );
+    result.insert(
+        crate::value::intern_key("minute"),
+        VmValue::Int(dt.minute() as i64),
+    );
+    result.insert(
+        crate::value::intern_key("second"),
+        VmValue::Int(dt.second() as i64),
+    );
+    result.insert(
+        crate::value::intern_key("weekday"),
         VmValue::Int(dt.weekday().num_days_from_sunday() as i64),
     );
     result
@@ -298,22 +316,40 @@ fn utc_datetime_dict(dt: DateTime<Utc>) -> crate::value::DictMap {
 
 fn zoned_datetime_dict(dt: DateTime<Tz>) -> crate::value::DictMap {
     let mut result = crate::value::DictMap::new();
-    result.insert("year".to_string(), VmValue::Int(dt.year() as i64));
-    result.insert("month".to_string(), VmValue::Int(dt.month() as i64));
-    result.insert("day".to_string(), VmValue::Int(dt.day() as i64));
-    result.insert("hour".to_string(), VmValue::Int(dt.hour() as i64));
-    result.insert("minute".to_string(), VmValue::Int(dt.minute() as i64));
-    result.insert("second".to_string(), VmValue::Int(dt.second() as i64));
     result.insert(
-        "weekday".to_string(),
+        crate::value::intern_key("year"),
+        VmValue::Int(dt.year() as i64),
+    );
+    result.insert(
+        crate::value::intern_key("month"),
+        VmValue::Int(dt.month() as i64),
+    );
+    result.insert(
+        crate::value::intern_key("day"),
+        VmValue::Int(dt.day() as i64),
+    );
+    result.insert(
+        crate::value::intern_key("hour"),
+        VmValue::Int(dt.hour() as i64),
+    );
+    result.insert(
+        crate::value::intern_key("minute"),
+        VmValue::Int(dt.minute() as i64),
+    );
+    result.insert(
+        crate::value::intern_key("second"),
+        VmValue::Int(dt.second() as i64),
+    );
+    result.insert(
+        crate::value::intern_key("weekday"),
         VmValue::Int(dt.weekday().num_days_from_sunday() as i64),
     );
     result.insert(
-        "offset_seconds".to_string(),
+        crate::value::intern_key("offset_seconds"),
         VmValue::Int(dt.offset().fix().local_minus_utc() as i64),
     );
     result.insert(
-        "timestamp".to_string(),
+        crate::value::intern_key("timestamp"),
         timestamp_value(dt.with_timezone(&Utc)),
     );
     result.put_str("iso8601", dt.to_rfc3339());

--- a/crates/harn-vm/src/stdlib/event_log.rs
+++ b/crates/harn-vm/src/stdlib/event_log.rs
@@ -227,7 +227,7 @@ fn parse_headers(
             for (key, value) in dict.iter() {
                 match value {
                     VmValue::String(value) => {
-                        out.insert(key.clone(), value.to_string());
+                        out.insert(key.to_string(), value.to_string());
                     }
                     other => {
                         return Err(VmError::TypeError(format!(

--- a/crates/harn-vm/src/stdlib/flow.rs
+++ b/crates/harn-vm/src/stdlib/flow.rs
@@ -355,7 +355,7 @@ fn value_to_json(value: &VmValue) -> serde_json::Value {
         VmValue::Dict(map) => {
             let mut object = BTreeMap::new();
             for (key, item) in map.iter() {
-                object.insert(key.clone(), value_to_json(item));
+                object.insert(key.to_string(), value_to_json(item));
             }
             serde_json::Value::Object(object.into_iter().collect())
         }

--- a/crates/harn-vm/src/stdlib/git.rs
+++ b/crates/harn-vm/src/stdlib/git.rs
@@ -390,8 +390,8 @@ fn register_git_namespace(vm: &mut Vm) {
     ]);
     let mut root = crate::value::DictMap::new();
     root.put_str("_namespace", "git");
-    root.insert("repo".to_string(), repo);
-    root.insert("worktree".to_string(), worktree);
+    root.insert(crate::value::intern_key("repo"), repo);
+    root.insert(crate::value::intern_key("worktree"), worktree);
     for (name, builtin) in [
         ("fetch", "git.fetch"),
         ("rebase", "git.rebase"),
@@ -405,7 +405,7 @@ fn register_git_namespace(vm: &mut Vm) {
         ("worktree_remove", "git.worktree.remove"),
     ] {
         root.insert(
-            name.to_string(),
+            crate::value::intern_key(name),
             VmValue::BuiltinRef(arcstr::ArcStr::from(builtin)),
         );
     }
@@ -418,7 +418,7 @@ fn namespace(entries: &[(&str, &str)]) -> VmValue {
             .iter()
             .map(|(name, builtin)| {
                 (
-                    name.to_string(),
+                    crate::value::intern_key(name),
                     VmValue::BuiltinRef(arcstr::ArcStr::from(*builtin)),
                 )
             })
@@ -581,7 +581,7 @@ async fn exec_argv(command: &GitCommand) -> Result<VmValue, VmError> {
     let mut params = crate::value::DictMap::new();
     params.put_str("mode", "argv");
     params.insert(
-        "argv".to_string(),
+        crate::value::intern_key("argv"),
         VmValue::List(std::sync::Arc::new(
             command
                 .argv
@@ -591,9 +591,12 @@ async fn exec_argv(command: &GitCommand) -> Result<VmValue, VmError> {
         )),
     );
     params.put_str("cwd", display_path(&command.cwd));
-    params.insert("timeout_ms".to_string(), VmValue::Int(120_000));
     params.insert(
-        "env_remove".to_string(),
+        crate::value::intern_key("timeout_ms"),
+        VmValue::Int(120_000),
+    );
+    params.insert(
+        crate::value::intern_key("env_remove"),
         VmValue::List(std::sync::Arc::new(
             GIT_ENV_OVERRIDES
                 .iter()
@@ -608,11 +611,11 @@ async fn exec_argv(command: &GitCommand) -> Result<VmValue, VmError> {
     let mut env = crate::value::DictMap::new();
     for (key, value) in GIT_NONINTERACTIVE_ENV {
         env.insert(
-            (*key).to_string(),
+            crate::value::intern_key(key),
             VmValue::String(arcstr::ArcStr::from(*value)),
         );
     }
-    params.insert("env".to_string(), VmValue::dict(env));
+    params.insert(crate::value::intern_key("env"), VmValue::dict(env));
     params.put_str("env_mode", "merge");
     let caller = json!({
         "surface": "stdlib.git",

--- a/crates/harn-vm/src/stdlib/hitl.rs
+++ b/crates/harn-vm/src/stdlib/hitl.rs
@@ -620,14 +620,17 @@ pub(crate) async fn request_approval_for_side_effect(
     capabilities_requested: Vec<String>,
 ) -> Result<VmValue, VmError> {
     let mut options = crate::value::DictMap::new();
-    options.insert("args".to_string(), crate::stdlib::json_to_vm_value(&detail));
     options.insert(
-        "detail".to_string(),
+        crate::value::intern_key("args"),
+        crate::stdlib::json_to_vm_value(&detail),
+    );
+    options.insert(
+        crate::value::intern_key("detail"),
         crate::stdlib::json_to_vm_value(&detail),
     );
     options.put_str("principal", principal);
     options.insert(
-        "reviewers".to_string(),
+        crate::value::intern_key("reviewers"),
         VmValue::List(std::sync::Arc::new(
             reviewers
                 .into_iter()
@@ -636,7 +639,7 @@ pub(crate) async fn request_approval_for_side_effect(
         )),
     );
     options.insert(
-        "capabilities_requested".to_string(),
+        crate::value::intern_key("capabilities_requested"),
         VmValue::List(std::sync::Arc::new(
             capabilities_requested
                 .into_iter()
@@ -1396,7 +1399,12 @@ async fn maybe_apply_mock_response(
         .cloned()
         .unwrap_or_default()
         .into_iter()
-        .map(|(key, value)| (key, crate::stdlib::json_to_vm_value(&value)))
+        .map(|(key, value)| {
+            (
+                crate::value::intern_key(&key),
+                crate::stdlib::json_to_vm_value(&value),
+            )
+        })
         .collect::<crate::value::DictMap>();
     params.put_str("request_id", request_id);
     let Some(result) = dispatch_mock_host_call("hitl", kind.as_str(), &params) else {

--- a/crates/harn-vm/src/stdlib/host.rs
+++ b/crates/harn-vm/src/stdlib/host.rs
@@ -90,7 +90,7 @@ fn pop_host_mock_scope() -> bool {
 fn capability_manifest_map() -> crate::value::DictMap {
     let mut root = crate::value::DictMap::new();
     root.insert(
-        "process".to_string(),
+        crate::value::intern_key("process"),
         capability(
             "Process execution.",
             &[
@@ -132,21 +132,21 @@ fn capability_manifest_map() -> crate::value::DictMap {
         ),
     );
     root.insert(
-        "template".to_string(),
+        crate::value::intern_key("template"),
         capability(
             "Template rendering.",
             &[op("render", "Render a template file.")],
         ),
     );
     root.insert(
-        "interaction".to_string(),
+        crate::value::intern_key("interaction"),
         capability(
             "User interaction.",
             &[op("ask", "Ask the user a question.")],
         ),
     );
     root.insert(
-        "memory".to_string(),
+        crate::value::intern_key("memory"),
         capability(
             "Vector-aware memory: host-provided embeddings.",
             &[op(
@@ -174,7 +174,7 @@ fn ensure_mocked_capability(
 ) {
     let Some(existing) = root.get(capability_name).cloned() else {
         root.insert(
-            capability_name.to_string(),
+            crate::value::intern_key(capability_name),
             capability(
                 "Mocked host capability registered at runtime for tests.",
                 &[(operation_name.to_string(), mocked_operation_entry())],
@@ -206,12 +206,21 @@ fn ensure_mocked_capability(
         .map(|dict| (*dict).clone())
         .unwrap_or_default();
     operations
-        .entry(operation_name.to_string())
+        .entry(crate::value::intern_key(operation_name))
         .or_insert_with(mocked_operation_entry);
 
-    entry.insert("ops".to_string(), VmValue::List(std::sync::Arc::new(ops)));
-    entry.insert("operations".to_string(), VmValue::dict(operations));
-    root.insert(capability_name.to_string(), VmValue::dict(entry));
+    entry.insert(
+        crate::value::intern_key("ops"),
+        VmValue::List(std::sync::Arc::new(ops)),
+    );
+    entry.insert(
+        crate::value::intern_key("operations"),
+        VmValue::dict(operations),
+    );
+    root.insert(
+        crate::value::intern_key(capability_name),
+        VmValue::dict(entry),
+    );
 }
 
 fn capability_manifest_with_mocks() -> VmValue {
@@ -234,7 +243,7 @@ fn capability(description: &str, ops: &[(String, VmValue)]) -> VmValue {
     let mut entry = crate::value::DictMap::new();
     entry.put_str("description", description);
     entry.insert(
-        "ops".to_string(),
+        crate::value::intern_key("ops"),
         VmValue::List(std::sync::Arc::new(
             ops.iter()
                 .map(|(name, _)| VmValue::String(arcstr::ArcStr::from(name.as_str())))
@@ -243,9 +252,12 @@ fn capability(description: &str, ops: &[(String, VmValue)]) -> VmValue {
     );
     let mut op_dict = crate::value::DictMap::new();
     for (name, op) in ops {
-        op_dict.insert(name.clone(), op.clone());
+        op_dict.insert(crate::value::intern_key(name), op.clone());
     }
-    entry.insert("operations".to_string(), VmValue::dict(op_dict));
+    entry.insert(
+        crate::value::intern_key("operations"),
+        VmValue::dict(op_dict),
+    );
     VmValue::dict(entry)
 }
 
@@ -337,7 +349,10 @@ fn mock_call_value(call: &HostMockCall) -> VmValue {
     let mut item = crate::value::DictMap::new();
     item.put_str("capability", call.capability.clone());
     item.put_str("operation", call.operation.clone());
-    item.insert("params".to_string(), VmValue::dict(call.params.clone()));
+    item.insert(
+        crate::value::intern_key("params"),
+        VmValue::dict(call.params.clone()),
+    );
     VmValue::dict(item)
 }
 
@@ -916,47 +931,53 @@ fn process_exec_response(response: ProcessExecResponse<'_>) -> VmValue {
     );
     result.put_str("status", response.status);
     result.insert(
-        "pid".to_string(),
+        crate::value::intern_key("pid"),
         response
             .pid
             .map(|pid| VmValue::Int(pid as i64))
             .unwrap_or(VmValue::Nil),
     );
     result.insert(
-        "process_group_id".to_string(),
+        crate::value::intern_key("process_group_id"),
         response
             .pid
             .map(|pid| VmValue::Int(pid as i64))
             .unwrap_or(VmValue::Nil),
     );
-    result.insert("handle_id".to_string(), VmValue::Nil);
+    result.insert(crate::value::intern_key("handle_id"), VmValue::Nil);
     result.put_str("started_at", response.started_at);
     result.put_str(
         "ended_at",
         audited_utc_now_rfc3339("host_call/process.exec.ended_at"),
     );
     result.insert(
-        "duration_ms".to_string(),
+        crate::value::intern_key("duration_ms"),
         VmValue::Int(response.started.elapsed().as_millis() as i64),
     );
     result.insert(
-        "exit_code".to_string(),
+        crate::value::intern_key("exit_code"),
         VmValue::Int(response.exit_code as i64),
     );
-    result.insert("signal".to_string(), VmValue::Nil);
-    result.insert("timed_out".to_string(), VmValue::Bool(response.timed_out));
+    result.insert(crate::value::intern_key("signal"), VmValue::Nil);
+    result.insert(
+        crate::value::intern_key("timed_out"),
+        VmValue::Bool(response.timed_out),
+    );
     result.put_str("stdout", response.stdout);
     result.put_str("stderr", response.stderr);
     result.put_str("combined", combined);
     result.insert(
-        "exit_status".to_string(),
+        crate::value::intern_key("exit_status"),
         VmValue::Int(response.exit_code as i64),
     );
     result.insert(
-        "legacy_status".to_string(),
+        crate::value::intern_key("legacy_status"),
         VmValue::Int(response.exit_code as i64),
     );
-    result.insert("success".to_string(), VmValue::Bool(response.success));
+    result.insert(
+        crate::value::intern_key("success"),
+        VmValue::Bool(response.success),
+    );
     VmValue::dict(result)
 }
 
@@ -1075,7 +1096,7 @@ fn optional_string_dict(
                 "host_call process.exec env value for {key:?} must be a string"
             )));
         };
-        out.insert(key.clone(), value.to_string());
+        out.insert(key.to_string(), value.to_string());
     }
     Ok(Some(out))
 }
@@ -1152,7 +1173,7 @@ fn host_has_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
     let manifest = capability_manifest_with_mocks();
     let has = manifest
         .as_dict()
-        .and_then(|d| d.get(&capability))
+        .and_then(|d| d.get(capability.as_str()))
         .and_then(|v| v.as_dict())
         .is_some_and(|cap| {
             if let Some(operation) = operation {
@@ -1374,23 +1395,23 @@ mod tests {
         fn list_tools(&self) -> Result<Option<VmValue>, VmError> {
             let tool = VmValue::dict(crate::value::DictMap::from_iter([
                 (
-                    "name".to_string(),
+                    crate::value::intern_key("name"),
                     VmValue::String(arcstr::ArcStr::from("Read".to_string())),
                 ),
                 (
-                    "description".to_string(),
+                    crate::value::intern_key("description"),
                     VmValue::String(arcstr::ArcStr::from(
                         "Read a file from the host".to_string(),
                     )),
                 ),
                 (
-                    "schema".to_string(),
+                    crate::value::intern_key("schema"),
                     VmValue::dict(crate::value::DictMap::from_iter([(
-                        "type".to_string(),
+                        crate::value::intern_key("type"),
                         VmValue::String(arcstr::ArcStr::from("object".to_string())),
                     )])),
                 ),
-                ("deprecated".to_string(), VmValue::Bool(false)),
+                (crate::value::intern_key("deprecated"), VmValue::Bool(false)),
             ]));
             Ok(Some(VmValue::List(std::sync::Arc::new(vec![tool]))))
         }
@@ -1427,11 +1448,11 @@ mod tests {
             self.calls.fetch_add(1, Ordering::SeqCst);
             Ok(Some(VmValue::dict(crate::value::DictMap::from_iter([
                 (
-                    "status".to_string(),
+                    crate::value::intern_key("status"),
                     VmValue::String(arcstr::ArcStr::from("completed".to_string())),
                 ),
-                ("exit_code".to_string(), VmValue::Int(0)),
-                ("success".to_string(), VmValue::Bool(true)),
+                (crate::value::intern_key("exit_code"), VmValue::Int(0)),
+                (crate::value::intern_key("success"), VmValue::Bool(true)),
             ]))))
         }
     }
@@ -1474,7 +1495,7 @@ mod tests {
         run_host_async_test(|| async {
             set_host_call_bridge(Arc::new(TestHostToolBridge));
             let args = VmValue::dict(crate::value::DictMap::from_iter([(
-                "path".to_string(),
+                crate::value::intern_key("path"),
                 VmValue::String(arcstr::ArcStr::from("README.md".to_string())),
             )]));
             let value = dispatch_host_tool_call("Read", &args)
@@ -1509,11 +1530,11 @@ mod tests {
                 "exec",
                 &crate::value::DictMap::from_iter([
                     (
-                        "mode".to_string(),
+                        crate::value::intern_key("mode"),
                         VmValue::String(arcstr::ArcStr::from("shell")),
                     ),
                     (
-                        "command".to_string(),
+                        crate::value::intern_key("command"),
                         VmValue::String(arcstr::ArcStr::from("cat Cargo.toml")),
                     ),
                 ]),
@@ -1551,11 +1572,11 @@ mod tests {
         std::env::set_var("PARENT_VAR", "inherited");
         let mut params = crate::value::DictMap::from_iter([
             (
-                "mode".to_string(),
+                crate::value::intern_key("mode"),
                 VmValue::String(arcstr::ArcStr::from("argv")),
             ),
             (
-                "argv".to_string(),
+                crate::value::intern_key("argv"),
                 VmValue::List(std::sync::Arc::new(vec![
                     // Absolute path so the spawn does not depend on PATH,
                     // which the `replace` case intentionally clears.
@@ -1566,7 +1587,7 @@ mod tests {
                     )),
                 ])),
             ),
-            ("env".to_string(), env),
+            (crate::value::intern_key("env"), env),
         ]);
         if let Some(mode) = env_mode {
             params.put_str("env_mode", mode);
@@ -1588,7 +1609,7 @@ mod tests {
             // No `env_mode`: the provided key must be added WITHOUT clearing
             // the inherited parent environment (the env-clear footgun fix).
             let child_env = VmValue::dict(crate::value::DictMap::from_iter([(
-                "CHILD_VAR".to_string(),
+                crate::value::intern_key("CHILD_VAR"),
                 VmValue::String(arcstr::ArcStr::from("provided")),
             )]));
             let (parent, child) = process_exec_env_probe(child_env, None).await;
@@ -1611,7 +1632,7 @@ mod tests {
             // only the provided key survives. This preserves the ability to
             // fully replace the environment when intentionally requested.
             let child_env = VmValue::dict(crate::value::DictMap::from_iter([(
-                "CHILD_VAR".to_string(),
+                crate::value::intern_key("CHILD_VAR"),
                 VmValue::String(arcstr::ArcStr::from("provided")),
             )]));
             let (parent, child) = process_exec_env_probe(child_env, Some("replace")).await;
@@ -1629,24 +1650,24 @@ mod tests {
         run_host_async_test(|| async {
             let params = crate::value::DictMap::from_iter([
                 (
-                    "mode".to_string(),
+                    crate::value::intern_key("mode"),
                     VmValue::String(arcstr::ArcStr::from("argv")),
                 ),
                 (
-                    "argv".to_string(),
+                    crate::value::intern_key("argv"),
                     VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                         arcstr::ArcStr::from("true"),
                     )])),
                 ),
                 (
-                    "env".to_string(),
+                    crate::value::intern_key("env"),
                     VmValue::dict(crate::value::DictMap::from_iter([(
-                        "CHILD_VAR".to_string(),
+                        crate::value::intern_key("CHILD_VAR"),
                         VmValue::String(arcstr::ArcStr::from("x")),
                     )])),
                 ),
                 (
-                    "env_mode".to_string(),
+                    crate::value::intern_key("env_mode"),
                     VmValue::String(arcstr::ArcStr::from("bogus")),
                 ),
             ]);

--- a/crates/harn-vm/src/stdlib/http_response.rs
+++ b/crates/harn-vm/src/stdlib/http_response.rs
@@ -97,7 +97,7 @@ fn http_error_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
     body.put_str("code", code);
     body.put_str("message", message);
     if !matches!(details, VmValue::Nil) {
-        body.insert("details".to_string(), details);
+        body.insert(crate::value::intern_key("details"), details);
     }
     let mut env = envelope_map(
         status,
@@ -105,7 +105,7 @@ fn http_error_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
         BODY_KIND_JSON,
         crate::value::DictMap::new(),
     );
-    env.insert("is_error".to_string(), VmValue::Bool(true));
+    env.insert(crate::value::intern_key("is_error"), VmValue::Bool(true));
     Ok(VmValue::dict(env))
 }
 
@@ -291,7 +291,7 @@ async fn http_sse_impl(
         headers,
     );
     if let Some(retry_ms) = retry_ms {
-        env.insert("retry_ms".to_string(), VmValue::Int(retry_ms));
+        env.insert(crate::value::intern_key("retry_ms"), VmValue::Int(retry_ms));
     }
     Ok(VmValue::dict(env))
 }
@@ -313,14 +313,14 @@ fn envelope_map(
 ) -> crate::value::DictMap {
     let mut map = crate::value::DictMap::new();
     map.insert(
-        HTTP_RESPONSE_TAG_KEY.to_string(),
+        crate::value::intern_key(HTTP_RESPONSE_TAG_KEY),
         VmValue::String(arcstr::ArcStr::from(HTTP_RESPONSE_TAG_VERSION)),
     );
-    map.insert("status".to_string(), VmValue::Int(status));
+    map.insert(crate::value::intern_key("status"), VmValue::Int(status));
     map.put_str("body_kind", body_kind);
-    map.insert("headers".to_string(), VmValue::dict(headers));
+    map.insert(crate::value::intern_key("headers"), VmValue::dict(headers));
     if !matches!(body, VmValue::Nil) {
-        map.insert("body".to_string(), body);
+        map.insert(crate::value::intern_key("body"), body);
     }
     map
 }
@@ -734,10 +734,10 @@ fn http_push_hints_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
     );
 
     headers.insert(
-        "Link".to_string(),
+        crate::value::intern_key("Link"),
         VmValue::List(std::sync::Arc::new(combined)),
     );
-    envelope_map.insert("headers".to_string(), VmValue::dict(headers));
+    envelope_map.insert(crate::value::intern_key("headers"), VmValue::dict(headers));
     Ok(VmValue::dict(envelope_map))
 }
 
@@ -847,18 +847,18 @@ fn http_upgrade_ws_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
 
     let mut env_map = envelope_map(101, VmValue::Nil, BODY_KIND_NONE, headers);
     env_map.insert(
-        "ws_upgrade".to_string(),
+        crate::value::intern_key("ws_upgrade"),
         VmValue::dict({
             let mut map = crate::value::DictMap::new();
             map.insert(
-                "subprotocol".to_string(),
+                crate::value::intern_key("subprotocol"),
                 match &negotiated {
                     Some(name) => VmValue::String(arcstr::ArcStr::from(name.clone())),
                     None => VmValue::Nil,
                 },
             );
             map.insert(
-                "offered".to_string(),
+                crate::value::intern_key("offered"),
                 VmValue::List(std::sync::Arc::new(
                     offered_subprotocols
                         .iter()
@@ -867,10 +867,13 @@ fn http_upgrade_ws_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
                 )),
             );
             if let Some(ms) = idle_ping_ms {
-                map.insert("idle_ping_ms".to_string(), VmValue::Int(ms));
+                map.insert(crate::value::intern_key("idle_ping_ms"), VmValue::Int(ms));
             }
             if let Some(bytes) = max_message_bytes {
-                map.insert("max_message_bytes".to_string(), VmValue::Int(bytes));
+                map.insert(
+                    crate::value::intern_key("max_message_bytes"),
+                    VmValue::Int(bytes),
+                );
             }
             if let Some(handler) = &on_message {
                 map.put_str("on_message", handler.clone());
@@ -1064,7 +1067,7 @@ mod tests {
     #[test]
     fn http_created_sets_location_header() {
         let body = VmValue::dict(crate::value::DictMap::from_iter([(
-            "id".to_string(),
+            crate::value::intern_key("id"),
             VmValue::String(arcstr::ArcStr::from("sess_1")),
         )]));
         let location = VmValue::String(arcstr::ArcStr::from("/v1/sessions/sess_1"));
@@ -1160,7 +1163,7 @@ mod tests {
     fn http_reply_bytes_uses_bytes_body_kind() {
         let bytes = VmValue::Bytes(std::sync::Arc::new(vec![0x00, 0xff, 0xfe, 0x80]));
         let headers = VmValue::dict(crate::value::DictMap::from_iter([(
-            "Content-Type".to_string(),
+            crate::value::intern_key("Content-Type"),
             VmValue::String(arcstr::ArcStr::from("application/octet-stream")),
         )]));
         let response =
@@ -1179,16 +1182,19 @@ mod tests {
     #[test]
     fn http_reply_from_wraps_stream_body_as_chunk_list() {
         let result = VmValue::dict(crate::value::DictMap::from_iter([
-            ("status".to_string(), VmValue::Int(202)),
-            ("body_kind".to_string(), VmValue::string("stream")),
+            (crate::value::intern_key("status"), VmValue::Int(202)),
             (
-                "headers".to_string(),
+                crate::value::intern_key("body_kind"),
+                VmValue::string("stream"),
+            ),
+            (
+                crate::value::intern_key("headers"),
                 VmValue::dict(crate::value::DictMap::from_iter([(
-                    "Content-Type".to_string(),
+                    crate::value::intern_key("Content-Type"),
                     VmValue::string("text/plain"),
                 )])),
             ),
-            ("body".to_string(), VmValue::string("queued")),
+            (crate::value::intern_key("body"), VmValue::string("queued")),
         ]));
 
         let response = http_reply_from_impl(&[result], &mut String::new()).unwrap();
@@ -1216,9 +1222,12 @@ mod tests {
             VmValue::string("bravo"),
         ]));
         let result = VmValue::dict(crate::value::DictMap::from_iter([
-            ("status".to_string(), VmValue::Int(200)),
-            ("body_kind".to_string(), VmValue::string("stream")),
-            ("body".to_string(), chunks),
+            (crate::value::intern_key("status"), VmValue::Int(200)),
+            (
+                crate::value::intern_key("body_kind"),
+                VmValue::string("stream"),
+            ),
+            (crate::value::intern_key("body"), chunks),
         ]));
 
         let response = http_reply_from_impl(&[result], &mut String::new()).unwrap();
@@ -1236,10 +1245,13 @@ mod tests {
     fn http_reply_from_preserves_raw_body_for_bytes_kind() {
         let raw = VmValue::Bytes(std::sync::Arc::new(vec![0x00, 0xff, 0xfe, 0x80]));
         let result = VmValue::dict(crate::value::DictMap::from_iter([
-            ("status".to_string(), VmValue::Int(200)),
-            ("body_kind".to_string(), VmValue::string("bytes")),
-            ("body".to_string(), VmValue::string("<lossy>")),
-            ("raw_body".to_string(), raw),
+            (crate::value::intern_key("status"), VmValue::Int(200)),
+            (
+                crate::value::intern_key("body_kind"),
+                VmValue::string("bytes"),
+            ),
+            (crate::value::intern_key("body"), VmValue::string("<lossy>")),
+            (crate::value::intern_key("raw_body"), raw),
         ]));
 
         let response = http_reply_from_impl(&[result], &mut String::new()).unwrap();
@@ -1260,9 +1272,15 @@ mod tests {
     #[test]
     fn http_reply_from_rejects_non_bytes_for_bytes_kind() {
         let result = VmValue::dict(crate::value::DictMap::from_iter([
-            ("status".to_string(), VmValue::Int(200)),
-            ("body_kind".to_string(), VmValue::string("bytes")),
-            ("body".to_string(), VmValue::string("not bytes")),
+            (crate::value::intern_key("status"), VmValue::Int(200)),
+            (
+                crate::value::intern_key("body_kind"),
+                VmValue::string("bytes"),
+            ),
+            (
+                crate::value::intern_key("body"),
+                VmValue::string("not bytes"),
+            ),
         ]));
 
         let err =
@@ -1278,9 +1296,12 @@ mod tests {
     #[test]
     fn http_reply_from_falls_back_to_http_reply_for_text_kind() {
         let result = VmValue::dict(crate::value::DictMap::from_iter([
-            ("status".to_string(), VmValue::Int(200)),
-            ("body_kind".to_string(), VmValue::string("text")),
-            ("body".to_string(), VmValue::string("hello")),
+            (crate::value::intern_key("status"), VmValue::Int(200)),
+            (
+                crate::value::intern_key("body_kind"),
+                VmValue::string("text"),
+            ),
+            (crate::value::intern_key("body"), VmValue::string("hello")),
         ]));
 
         let response = http_reply_from_impl(&[result], &mut String::new()).unwrap();
@@ -1357,7 +1378,7 @@ mod tests {
     #[test]
     fn http_sse_sets_event_stream_headers_and_optional_retry() {
         let events = vec![VmValue::dict(crate::value::DictMap::from_iter([(
-            "data".to_string(),
+            crate::value::intern_key("data"),
             VmValue::String(arcstr::ArcStr::from("ping")),
         )]))];
         let response = run_sync(|| {
@@ -1394,7 +1415,7 @@ mod tests {
                 VmValue::String(arcstr::ArcStr::from("not_found")),
                 VmValue::String(arcstr::ArcStr::from("missing")),
                 VmValue::dict(crate::value::DictMap::from_iter([(
-                    "id".to_string(),
+                    crate::value::intern_key("id"),
                     VmValue::String(arcstr::ArcStr::from("sess_404")),
                 )])),
             ],
@@ -1599,7 +1620,7 @@ mod tests {
     #[test]
     fn http_push_hints_rejects_untagged_envelope() {
         let plain = VmValue::dict(crate::value::DictMap::from_iter([(
-            "status".to_string(),
+            crate::value::intern_key("status"),
             VmValue::Int(200),
         )]));
         let paths = VmValue::List(std::sync::Arc::new(vec![VmValue::String(
@@ -1619,7 +1640,7 @@ mod tests {
                 VmValue::Int(200),
                 VmValue::dict(crate::value::DictMap::new()),
                 VmValue::dict(crate::value::DictMap::from_iter([(
-                    "Link".to_string(),
+                    crate::value::intern_key("Link"),
                     VmValue::String(arcstr::ArcStr::from("</legacy.css>; rel=preload; as=style")),
                 )])),
             ],
@@ -1647,14 +1668,14 @@ mod tests {
     #[test]
     fn http_upgrade_ws_envelope_negotiates_subprotocol() {
         let req = VmValue::dict(crate::value::DictMap::from_iter([(
-            "headers".to_string(),
+            crate::value::intern_key("headers"),
             VmValue::dict(crate::value::DictMap::from_iter([(
-                "Sec-WebSocket-Protocol".to_string(),
+                crate::value::intern_key("Sec-WebSocket-Protocol"),
                 VmValue::String(arcstr::ArcStr::from("v0.harn, v1.harn")),
             )])),
         )]));
         let options = VmValue::dict(crate::value::DictMap::from_iter([(
-            "subprotocols".to_string(),
+            crate::value::intern_key("subprotocols"),
             VmValue::List(std::sync::Arc::new(vec![
                 VmValue::String(arcstr::ArcStr::from("v1.harn")),
                 VmValue::String(arcstr::ArcStr::from("v2.harn")),
@@ -1699,14 +1720,14 @@ mod tests {
         // The envelope MUST match what the upgrade handshake echoes
         // back, so we honour client preference everywhere.
         let req = VmValue::dict(crate::value::DictMap::from_iter([(
-            "headers".to_string(),
+            crate::value::intern_key("headers"),
             VmValue::dict(crate::value::DictMap::from_iter([(
-                "Sec-WebSocket-Protocol".to_string(),
+                crate::value::intern_key("Sec-WebSocket-Protocol"),
                 VmValue::String(arcstr::ArcStr::from("v2.harn, v1.harn")),
             )])),
         )]));
         let options = VmValue::dict(crate::value::DictMap::from_iter([(
-            "subprotocols".to_string(),
+            crate::value::intern_key("subprotocols"),
             VmValue::List(std::sync::Arc::new(vec![
                 VmValue::String(arcstr::ArcStr::from("v1.harn")),
                 VmValue::String(arcstr::ArcStr::from("v2.harn")),
@@ -1726,20 +1747,23 @@ mod tests {
     #[test]
     fn parse_envelope_round_trips_ws_upgrade_marker() {
         let req = VmValue::dict(crate::value::DictMap::from_iter([(
-            "headers".to_string(),
+            crate::value::intern_key("headers"),
             VmValue::dict(crate::value::DictMap::from_iter([(
-                "Sec-WebSocket-Protocol".to_string(),
+                crate::value::intern_key("Sec-WebSocket-Protocol"),
                 VmValue::String(arcstr::ArcStr::from("v1.harn")),
             )])),
         )]));
         let options = VmValue::dict(crate::value::DictMap::from_iter([
             (
-                "subprotocols".to_string(),
+                crate::value::intern_key("subprotocols"),
                 VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                     arcstr::ArcStr::from("v1.harn"),
                 )])),
             ),
-            ("idle_ping_ms".to_string(), VmValue::Int(15_000)),
+            (
+                crate::value::intern_key("idle_ping_ms"),
+                VmValue::Int(15_000),
+            ),
         ]));
         let response = http_upgrade_ws_impl(&[req, options], &mut String::new()).unwrap();
         let json = vm_value_to_json(&response);

--- a/crates/harn-vm/src/stdlib/json.rs
+++ b/crates/harn-vm/src/stdlib/json.rs
@@ -347,7 +347,7 @@ fn json_extract_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
 
     match key {
         Some(k) => match &parsed {
-            VmValue::Dict(map) => match map.get(&k) {
+            VmValue::Dict(map) => match map.get(k.as_str()) {
                 Some(val) => Ok(val.clone()),
                 None => Err(VmError::Thrown(VmValue::String(arcstr::ArcStr::from(
                     format!("json_extract: key '{k}' not found"),
@@ -488,7 +488,7 @@ fn json_pointer_get(value: &VmValue, ptr: &str) -> Result<VmValue, VmError> {
     for token in tokens {
         match current {
             VmValue::Dict(map) => {
-                let Some(next) = map.get(&token) else {
+                let Some(next) = map.get(token.as_str()) else {
                     return Ok(VmValue::Nil);
                 };
                 current = next;
@@ -524,10 +524,13 @@ fn pointer_set_at(value: &VmValue, tokens: &[String], replacement: VmValue) -> V
         VmValue::Dict(map) => {
             let mut next = map.as_ref().clone();
             if tail.is_empty() {
-                next.insert(head.clone(), replacement);
+                next.insert(crate::value::intern_key(head), replacement);
                 VmValue::dict(next)
-            } else if let Some(child) = map.get(head) {
-                next.insert(head.clone(), pointer_set_at(child, tail, replacement));
+            } else if let Some(child) = map.get(head.as_str()) {
+                next.insert(
+                    crate::value::intern_key(head),
+                    pointer_set_at(child, tail, replacement),
+                );
                 VmValue::dict(next)
             } else {
                 value.clone()
@@ -578,10 +581,13 @@ fn pointer_delete_at(value: &VmValue, tokens: &[String]) -> VmValue {
         VmValue::Dict(map) => {
             let mut next = map.as_ref().clone();
             if tail.is_empty() {
-                next.remove(head);
+                next.remove(head.as_str());
                 VmValue::dict(next)
-            } else if let Some(child) = map.get(head) {
-                next.insert(head.clone(), pointer_delete_at(child, tail));
+            } else if let Some(child) = map.get(head.as_str()) {
+                next.insert(
+                    crate::value::intern_key(head),
+                    pointer_delete_at(child, tail),
+                );
                 VmValue::dict(next)
             } else {
                 value.clone()
@@ -656,7 +662,7 @@ pub(crate) fn vm_value_to_data_value(value: &VmValue) -> serde_json::Value {
         VmValue::Dict(map) => crate::value::recursion::guard_recursion(|| {
             serde_json::Value::Object(
                 map.iter()
-                    .map(|(key, value)| (key.clone(), vm_value_to_data_value(value)))
+                    .map(|(key, value)| (key.to_string(), vm_value_to_data_value(value)))
                     .collect(),
             )
         }),
@@ -666,7 +672,7 @@ pub(crate) fn vm_value_to_data_value(value: &VmValue) -> serde_json::Value {
                     .struct_fields_map()
                     .unwrap_or_default()
                     .iter()
-                    .map(|(key, value)| (key.clone(), vm_value_to_data_value(value)))
+                    .map(|(key, value)| (key.to_string(), vm_value_to_data_value(value)))
                     .collect(),
             )
         }),

--- a/crates/harn-vm/src/stdlib/json_query.rs
+++ b/crates/harn-vm/src/stdlib/json_query.rs
@@ -158,7 +158,7 @@ fn eval_path(input: &VmValue, steps: &[PathStep]) -> Vec<VmValue> {
             match step {
                 PathStep::Field(name) => match value {
                     VmValue::Dict(map) => {
-                        next.push(map.get(name).cloned().unwrap_or(VmValue::Nil));
+                        next.push(map.get(name.as_str()).cloned().unwrap_or(VmValue::Nil));
                     }
                     VmValue::StructInstance { .. } => {
                         next.push(value.struct_field(name).cloned().unwrap_or(VmValue::Nil));

--- a/crates/harn-vm/src/stdlib/json_stream.rs
+++ b/crates/harn-vm/src/stdlib/json_stream.rs
@@ -823,7 +823,7 @@ fn early_invalid_object(
         index = skip_ws(buffer, index);
 
         let child_path = child_json_path(path, &key);
-        if let Some(child_schema) = properties.get(&key).and_then(VmValue::as_dict) {
+        if let Some(child_schema) = properties.get(key.as_str()).and_then(VmValue::as_dict) {
             let first = char_at(buffer, index)?;
             if let Some(invalid) = invalid_type_start(first, child_schema, &child_path) {
                 return Some(invalid);
@@ -1090,7 +1090,7 @@ mod tests {
         VmValue::dict(
             entries
                 .into_iter()
-                .map(|(key, value)| (key.to_string(), value))
+                .map(|(key, value)| (crate::value::intern_key(key), value))
                 .collect::<crate::value::DictMap>(),
         )
     }

--- a/crates/harn-vm/src/stdlib/jsonrpc.rs
+++ b/crates/harn-vm/src/stdlib/jsonrpc.rs
@@ -175,13 +175,13 @@ fn build_request_options(
     }
     let mut request_options = crate::value::DictMap::new();
     request_options.put_str("body", body);
-    request_options.insert("headers".to_string(), VmValue::dict(headers));
+    request_options.insert(crate::value::intern_key("headers"), VmValue::dict(headers));
     if let Some(d) = options {
         if let Some(timeout) = d.get("timeout_ms") {
-            request_options.insert("timeout_ms".to_string(), timeout.clone());
+            request_options.insert(crate::value::intern_key("timeout_ms"), timeout.clone());
         }
         if let Some(retries) = d.get("retries") {
-            request_options.insert("retries".to_string(), retries.clone());
+            request_options.insert(crate::value::intern_key("retries"), retries.clone());
         }
     }
     request_options
@@ -213,10 +213,10 @@ fn build_envelope(method: &str, params: &VmValue, id: &VmValue, notify: bool) ->
     m.put_str("jsonrpc", "2.0");
     m.put_str("method", method);
     if !matches!(params, VmValue::Nil) {
-        m.insert("params".to_string(), params.clone());
+        m.insert(crate::value::intern_key("params"), params.clone());
     }
     if !notify {
-        m.insert("id".to_string(), id.clone());
+        m.insert(crate::value::intern_key("id"), id.clone());
     }
     VmValue::dict(m)
 }
@@ -284,8 +284,11 @@ fn unwrap_batch_response(response: VmValue, slots: &[BatchSlot]) -> Result<VmVal
             // a synthetic error so the slot is still populated and
             // callers can detect the mismatch.
             let mut err_dict = crate::value::DictMap::new();
-            err_dict.insert("jsonrpc_error".to_string(), VmValue::Bool(true));
-            err_dict.insert("code".to_string(), VmValue::Int(0));
+            err_dict.insert(
+                crate::value::intern_key("jsonrpc_error"),
+                VmValue::Bool(true),
+            );
+            err_dict.insert(crate::value::intern_key("code"), VmValue::Int(0));
             err_dict.put_str("message", "missing response for call");
             out.push(VmValue::dict(err_dict));
             continue;
@@ -340,11 +343,17 @@ fn error_to_dict(err: &serde_json::Value) -> crate::value::DictMap {
         .and_then(|m| m.as_str())
         .unwrap_or("jsonrpc error");
     let mut error_dict = crate::value::DictMap::new();
-    error_dict.insert("jsonrpc_error".to_string(), VmValue::Bool(true));
-    error_dict.insert("code".to_string(), VmValue::Int(code));
+    error_dict.insert(
+        crate::value::intern_key("jsonrpc_error"),
+        VmValue::Bool(true),
+    );
+    error_dict.insert(crate::value::intern_key("code"), VmValue::Int(code));
     error_dict.put_str("message", message);
     if let Some(data) = err.get("data") {
-        error_dict.insert("data".to_string(), crate::schema::json_to_vm_value(data));
+        error_dict.insert(
+            crate::value::intern_key("data"),
+            crate::schema::json_to_vm_value(data),
+        );
     }
     error_dict
 }
@@ -398,7 +407,7 @@ mod tests {
     #[test]
     fn envelope_includes_params_when_present() {
         let mut params = crate::value::DictMap::new();
-        params.insert("x".to_string(), VmValue::Int(42));
+        params.insert(crate::value::intern_key("x"), VmValue::Int(42));
         let env = build_envelope("echo", &VmValue::dict(params), &VmValue::Int(1), false);
         let dict = env.as_dict().unwrap();
         let params = dict.get("params").and_then(VmValue::as_dict).unwrap();
@@ -409,7 +418,7 @@ mod tests {
     fn unwrap_returns_result_field() {
         let body = serde_json::json!({"jsonrpc":"2.0","result":{"ok":true},"id":1});
         let mut response = crate::value::DictMap::new();
-        response.insert("status".to_string(), VmValue::Int(200));
+        response.insert(crate::value::intern_key("status"), VmValue::Int(200));
         response.put_str("body", body.to_string());
         let result = unwrap_jsonrpc_response(VmValue::dict(response)).unwrap();
         let dict = result.as_dict().unwrap();
@@ -427,7 +436,7 @@ mod tests {
             "id":1,
         });
         let mut response = crate::value::DictMap::new();
-        response.insert("status".to_string(), VmValue::Int(200));
+        response.insert(crate::value::intern_key("status"), VmValue::Int(200));
         response.put_str("body", body.to_string());
         let err = unwrap_jsonrpc_response(VmValue::dict(response)).unwrap_err();
         match err {
@@ -447,7 +456,10 @@ mod tests {
         let mut user_headers = crate::value::DictMap::new();
         user_headers.put_str("content-type", "application/x-test");
         let mut opts = crate::value::DictMap::new();
-        opts.insert("headers".to_string(), VmValue::dict(user_headers));
+        opts.insert(
+            crate::value::intern_key("headers"),
+            VmValue::dict(user_headers),
+        );
         let request_options = build_request_options("{}".to_string(), Some(&opts));
         let headers = request_options
             .get("headers")
@@ -479,7 +491,7 @@ mod tests {
             {"jsonrpc":"2.0","result":"first","id":1},
         ]);
         let mut response = crate::value::DictMap::new();
-        response.insert("status".to_string(), VmValue::Int(200));
+        response.insert(crate::value::intern_key("status"), VmValue::Int(200));
         response.put_str("body", body.to_string());
         let slots = vec![
             BatchSlot {
@@ -507,7 +519,7 @@ mod tests {
             {"jsonrpc":"2.0","error":{"code":-32602,"message":"bad params"},"id":2},
         ]);
         let mut response = crate::value::DictMap::new();
-        response.insert("status".to_string(), VmValue::Int(200));
+        response.insert(crate::value::intern_key("status"), VmValue::Int(200));
         response.put_str("body", body.to_string());
         let slots = vec![
             BatchSlot {

--- a/crates/harn-vm/src/stdlib/junit.rs
+++ b/crates/harn-vm/src/stdlib/junit.rs
@@ -100,25 +100,25 @@ fn record_to_value(record: TestRecord) -> VmValue {
     map.put_str("name", record.name.as_str());
     map.put_str("status", record.status.as_str());
     map.insert(
-        "duration_ms".to_string(),
+        crate::value::intern_key("duration_ms"),
         VmValue::Int(record.duration_ms as i64),
     );
     map.insert(
-        "message".to_string(),
+        crate::value::intern_key("message"),
         record
             .message
             .map(|s| VmValue::String(arcstr::ArcStr::from(s)))
             .unwrap_or(VmValue::Nil),
     );
     map.insert(
-        "stdout".to_string(),
+        crate::value::intern_key("stdout"),
         record
             .stdout
             .map(|s| VmValue::String(arcstr::ArcStr::from(s)))
             .unwrap_or(VmValue::Nil),
     );
     map.insert(
-        "stderr".to_string(),
+        crate::value::intern_key("stderr"),
         record
             .stderr
             .map(|s| VmValue::String(arcstr::ArcStr::from(s)))

--- a/crates/harn-vm/src/stdlib/memory.rs
+++ b/crates/harn-vm/src/stdlib/memory.rs
@@ -1277,12 +1277,12 @@ fn memory_record_to_vm(record: &MemoryRecord, score: Option<f64>) -> VmValue {
     map.put_str("namespace", record.namespace.as_str());
     map.put_str("key", record.key.as_str());
     map.insert(
-        "value".to_string(),
+        crate::value::intern_key("value"),
         crate::stdlib::json_to_vm_value(&record.value),
     );
     map.put_str("text", record.text.as_str());
     map.insert(
-        "tags".to_string(),
+        crate::value::intern_key("tags"),
         VmValue::List(std::sync::Arc::new(
             record
                 .tags
@@ -1293,7 +1293,7 @@ fn memory_record_to_vm(record: &MemoryRecord, score: Option<f64>) -> VmValue {
     );
     map.put_str("stored_at", record.stored_at.as_str());
     map.insert(
-        "provenance".to_string(),
+        crate::value::intern_key("provenance"),
         record
             .provenance
             .as_ref()
@@ -1301,7 +1301,7 @@ fn memory_record_to_vm(record: &MemoryRecord, score: Option<f64>) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     if let Some(score) = score {
-        map.insert("score".to_string(), VmValue::Float(score));
+        map.insert(crate::value::intern_key("score"), VmValue::Float(score));
     }
     VmValue::dict(map)
 }
@@ -1323,10 +1323,13 @@ fn summary_to_vm(namespace: &str, records: Vec<MemoryRecord>) -> VmValue {
     let mut map = crate::value::DictMap::new();
     map.put_str("_type", "memory_summary");
     map.put_str("namespace", namespace);
-    map.insert("count".to_string(), VmValue::Int(records.len() as i64));
+    map.insert(
+        crate::value::intern_key("count"),
+        VmValue::Int(records.len() as i64),
+    );
     map.put_str("text", text);
     map.insert(
-        "records".to_string(),
+        crate::value::intern_key("records"),
         VmValue::List(std::sync::Arc::new(
             records
                 .iter()
@@ -1343,11 +1346,11 @@ fn forget_result_to_vm(event: &ForgetEvent) -> VmValue {
     map.put_str("id", event.id.as_str());
     map.put_str("namespace", event.namespace.as_str());
     map.insert(
-        "forgotten".to_string(),
+        crate::value::intern_key("forgotten"),
         VmValue::Int(event.forgotten_ids.len() as i64),
     );
     map.insert(
-        "forgotten_ids".to_string(),
+        crate::value::intern_key("forgotten_ids"),
         VmValue::List(std::sync::Arc::new(
             event
                 .forgotten_ids
@@ -1372,7 +1375,7 @@ fn memory_open_to_vm(event: &OpenEvent) -> VmValue {
     };
     map.put_str("backend", backend);
     map.insert(
-        "embed_model_hint".to_string(),
+        crate::value::intern_key("embed_model_hint"),
         event
             .embed_model_hint
             .as_deref()
@@ -1380,21 +1383,21 @@ fn memory_open_to_vm(event: &OpenEvent) -> VmValue {
             .unwrap_or(VmValue::Nil),
     );
     map.insert(
-        "embed_dim".to_string(),
+        crate::value::intern_key("embed_dim"),
         event
             .embed_dim
             .map(|dim| VmValue::Int(dim as i64))
             .unwrap_or(VmValue::Nil),
     );
     map.insert(
-        "bm25_weight".to_string(),
+        crate::value::intern_key("bm25_weight"),
         event
             .bm25_weight
             .map(VmValue::Float)
             .unwrap_or(VmValue::Nil),
     );
     map.insert(
-        "cosine_weight".to_string(),
+        crate::value::intern_key("cosine_weight"),
         event
             .cosine_weight
             .map(VmValue::Float)
@@ -1558,14 +1561,14 @@ mod tests {
     fn parse_embedding_response_validates_dim_and_vector_types() {
         let mut dict = crate::value::DictMap::new();
         dict.insert(
-            "vector".to_string(),
+            crate::value::intern_key("vector"),
             VmValue::List(std::sync::Arc::new(vec![
                 VmValue::Float(0.1),
                 VmValue::Float(0.2),
                 VmValue::Int(1),
             ])),
         );
-        dict.insert("dim".to_string(), VmValue::Int(3));
+        dict.insert(crate::value::intern_key("dim"), VmValue::Int(3));
         dict.put_str("model", "test-model");
         let value = VmValue::dict(dict);
         let parsed = parse_embedding_response(value, "fallback").unwrap();
@@ -1575,10 +1578,10 @@ mod tests {
 
         let mut bad = crate::value::DictMap::new();
         bad.insert(
-            "vector".to_string(),
+            crate::value::intern_key("vector"),
             VmValue::List(std::sync::Arc::new(vec![VmValue::Float(0.1)])),
         );
-        bad.insert("dim".to_string(), VmValue::Int(2));
+        bad.insert(crate::value::intern_key("dim"), VmValue::Int(2));
         let err = parse_embedding_response(VmValue::dict(bad), "fallback")
             .expect_err("dim mismatch must error");
         assert!(err.to_string().contains("dim=2"));

--- a/crates/harn-vm/src/stdlib/multipart.rs
+++ b/crates/harn-vm/src/stdlib/multipart.rs
@@ -425,7 +425,7 @@ fn parse_multipart_body(
 fn headers_value(headers: &BTreeMap<String, String>) -> VmValue {
     let map = headers
         .iter()
-        .map(|(key, value)| (key.clone(), VmValue::string(value)))
+        .map(|(key, value)| (crate::value::intern_key(key), VmValue::string(value)))
         .collect();
     dict_value(map)
 }
@@ -436,15 +436,24 @@ fn parsed_field_value(field: ParsedField) -> VmValue {
         Err(_) => VmValue::Nil,
     };
     let mut map = crate::value::DictMap::new();
-    map.insert("name".to_string(), VmValue::string(field.name));
-    map.insert("filename".to_string(), nil_or_string(field.filename));
     map.insert(
-        "content_type".to_string(),
+        crate::value::intern_key("name"),
+        VmValue::string(field.name),
+    );
+    map.insert(
+        crate::value::intern_key("filename"),
+        nil_or_string(field.filename),
+    );
+    map.insert(
+        crate::value::intern_key("content_type"),
         nil_or_string(field.content_type),
     );
-    map.insert("headers".to_string(), headers_value(&field.headers));
-    map.insert("bytes".to_string(), bytes_value(field.bytes));
-    map.insert("text".to_string(), text);
+    map.insert(
+        crate::value::intern_key("headers"),
+        headers_value(&field.headers),
+    );
+    map.insert(crate::value::intern_key("bytes"), bytes_value(field.bytes));
+    map.insert(crate::value::intern_key("text"), text);
     dict_value(map)
 }
 
@@ -463,13 +472,22 @@ fn multipart_parse_builtin(args: &[VmValue], _out: &mut String) -> Result<VmValu
     let field_count = fields.len() as i64;
 
     let mut result = crate::value::DictMap::new();
-    result.insert("boundary".to_string(), VmValue::string(boundary));
     result.insert(
-        "fields".to_string(),
+        crate::value::intern_key("boundary"),
+        VmValue::string(boundary),
+    );
+    result.insert(
+        crate::value::intern_key("fields"),
         list_value(fields.into_iter().map(parsed_field_value).collect()),
     );
-    result.insert("field_count".to_string(), VmValue::Int(field_count));
-    result.insert("total_bytes".to_string(), VmValue::Int(total_bytes));
+    result.insert(
+        crate::value::intern_key("field_count"),
+        VmValue::Int(field_count),
+    );
+    result.insert(
+        crate::value::intern_key("total_bytes"),
+        VmValue::Int(total_bytes),
+    );
     Ok(dict_value(result))
 }
 
@@ -589,7 +607,7 @@ fn input_headers(
         if value.contains('\r') || value.contains('\n') {
             return Err(builtin_error(builtin, "header values must be single-line"));
         }
-        out.insert(name.clone(), value.to_string());
+        out.insert(name.to_string(), value.to_string());
     }
     Ok(out)
 }
@@ -750,9 +768,15 @@ fn multipart_form_data_builtin(args: &[VmValue], _out: &mut String) -> Result<Vm
 fn form_data_result(boundary: String, body: Vec<u8>) -> Result<VmValue, VmError> {
     let content_type = format!("multipart/form-data; boundary={boundary}");
     let mut result = crate::value::DictMap::new();
-    result.insert("boundary".to_string(), VmValue::string(boundary));
-    result.insert("content_type".to_string(), VmValue::string(content_type));
-    result.insert("body".to_string(), bytes_value(body));
+    result.insert(
+        crate::value::intern_key("boundary"),
+        VmValue::string(boundary),
+    );
+    result.insert(
+        crate::value::intern_key("content_type"),
+        VmValue::string(content_type),
+    );
+    result.insert(crate::value::intern_key("body"), bytes_value(body));
     Ok(dict_value(result))
 }
 
@@ -835,7 +859,7 @@ mod tests {
                 body,
                 s("multipart/form-data; boundary=x"),
                 dict_value(crate::value::DictMap::from_iter([(
-                    "max_fields".to_string(),
+                    crate::value::intern_key("max_fields"),
                     VmValue::Int(0),
                 )])),
             ],

--- a/crates/harn-vm/src/stdlib/net.rs
+++ b/crates/harn-vm/src/stdlib/net.rs
@@ -45,13 +45,13 @@ fn unix_socket_options(value: Option<&VmValue>) -> UnixSocketOptions {
 
 fn insert_string(dict: &mut crate::value::DictMap, key: &str, value: impl Into<String>) {
     dict.insert(
-        key.to_string(),
+        crate::value::intern_key(key),
         VmValue::String(arcstr::ArcStr::from(value.into())),
     );
 }
 
 fn insert_int(dict: &mut crate::value::DictMap, key: &str, value: i64) {
-    dict.insert(key.to_string(), VmValue::Int(value));
+    dict.insert(crate::value::intern_key(key), VmValue::Int(value));
 }
 
 fn elapsed_ms(started_ms: i64) -> i64 {
@@ -68,7 +68,7 @@ fn socket_result(
     response: Option<VmValue>,
 ) -> VmValue {
     let mut out = crate::value::DictMap::new();
-    out.insert("ok".to_string(), VmValue::Bool(ok));
+    out.insert(crate::value::intern_key("ok"), VmValue::Bool(ok));
     insert_string(&mut out, "status", status);
     insert_string(&mut out, "path", path);
     insert_int(&mut out, "duration_ms", elapsed_ms(started_ms));
@@ -80,7 +80,7 @@ fn socket_result(
         insert_string(&mut out, "raw_response", raw_response);
     }
     if let Some(response) = response {
-        out.insert("response".to_string(), response);
+        out.insert(crate::value::intern_key("response"), response);
     }
     VmValue::dict(out)
 }

--- a/crates/harn-vm/src/stdlib/oauth_dynreg.rs
+++ b/crates/harn-vm/src/stdlib/oauth_dynreg.rs
@@ -240,10 +240,10 @@ fn next_store_id() -> String {
 fn store_handle(id: &str) -> VmValue {
     let mut fields = crate::value::DictMap::new();
     fields.insert(
-        HANDLE_KEY_KIND.to_string(),
+        crate::value::intern_key(HANDLE_KEY_KIND),
         VmValue::string(KIND_DYNREG_STORE),
     );
-    fields.insert(HANDLE_KEY_ID.to_string(), VmValue::string(id));
+    fields.insert(crate::value::intern_key(HANDLE_KEY_ID), VmValue::string(id));
     VmValue::dict(fields)
 }
 
@@ -282,9 +282,12 @@ fn validate_metadata_value(metadata: &crate::value::DictMap) -> VmValue {
     let mut errors: Vec<String> = Vec::new();
     validate_metadata(metadata, &mut errors);
     let mut out = crate::value::DictMap::new();
-    out.insert("ok".to_string(), VmValue::Bool(errors.is_empty()));
     out.insert(
-        "errors".to_string(),
+        crate::value::intern_key("ok"),
+        VmValue::Bool(errors.is_empty()),
+    );
+    out.insert(
+        crate::value::intern_key("errors"),
         VmValue::List(std::sync::Arc::new(
             errors.iter().map(VmValue::string).collect::<Vec<_>>(),
         )),
@@ -556,14 +559,15 @@ fn build_client_metadata_value(metadata: &crate::value::DictMap) -> Result<VmVal
     // defaults to `["code"]`; grant_types defaults to `["authorization_code"]`;
     // token_endpoint_auth_method defaults to `client_secret_basic`.
     let mut out: crate::value::DictMap = metadata.clone();
-    out.entry("response_types".to_string())
+    out.entry(crate::value::intern_key("response_types"))
         .or_insert_with(|| VmValue::List(std::sync::Arc::new(vec![VmValue::string("code")])));
-    out.entry("grant_types".to_string()).or_insert_with(|| {
-        VmValue::List(std::sync::Arc::new(vec![VmValue::string(
-            "authorization_code",
-        )]))
-    });
-    out.entry("token_endpoint_auth_method".to_string())
+    out.entry(crate::value::intern_key("grant_types"))
+        .or_insert_with(|| {
+            VmValue::List(std::sync::Arc::new(vec![VmValue::string(
+                "authorization_code",
+            )]))
+        });
+    out.entry(crate::value::intern_key("token_endpoint_auth_method"))
         .or_insert_with(|| VmValue::string("client_secret_basic"));
     Ok(VmValue::dict(out))
 }
@@ -577,33 +581,39 @@ fn build_authorization_server_metadata_value(
     let issuer = derive_issuer(&auth_url)?;
 
     let mut out: crate::value::DictMap = crate::value::DictMap::new();
-    out.insert("issuer".to_string(), VmValue::string(&issuer));
+    out.insert(crate::value::intern_key("issuer"), VmValue::string(&issuer));
     out.insert(
-        "authorization_endpoint".to_string(),
+        crate::value::intern_key("authorization_endpoint"),
         VmValue::string(&auth_url),
     );
-    out.insert("token_endpoint".to_string(), VmValue::string(&token_url));
+    out.insert(
+        crate::value::intern_key("token_endpoint"),
+        VmValue::string(&token_url),
+    );
     if let Some(VmValue::String(s)) = provider.get("device_code_url") {
         out.insert(
-            "device_authorization_endpoint".to_string(),
+            crate::value::intern_key("device_authorization_endpoint"),
             VmValue::string(s.as_str()),
         );
     }
     if let Some(VmValue::String(s)) = provider.get("revoke_url") {
         out.insert(
-            "revocation_endpoint".to_string(),
+            crate::value::intern_key("revocation_endpoint"),
             VmValue::string(s.as_str()),
         );
     }
     if let Some(VmValue::String(s)) = provider.get("userinfo_url") {
-        out.insert("userinfo_endpoint".to_string(), VmValue::string(s.as_str()));
+        out.insert(
+            crate::value::intern_key("userinfo_endpoint"),
+            VmValue::string(s.as_str()),
+        );
     }
     out.insert(
-        "response_types_supported".to_string(),
+        crate::value::intern_key("response_types_supported"),
         VmValue::List(std::sync::Arc::new(vec![VmValue::string("code")])),
     );
     out.insert(
-        "grant_types_supported".to_string(),
+        crate::value::intern_key("grant_types_supported"),
         VmValue::List(std::sync::Arc::new(vec![
             VmValue::string("authorization_code"),
             VmValue::string("refresh_token"),
@@ -611,7 +621,7 @@ fn build_authorization_server_metadata_value(
         ])),
     );
     out.insert(
-        "token_endpoint_auth_methods_supported".to_string(),
+        crate::value::intern_key("token_endpoint_auth_methods_supported"),
         VmValue::List(std::sync::Arc::new(vec![
             VmValue::string("client_secret_basic"),
             VmValue::string("client_secret_post"),
@@ -620,18 +630,18 @@ fn build_authorization_server_metadata_value(
     );
     if let Some(VmValue::Bool(true)) | Some(VmValue::Bool(false)) = provider.get("pkce_required") {
         out.insert(
-            "code_challenge_methods_supported".to_string(),
+            crate::value::intern_key("code_challenge_methods_supported"),
             VmValue::List(std::sync::Arc::new(vec![VmValue::string("S256")])),
         );
     } else {
         out.insert(
-            "code_challenge_methods_supported".to_string(),
+            crate::value::intern_key("code_challenge_methods_supported"),
             VmValue::List(std::sync::Arc::new(vec![VmValue::string("S256")])),
         );
     }
     if let Some(VmValue::List(scopes)) = provider.get("default_scopes") {
         out.insert(
-            "scopes_supported".to_string(),
+            crate::value::intern_key("scopes_supported"),
             VmValue::List(scopes.clone()),
         );
     }
@@ -684,17 +694,17 @@ fn register_client_value(
 
     let mut canonical = metadata.clone();
     canonical
-        .entry("response_types".to_string())
+        .entry(crate::value::intern_key("response_types"))
         .or_insert_with(|| VmValue::List(std::sync::Arc::new(vec![VmValue::string("code")])));
     canonical
-        .entry("grant_types".to_string())
+        .entry(crate::value::intern_key("grant_types"))
         .or_insert_with(|| {
             VmValue::List(std::sync::Arc::new(vec![VmValue::string(
                 "authorization_code",
             )]))
         });
     canonical
-        .entry("token_endpoint_auth_method".to_string())
+        .entry(crate::value::intern_key("token_endpoint_auth_method"))
         .or_insert_with(|| VmValue::string("client_secret_basic"));
 
     let canonical_dict = VmValue::dict(canonical.clone());
@@ -718,11 +728,23 @@ fn register_client_value(
 
     // Build the response dict — full RFC 7591 §3.2.1 success body.
     let mut response: crate::value::DictMap = canonical;
-    response.insert("client_id".to_string(), VmValue::string(&client_id));
-    response.insert("client_secret".to_string(), VmValue::string(&client_secret));
-    response.insert("client_id_issued_at".to_string(), VmValue::Int(issued_at));
+    response.insert(
+        crate::value::intern_key("client_id"),
+        VmValue::string(&client_id),
+    );
+    response.insert(
+        crate::value::intern_key("client_secret"),
+        VmValue::string(&client_secret),
+    );
+    response.insert(
+        crate::value::intern_key("client_id_issued_at"),
+        VmValue::Int(issued_at),
+    );
     // Per RFC 7591 §3.2.1, `client_secret_expires_at: 0` means non-expiring.
-    response.insert("client_secret_expires_at".to_string(), VmValue::Int(0));
+    response.insert(
+        crate::value::intern_key("client_secret_expires_at"),
+        VmValue::Int(0),
+    );
     Ok(VmValue::dict(response))
 }
 
@@ -748,12 +770,18 @@ fn get_client_value(handle: &crate::value::DictMap, client_id: &str) -> VmValue 
             VmValue::Dict(dict) => dict.as_ref().clone(),
             _ => crate::value::DictMap::new(),
         };
-        response.insert("client_id".to_string(), VmValue::string(&client.client_id));
         response.insert(
-            "client_id_issued_at".to_string(),
+            crate::value::intern_key("client_id"),
+            VmValue::string(&client.client_id),
+        );
+        response.insert(
+            crate::value::intern_key("client_id_issued_at"),
             VmValue::Int(client.client_id_issued_at),
         );
-        response.insert("client_secret_expires_at".to_string(), VmValue::Int(0));
+        response.insert(
+            crate::value::intern_key("client_secret_expires_at"),
+            VmValue::Int(0),
+        );
         VmValue::dict(response)
     })
 }
@@ -885,7 +913,7 @@ mod tests {
     fn metadata_with_redirect(uri: &str) -> crate::value::DictMap {
         let mut m = crate::value::DictMap::new();
         m.insert(
-            "redirect_uris".to_string(),
+            crate::value::intern_key("redirect_uris"),
             VmValue::List(std::sync::Arc::new(vec![VmValue::string(uri)])),
         );
         m
@@ -946,7 +974,7 @@ mod tests {
     fn empty_redirect_uris_fails() {
         let mut m = crate::value::DictMap::new();
         m.insert(
-            "redirect_uris".to_string(),
+            crate::value::intern_key("redirect_uris"),
             VmValue::List(std::sync::Arc::new(Vec::new())),
         );
         let mut errors = Vec::new();
@@ -966,7 +994,7 @@ mod tests {
     fn unknown_grant_type_fails() {
         let mut m = metadata_with_redirect("https://app.example/cb");
         m.insert(
-            "grant_types".to_string(),
+            crate::value::intern_key("grant_types"),
             VmValue::List(std::sync::Arc::new(vec![VmValue::string("password")])),
         );
         let mut errors = Vec::new();
@@ -990,11 +1018,11 @@ mod tests {
     fn build_authorization_server_metadata_minimal() {
         let mut provider = crate::value::DictMap::new();
         provider.insert(
-            "auth_url".to_string(),
+            crate::value::intern_key("auth_url"),
             VmValue::string("https://idp.example/authorize"),
         );
         provider.insert(
-            "token_url".to_string(),
+            crate::value::intern_key("token_url"),
             VmValue::string("https://idp.example/token"),
         );
         let built = build_authorization_server_metadata_value(&provider, None).expect("ok");
@@ -1028,8 +1056,11 @@ mod tests {
                 .insert(id.clone(), DynregStore::default());
         });
         let mut handle = crate::value::DictMap::new();
-        handle.insert("kind".to_string(), VmValue::string(KIND_DYNREG_STORE));
-        handle.insert("id".to_string(), VmValue::string(&id));
+        handle.insert(
+            crate::value::intern_key("kind"),
+            VmValue::string(KIND_DYNREG_STORE),
+        );
+        handle.insert(crate::value::intern_key("id"), VmValue::string(&id));
         let m = metadata_with_redirect("https://app.example/cb");
         let response = register_client_value(&handle, &m).expect("registration ok");
         let VmValue::Dict(dict) = response else {
@@ -1061,8 +1092,11 @@ mod tests {
                 .insert(id.clone(), DynregStore::default());
         });
         let mut handle = crate::value::DictMap::new();
-        handle.insert("kind".to_string(), VmValue::string(KIND_DYNREG_STORE));
-        handle.insert("id".to_string(), VmValue::string(&id));
+        handle.insert(
+            crate::value::intern_key("kind"),
+            VmValue::string(KIND_DYNREG_STORE),
+        );
+        handle.insert(crate::value::intern_key("id"), VmValue::string(&id));
         let m = metadata_with_redirect("http://attacker.example/cb");
         let err = register_client_value(&handle, &m).unwrap_err();
         let VmError::Runtime(text) = err else {

--- a/crates/harn-vm/src/stdlib/oauth_storage.rs
+++ b/crates/harn-vm/src/stdlib/oauth_storage.rs
@@ -210,8 +210,14 @@ fn memory_handle() -> VmValue {
         format!("memory-{}", *guard)
     };
     let mut fields = crate::value::DictMap::new();
-    fields.insert(HANDLE_KEY_KIND.to_string(), VmValue::string(KIND_MEMORY));
-    fields.insert(HANDLE_KEY_ID.to_string(), VmValue::string(&id));
+    fields.insert(
+        crate::value::intern_key(HANDLE_KEY_KIND),
+        VmValue::string(KIND_MEMORY),
+    );
+    fields.insert(
+        crate::value::intern_key(HANDLE_KEY_ID),
+        VmValue::string(&id),
+    );
     VmValue::dict(fields)
 }
 
@@ -226,9 +232,18 @@ fn file_handle(path: &str, secret: &[u8]) -> VmValue {
         secrets.borrow_mut().insert(id.clone(), secret.to_vec());
     });
     let mut fields = crate::value::DictMap::new();
-    fields.insert(HANDLE_KEY_KIND.to_string(), VmValue::string(KIND_FILE));
-    fields.insert(HANDLE_KEY_ID.to_string(), VmValue::string(&id));
-    fields.insert(HANDLE_KEY_PATH.to_string(), VmValue::string(path));
+    fields.insert(
+        crate::value::intern_key(HANDLE_KEY_KIND),
+        VmValue::string(KIND_FILE),
+    );
+    fields.insert(
+        crate::value::intern_key(HANDLE_KEY_ID),
+        VmValue::string(&id),
+    );
+    fields.insert(
+        crate::value::intern_key(HANDLE_KEY_PATH),
+        VmValue::string(path),
+    );
     VmValue::dict(fields)
 }
 
@@ -239,9 +254,18 @@ fn cloud_handle(kind: &'static str) -> VmValue {
         "session"
     };
     let mut fields = crate::value::DictMap::new();
-    fields.insert(HANDLE_KEY_KIND.to_string(), VmValue::string(kind));
-    fields.insert(HANDLE_KEY_ID.to_string(), VmValue::string(kind));
-    fields.insert(HANDLE_KEY_SCOPE.to_string(), VmValue::string(scope));
+    fields.insert(
+        crate::value::intern_key(HANDLE_KEY_KIND),
+        VmValue::string(kind),
+    );
+    fields.insert(
+        crate::value::intern_key(HANDLE_KEY_ID),
+        VmValue::string(kind),
+    );
+    fields.insert(
+        crate::value::intern_key(HANDLE_KEY_SCOPE),
+        VmValue::string(scope),
+    );
     VmValue::dict(fields)
 }
 
@@ -604,8 +628,8 @@ fn cloud_scope(handle: &crate::value::DictMap) -> Result<String, VmError> {
 async fn cloud_get(handle: &crate::value::DictMap, key: &str) -> Result<VmValue, VmError> {
     let scope = cloud_scope(handle)?;
     let mut params = crate::value::DictMap::new();
-    params.insert("scope".to_string(), VmValue::string(&scope));
-    params.insert("key".to_string(), VmValue::string(key));
+    params.insert(crate::value::intern_key("scope"), VmValue::string(&scope));
+    params.insert(crate::value::intern_key("key"), VmValue::string(key));
     dispatch_host_operation("oauth_storage", "cloud_get", &params).await
 }
 
@@ -617,11 +641,11 @@ async fn cloud_set(
 ) -> Result<(), VmError> {
     let scope = cloud_scope(handle)?;
     let mut params = crate::value::DictMap::new();
-    params.insert("scope".to_string(), VmValue::string(&scope));
-    params.insert("key".to_string(), VmValue::string(key));
-    params.insert("token".to_string(), json_to_vm_dict(&token));
+    params.insert(crate::value::intern_key("scope"), VmValue::string(&scope));
+    params.insert(crate::value::intern_key("key"), VmValue::string(key));
+    params.insert(crate::value::intern_key("token"), json_to_vm_dict(&token));
     if let Some(ttl) = ttl_seconds {
-        params.insert("ttl_seconds".to_string(), VmValue::Int(ttl));
+        params.insert(crate::value::intern_key("ttl_seconds"), VmValue::Int(ttl));
     }
     dispatch_host_operation("oauth_storage", "cloud_set", &params).await?;
     Ok(())
@@ -630,8 +654,8 @@ async fn cloud_set(
 async fn cloud_delete(handle: &crate::value::DictMap, key: &str) -> Result<(), VmError> {
     let scope = cloud_scope(handle)?;
     let mut params = crate::value::DictMap::new();
-    params.insert("scope".to_string(), VmValue::string(&scope));
-    params.insert("key".to_string(), VmValue::string(key));
+    params.insert(crate::value::intern_key("scope"), VmValue::string(&scope));
+    params.insert(crate::value::intern_key("key"), VmValue::string(key));
     dispatch_host_operation("oauth_storage", "cloud_delete", &params).await?;
     Ok(())
 }
@@ -751,7 +775,10 @@ mod tests {
 
     fn token_dict(access: &str) -> crate::value::DictMap {
         let mut dict = crate::value::DictMap::new();
-        dict.insert("access_token".to_string(), VmValue::string(access));
+        dict.insert(
+            crate::value::intern_key("access_token"),
+            VmValue::string(access),
+        );
         dict
     }
 

--- a/crates/harn-vm/src/stdlib/observability.rs
+++ b/crates/harn-vm/src/stdlib/observability.rs
@@ -506,7 +506,7 @@ fn span_to_vm_value(span: &ObsSpan) -> VmValue {
     out.put_str("span_id", span.id.as_str());
     out.put_str("name", span.name.as_str());
     out.insert(
-        "attrs".to_string(),
+        crate::value::intern_key("attrs"),
         json_to_vm_value(&serde_json::Value::Object(span.attrs.clone())),
     );
     VmValue::dict(out)
@@ -857,7 +857,7 @@ fn pretty_payload(event: &serde_json::Value) -> serde_json::Value {
     let mut fields = crate::value::DictMap::new();
     if let Some(serde_json::Value::Object(map)) = event.get("fields") {
         for (key, value) in map {
-            fields.insert(key.clone(), json_to_vm_value(value));
+            fields.insert(crate::value::intern_key(key), json_to_vm_value(value));
         }
     }
     serde_json::Value::String(
@@ -915,14 +915,14 @@ pub(crate) fn vm_value_to_json(value: &VmValue) -> serde_json::Value {
         VmValue::Dict(map) => {
             let mut out = serde_json::Map::new();
             for (key, value) in map.iter() {
-                out.insert(key.clone(), vm_value_to_json(value));
+                out.insert(key.to_string(), vm_value_to_json(value));
             }
             serde_json::Value::Object(out)
         }
         VmValue::StructInstance { .. } => {
             let mut out = serde_json::Map::new();
             for (key, value) in value.struct_fields_map().unwrap_or_default().iter() {
-                out.insert(key.clone(), vm_value_to_json(value));
+                out.insert(key.to_string(), vm_value_to_json(value));
             }
             serde_json::Value::Object(out)
         }

--- a/crates/harn-vm/src/stdlib/pool/mod.rs
+++ b/crates/harn-vm/src/stdlib/pool/mod.rs
@@ -903,40 +903,52 @@ fn pool_snapshot_value(pool: &PoolEntry) -> VmValue {
     snapshot.put_str("id", pool.id.as_str());
     snapshot.put_str("name", pool.name.as_str());
     snapshot.insert(
-        "max_concurrent".to_string(),
+        crate::value::intern_key("max_concurrent"),
         VmValue::Int(pool.max_concurrent as i64),
     );
     snapshot.put_str("created_at", pool.created_at.as_str());
-    snapshot.insert("active".to_string(), VmValue::Int(active));
-    snapshot.insert("queued".to_string(), VmValue::Int(queued));
-    snapshot.insert("completed".to_string(), VmValue::Int(completed));
-    snapshot.insert("failed".to_string(), VmValue::Int(failed));
-    snapshot.insert("rejected".to_string(), VmValue::Int(rejected));
-    snapshot.insert("total".to_string(), VmValue::Int(pool.tasks.len() as i64));
+    snapshot.insert(crate::value::intern_key("active"), VmValue::Int(active));
+    snapshot.insert(crate::value::intern_key("queued"), VmValue::Int(queued));
+    snapshot.insert(
+        crate::value::intern_key("completed"),
+        VmValue::Int(completed),
+    );
+    snapshot.insert(crate::value::intern_key("failed"), VmValue::Int(failed));
+    snapshot.insert(crate::value::intern_key("rejected"), VmValue::Int(rejected));
+    snapshot.insert(
+        crate::value::intern_key("total"),
+        VmValue::Int(pool.tasks.len() as i64),
+    );
     snapshot.put_str("queue_strategy", pool.queue_strategy.name());
     snapshot.insert(
-        "backpressure".to_string(),
+        crate::value::intern_key("backpressure"),
         backpressure_snapshot_value(&pool.backpressure),
     );
     snapshot.insert(
-        "blocked_submitters".to_string(),
+        crate::value::intern_key("blocked_submitters"),
         VmValue::Int(pool.space_waiters.len() as i64),
     );
     snapshot.insert(
-        "tasks".to_string(),
+        crate::value::intern_key("tasks"),
         VmValue::List(std::sync::Arc::new(tasks)),
     );
     snapshot.put_str("scope", pool.scope.as_str());
     if !pool.scope_id.is_empty() {
         snapshot.put_str("scope_id", pool.scope_id.as_str());
     }
-    snapshot.insert("durable".to_string(), VmValue::Bool(pool.store.is_some()));
     snapshot.insert(
-        "stale_after_ms".to_string(),
+        crate::value::intern_key("durable"),
+        VmValue::Bool(pool.store.is_some()),
+    );
+    snapshot.insert(
+        crate::value::intern_key("stale_after_ms"),
         VmValue::Int(pool.stale_after_ms),
     );
     if !pool.config.is_empty() {
-        snapshot.insert("config".to_string(), VmValue::dict(pool.config.clone()));
+        snapshot.insert(
+            crate::value::intern_key("config"),
+            VmValue::dict(pool.config.clone()),
+        );
     }
     VmValue::dict(snapshot)
 }
@@ -946,7 +958,10 @@ fn backpressure_snapshot_value(backpressure: &BackpressureStrategy) -> VmValue {
     value.put_str("_type", "backpressure");
     value.put_str("kind", backpressure.name());
     if let Some(max_depth) = backpressure.max_depth() {
-        value.insert("max_depth".to_string(), VmValue::Int(max_depth as i64));
+        value.insert(
+            crate::value::intern_key("max_depth"),
+            VmValue::Int(max_depth as i64),
+        );
     }
     if let BackpressureStrategy::Queue { on_full, .. } = backpressure {
         value.put_str("on_full", on_full.as_str());
@@ -971,13 +986,16 @@ fn task_snapshot_value(task: &TaskState) -> VmValue {
     entry.put_str("pool_id", task.pool_id.as_str());
     entry.put_str("pool", task.pool_name.as_str());
     entry.put_str("status", task.status.as_str());
-    entry.insert("priority".to_string(), VmValue::Int(task.priority));
+    entry.insert(
+        crate::value::intern_key("priority"),
+        VmValue::Int(task.priority),
+    );
     entry.put_str("submitted_at", task.submitted_at.as_str());
     entry.put_opt_str("key", task.key.as_deref());
     entry.put_opt_str("started_at", task.started_at.as_deref());
     entry.put_opt_str("finished_at", task.finished_at.as_deref());
     if let Some(result) = &task.result {
-        entry.insert("result".to_string(), result.clone());
+        entry.insert(crate::value::intern_key("result"), result.clone());
     }
     entry.put_opt_str("error", task.error.as_deref());
     entry.put_opt_str("rejection_reason", task.rejection_reason.as_deref());
@@ -1004,7 +1022,7 @@ fn ordered_pool_config(opts: &crate::value::DictMap) -> crate::value::DictMap {
     let mut config = crate::value::DictMap::new();
     for key in ["queue", "backpressure", "priority"] {
         if let Some(value) = opts.get(key) {
-            config.insert(key.to_string(), value.clone());
+            config.insert(crate::value::intern_key(key), value.clone());
         }
     }
     config

--- a/crates/harn-vm/src/stdlib/postgres/introspect.rs
+++ b/crates/harn-vm/src/stdlib/postgres/introspect.rs
@@ -210,17 +210,26 @@ async fn pg_pool_stats_impl(
     let in_use = (size as usize).saturating_sub(idle);
 
     let mut dict = crate::value::DictMap::new();
-    dict.insert("size".to_string(), VmValue::Int(i64::from(size)));
-    dict.insert("idle".to_string(), VmValue::Int(idle as i64));
-    dict.insert("in_use".to_string(), VmValue::Int(in_use as i64));
-    dict.insert("max_connections".to_string(), VmValue::Int(i64::from(max)));
     dict.insert(
-        "statement_cache_capacity".to_string(),
+        crate::value::intern_key("size"),
+        VmValue::Int(i64::from(size)),
+    );
+    dict.insert(crate::value::intern_key("idle"), VmValue::Int(idle as i64));
+    dict.insert(
+        crate::value::intern_key("in_use"),
+        VmValue::Int(in_use as i64),
+    );
+    dict.insert(
+        crate::value::intern_key("max_connections"),
+        VmValue::Int(i64::from(max)),
+    );
+    dict.insert(
+        crate::value::intern_key("statement_cache_capacity"),
         VmValue::Int(record.statement_cache_capacity as i64),
     );
     dict.put_str("read_routing_policy", record.read_routing_policy.as_str());
     dict.insert(
-        "replicas".to_string(),
+        crate::value::intern_key("replicas"),
         VmValue::Int(record.replicas.len() as i64),
     );
     if !record.replicas.is_empty() {
@@ -229,24 +238,30 @@ async fn pg_pool_stats_impl(
             .iter()
             .map(|pool| {
                 let mut entry = crate::value::DictMap::new();
-                entry.insert("size".to_string(), VmValue::Int(i64::from(pool.size())));
-                entry.insert("idle".to_string(), VmValue::Int(pool.num_idle() as i64));
+                entry.insert(
+                    crate::value::intern_key("size"),
+                    VmValue::Int(i64::from(pool.size())),
+                );
+                entry.insert(
+                    crate::value::intern_key("idle"),
+                    VmValue::Int(pool.num_idle() as i64),
+                );
                 VmValue::dict(entry)
             })
             .collect();
         dict.insert(
-            "replica_stats".to_string(),
+            crate::value::intern_key("replica_stats"),
             VmValue::List(std::sync::Arc::new(replica_stats)),
         );
     }
     let circuit_state = record.circuit.snapshot();
     dict.put_str("circuit_state", circuit_state.state);
     dict.insert(
-        "circuit_failures".to_string(),
+        crate::value::intern_key("circuit_failures"),
         VmValue::Int(circuit_state.failures as i64),
     );
     dict.insert(
-        "circuit_opened_at_ms".to_string(),
+        crate::value::intern_key("circuit_opened_at_ms"),
         circuit_state
             .opened_at_ms
             .map(VmValue::Int)
@@ -920,11 +935,11 @@ mod tests {
     fn render_bounds_clause_handles_three_shapes() {
         let from_to = crate::value::DictMap::from_iter([
             (
-                "from".to_string(),
+                crate::value::intern_key("from"),
                 VmValue::String(arcstr::ArcStr::from("2026-01-01")),
             ),
             (
-                "to".to_string(),
+                crate::value::intern_key("to"),
                 VmValue::String(arcstr::ArcStr::from("2026-02-01")),
             ),
         ]);
@@ -933,15 +948,17 @@ mod tests {
             "FOR VALUES FROM ('2026-01-01') TO ('2026-02-01')"
         );
         let in_clause = crate::value::DictMap::from_iter([(
-            "in".to_string(),
+            crate::value::intern_key("in"),
             VmValue::List(std::sync::Arc::new(vec![VmValue::Int(1), VmValue::Int(2)])),
         )]);
         assert_eq!(
             render_bounds_clause(&in_clause).unwrap(),
             "FOR VALUES IN (1, 2)"
         );
-        let default =
-            crate::value::DictMap::from_iter([("default".to_string(), VmValue::Bool(true))]);
+        let default = crate::value::DictMap::from_iter([(
+            crate::value::intern_key("default"),
+            VmValue::Bool(true),
+        )]);
         assert_eq!(render_bounds_clause(&default).unwrap(), "DEFAULT");
         let bad = crate::value::DictMap::new();
         assert!(render_bounds_clause(&bad).is_err());
@@ -958,8 +975,8 @@ mod tests {
     #[test]
     fn render_bounds_clause_handles_hash() {
         let hash = crate::value::DictMap::from_iter([
-            ("modulus".to_string(), VmValue::Int(4)),
-            ("remainder".to_string(), VmValue::Int(0)),
+            (crate::value::intern_key("modulus"), VmValue::Int(4)),
+            (crate::value::intern_key("remainder"), VmValue::Int(0)),
         ]);
         assert_eq!(
             render_bounds_clause(&hash).unwrap(),
@@ -967,14 +984,14 @@ mod tests {
         );
         // remainder must be strictly less than modulus.
         let bad_remainder = crate::value::DictMap::from_iter([
-            ("modulus".to_string(), VmValue::Int(4)),
-            ("remainder".to_string(), VmValue::Int(4)),
+            (crate::value::intern_key("modulus"), VmValue::Int(4)),
+            (crate::value::intern_key("remainder"), VmValue::Int(4)),
         ]);
         assert!(render_bounds_clause(&bad_remainder).is_err());
         // modulus must be >= 1.
         let zero_modulus = crate::value::DictMap::from_iter([
-            ("modulus".to_string(), VmValue::Int(0)),
-            ("remainder".to_string(), VmValue::Int(0)),
+            (crate::value::intern_key("modulus"), VmValue::Int(0)),
+            (crate::value::intern_key("remainder"), VmValue::Int(0)),
         ]);
         assert!(render_bounds_clause(&zero_modulus).is_err());
     }
@@ -1020,9 +1037,15 @@ mod tests {
         let now = chrono::DateTime::parse_from_rfc3339("2026-05-28T12:34:56Z")
             .unwrap()
             .with_timezone(&chrono::Utc);
-        let days = crate::value::DictMap::from_iter([("keep_days".to_string(), VmValue::Int(90))]);
+        let days = crate::value::DictMap::from_iter([(
+            crate::value::intern_key("keep_days"),
+            VmValue::Int(90),
+        )]);
         assert_eq!(retention_cutoff(&days, now).unwrap(), "2026-02-27");
-        let hours = crate::value::DictMap::from_iter([("keep_hours".to_string(), VmValue::Int(6))]);
+        let hours = crate::value::DictMap::from_iter([(
+            crate::value::intern_key("keep_hours"),
+            VmValue::Int(6),
+        )]);
         assert_eq!(
             retention_cutoff(&hours, now).unwrap(),
             "2026-05-28 06:00:00"

--- a/crates/harn-vm/src/stdlib/postgres/listen.rs
+++ b/crates/harn-vm/src/stdlib/postgres/listen.rs
@@ -122,7 +122,7 @@ async fn pg_listen_impl(
 
     let mut meta = crate::value::DictMap::new();
     meta.insert(
-        "channels".to_string(),
+        crate::value::intern_key("channels"),
         VmValue::List(std::sync::Arc::new(
             channels
                 .iter()
@@ -130,7 +130,7 @@ async fn pg_listen_impl(
                 .collect(),
         )),
     );
-    meta.insert("bridge".to_string(), VmValue::Bool(bridge));
+    meta.insert(crate::value::intern_key("bridge"), VmValue::Bool(bridge));
     Ok(handle_value(HANDLE_LISTENER, &id, meta))
 }
 
@@ -180,7 +180,7 @@ async fn pg_listener_recv_impl(
     dict.put_str("channel", channel.clone());
     dict.put_str("payload", payload.clone());
     dict.insert(
-        "process_id".to_string(),
+        crate::value::intern_key("process_id"),
         VmValue::Int(i64::from(notification.process_id())),
     );
     let value = VmValue::dict(dict);

--- a/crates/harn-vm/src/stdlib/postgres/mod.rs
+++ b/crates/harn-vm/src/stdlib/postgres/mod.rs
@@ -146,10 +146,10 @@ fn register_postgres_namespace(vm: &mut Vm) {
         "pg",
         VmValue::dict(crate::value::DictMap::from_iter([
             (
-                "_namespace".to_string(),
+                crate::value::intern_key("_namespace"),
                 VmValue::String(arcstr::ArcStr::from("pg")),
             ),
-            ("jsonb".to_string(), jsonb),
+            (crate::value::intern_key("jsonb"), jsonb),
         ])),
     );
 }
@@ -315,13 +315,13 @@ fn stmt_cache_clear_result(
     connections_skipped: i64,
 ) -> VmValue {
     let mut result = crate::value::DictMap::new();
-    result.insert("pools".to_string(), VmValue::Int(pools));
+    result.insert(crate::value::intern_key("pools"), VmValue::Int(pools));
     result.insert(
-        "connections_cleared".to_string(),
+        crate::value::intern_key("connections_cleared"),
         VmValue::Int(connections_cleared),
     );
     result.insert(
-        "connections_skipped".to_string(),
+        crate::value::intern_key("connections_skipped"),
         VmValue::Int(connections_skipped),
     );
     VmValue::dict(result)
@@ -749,19 +749,19 @@ fn register_local_pool_handle(
     });
     let mut meta = crate::value::DictMap::new();
     meta.insert(
-        "max_connections".to_string(),
+        crate::value::intern_key("max_connections"),
         VmValue::Int(i64::from(record.max_connections)),
     );
     meta.insert(
-        "single_connection".to_string(),
+        crate::value::intern_key("single_connection"),
         VmValue::Bool(single_connection),
     );
     meta.insert(
-        "replicas".to_string(),
+        crate::value::intern_key("replicas"),
         VmValue::Int(record.replicas.len() as i64),
     );
     meta.insert(
-        "statement_cache_capacity".to_string(),
+        crate::value::intern_key("statement_cache_capacity"),
         VmValue::Int(record.statement_cache_capacity as i64),
     );
     meta.put_str("read_routing_policy", record.read_routing_policy.as_str());
@@ -1550,7 +1550,7 @@ pub(super) fn row_to_value(row: PgRow) -> Result<VmValue, VmError> {
     for (index, column) in row.columns().iter().enumerate() {
         let name = column.name().to_string();
         let value = column_value(&row, index, column.type_info().name())?;
-        map.insert(name, value);
+        map.insert(crate::value::intern_key(&name), value);
     }
     Ok(VmValue::dict(map))
 }
@@ -1680,7 +1680,7 @@ fn column_value(row: &PgRow, index: usize, type_name: &str) -> Result<VmValue, V
             let mut dict = crate::value::DictMap::new();
             for (key, value) in map.0 {
                 dict.insert(
-                    key,
+                    crate::value::intern_key(&key),
                     value
                         .map(|v| VmValue::String(arcstr::ArcStr::from(v)))
                         .unwrap_or(VmValue::Nil),
@@ -1808,7 +1808,7 @@ fn dict_value<const N: usize>(pairs: [(&'static str, VmValue); N]) -> VmValue {
     VmValue::dict(
         pairs
             .into_iter()
-            .map(|(key, value)| (key.to_string(), value))
+            .map(|(key, value)| (crate::value::intern_key(key), value))
             .collect::<crate::value::DictMap>(),
     )
 }
@@ -1898,11 +1898,11 @@ fn query_result_value(result: PgQueryResult, duration: std::time::Duration) -> V
 fn execute_result_value(rows_affected: u64, duration: std::time::Duration) -> VmValue {
     let mut map = crate::value::DictMap::new();
     map.insert(
-        "rows_affected".to_string(),
+        crate::value::intern_key("rows_affected"),
         VmValue::Int(rows_affected as i64),
     );
     map.insert(
-        "duration_ms".to_string(),
+        crate::value::intern_key("duration_ms"),
         VmValue::Int(duration.as_millis() as i64),
     );
     VmValue::dict(map)

--- a/crates/harn-vm/src/stdlib/postgres/shared.rs
+++ b/crates/harn-vm/src/stdlib/postgres/shared.rs
@@ -156,13 +156,13 @@ fn canonical_option_value(value: &VmValue) -> String {
         }
         VmValue::Dict(dict) => {
             // Sort keys for order-independence.
-            let sorted: BTreeMap<&String, &VmValue> = dict.iter().collect();
+            let sorted: BTreeMap<&crate::value::HarnStr, &VmValue> = dict.iter().collect();
             let mut out = String::from("{");
             for (i, (key, val)) in sorted.iter().enumerate() {
                 if i > 0 {
                     out.push(',');
                 }
-                out.push_str(key);
+                out.push_str(key.as_str());
                 out.push('=');
                 out.push_str(&canonical_option_value(val));
             }
@@ -256,7 +256,7 @@ mod tests {
     fn opts(pairs: &[(&str, VmValue)]) -> crate::value::DictMap {
         pairs
             .iter()
-            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .map(|(k, v)| (crate::value::intern_key(k), v.clone()))
             .collect()
     }
 

--- a/crates/harn-vm/src/stdlib/postgres/tests.rs
+++ b/crates/harn-vm/src/stdlib/postgres/tests.rs
@@ -10,7 +10,7 @@ fn dict(pairs: &[(&str, VmValue)]) -> VmValue {
     VmValue::dict(
         pairs
             .iter()
-            .map(|(key, value)| ((*key).to_string(), value.clone()))
+            .map(|(key, value)| (crate::value::intern_key(key), value.clone()))
             .collect::<crate::value::DictMap>(),
     )
 }
@@ -84,7 +84,7 @@ fn routing_record(replicas: usize, policy: ReadRoutingPolicy) -> Arc<PoolRecord>
 #[test]
 fn read_routing_policy_options_parse_named_modes() {
     let pool_options = crate::value::DictMap::from_iter([(
-        "read_routing_policy".to_string(),
+        crate::value::intern_key("read_routing_policy"),
         s("round_robin_replica"),
     )]);
     assert_eq!(
@@ -92,21 +92,26 @@ fn read_routing_policy_options_parse_named_modes() {
         ReadRoutingPolicy::RoundRobinReplica
     );
 
-    let query_options = crate::value::DictMap::from_iter([("route".to_string(), s("replica"))]);
+    let query_options =
+        crate::value::DictMap::from_iter([(crate::value::intern_key("route"), s("replica"))]);
     assert_eq!(
         routing_from_options(Some(&query_options)).unwrap(),
         QueryRouting::Policy(ReadRoutingPolicy::Replica)
     );
 
-    let read_only_options =
-        crate::value::DictMap::from_iter([("read_only".to_string(), VmValue::Bool(true))]);
+    let read_only_options = crate::value::DictMap::from_iter([(
+        crate::value::intern_key("read_only"),
+        VmValue::Bool(true),
+    )]);
     assert_eq!(
         routing_from_options(Some(&read_only_options)).unwrap(),
         QueryRouting::ReadOnly
     );
 
-    let bad_options =
-        crate::value::DictMap::from_iter([("routing_policy".to_string(), s("nearby"))]);
+    let bad_options = crate::value::DictMap::from_iter([(
+        crate::value::intern_key("routing_policy"),
+        s("nearby"),
+    )]);
     assert!(routing_from_options(Some(&bad_options)).is_err());
 }
 
@@ -282,9 +287,9 @@ async fn postgres_round_trip_when_env_url_is_set() {
     };
     reset_postgres_state();
     let mut options = crate::value::DictMap::new();
-    options.insert("max_connections".to_string(), VmValue::Int(1));
+    options.insert(crate::value::intern_key("max_connections"), VmValue::Int(1));
     options.insert(
-        "application_name".to_string(),
+        crate::value::intern_key("application_name"),
         s("harn-postgres-stdlib-test"),
     );
     let ctx = crate::vm::AsyncBuiltinCtx::for_test(crate::Vm::new());
@@ -324,8 +329,11 @@ async fn postgres_round_trip_when_env_url_is_set() {
 /// reuses the same physical connection (and prepared-statement cache).
 async fn open_single_conn_pool(url: &str) -> VmValue {
     let mut options = crate::value::DictMap::new();
-    options.insert("max_connections".to_string(), VmValue::Int(1));
-    options.insert("application_name".to_string(), s("harn-postgres-bind-test"));
+    options.insert(crate::value::intern_key("max_connections"), VmValue::Int(1));
+    options.insert(
+        crate::value::intern_key("application_name"),
+        s("harn-postgres-bind-test"),
+    );
     let ctx = crate::vm::AsyncBuiltinCtx::for_test(crate::Vm::new());
     open_pool(&ctx, &s(url), Some(&options), false)
         .await

--- a/crates/harn-vm/src/stdlib/process.rs
+++ b/crates/harn-vm/src/stdlib/process.rs
@@ -464,7 +464,10 @@ pub(crate) fn spawn_captured_value(args: &[VmValue]) -> Result<VmValue, VmError>
         .map(|v| v.display())
         .filter(|s| !s.is_empty());
     let env_overrides: Vec<(String, String)> = match opts.get("env") {
-        Some(VmValue::Dict(env)) => env.iter().map(|(k, v)| (k.clone(), v.display())).collect(),
+        Some(VmValue::Dict(env)) => env
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.display()))
+            .collect(),
         None | Some(VmValue::Nil) => Vec::new(),
         Some(other) => {
             return Err(VmError::Runtime(format!(
@@ -700,7 +703,10 @@ fn exec_options(label: &str, options: Option<&VmValue>) -> Result<ExecOptions, V
         }
     };
     let env: Vec<(String, String)> = match opts.get("env") {
-        Some(VmValue::Dict(env)) => env.iter().map(|(k, v)| (k.clone(), v.display())).collect(),
+        Some(VmValue::Dict(env)) => env
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.display()))
+            .collect(),
         None | Some(VmValue::Nil) => Vec::new(),
         Some(other) => {
             return Err(VmError::Thrown(VmValue::String(arcstr::ArcStr::from(
@@ -1253,7 +1259,7 @@ mod tests {
         VmValue::dict(
             pairs
                 .iter()
-                .map(|(k, v)| (k.to_string(), v.clone()))
+                .map(|(k, v)| (crate::value::intern_key(k), v.clone()))
                 .collect::<crate::value::DictMap>(),
         )
     }

--- a/crates/harn-vm/src/stdlib/project_enrich.rs
+++ b/crates/harn-vm/src/stdlib/project_enrich.rs
@@ -122,9 +122,12 @@ async fn project_enrich_impl(
         + estimate_tokens(&canonical_json(&vm_value_to_json(&options.schema)));
     if estimated_input_tokens > options.budget_tokens {
         let mut budget_result = (*base_dict).clone();
-        budget_result.insert("budget_exceeded".to_string(), VmValue::Bool(true));
         budget_result.insert(
-            "_provenance".to_string(),
+            crate::value::intern_key("budget_exceeded"),
+            VmValue::Bool(true),
+        );
+        budget_result.insert(
+            crate::value::intern_key("_provenance"),
             provenance_value(None, estimated_input_tokens, 0, false),
         );
         return Ok(VmValue::dict(budget_result));
@@ -455,7 +458,7 @@ fn augment_project_evidence(
     let mut merged = (*dict).clone();
     if include_operator_meta {
         merged.insert(
-            "ci".to_string(),
+            crate::value::intern_key("ci"),
             ci_evidence_value(collect_ci_evidence(root)),
         );
     }
@@ -1486,20 +1489,26 @@ fn enrichment_bindings(
 ) -> crate::value::DictMap {
     let mut bindings = crate::value::DictMap::new();
     bindings.put_str("path", root.to_string_lossy());
-    bindings.insert("base_evidence".to_string(), base_evidence.clone());
-    bindings.insert("evidence".to_string(), base_evidence.clone());
+    bindings.insert(
+        crate::value::intern_key("base_evidence"),
+        base_evidence.clone(),
+    );
+    bindings.insert(crate::value::intern_key("evidence"), base_evidence.clone());
     let file_values = files
         .iter()
         .map(|file| {
             let mut value = crate::value::DictMap::new();
             value.put_str("path", file.rel_path.clone());
             value.put_str("content", file.content.clone());
-            value.insert("truncated".to_string(), VmValue::Bool(file.truncated));
+            value.insert(
+                crate::value::intern_key("truncated"),
+                VmValue::Bool(file.truncated),
+            );
             VmValue::dict(value)
         })
         .collect::<Vec<_>>();
     bindings.insert(
-        "files".to_string(),
+        crate::value::intern_key("files"),
         VmValue::List(std::sync::Arc::new(file_values)),
     );
     if let Some(dict) = base_evidence.as_dict() {
@@ -1515,17 +1524,23 @@ fn llm_options_value(options: &ProjectEnrichOptions, rendered_prompt: &str) -> V
     llm_options.put_str("provider", options.provider.clone());
     llm_options.put_str("model", options.model.clone());
     if let Some(temperature) = options.temperature {
-        llm_options.insert("temperature".to_string(), VmValue::Float(temperature));
+        llm_options.insert(
+            crate::value::intern_key("temperature"),
+            VmValue::Float(temperature),
+        );
     }
-    llm_options.insert("output_schema".to_string(), options.schema.clone());
+    llm_options.insert(
+        crate::value::intern_key("output_schema"),
+        options.schema.clone(),
+    );
     llm_options.put_str("output_validation", "error");
     llm_options.insert(
-        "schema_retries".to_string(),
+        crate::value::intern_key("schema_retries"),
         VmValue::Int(options.schema_retries as i64),
     );
     llm_options.put_str("response_format", "json");
     llm_options.insert(
-        "messages".to_string(),
+        crate::value::intern_key("messages"),
         VmValue::List(std::sync::Arc::new(vec![json_to_vm_value(
             &serde_json::json!({
                 "role": "user",
@@ -1544,10 +1559,13 @@ fn validation_envelope(
     output_tokens: i64,
 ) -> VmValue {
     let mut dict = crate::value::DictMap::new();
-    dict.insert("base_evidence".to_string(), base_evidence.clone());
+    dict.insert(
+        crate::value::intern_key("base_evidence"),
+        base_evidence.clone(),
+    );
     dict.put_str("validation_error", message);
     dict.insert(
-        "_provenance".to_string(),
+        crate::value::intern_key("_provenance"),
         provenance_value(model, input_tokens, output_tokens, false),
     );
     VmValue::dict(dict)
@@ -1564,16 +1582,16 @@ fn attach_provenance(
         VmValue::Dict(dict) => {
             let mut merged = (*dict).clone();
             merged.insert(
-                "_provenance".to_string(),
+                crate::value::intern_key("_provenance"),
                 provenance_value(model, input_tokens, output_tokens, cached),
             );
             VmValue::dict(merged)
         }
         other => {
             let mut wrapped = crate::value::DictMap::new();
-            wrapped.insert("data".to_string(), other);
+            wrapped.insert(crate::value::intern_key("data"), other);
             wrapped.insert(
-                "_provenance".to_string(),
+                crate::value::intern_key("_provenance"),
                 provenance_value(model, input_tokens, output_tokens, cached),
             );
             VmValue::dict(wrapped)
@@ -1591,12 +1609,12 @@ fn attach_ci_metadata(value: VmValue, base_evidence: &VmValue) -> VmValue {
     };
     let Some(dict) = value.as_dict() else {
         let mut wrapped = crate::value::DictMap::new();
-        wrapped.insert("data".to_string(), value);
-        wrapped.insert("ci".to_string(), ci_value);
+        wrapped.insert(crate::value::intern_key("data"), value);
+        wrapped.insert(crate::value::intern_key("ci"), ci_value);
         return VmValue::dict(wrapped);
     };
     let mut merged = (*dict).clone();
-    merged.insert("ci".to_string(), ci_value);
+    merged.insert(crate::value::intern_key("ci"), ci_value);
     VmValue::dict(merged)
 }
 
@@ -1607,18 +1625,18 @@ fn provenance_value(
     cached: bool,
 ) -> VmValue {
     let mut tokens = crate::value::DictMap::new();
-    tokens.insert("in".to_string(), VmValue::Int(input_tokens));
-    tokens.insert("out".to_string(), VmValue::Int(output_tokens));
+    tokens.insert(crate::value::intern_key("in"), VmValue::Int(input_tokens));
+    tokens.insert(crate::value::intern_key("out"), VmValue::Int(output_tokens));
 
     let mut provenance = crate::value::DictMap::new();
     provenance.insert(
-        "model".to_string(),
+        crate::value::intern_key("model"),
         model
             .map(|value| VmValue::String(arcstr::ArcStr::from(value)))
             .unwrap_or(VmValue::Nil),
     );
-    provenance.insert("tokens".to_string(), VmValue::dict(tokens));
-    provenance.insert("cached".to_string(), VmValue::Bool(cached));
+    provenance.insert(crate::value::intern_key("tokens"), VmValue::dict(tokens));
+    provenance.insert(crate::value::intern_key("cached"), VmValue::Bool(cached));
     VmValue::dict(provenance)
 }
 
@@ -1632,8 +1650,11 @@ fn result_with_cached_flag(value: VmValue, cached: bool) -> VmValue {
         .and_then(VmValue::as_dict)
         .map(|value| (*value).clone())
         .unwrap_or_default();
-    provenance.insert("cached".to_string(), VmValue::Bool(cached));
-    merged.insert("_provenance".to_string(), VmValue::dict(provenance));
+    provenance.insert(crate::value::intern_key("cached"), VmValue::Bool(cached));
+    merged.insert(
+        crate::value::intern_key("_provenance"),
+        VmValue::dict(provenance),
+    );
     VmValue::dict(merged)
 }
 
@@ -2116,19 +2137,19 @@ jobs:
 
         let base = VmValue::dict(crate::value::DictMap::from_iter([
             (
-                "languages".to_string(),
+                crate::value::intern_key("languages"),
                 VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                     arcstr::ArcStr::from("rust"),
                 )])),
             ),
             (
-                "anchors".to_string(),
+                crate::value::intern_key("anchors"),
                 VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                     arcstr::ArcStr::from("Cargo.toml"),
                 )])),
             ),
             (
-                "lockfiles".to_string(),
+                crate::value::intern_key("lockfiles"),
                 VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                     arcstr::ArcStr::from("Cargo.lock"),
                 )])),
@@ -2147,18 +2168,18 @@ jobs:
     #[test]
     fn attach_ci_metadata_merges_ci_block_into_result() {
         let base = VmValue::dict(crate::value::DictMap::from_iter([(
-            "ci".to_string(),
+            crate::value::intern_key("ci"),
             VmValue::dict(crate::value::DictMap::from_iter([(
-                "merge_policy".to_string(),
+                crate::value::intern_key("merge_policy"),
                 VmValue::dict(crate::value::DictMap::from_iter([(
-                    "squash_only".to_string(),
+                    crate::value::intern_key("squash_only"),
                     VmValue::Bool(true),
                 )])),
             )])),
         )]));
         let result = attach_ci_metadata(
             VmValue::dict(crate::value::DictMap::from_iter([(
-                "summary".to_string(),
+                crate::value::intern_key("summary"),
                 VmValue::String(arcstr::ArcStr::from("ok")),
             )])),
             &base,

--- a/crates/harn-vm/src/stdlib/skills.rs
+++ b/crates/harn-vm/src/stdlib/skills.rs
@@ -125,11 +125,11 @@ fn who_signed_entry(entry: &crate::value::DictMap) -> VmValue {
         None => crate::value::DictMap::new(),
     };
     out.put_str("skill_id", vm_skill_entry_id(entry).as_str());
-    out.entry("signed".to_string())
+    out.entry(crate::value::intern_key("signed"))
         .or_insert(VmValue::Bool(false));
-    out.entry("trusted".to_string())
+    out.entry(crate::value::intern_key("trusted"))
         .or_insert(VmValue::Bool(false));
-    out.entry("endorsements".to_string())
+    out.entry(crate::value::intern_key("endorsements"))
         .or_insert_with(|| VmValue::List(std::sync::Arc::new(Vec::new())));
     VmValue::dict(out)
 }
@@ -360,7 +360,7 @@ fn skill_define_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
         }
     }
     for (k, v) in config.iter() {
-        entry.insert(k.clone(), v.clone());
+        entry.insert(k.to_string(), v.clone());
     }
     let entry_value = VmValue::dict(entry);
 
@@ -385,7 +385,7 @@ fn skill_define_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
 
     let mut new_registry = registry;
     new_registry.insert(
-        "skills".to_string(),
+        crate::value::intern_key("skills"),
         VmValue::List(std::sync::Arc::new(new_skills)),
     );
     Ok(VmValue::dict(new_registry))
@@ -414,7 +414,7 @@ fn skill_list_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErr
                 if matches!(value, VmValue::Closure(_) | VmValue::BuiltinRef(_)) {
                     continue;
                 }
-                desc.insert(key.clone(), value.clone());
+                desc.insert(key.to_string(), value.clone());
             }
             result.push(VmValue::dict(desc));
         }
@@ -571,7 +571,7 @@ fn skill_select_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
 
     let mut new_registry = (**registry).clone();
     new_registry.insert(
-        "skills".to_string(),
+        crate::value::intern_key("skills"),
         VmValue::List(std::sync::Arc::new(selected)),
     );
     Ok(VmValue::dict(new_registry))
@@ -664,7 +664,7 @@ fn skill_remove_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmE
 
     let mut new_registry = registry;
     new_registry.insert(
-        "skills".to_string(),
+        crate::value::intern_key("skills"),
         VmValue::List(std::sync::Arc::new(filtered)),
     );
     Ok(VmValue::dict(new_registry))

--- a/crates/harn-vm/src/stdlib/sqlite/mod.rs
+++ b/crates/harn-vm/src/stdlib/sqlite/mod.rs
@@ -399,8 +399,11 @@ fn open_db(path: &str, options: Option<&crate::value::DictMap>) -> Result<VmValu
     configure_connection(&conn, options, read_only)?;
     let id = next_id("sqlitedb");
     let mut meta = crate::value::DictMap::new();
-    meta.insert("read_only".to_string(), VmValue::Bool(read_only));
-    meta.insert("memory".to_string(), VmValue::Bool(is_memory));
+    meta.insert(
+        crate::value::intern_key("read_only"),
+        VmValue::Bool(read_only),
+    );
+    meta.insert(crate::value::intern_key("memory"), VmValue::Bool(is_memory));
     if let Some(path) = &stored_path {
         meta.put_str("path", path.to_string_lossy());
     }
@@ -645,13 +648,16 @@ async fn migrate(args: Vec<VmValue>) -> Result<VmValue, VmError> {
     }
 
     let mut response = crate::value::DictMap::new();
-    response.insert("applied".to_string(), string_list(applied_now));
-    response.insert("skipped".to_string(), string_list(skipped));
     response.insert(
-        "available".to_string(),
+        crate::value::intern_key("applied"),
+        string_list(applied_now),
+    );
+    response.insert(crate::value::intern_key("skipped"), string_list(skipped));
+    response.insert(
+        crate::value::intern_key("available"),
         string_list(entries.iter().map(|entry| entry.name.clone()).collect()),
     );
-    response.insert("dry_run".to_string(), VmValue::Bool(dry_run));
+    response.insert(crate::value::intern_key("dry_run"), VmValue::Bool(dry_run));
     response.put_str("table", table);
     Ok(VmValue::dict(response))
 }
@@ -805,7 +811,7 @@ fn row_to_value(
             }
             ValueRef::Blob(bytes) => VmValue::Bytes(Arc::new(bytes.to_vec())),
         };
-        map.insert(name.clone(), value);
+        map.insert(crate::value::intern_key(name), value);
     }
     Ok(VmValue::dict(map))
 }
@@ -909,7 +915,7 @@ fn mock_query(
 
 fn execute_result_value(rows_affected: u64) -> VmValue {
     VmValue::dict(crate::value::DictMap::from_iter([(
-        "rows_affected".to_string(),
+        crate::value::intern_key("rows_affected"),
         VmValue::Int(rows_affected as i64),
     )]))
 }
@@ -1141,7 +1147,7 @@ mod tests {
         VmValue::dict(
             pairs
                 .iter()
-                .map(|(key, value)| ((*key).to_string(), value.clone()))
+                .map(|(key, value)| (crate::value::intern_key(key), value.clone()))
                 .collect::<crate::value::DictMap>(),
         )
     }

--- a/crates/harn-vm/src/stdlib/strings.rs
+++ b/crates/harn-vm/src/stdlib/strings.rs
@@ -177,7 +177,7 @@ fn provenance_result_dict(
 }
 
 fn span_to_vm_dict(span: &PromptSourceSpan) -> VmValue {
-    let mut d = std::collections::BTreeMap::new();
+    let mut d: std::collections::BTreeMap<String, VmValue> = std::collections::BTreeMap::new();
     d.insert(
         "template_line".into(),
         VmValue::Int(span.template_line as i64),

--- a/crates/harn-vm/src/stdlib/template/mod.rs
+++ b/crates/harn-vm/src/stdlib/template/mod.rs
@@ -255,7 +255,7 @@ fn augment_bindings_with_llm(
         return None;
     }
     let mut merged = bindings.cloned().unwrap_or_default();
-    merged.insert("llm".to_string(), ctx.to_vm_value());
+    merged.insert(crate::value::intern_key("llm"), ctx.to_vm_value());
     Some(merged)
 }
 

--- a/crates/harn-vm/src/stdlib/template/render.rs
+++ b/crates/harn-vm/src/stdlib/template/render.rs
@@ -210,17 +210,23 @@ fn render_node(
                 let length = items.len() as i64;
                 for (idx, (k, val)) in items.iter().enumerate() {
                     let mut layer: crate::value::DictMap = crate::value::DictMap::new();
-                    layer.insert(value_var.clone(), val.clone());
+                    layer.insert(crate::value::intern_key(value_var), val.clone());
                     if let Some(kv) = key_var {
-                        layer.insert(kv.clone(), k.clone());
+                        layer.insert(crate::value::intern_key(kv), k.clone());
                     }
                     let mut loop_map: crate::value::DictMap = crate::value::DictMap::new();
-                    loop_map.insert("index".into(), VmValue::Int(idx as i64 + 1));
-                    loop_map.insert("index0".into(), VmValue::Int(idx as i64));
-                    loop_map.insert("first".into(), VmValue::Bool(idx == 0));
-                    loop_map.insert("last".into(), VmValue::Bool(idx as i64 == length - 1));
-                    loop_map.insert("length".into(), VmValue::Int(length));
-                    layer.insert("loop".into(), VmValue::dict(loop_map));
+                    loop_map.insert(
+                        crate::value::intern_key("index"),
+                        VmValue::Int(idx as i64 + 1),
+                    );
+                    loop_map.insert(crate::value::intern_key("index0"), VmValue::Int(idx as i64));
+                    loop_map.insert(crate::value::intern_key("first"), VmValue::Bool(idx == 0));
+                    loop_map.insert(
+                        crate::value::intern_key("last"),
+                        VmValue::Bool(idx as i64 == length - 1),
+                    );
+                    loop_map.insert(crate::value::intern_key("length"), VmValue::Int(length));
+                    layer.insert(crate::value::intern_key("loop"), VmValue::dict(loop_map));
                     scope.push(layer);
                     let iter_start = out.len();
                     let res = render_nodes(body, scope, rc, out, spans.as_deref_mut());
@@ -284,7 +290,7 @@ fn render_node(
             if let Some(pairs) = with {
                 for (k, e) in pairs {
                     let v = eval_expr(e, scope, *line, *col)?;
-                    child_bindings.insert(k.clone(), v);
+                    child_bindings.insert(crate::value::intern_key(k), v);
                 }
             }
             let child_nodes = super::assets::parse_cached(&asset)?;
@@ -337,7 +343,10 @@ fn render_node(
         } => {
             let mut evaluated_args = crate::value::DictMap::new();
             for (key, expr) in args {
-                evaluated_args.insert(key.clone(), eval_expr(expr, scope, *line, *col)?);
+                evaluated_args.insert(
+                    crate::value::intern_key(key),
+                    eval_expr(expr, scope, *line, *col)?,
+                );
             }
             let mut body_out = String::new();
             let mut body_spans = spans.as_ref().map(|_| Vec::new());
@@ -575,8 +584,12 @@ fn resolve_path(segs: &[PathSeg], scope: &Scope<'_>) -> VmValue {
     };
     for seg in &segs[1..] {
         cur = match (seg, &cur) {
-            (PathSeg::Field(n), VmValue::Dict(d)) => d.get(n).cloned().unwrap_or(VmValue::Nil),
-            (PathSeg::Key(k), VmValue::Dict(d)) => d.get(k).cloned().unwrap_or(VmValue::Nil),
+            (PathSeg::Field(n), VmValue::Dict(d)) => {
+                d.get(n.as_str()).cloned().unwrap_or(VmValue::Nil)
+            }
+            (PathSeg::Key(k), VmValue::Dict(d)) => {
+                d.get(k.as_str()).cloned().unwrap_or(VmValue::Nil)
+            }
             (PathSeg::Index(i), VmValue::List(items)) => {
                 let idx = if *i < 0 { items.len() as i64 + *i } else { *i };
                 if idx < 0 || (idx as usize) >= items.len() {

--- a/crates/harn-vm/src/stdlib/template/tests.rs
+++ b/crates/harn-vm/src/stdlib/template/tests.rs
@@ -4,7 +4,7 @@ use crate::value::VmValue;
 fn dict(pairs: &[(&str, VmValue)]) -> crate::value::DictMap {
     pairs
         .iter()
-        .map(|(k, v)| (k.to_string(), v.clone()))
+        .map(|(k, v)| (crate::value::intern_key(k), v.clone()))
         .collect()
 }
 
@@ -33,7 +33,7 @@ fn bare_interp() {
 #[test]
 fn provenance_expr_span_matches_output_range() {
     let mut user = crate::value::DictMap::new();
-    user.insert("name".to_string(), s("alice"));
+    user.insert(crate::value::intern_key("name"), s("alice"));
     let b = dict(&[("user", VmValue::dict(user)), ("count", VmValue::Int(42))]);
     let (out, spans) = render_with_spans("hello {{ user.name }} ({{ count | default: 0 }})", &b);
     assert_eq!(out, "hello alice (42)");
@@ -96,7 +96,7 @@ fn provenance_includes_loop_iterations() {
 #[test]
 fn provenance_preview_is_truncated() {
     let mut wrap = crate::value::DictMap::new();
-    wrap.insert("val".to_string(), s(&"x".repeat(500)));
+    wrap.insert(crate::value::intern_key("val"), s(&"x".repeat(500)));
     let b = dict(&[("blob", VmValue::dict(wrap))]);
     let (_, spans) = render_with_spans("{{blob.val}}", &b);
     let expr = spans
@@ -275,15 +275,15 @@ fn logical_section_scaffolding_follows_llm_capabilities() {
 #[test]
 fn logical_section_tools_and_output_format_use_section_args() {
     let tool = VmValue::dict(crate::value::DictMap::from_iter([
-        ("name".to_string(), s("read_file")),
-        ("description".to_string(), s("Read a file")),
+        (crate::value::intern_key("name"), s("read_file")),
+        (crate::value::intern_key("description"), s("Read a file")),
     ]));
     let schema = VmValue::dict(crate::value::DictMap::from_iter([
-        ("type".to_string(), s("object")),
+        (crate::value::intern_key("type"), s("object")),
         (
-            "properties".to_string(),
+            crate::value::intern_key("properties"),
             VmValue::dict(crate::value::DictMap::from_iter([(
-                "answer".to_string(),
+                crate::value::intern_key("answer"),
                 s("string"),
             )])),
         ),

--- a/crates/harn-vm/src/stdlib/token_redaction.rs
+++ b/crates/harn-vm/src/stdlib/token_redaction.rs
@@ -246,11 +246,11 @@ fn token_redaction_drain_audit_impl(
             entry.put_str("code", TOKEN_REDACTION_DIAGNOSTIC);
             entry.put_str("pattern", event.pattern_name.as_str());
             entry.insert(
-                "match_count".to_string(),
+                crate::value::intern_key("match_count"),
                 VmValue::Int(event.match_count as i64),
             );
             entry.insert(
-                "bytes_redacted".to_string(),
+                crate::value::intern_key("bytes_redacted"),
                 VmValue::Int(event.bytes_redacted as i64),
             );
             VmValue::dict(entry)

--- a/crates/harn-vm/src/stdlib/tool_hooks.rs
+++ b/crates/harn-vm/src/stdlib/tool_hooks.rs
@@ -232,9 +232,9 @@ fn validate_rule_dict(
     let mut rule = crate::value::DictMap::new();
     rule.put_str("_type", TOOL_RULE_TYPE);
     rule.put_str("id", id.as_str());
-    rule.insert("pattern".to_string(), pattern.clone());
+    rule.insert(crate::value::intern_key("pattern"), pattern.clone());
     rule.insert(
-        "applies_to".to_string(),
+        crate::value::intern_key("applies_to"),
         VmValue::List(std::sync::Arc::new(
             applies_to
                 .into_iter()
@@ -244,25 +244,25 @@ fn validate_rule_dict(
     );
     rule.put_str("severity", severity.as_str());
     rule.insert(
-        "rewrite".to_string(),
+        crate::value::intern_key("rewrite"),
         config.get("rewrite").cloned().unwrap_or(VmValue::Nil),
     );
     rule.insert(
-        "explanation".to_string(),
+        crate::value::intern_key("explanation"),
         config
             .get("explanation")
             .cloned()
             .unwrap_or_else(|| VmValue::String(arcstr::ArcStr::from(""))),
     );
     rule.insert(
-        "references".to_string(),
+        crate::value::intern_key("references"),
         config
             .get("references")
             .cloned()
             .unwrap_or_else(|| VmValue::List(std::sync::Arc::new(Vec::new()))),
     );
     rule.insert(
-        "priority".to_string(),
+        crate::value::intern_key("priority"),
         config.get("priority").cloned().unwrap_or(VmValue::Int(0)),
     );
     Ok(rule)
@@ -335,9 +335,9 @@ fn build_catalogue(config: &crate::value::DictMap) -> Result<VmValue, VmError> {
     catalogue.put_str("stack", stack.as_str());
     catalogue.put_str("version", version.as_str());
     catalogue.put_str("source", source.as_str());
-    catalogue.insert("priority".to_string(), VmValue::Int(priority));
+    catalogue.insert(crate::value::intern_key("priority"), VmValue::Int(priority));
     catalogue.insert(
-        "rules".to_string(),
+        crate::value::intern_key("rules"),
         VmValue::List(std::sync::Arc::new(rules)),
     );
     Ok(VmValue::dict(catalogue))
@@ -469,28 +469,34 @@ fn make_match_record(catalogue: &crate::value::DictMap, rule: &crate::value::Dic
         .cloned()
         .unwrap_or_else(|| VmValue::String(arcstr::ArcStr::from("")));
     let mut out = crate::value::DictMap::new();
-    out.insert("catalogue_id".to_string(), catalogue_id);
-    out.insert("stack".to_string(), stack);
+    out.insert(crate::value::intern_key("catalogue_id"), catalogue_id);
+    out.insert(crate::value::intern_key("stack"), stack);
     out.put_str("rule_id", rule_id(rule).as_str());
     out.put_str("severity", rule_severity(rule).as_str());
     out.insert(
-        "explanation".to_string(),
+        crate::value::intern_key("explanation"),
         rule.get("explanation")
             .cloned()
             .unwrap_or_else(|| VmValue::String(arcstr::ArcStr::from(""))),
     );
     out.insert(
-        "references".to_string(),
+        crate::value::intern_key("references"),
         rule.get("references")
             .cloned()
             .unwrap_or_else(|| VmValue::List(std::sync::Arc::new(Vec::new()))),
     );
-    out.insert("priority".to_string(), VmValue::Int(rule_priority(rule)));
     out.insert(
-        "rewrite".to_string(),
+        crate::value::intern_key("priority"),
+        VmValue::Int(rule_priority(rule)),
+    );
+    out.insert(
+        crate::value::intern_key("rewrite"),
         rule.get("rewrite").cloned().unwrap_or(VmValue::Nil),
     );
-    out.insert("rule".to_string(), VmValue::dict(rule.clone()));
+    out.insert(
+        crate::value::intern_key("rule"),
+        VmValue::dict(rule.clone()),
+    );
     VmValue::dict(out)
 }
 
@@ -528,7 +534,7 @@ fn tool_hooks_registry_impl(_args: &[VmValue], _out: &mut String) -> Result<VmVa
     let mut registry = crate::value::DictMap::new();
     registry.put_str("_type", REGISTRY_TYPE);
     registry.insert(
-        "catalogues".to_string(),
+        crate::value::intern_key("catalogues"),
         VmValue::List(std::sync::Arc::new(Vec::new())),
     );
     Ok(VmValue::dict(registry))
@@ -592,7 +598,7 @@ fn tool_hooks_register_impl(args: &[VmValue], _out: &mut String) -> Result<VmVal
     }
     let mut next = registry;
     next.insert(
-        "catalogues".to_string(),
+        crate::value::intern_key("catalogues"),
         VmValue::List(std::sync::Arc::new(new_catalogues)),
     );
     Ok(VmValue::dict(next))
@@ -640,7 +646,7 @@ fn tool_hooks_unregister_impl(args: &[VmValue], _out: &mut String) -> Result<VmV
         .collect();
     let mut next = registry;
     next.insert(
-        "catalogues".to_string(),
+        crate::value::intern_key("catalogues"),
         VmValue::List(std::sync::Arc::new(new_catalogues)),
     );
     Ok(VmValue::dict(next))
@@ -707,7 +713,7 @@ fn tool_hooks_filter_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue
     };
     let mut next = registry;
     next.insert(
-        "catalogues".to_string(),
+        crate::value::intern_key("catalogues"),
         VmValue::List(std::sync::Arc::new(filtered)),
     );
     Ok(VmValue::dict(next))
@@ -736,26 +742,29 @@ fn tool_hooks_list_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, 
         };
         let mut summary = crate::value::DictMap::new();
         summary.insert(
-            "id".to_string(),
+            crate::value::intern_key("id"),
             dict.get("id").cloned().unwrap_or(VmValue::Nil),
         );
         summary.insert(
-            "stack".to_string(),
+            crate::value::intern_key("stack"),
             dict.get("stack").cloned().unwrap_or(VmValue::Nil),
         );
         summary.insert(
-            "version".to_string(),
+            crate::value::intern_key("version"),
             dict.get("version").cloned().unwrap_or(VmValue::Nil),
         );
         summary.insert(
-            "source".to_string(),
+            crate::value::intern_key("source"),
             dict.get("source").cloned().unwrap_or(VmValue::Nil),
         );
         summary.insert(
-            "priority".to_string(),
+            crate::value::intern_key("priority"),
             dict.get("priority").cloned().unwrap_or(VmValue::Int(0)),
         );
-        summary.insert("rule_count".to_string(), VmValue::Int(rule_count as i64));
+        summary.insert(
+            crate::value::intern_key("rule_count"),
+            VmValue::Int(rule_count as i64),
+        );
         entries.push(VmValue::dict(summary));
     }
     Ok(VmValue::List(std::sync::Arc::new(entries)))
@@ -952,9 +961,12 @@ fn tool_hooks_inject_reminder_impl(
 
     let mut out = crate::value::DictMap::new();
     out.put_str("reminder_id", reminder_id.as_str());
-    out.insert("deduped_count".to_string(), VmValue::Int(deduped_count));
     out.insert(
-        "session_attached".to_string(),
+        crate::value::intern_key("deduped_count"),
+        VmValue::Int(deduped_count),
+    );
+    out.insert(
+        crate::value::intern_key("session_attached"),
         VmValue::Bool(session_attached),
     );
     Ok(VmValue::dict(out))
@@ -1135,7 +1147,7 @@ mod tests {
         config.put_str("id", "rust.cargo.target_dir_conflict");
         config.put_str("pattern", r"^cargo (build|test)\b");
         config.insert(
-            "applies_to".to_string(),
+            crate::value::intern_key("applies_to"),
             VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                 arcstr::ArcStr::from("rust"),
             )])),
@@ -1155,7 +1167,7 @@ mod tests {
         config.put_str("version", "0.1.0");
         config.put_str("source", "harn-canon");
         config.insert(
-            "rules".to_string(),
+            crate::value::intern_key("rules"),
             VmValue::List(std::sync::Arc::new(vec![rule])),
         );
         VmValue::dict(config)
@@ -1266,7 +1278,7 @@ mod tests {
     #[test]
     fn context_stacks_normalizes_shapes() {
         let dict_form = VmValue::dict(crate::value::DictMap::from_iter([(
-            "stacks".to_string(),
+            crate::value::intern_key("stacks"),
             VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                 arcstr::ArcStr::from("rust"),
             )])),
@@ -1274,7 +1286,7 @@ mod tests {
         assert_eq!(context_stacks(Some(&dict_form)), vec!["rust".to_string()]);
 
         let dict_string = VmValue::dict(crate::value::DictMap::from_iter([(
-            "stacks".to_string(),
+            crate::value::intern_key("stacks"),
             VmValue::String(arcstr::ArcStr::from("python")),
         )]));
         assert_eq!(
@@ -1308,7 +1320,7 @@ mod tests {
         shell_cfg.put_str("id", "harn-canon/shell");
         // Stackless catalogue: matches every requested stack — universal rules.
         shell_cfg.insert(
-            "rules".to_string(),
+            crate::value::intern_key("rules"),
             VmValue::List(std::sync::Arc::new(vec![rule.clone()])),
         );
         let shell_cat = call_sync(&vm, "catalogue", &[VmValue::dict(shell_cfg)]).expect("cat");
@@ -1316,7 +1328,7 @@ mod tests {
         python_cfg.put_str("id", "harn-canon/python");
         python_cfg.put_str("stack", "python");
         python_cfg.insert(
-            "rules".to_string(),
+            crate::value::intern_key("rules"),
             VmValue::List(std::sync::Arc::new(vec![rule])),
         );
         let py_cat = call_sync(&vm, "catalogue", &[VmValue::dict(python_cfg)]).expect("cat");
@@ -1401,12 +1413,12 @@ mod tests {
         let mut options: crate::value::DictMap = crate::value::DictMap::new();
         options.put_str("body", body);
         options.insert(
-            "tags".to_string(),
+            crate::value::intern_key("tags"),
             VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                 arcstr::ArcStr::from(tag),
             )])),
         );
-        options.insert("ttl_turns".to_string(), VmValue::Int(ttl));
+        options.insert(crate::value::intern_key("ttl_turns"), VmValue::Int(ttl));
         VmValue::dict(options)
     }
 
@@ -1488,7 +1500,7 @@ mod tests {
         let vm = vm_with_stdlib();
         let mut options: crate::value::DictMap = crate::value::DictMap::new();
         options.insert(
-            "tags".to_string(),
+            crate::value::intern_key("tags"),
             VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                 arcstr::ArcStr::from("x"),
             )])),
@@ -1505,7 +1517,7 @@ mod tests {
     fn verdict_value(kind: &str) -> VmValue {
         let mut dict: crate::value::DictMap = crate::value::DictMap::new();
         dict.put_str("kind", kind);
-        dict.insert("confidence".to_string(), VmValue::Float(0.9));
+        dict.insert(crate::value::intern_key("confidence"), VmValue::Float(0.9));
         VmValue::dict(dict)
     }
 

--- a/crates/harn-vm/src/stdlib/tools.rs
+++ b/crates/harn-vm/src/stdlib/tools.rs
@@ -206,7 +206,7 @@ fn tool_registry_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, V
     let mut registry = crate::value::DictMap::new();
     registry.put_str("_type", "tool_registry");
     registry.insert(
-        "tools".to_string(),
+        crate::value::intern_key("tools"),
         VmValue::List(std::sync::Arc::new(Vec::new())),
     );
     Ok(VmValue::dict(registry))
@@ -233,7 +233,7 @@ fn tool_list_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
         if let VmValue::Dict(entry) = tool {
             let mut desc = crate::value::DictMap::new();
             for (key, value) in entry.iter() {
-                if key == "handler" {
+                if key.as_str() == "handler" {
                     continue;
                 }
                 desc.insert(key.clone(), value.clone());
@@ -323,7 +323,7 @@ fn tool_select_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
 
     let mut new_registry = (**registry).clone();
     new_registry.insert(
-        "tools".to_string(),
+        crate::value::intern_key("tools"),
         VmValue::List(std::sync::Arc::new(selected)),
     );
     Ok(VmValue::dict(new_registry))
@@ -421,7 +421,7 @@ fn tool_remove_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
 
     let mut new_registry = registry;
     new_registry.insert(
-        "tools".to_string(),
+        crate::value::intern_key("tools"),
         VmValue::List(std::sync::Arc::new(filtered)),
     );
     Ok(VmValue::dict(new_registry))
@@ -485,9 +485,9 @@ fn tool_schema_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
             let mut tool_def = crate::value::DictMap::new();
             tool_def.put_str("name", name);
             tool_def.put_str("description", description);
-            tool_def.insert("inputSchema".to_string(), input_schema);
+            tool_def.insert(crate::value::intern_key("inputSchema"), input_schema);
             if let Some(output_schema) = output_schema {
-                tool_def.insert("outputSchema".to_string(), output_schema);
+                tool_def.insert(crate::value::intern_key("outputSchema"), output_schema);
             }
             tool_schemas.push(VmValue::dict(tool_def));
         }
@@ -498,12 +498,18 @@ fn tool_schema_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
 
     if let Some(comps) = &components {
         let mut comp_wrapper = crate::value::DictMap::new();
-        comp_wrapper.insert("schemas".to_string(), VmValue::dict(comps.clone()));
-        schema.insert("components".to_string(), VmValue::dict(comp_wrapper));
+        comp_wrapper.insert(
+            crate::value::intern_key("schemas"),
+            VmValue::dict(comps.clone()),
+        );
+        schema.insert(
+            crate::value::intern_key("components"),
+            VmValue::dict(comp_wrapper),
+        );
     }
 
     schema.insert(
-        "tools".to_string(),
+        crate::value::intern_key("tools"),
         VmValue::List(std::sync::Arc::new(tool_schemas)),
     );
     Ok(VmValue::dict(schema))
@@ -750,17 +756,17 @@ fn tool_define_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
     let mut tool_entry = crate::value::DictMap::new();
     tool_entry.put_str("name", name.as_str());
     tool_entry.put_str("description", description);
-    tool_entry.insert("handler".to_string(), handler);
-    tool_entry.insert("parameters".to_string(), parameters);
+    tool_entry.insert(crate::value::intern_key("handler"), handler);
+    tool_entry.insert(crate::value::intern_key("parameters"), parameters);
     // Store the canonical executor as a plain string; wire
     // serialization is handled by the ACP adapter.
     tool_entry.put_str("executor", resolved_executor);
     if !matches!(output_schema, VmValue::Nil) {
-        tool_entry.insert("outputSchema".to_string(), output_schema);
+        tool_entry.insert(crate::value::intern_key("outputSchema"), output_schema);
     }
 
     if let Some(annotations) = config.get("annotations") {
-        tool_entry.insert("annotations".to_string(), annotations.clone());
+        tool_entry.insert(crate::value::intern_key("annotations"), annotations.clone());
     }
 
     for (key, value) in config.iter() {
@@ -791,7 +797,7 @@ fn tool_define_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
 
     let mut new_registry = registry;
     new_registry.insert(
-        "tools".to_string(),
+        crate::value::intern_key("tools"),
         VmValue::List(std::sync::Arc::new(tools)),
     );
     Ok(VmValue::dict(new_registry))
@@ -1004,7 +1010,7 @@ fn tool_def_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError
     if let Some(entry) = vm_find_tool_entry(registry, &name) {
         let mut desc = crate::value::DictMap::new();
         for (key, value) in entry.iter() {
-            if key == "handler" {
+            if key.as_str() == "handler" {
                 continue;
             }
             desc.insert(key.clone(), value.clone());
@@ -1227,7 +1233,7 @@ async fn invoke_synthesized_tool(id: &str, call_args: VmValue) -> Result<VmValue
             let arguments = match &call_args {
                 VmValue::Dict(map) => serde_json::Value::Object(
                     map.iter()
-                        .map(|(key, value)| (key.clone(), crate::llm::vm_value_to_json(value)))
+                        .map(|(key, value)| (key.to_string(), crate::llm::vm_value_to_json(value)))
                         .collect(),
                 ),
                 VmValue::Nil => serde_json::json!({}),
@@ -1289,9 +1295,9 @@ fn synthesized_tool_dry_run_result(spec: &SynthesizedToolSpec, call_args: VmValu
     result.put_str("tool_id", spec.id.as_str());
     result.put_str("name", spec.name.as_str());
     result.put_str("description", spec.description.as_str());
-    result.insert("args".to_string(), call_args);
+    result.insert(crate::value::intern_key("args"), call_args);
     result.insert(
-        "capabilities".to_string(),
+        crate::value::intern_key("capabilities"),
         VmValue::List(std::sync::Arc::new(
             spec.capabilities
                 .iter()
@@ -1313,10 +1319,16 @@ fn synthesized_tool_spec_value(spec: &SynthesizedToolSpec) -> VmValue {
     value.put_str("id", spec.id.as_str());
     value.put_str("name", spec.name.as_str());
     value.put_str("description", spec.description.as_str());
-    value.insert("parameters".to_string(), spec.parameters.clone());
-    value.insert("return_type".to_string(), spec.return_type.clone());
     value.insert(
-        "capabilities".to_string(),
+        crate::value::intern_key("parameters"),
+        spec.parameters.clone(),
+    );
+    value.insert(
+        crate::value::intern_key("return_type"),
+        spec.return_type.clone(),
+    );
+    value.insert(
+        crate::value::intern_key("capabilities"),
         VmValue::List(std::sync::Arc::new(
             spec.capabilities
                 .iter()
@@ -1516,8 +1528,10 @@ fn vm_get_tools(dict: &crate::value::DictMap) -> &[VmValue] {
 fn vm_format_parameters(params: Option<&VmValue>) -> String {
     match params {
         Some(VmValue::Dict(map)) if !map.is_empty() => {
-            let mut pairs: Vec<(String, String)> =
-                map.iter().map(|(k, v)| (k.clone(), v.display())).collect();
+            let mut pairs: Vec<(String, String)> = map
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.display()))
+                .collect();
             pairs.sort_by(|a, b| a.0.cmp(&b.0));
             pairs
                 .iter()
@@ -1536,8 +1550,10 @@ fn vm_format_schema(schema: Option<&VmValue>) -> String {
             if let Some(VmValue::String(reference)) = map.get("$ref") {
                 return format!("$ref({reference})");
             }
-            let mut pairs: Vec<(String, String)> =
-                map.iter().map(|(k, v)| (k.clone(), v.display())).collect();
+            let mut pairs: Vec<(String, String)> = map
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.display()))
+                .collect();
             pairs.sort_by(|a, b| a.0.cmp(&b.0));
             pairs
                 .iter()
@@ -1553,7 +1569,7 @@ fn vm_build_empty_schema() -> crate::value::DictMap {
     let mut schema = crate::value::DictMap::new();
     schema.put_str("schema_version", "harn-tools/1.0");
     schema.insert(
-        "tools".to_string(),
+        crate::value::intern_key("tools"),
         VmValue::List(std::sync::Arc::new(Vec::new())),
     );
     schema
@@ -1570,7 +1586,7 @@ fn vm_build_input_schema(
         Some(VmValue::Dict(map)) if !map.is_empty() => map,
         _ => {
             schema.insert(
-                "properties".to_string(),
+                crate::value::intern_key("properties"),
                 VmValue::dict(crate::value::DictMap::new()),
             );
             return VmValue::dict(schema);
@@ -1586,11 +1602,14 @@ fn vm_build_input_schema(
         required.push(VmValue::String(arcstr::ArcStr::from(key.as_str())));
     }
 
-    schema.insert("properties".to_string(), VmValue::dict(properties));
+    schema.insert(
+        crate::value::intern_key("properties"),
+        VmValue::dict(properties),
+    );
     if !required.is_empty() {
         required.sort_by_key(|a| a.display());
         schema.insert(
-            "required".to_string(),
+            crate::value::intern_key("required"),
             VmValue::List(std::sync::Arc::new(required)),
         );
     }

--- a/crates/harn-vm/src/stdlib/tracing.rs
+++ b/crates/harn-vm/src/stdlib/tracing.rs
@@ -98,7 +98,7 @@ fn trace_start_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, VmEr
     span.put_str("trace_id", trace_id);
     span.put_str("span_id", span_id);
     span.put_str("name", name);
-    span.insert("start_ms".to_string(), VmValue::Int(start_ms));
+    span.insert(crate::value::intern_key("start_ms"), VmValue::Int(start_ms));
     Ok(VmValue::dict(span))
 }
 
@@ -111,7 +111,10 @@ fn trace_end_impl(args: &[VmValue], out: &mut String) -> Result<VmValue, VmError
         fields.put_str("trace_id", trace_id);
         fields.put_str("span_id", span_id);
         fields.put_str("name", name);
-        fields.insert("duration_ms".to_string(), VmValue::Int(duration_ms));
+        fields.insert(
+            crate::value::intern_key("duration_ms"),
+            VmValue::Int(duration_ms),
+        );
         let line = vm_build_log_line("info", "span_end", Some(&fields));
         out.push_str(&line);
     }
@@ -140,7 +143,10 @@ fn llm_info_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmErro
     let mut info = crate::value::DictMap::new();
     info.put_str("provider", provider);
     info.put_str("model", model);
-    info.insert("api_key_set".to_string(), VmValue::Bool(api_key_set));
+    info.insert(
+        crate::value::intern_key("api_key_set"),
+        VmValue::Bool(api_key_set),
+    );
     Ok(VmValue::dict(info))
 }
 
@@ -198,14 +204,26 @@ fn lifecycle_span_end_impl(args: &[VmValue], _out: &mut String) -> Result<VmValu
 fn llm_usage_impl(_args: &[VmValue], _out: &mut String) -> Result<VmValue, VmError> {
     let (total_input, total_output, total_duration, call_count) = crate::llm::peek_trace_summary();
     let mut usage = crate::value::DictMap::new();
-    usage.insert("input_tokens".to_string(), VmValue::Int(total_input));
-    usage.insert("output_tokens".to_string(), VmValue::Int(total_output));
     usage.insert(
-        "total_duration_ms".to_string(),
+        crate::value::intern_key("input_tokens"),
+        VmValue::Int(total_input),
+    );
+    usage.insert(
+        crate::value::intern_key("output_tokens"),
+        VmValue::Int(total_output),
+    );
+    usage.insert(
+        crate::value::intern_key("total_duration_ms"),
         VmValue::Int(total_duration),
     );
-    usage.insert("call_count".to_string(), VmValue::Int(call_count));
-    usage.insert("total_calls".to_string(), VmValue::Int(call_count));
+    usage.insert(
+        crate::value::intern_key("call_count"),
+        VmValue::Int(call_count),
+    );
+    usage.insert(
+        crate::value::intern_key("total_calls"),
+        VmValue::Int(call_count),
+    );
     Ok(VmValue::dict(usage))
 }
 

--- a/crates/harn-vm/src/stdlib/transcript_project.rs
+++ b/crates/harn-vm/src/stdlib/transcript_project.rs
@@ -1480,13 +1480,13 @@ pub(crate) fn result_to_vm(result: &ProjectionResult, policy: &ProjectionPolicy)
     dict.put_str("reason", result.reason.clone());
     dict.put_str("prefix_hash", result.prefix_hash.clone());
     dict.insert(
-        "messages".to_string(),
+        crate::value::intern_key("messages"),
         VmValue::List(std::sync::Arc::new(
             result.messages.iter().map(json_to_vm_value).collect(),
         )),
     );
     dict.insert(
-        "kept_indices".to_string(),
+        crate::value::intern_key("kept_indices"),
         VmValue::List(std::sync::Arc::new(
             result
                 .kept_indices
@@ -1496,7 +1496,7 @@ pub(crate) fn result_to_vm(result: &ProjectionResult, policy: &ProjectionPolicy)
         )),
     );
     dict.insert(
-        "dropped_indices".to_string(),
+        crate::value::intern_key("dropped_indices"),
         VmValue::List(std::sync::Arc::new(
             result
                 .dropped_indices
@@ -1506,15 +1506,15 @@ pub(crate) fn result_to_vm(result: &ProjectionResult, policy: &ProjectionPolicy)
         )),
     );
     dict.insert(
-        "kept_count".to_string(),
+        crate::value::intern_key("kept_count"),
         VmValue::Int(result.kept_indices.len() as i64),
     );
     dict.insert(
-        "dropped_count".to_string(),
+        crate::value::intern_key("dropped_count"),
         VmValue::Int(result.dropped_indices.len() as i64),
     );
     dict.insert(
-        "redacted_indices".to_string(),
+        crate::value::intern_key("redacted_indices"),
         VmValue::List(std::sync::Arc::new(
             result
                 .redacted_indices
@@ -1524,19 +1524,19 @@ pub(crate) fn result_to_vm(result: &ProjectionResult, policy: &ProjectionPolicy)
         )),
     );
     dict.insert(
-        "redacted_count".to_string(),
+        crate::value::intern_key("redacted_count"),
         VmValue::Int(result.redaction_pointers.len() as i64),
     );
     dict.insert(
-        "reclaimed_tokens".to_string(),
+        crate::value::intern_key("reclaimed_tokens"),
         VmValue::Int(result.reclaimed_tokens as i64),
     );
     dict.insert(
-        "reclaimed_chars".to_string(),
+        crate::value::intern_key("reclaimed_chars"),
         VmValue::Int(result.reclaimed_chars as i64),
     );
     dict.insert(
-        "roots_consulted".to_string(),
+        crate::value::intern_key("roots_consulted"),
         VmValue::List(std::sync::Arc::new(
             result
                 .roots_consulted
@@ -1546,7 +1546,7 @@ pub(crate) fn result_to_vm(result: &ProjectionResult, policy: &ProjectionPolicy)
         )),
     );
     dict.insert(
-        "redaction_pointers".to_string(),
+        crate::value::intern_key("redaction_pointers"),
         VmValue::List(std::sync::Arc::new(
             result
                 .redaction_pointers
@@ -1556,10 +1556,13 @@ pub(crate) fn result_to_vm(result: &ProjectionResult, policy: &ProjectionPolicy)
         )),
     );
     dict.insert(
-        "provider_safety_blocked".to_string(),
+        crate::value::intern_key("provider_safety_blocked"),
         VmValue::Bool(result.provider_safety_blocked),
     );
-    dict.insert("event".to_string(), projection_event_value(result, policy));
+    dict.insert(
+        crate::value::intern_key("event"),
+        projection_event_value(result, policy),
+    );
     VmValue::dict(dict)
 }
 

--- a/crates/harn-vm/src/stdlib/triggers_stdlib.rs
+++ b/crates/harn-vm/src/stdlib/triggers_stdlib.rs
@@ -1490,9 +1490,11 @@ fn parse_trigger_config(config: &crate::value::DictMap) -> Result<TriggerBinding
 
 pub(crate) fn validate_resume_trigger_spec(config: &crate::value::DictMap) -> Result<(), VmError> {
     let mut normalized = config.clone();
-    normalized.entry("handler".to_string()).or_insert_with(|| {
-        VmValue::String(arcstr::ArcStr::from("worker://__resume_auto_resume__"))
-    });
+    normalized
+        .entry(crate::value::intern_key("handler"))
+        .or_insert_with(|| {
+            VmValue::String(arcstr::ArcStr::from("worker://__resume_auto_resume__"))
+        });
     parse_trigger_config(&normalized).map(|_| ())
 }
 
@@ -2747,10 +2749,10 @@ fn parse_webhook_intake_request(
         Some(VmValue::Dict(dict)) => dict
             .iter()
             .map(|(key, value)| match value {
-                VmValue::String(text) => Ok((key.clone(), text.to_string())),
-                VmValue::Int(value) => Ok((key.clone(), value.to_string())),
-                VmValue::Float(value) => Ok((key.clone(), value.to_string())),
-                VmValue::Bool(value) => Ok((key.clone(), value.to_string())),
+                VmValue::String(text) => Ok((key.to_string(), text.to_string())),
+                VmValue::Int(value) => Ok((key.to_string(), value.to_string())),
+                VmValue::Float(value) => Ok((key.to_string(), value.to_string())),
+                VmValue::Bool(value) => Ok((key.to_string(), value.to_string())),
                 other => Err(VmError::Runtime(format!(
                     "webhook_intake_feed: headers.{key} must be a string, got {}",
                     other.type_name()

--- a/crates/harn-vm/src/stdlib/waitpoints.rs
+++ b/crates/harn-vm/src/stdlib/waitpoints.rs
@@ -470,7 +470,7 @@ fn json_dict_field(
     };
     Ok(entries
         .iter()
-        .map(|(key, value)| (key.clone(), vm_value_to_json(value)))
+        .map(|(key, value)| (key.to_string(), vm_value_to_json(value)))
         .collect())
 }
 

--- a/crates/harn-vm/src/stdlib/web.rs
+++ b/crates/harn-vm/src/stdlib/web.rs
@@ -100,7 +100,7 @@ fn extract_meta(document: &Html) -> VmValue {
             .or_else(|| element.value().attr("charset"))
             .map(|key| key.trim().to_ascii_lowercase());
         if let Some(key) = key.filter(|key| !key.is_empty()) {
-            meta.insert(key, vm_str(value));
+            meta.insert(crate::value::intern_key(&key), vm_str(value));
         }
     }
     vm_dict(meta)
@@ -131,16 +131,22 @@ fn extract_links(document: &Html, base: Option<&Url>) -> VmValue {
             continue;
         };
         let mut row = crate::value::DictMap::new();
-        row.insert("href".to_string(), vm_str(href));
-        row.insert("url".to_string(), vm_str(resolve_url(base, href)));
-        row.insert("text".to_string(), vm_str(element_text(element)));
+        row.insert(crate::value::intern_key("href"), vm_str(href));
+        row.insert(
+            crate::value::intern_key("url"),
+            vm_str(resolve_url(base, href)),
+        );
+        row.insert(
+            crate::value::intern_key("text"),
+            vm_str(element_text(element)),
+        );
         if let Some(title) = element
             .value()
             .attr("title")
             .map(str::trim)
             .filter(|value| !value.is_empty())
         {
-            row.insert("title".to_string(), vm_str(title));
+            row.insert(crate::value::intern_key("title"), vm_str(title));
         }
         if let Some(rel) = element
             .value()
@@ -148,7 +154,7 @@ fn extract_links(document: &Html, base: Option<&Url>) -> VmValue {
             .map(str::trim)
             .filter(|value| !value.is_empty())
         {
-            row.insert("rel".to_string(), vm_str(rel));
+            row.insert(crate::value::intern_key("rel"), vm_str(rel));
         }
         links.push(vm_dict(row));
     }
@@ -196,7 +202,7 @@ fn extract_tables(document: &Html) -> VmValue {
             .next()
             .map(element_text)
             .unwrap_or_default();
-        rendered.insert("caption".to_string(), vm_str(caption));
+        rendered.insert(crate::value::intern_key("caption"), vm_str(caption));
 
         let mut headers: Vec<VmValue> = Vec::new();
         let mut rows: Vec<VmValue> = Vec::new();
@@ -224,8 +230,8 @@ fn extract_tables(document: &Html) -> VmValue {
                 rows.push(vm_list(cells));
             }
         }
-        rendered.insert("headers".to_string(), vm_list(headers));
-        rendered.insert("rows".to_string(), vm_list(rows));
+        rendered.insert(crate::value::intern_key("headers"), vm_list(headers));
+        rendered.insert(crate::value::intern_key("rows"), vm_list(rows));
         tables.push(vm_dict(rendered));
     }
     vm_list(tables)
@@ -244,16 +250,28 @@ fn extract_html(html: &str, source_url: Option<&str>) -> VmValue {
         .unwrap_or(VmValue::Nil);
 
     let mut out = crate::value::DictMap::new();
-    out.insert("title".to_string(), title);
-    out.insert("meta".to_string(), extract_meta(&document));
+    out.insert(crate::value::intern_key("title"), title);
+    out.insert(crate::value::intern_key("meta"), extract_meta(&document));
     out.insert(
-        "canonical_url".to_string(),
+        crate::value::intern_key("canonical_url"),
         extract_canonical(&document, base.as_ref()),
     );
-    out.insert("links".to_string(), extract_links(&document, base.as_ref()));
-    out.insert("tables".to_string(), extract_tables(&document));
-    out.insert("json_ld".to_string(), extract_json_ld(&document));
-    out.insert("text".to_string(), vm_str(html_text_without_scripts(html)));
+    out.insert(
+        crate::value::intern_key("links"),
+        extract_links(&document, base.as_ref()),
+    );
+    out.insert(
+        crate::value::intern_key("tables"),
+        extract_tables(&document),
+    );
+    out.insert(
+        crate::value::intern_key("json_ld"),
+        extract_json_ld(&document),
+    );
+    out.insert(
+        crate::value::intern_key("text"),
+        vm_str(html_text_without_scripts(html)),
+    );
     vm_dict(out)
 }
 

--- a/crates/harn-vm/src/stdlib/workflow/convert.rs
+++ b/crates/harn-vm/src/stdlib/workflow/convert.rs
@@ -31,17 +31,17 @@ pub(in crate::stdlib) fn workflow_graph_to_vm(graph: &WorkflowGraph) -> Result<V
         let Some(raw_tools) = node.raw_tools.clone() else {
             continue;
         };
-        let Some(node_value) = nodes.get(node_id).cloned() else {
+        let Some(node_value) = nodes.get(node_id.as_str()).cloned() else {
             continue;
         };
         let VmValue::Dict(node_dict) = node_value else {
             continue;
         };
         let mut node_map = (*node_dict).clone();
-        node_map.insert("tools".to_string(), raw_tools);
-        nodes.insert(node_id.clone(), VmValue::dict(node_map));
+        node_map.insert(crate::value::intern_key("tools"), raw_tools);
+        nodes.insert(crate::value::intern_key(node_id), VmValue::dict(node_map));
     }
-    graph_dict.insert("nodes".to_string(), VmValue::dict(nodes));
+    graph_dict.insert(crate::value::intern_key("nodes"), VmValue::dict(nodes));
     Ok(VmValue::dict(graph_dict))
 }
 
@@ -117,7 +117,7 @@ pub(super) fn filter_workflow_tools_vm(tools: &VmValue, allowed: &[String]) -> V
                 .get("tools")
                 .map(|value| filter_workflow_tools_vm(value, allowed))
                 .unwrap_or_else(|| VmValue::List(std::sync::Arc::new(Vec::new())));
-            filtered.insert("tools".to_string(), tool_items);
+            filtered.insert(crate::value::intern_key("tools"), tool_items);
             VmValue::dict(filtered)
         }
         VmValue::Dict(map) => {

--- a/crates/harn-vm/src/stdlib/workflow/hooks.rs
+++ b/crates/harn-vm/src/stdlib/workflow/hooks.rs
@@ -633,7 +633,7 @@ pub(super) async fn fire_session_hook_builtin(
         crate::orchestration::HookControl::Modify { payload: modified } => {
             out.put_str("control", "modify");
             out.insert(
-                "modify".to_string(),
+                crate::value::intern_key("modify"),
                 crate::stdlib::json_to_vm_value(&modified),
             );
         }
@@ -710,7 +710,7 @@ mod tests {
         VmValue::dict(
             entries
                 .iter()
-                .map(|(key, value)| ((*key).to_string(), value.clone()))
+                .map(|(key, value)| (crate::value::intern_key(key), value.clone()))
                 .collect::<crate::value::DictMap>(),
         )
     }

--- a/crates/harn-vm/src/stdlib/workflow/inspect.rs
+++ b/crates/harn-vm/src/stdlib/workflow/inspect.rs
@@ -23,7 +23,7 @@ pub(super) fn workflow_graph_builtin(
     let input = args
         .first()
         .cloned()
-        .unwrap_or(VmValue::dict(BTreeMap::new()));
+        .unwrap_or(VmValue::dict_map(Default::default()));
     let graph = normalize_workflow_value(&input)?;
     workflow_graph_to_vm(&graph)
 }
@@ -40,7 +40,7 @@ pub(super) fn workflow_validate_builtin(
     let input = args
         .first()
         .cloned()
-        .unwrap_or(VmValue::dict(BTreeMap::new()));
+        .unwrap_or(VmValue::dict_map(Default::default()));
     let graph = normalize_workflow_value(&input)?;
     let ceiling = args.get(1).map(normalize_policy).transpose()?;
     to_vm(&validate_workflow(
@@ -61,7 +61,7 @@ pub(super) fn workflow_inspect_builtin(
     let input = args
         .first()
         .cloned()
-        .unwrap_or(VmValue::dict(BTreeMap::new()));
+        .unwrap_or(VmValue::dict_map(Default::default()));
     let graph = normalize_workflow_value(&input)?;
     let ceiling = args.get(1).map(normalize_policy).transpose()?;
     let builtin = builtin_ceiling();
@@ -86,7 +86,7 @@ pub(super) fn workflow_policy_report_builtin(
     let input = args
         .first()
         .cloned()
-        .unwrap_or(VmValue::dict(BTreeMap::new()));
+        .unwrap_or(VmValue::dict_map(Default::default()));
     let graph = normalize_workflow_value(&input)?;
     let ceiling = args.get(1).map(normalize_policy).transpose()?;
     let builtin = builtin_ceiling();
@@ -116,7 +116,7 @@ pub(super) fn workflow_clone_builtin(
     let input = args
         .first()
         .cloned()
-        .unwrap_or(VmValue::dict(BTreeMap::new()));
+        .unwrap_or(VmValue::dict_map(Default::default()));
     let mut graph = normalize_workflow_value(&input)?;
     graph.id = format!("{}_clone", graph.id);
     graph.version += 1;

--- a/crates/harn-vm/src/stdlib/workflow/state.rs
+++ b/crates/harn-vm/src/stdlib/workflow/state.rs
@@ -168,19 +168,22 @@ pub(super) fn workflow_control_to_vm(
     dict.put_str("state_id", state.state_id.as_str());
     dict.put_str("run_id", state.run.id.as_str());
     dict.insert(
-        "ready_nodes".to_string(),
+        crate::value::intern_key("ready_nodes"),
         string_list_to_vm(&state.ready_nodes),
     );
     dict.insert(
-        "completed_nodes".to_string(),
+        crate::value::intern_key("completed_nodes"),
         string_list_to_vm(&state.completed_nodes),
     );
     dict.insert(
-        "max_steps".to_string(),
+        crate::value::intern_key("max_steps"),
         VmValue::Int(state.max_steps as i64),
     );
     if include_graph {
-        dict.insert("graph".to_string(), workflow_graph_to_vm(&state.graph)?);
+        dict.insert(
+            crate::value::intern_key("graph"),
+            workflow_graph_to_vm(&state.graph)?,
+        );
     }
     Ok(VmValue::dict(dict))
 }
@@ -262,7 +265,10 @@ fn validate_workflow_skill_registry(value: VmValue) -> Option<VmValue> {
         VmValue::List(list) => {
             let mut dict = crate::value::DictMap::new();
             dict.put_str("_type", "skill_registry");
-            dict.insert("skills".to_string(), VmValue::List(list.clone()));
+            dict.insert(
+                crate::value::intern_key("skills"),
+                VmValue::List(list.clone()),
+            );
             Some(VmValue::dict(dict))
         }
         _ => None,
@@ -662,20 +668,20 @@ fn workflow_stage_plan_to_vm(scope: &StageExecutionScope) -> Result<VmValue, VmE
     match &scope.execution {
         StageExecution::Precomputed(executed) => {
             dict.insert(
-                "result".to_string(),
+                crate::value::intern_key("result"),
                 crate::stdlib::json_to_vm_value(&executed.result),
             );
         }
         StageExecution::HarnCall { prepared, .. } => {
             if let Some(result) = &prepared.result {
                 dict.insert(
-                    "result".to_string(),
+                    crate::value::intern_key("result"),
                     crate::stdlib::json_to_vm_value(result),
                 );
             } else {
                 dict.put_str("prompt", prepared.prompt.as_str());
                 dict.insert(
-                    "system".to_string(),
+                    crate::value::intern_key("system"),
                     prepared
                         .system
                         .as_ref()
@@ -683,15 +689,15 @@ fn workflow_stage_plan_to_vm(scope: &StageExecutionScope) -> Result<VmValue, VmE
                         .unwrap_or(VmValue::Nil),
                 );
                 dict.insert(
-                    "run_agent_loop".to_string(),
+                    crate::value::intern_key("run_agent_loop"),
                     VmValue::Bool(prepared.run_agent_loop),
                 );
                 dict.insert(
-                    "llm_options".to_string(),
+                    crate::value::intern_key("llm_options"),
                     VmValue::dict(prepared.llm_options.clone()),
                 );
                 dict.insert(
-                    "agent_loop_options".to_string(),
+                    crate::value::intern_key("agent_loop_options"),
                     VmValue::dict(prepared.agent_loop_options.clone()),
                 );
             }
@@ -701,11 +707,14 @@ fn workflow_stage_plan_to_vm(scope: &StageExecutionScope) -> Result<VmValue, VmE
             map_options,
             ..
         } => {
-            dict.insert("run_map_stage".to_string(), VmValue::Bool(true));
-            dict.insert("node".to_string(), to_vm(&scope.node)?);
-            dict.insert("artifacts".to_string(), to_vm(artifacts)?);
             dict.insert(
-                "map_options".to_string(),
+                crate::value::intern_key("run_map_stage"),
+                VmValue::Bool(true),
+            );
+            dict.insert(crate::value::intern_key("node"), to_vm(&scope.node)?);
+            dict.insert(crate::value::intern_key("artifacts"), to_vm(artifacts)?);
+            dict.insert(
+                crate::value::intern_key("map_options"),
                 VmValue::dict(map_options.clone()),
             );
         }
@@ -1048,7 +1057,7 @@ pub(super) async fn prepare_workflow_stage_state(
         let mut map_options = crate::value::DictMap::new();
         map_options.put_str("task", state.run.task.clone());
         if let Some(transcript) = transcript.clone() {
-            map_options.insert("transcript".to_string(), transcript);
+            map_options.insert(crate::value::intern_key("transcript"), transcript);
         }
         StageExecution::HarnMapCall {
             artifacts: state.artifacts.clone(),

--- a/crates/harn-vm/src/stdlib/xml.rs
+++ b/crates/harn-vm/src/stdlib/xml.rs
@@ -340,7 +340,7 @@ fn parse_xml(text: &str, parse_opts: &ParseOptions) -> Result<VmValue, VmError> 
     };
     p.skip_ws_and_prologue()?;
     if p.pos >= p.src.len() {
-        return Ok(VmValue::dict(BTreeMap::new()));
+        return Ok(VmValue::dict_map(Default::default()));
     }
     let (tag, value) = p.parse_element()?;
     p.skip_ws_and_prologue().ok();

--- a/crates/harn-vm/src/step_runtime.rs
+++ b/crates/harn-vm/src/step_runtime.rs
@@ -863,13 +863,16 @@ fn budget_exhausted_error(
     dict.put_str("step", definition.name.clone());
     dict.put_str("function", definition.function.clone());
     dict.put_str("limit", limit);
-    dict.insert("limit_value".to_string(), VmValue::Float(limit_value));
     dict.insert(
-        "consumed_tokens".to_string(),
+        crate::value::intern_key("limit_value"),
+        VmValue::Float(limit_value),
+    );
+    dict.insert(
+        crate::value::intern_key("consumed_tokens"),
         VmValue::Float(consumed_tokens),
     );
     dict.insert(
-        "consumed_cost_usd".to_string(),
+        crate::value::intern_key("consumed_cost_usd"),
         VmValue::Float(consumed_cost_usd),
     );
     dict.put_str(
@@ -920,14 +923,14 @@ pub fn mark_escalated(err: VmError, step_name: Option<&str>, function: Option<&s
         return err;
     };
     let mut next = (*dict).clone();
-    next.insert("escalated".to_string(), VmValue::Bool(true));
+    next.insert(crate::value::intern_key("escalated"), VmValue::Bool(true));
     next.put_str("category", "handoff_escalation");
     if let Some(step) = step_name {
-        next.entry("step".to_string())
+        next.entry(crate::value::intern_key("step"))
             .or_insert_with(|| VmValue::String(arcstr::ArcStr::from(step.to_string())));
     }
     if let Some(function) = function {
-        next.entry("function".to_string())
+        next.entry(crate::value::intern_key("function"))
             .or_insert_with(|| VmValue::String(arcstr::ArcStr::from(function.to_string())));
     }
     VmError::Thrown(VmValue::dict(next))
@@ -987,13 +990,13 @@ mod tests {
     fn registers_and_pops_step_from_dict() {
         fresh_state();
         let mut budget: crate::value::DictMap = crate::value::DictMap::new();
-        budget.insert("max_tokens".to_string(), VmValue::Int(100));
-        budget.insert("max_usd".to_string(), VmValue::Float(0.05));
+        budget.insert(crate::value::intern_key("max_tokens"), VmValue::Int(100));
+        budget.insert(crate::value::intern_key("max_usd"), VmValue::Float(0.05));
         let mut meta: crate::value::DictMap = crate::value::DictMap::new();
         meta.put_str("name", "plan");
         meta.put_str("model", "claude-haiku-4-5");
         meta.put_str("error_boundary", "continue");
-        meta.insert("budget".to_string(), VmValue::dict(budget));
+        meta.insert(crate::value::intern_key("budget"), VmValue::dict(budget));
 
         register_step_from_dict(vec![
             VmValue::String(arcstr::ArcStr::from("plan_step")),
@@ -1080,7 +1083,7 @@ mod tests {
         stage_dict.put_str("name", "research");
         // Stage tries to add `edit` on top of a parent that only allowed `read`.
         stage_dict.insert(
-            "allowed_tools".to_string(),
+            crate::value::intern_key("allowed_tools"),
             VmValue::List(std::sync::Arc::new(vec![
                 VmValue::String(arcstr::ArcStr::from("read")),
                 VmValue::String(arcstr::ArcStr::from("edit")),
@@ -1089,7 +1092,7 @@ mod tests {
         let mut persona_meta: crate::value::DictMap = crate::value::DictMap::new();
         persona_meta.put_str("name", "scoped");
         persona_meta.insert(
-            "stages".to_string(),
+            crate::value::intern_key("stages"),
             VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
                 std::sync::Arc::new(stage_dict),
             )])),
@@ -1129,7 +1132,7 @@ mod tests {
         let mut stage_dict: crate::value::DictMap = crate::value::DictMap::new();
         stage_dict.put_str("name", "research");
         stage_dict.insert(
-            "allowed_tools".to_string(),
+            crate::value::intern_key("allowed_tools"),
             VmValue::List(std::sync::Arc::new(vec![VmValue::String(
                 arcstr::ArcStr::from("read"),
             )])),
@@ -1137,7 +1140,7 @@ mod tests {
         let mut persona_meta: crate::value::DictMap = crate::value::DictMap::new();
         persona_meta.put_str("name", "scoped");
         persona_meta.insert(
-            "stages".to_string(),
+            crate::value::intern_key("stages"),
             VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
                 std::sync::Arc::new(stage_dict),
             )])),

--- a/crates/harn-vm/src/tool_surface.rs
+++ b/crates/harn-vm/src/tool_surface.rs
@@ -1311,7 +1311,7 @@ mod tests {
         policy
             .tool_annotations
             .insert("run".into(), execute_annotations());
-        let tools = VmValue::dict(std::collections::BTreeMap::from_iter([
+        let tools = VmValue::dict(std::collections::BTreeMap::<String, VmValue>::from_iter([
             (
                 "_type".into(),
                 VmValue::String(arcstr::ArcStr::from("tool_registry")),
@@ -1321,15 +1321,15 @@ mod tests {
                 VmValue::List(std::sync::Arc::new(vec![VmValue::Dict(
                     std::sync::Arc::new(crate::value::DictMap::from_iter([
                         (
-                            "name".to_string(),
+                            crate::value::intern_key("name"),
                             VmValue::String(arcstr::ArcStr::from("run")),
                         ),
                         (
-                            "parameters".to_string(),
+                            crate::value::intern_key("parameters"),
                             VmValue::dict(crate::value::DictMap::new()),
                         ),
                         (
-                            "executor".to_string(),
+                            crate::value::intern_key("executor"),
                             VmValue::String(arcstr::ArcStr::from("host_bridge")),
                         ),
                     ])),

--- a/crates/harn-vm/src/tracing.rs
+++ b/crates/harn-vm/src/tracing.rs
@@ -566,7 +566,7 @@ pub fn reset_tracing() {
 
 /// Convert a span to a VmValue dict for user access.
 pub fn span_to_vm_value(span: &Span) -> VmValue {
-    let mut d = BTreeMap::new();
+    let mut d: BTreeMap<String, VmValue> = BTreeMap::new();
     d.insert(
         "trace_id".into(),
         VmValue::String(arcstr::ArcStr::from(span.trace_id.as_str())),
@@ -597,7 +597,12 @@ pub fn span_to_vm_value(span: &Span) -> VmValue {
         let meta: crate::value::DictMap = span
             .metadata
             .iter()
-            .map(|(k, v)| (k.clone(), crate::stdlib::json_to_vm_value(v)))
+            .map(|(k, v)| {
+                (
+                    crate::value::intern_key(k),
+                    crate::stdlib::json_to_vm_value(v),
+                )
+            })
             .collect();
         d.insert("metadata".into(), VmValue::dict(meta));
     }

--- a/crates/harn-vm/src/triggers/dispatcher/mod.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/mod.rs
@@ -2670,11 +2670,11 @@ impl Dispatcher {
             serde_json::to_value(event).map_err(|error| DispatchError::Serde(error.to_string()))?;
         let mut bindings = crate::value::DictMap::new();
         bindings.insert(
-            "event".to_string(),
+            crate::value::intern_key("event"),
             crate::schema::json_to_vm_value(&event_json),
         );
         bindings.insert(
-            "match".to_string(),
+            crate::value::intern_key("match"),
             crate::schema::json_to_vm_value(&serde_json::json!({
                 "matched_at": event_json.get("received_at").cloned().unwrap_or(serde_json::Value::Null),
             })),
@@ -2685,7 +2685,7 @@ impl Dispatcher {
                 .and_then(|payload| payload.get("batch"))
         }) {
             bindings.insert(
-                "batch".to_string(),
+                crate::value::intern_key("batch"),
                 crate::schema::json_to_vm_value(batch_value),
             );
         }

--- a/crates/harn-vm/src/triggers/dispatcher/util.rs
+++ b/crates/harn-vm/src/triggers/dispatcher/util.rs
@@ -118,7 +118,7 @@ pub(super) fn event_to_handler_value(event: &TriggerEvent) -> Result<VmValue, Di
         (Some(raw_body), VmValue::Dict(dict)) => {
             let mut map = (*dict).clone();
             map.insert(
-                "raw_body".to_string(),
+                crate::value::intern_key("raw_body"),
                 VmValue::Bytes(std::sync::Arc::new(raw_body.clone())),
             );
             Ok(VmValue::dict(map))

--- a/crates/harn-vm/src/typecheck.rs
+++ b/crates/harn-vm/src/typecheck.rs
@@ -193,7 +193,7 @@ fn matches_type_with_generics(
         // a closed shape; the row tail just means "and possibly more fields,"
         // which any dict already satisfies — so no extra runtime constraint.
         TypeExpr::Shape(fields) | TypeExpr::OpenShape { fields, .. } => match value {
-            VmValue::Dict(map) => fields.iter().all(|f| match map.get(&f.name) {
+            VmValue::Dict(map) => fields.iter().all(|f| match map.get(f.name.as_str()) {
                 // Optional fields treat an explicit `nil` value the same as
                 // "field missing" so callers can write `{flag: nil}` to mean
                 // "default" without having to omit the key entirely.
@@ -573,7 +573,7 @@ mod tests {
         good.insert("x".to_string(), vm_int(7));
         assert!(matches_type(&VmValue::dict(good), &shape));
         assert!(!matches_type(
-            &VmValue::dict(std::collections::BTreeMap::new()),
+            &VmValue::dict_map(Default::default()),
             &shape
         ));
     }

--- a/crates/harn-vm/src/value/build.rs
+++ b/crates/harn-vm/src/value/build.rs
@@ -29,7 +29,7 @@ impl DictInsert for BTreeMap<String, VmValue> {
 
 impl DictInsert for DictMap {
     fn dict_insert(&mut self, key: String, value: VmValue) {
-        self.insert(key, value);
+        self.insert(super::intern_key(&key), value);
     }
 }
 
@@ -61,11 +61,11 @@ pub trait VmDictExt {
 /// read identically. Cold-path helper (filter/dedup), so the rebuild cost is
 /// not on any hot loop.
 pub trait DictRetain {
-    fn retain(&mut self, keep: impl FnMut(&String, &mut VmValue) -> bool);
+    fn retain(&mut self, keep: impl FnMut(&super::HarnStr, &mut VmValue) -> bool);
 }
 
 impl DictRetain for DictMap {
-    fn retain(&mut self, mut keep: impl FnMut(&String, &mut VmValue) -> bool) {
+    fn retain(&mut self, mut keep: impl FnMut(&super::HarnStr, &mut VmValue) -> bool) {
         let mut result = DictMap::new();
         for (k, v) in self.iter() {
             let mut v = v.clone();

--- a/crates/harn-vm/src/value/core.rs
+++ b/crates/harn-vm/src/value/core.rs
@@ -52,7 +52,66 @@ pub type HarnStr = arcstr::ArcStr;
 /// `range` / `len`) match `BTreeMap`, so dict reads are unchanged. The `Arc`
 /// wrapper is retained so reference identity (`Arc::ptr_eq`) — used by the `===`
 /// operator and `value_identity_key` — keeps its current semantics.
-pub type DictMap = imbl::OrdMap<String, VmValue>;
+pub type DictMap = imbl::OrdMap<HarnStr, VmValue>;
+
+/// Intern a dict key into a shared [`HarnStr`].
+///
+/// Agent workloads are dict-heavy and the same field names (`role`, `content`,
+/// `arguments`, …) recur across thousands of message/JSON dicts. Interning
+/// short keys lets every occurrence share one allocation (a refcount bump on
+/// reuse) instead of allocating a fresh string per key. The table is *bounded*
+/// — only keys up to [`MAX_INTERNED_KEY_LEN`] bytes are eligible, and once
+/// [`MAX_INTERNED_KEYS`] distinct keys are cached no new entries are added — so
+/// adversarial or high-cardinality keys (UUIDs, user input) fall back to a
+/// plain allocation and can never grow the table without bound.
+pub fn intern_key(key: &str) -> HarnStr {
+    const MAX_INTERNED_KEY_LEN: usize = 64;
+    const MAX_INTERNED_KEYS: usize = 8192;
+    static INTERNED_KEYS: std::sync::LazyLock<parking_lot::Mutex<HashMap<Box<str>, HarnStr>>> =
+        std::sync::LazyLock::new(|| parking_lot::Mutex::new(HashMap::new()));
+
+    if key.len() > MAX_INTERNED_KEY_LEN {
+        return HarnStr::from(key);
+    }
+    let mut table = INTERNED_KEYS.lock();
+    if let Some(existing) = table.get(key) {
+        return existing.clone();
+    }
+    let interned = HarnStr::from(key);
+    if table.len() < MAX_INTERNED_KEYS {
+        table.insert(Box::from(key), interned.clone());
+    }
+    interned
+}
+
+/// Conversion into an interned dict key.
+///
+/// Lets [`VmValue::dict`] accept the maps callers already build —
+/// `BTreeMap<String, _>` and the persistent [`DictMap`] (`OrdMap<HarnStr, _>`) —
+/// while routing freshly-owned string keys through [`intern_key`] and passing an
+/// already-shared [`HarnStr`] (e.g. from re-wrapping an existing dict) straight
+/// through without re-interning.
+pub trait IntoDictKey {
+    fn into_dict_key(self) -> HarnStr;
+}
+
+impl IntoDictKey for String {
+    fn into_dict_key(self) -> HarnStr {
+        intern_key(&self)
+    }
+}
+
+impl IntoDictKey for &str {
+    fn into_dict_key(self) -> HarnStr {
+        intern_key(self)
+    }
+}
+
+impl IntoDictKey for HarnStr {
+    fn into_dict_key(self) -> HarnStr {
+        self
+    }
+}
 
 /// Character count with a byte-length fast path for ASCII text.
 ///
@@ -96,7 +155,10 @@ impl StructLayout {
     }
 
     pub fn from_map(struct_name: impl Into<String>, fields: &crate::value::DictMap) -> Self {
-        Self::new(struct_name, fields.keys().cloned().collect())
+        Self::new(
+            struct_name,
+            fields.keys().map(|key| key.to_string()).collect(),
+        )
     }
 
     pub fn struct_name(&self) -> &str {
@@ -329,8 +391,13 @@ impl VmValue {
     /// `IntoIterator<Item = (String, VmValue)>`) and collects it into the
     /// persistent [`DictMap`], so callers keep their familiar map-building code
     /// while the stored value gains structural sharing.
-    pub fn dict(entries: impl IntoIterator<Item = (String, VmValue)>) -> Self {
-        VmValue::Dict(Shared::new(entries.into_iter().collect::<DictMap>()))
+    pub fn dict<K: IntoDictKey>(entries: impl IntoIterator<Item = (K, VmValue)>) -> Self {
+        VmValue::Dict(Shared::new(
+            entries
+                .into_iter()
+                .map(|(k, v)| (k.into_dict_key(), v))
+                .collect::<DictMap>(),
+        ))
     }
 
     /// Construct a [`VmValue::Dict`] from an already-built [`DictMap`].
@@ -511,7 +578,7 @@ impl VmValue {
         let slots = layout
             .field_names()
             .iter()
-            .map(|name| fields.get(name).cloned())
+            .map(|name| fields.get(name.as_str()).cloned())
             .collect();
         VmValue::StructInstance(Shared::new(StructInstanceData {
             layout,
@@ -528,7 +595,7 @@ impl VmValue {
         let fields = layout
             .field_names()
             .iter()
-            .map(|name| field_values.get(name).cloned())
+            .map(|name| field_values.get(name.as_str()).cloned())
             .collect();
         VmValue::StructInstance(Shared::new(StructInstanceData {
             layout,
@@ -804,7 +871,7 @@ pub fn struct_fields_to_map(
             fields
                 .get(index)
                 .and_then(Option::as_ref)
-                .map(|value| (name.clone(), value.clone()))
+                .map(|value| (intern_key(name), value.clone()))
         })
         .collect()
 }

--- a/crates/harn-vm/src/value/env.rs
+++ b/crates/harn-vm/src/value/env.rs
@@ -191,7 +191,7 @@ impl VmEnv {
         let mut vars = crate::value::DictMap::new();
         for scope in &self.scopes {
             for (name, (value, _)) in scope.vars.iter() {
-                vars.insert(name.clone(), value.clone());
+                vars.insert(crate::value::intern_key(name), value.clone());
             }
         }
         vars

--- a/crates/harn-vm/src/value/mod.rs
+++ b/crates/harn-vm/src/value/mod.rs
@@ -12,8 +12,8 @@ pub type VmMutex<T> = parking_lot::Mutex<T>;
 
 pub use build::{DictRetain, VmDictExt};
 pub use core::{
-    string_char_count, struct_fields_to_map, DictMap, HarnStr, StructInstanceData, StructLayout,
-    VmAsyncBuiltinFn, VmBuiltinFn, VmBuiltinRefId, VmEnumVariant, VmValue,
+    intern_key, string_char_count, struct_fields_to_map, DictMap, HarnStr, StructInstanceData,
+    StructLayout, VmAsyncBuiltinFn, VmBuiltinFn, VmBuiltinRefId, VmEnumVariant, VmValue,
 };
 pub use env::{closest_match, ModuleFunctionRegistry, ModuleState, VmClosure, VmEnv};
 pub use error::{

--- a/crates/harn-vm/src/value/storage_json.rs
+++ b/crates/harn-vm/src/value/storage_json.rs
@@ -29,7 +29,7 @@ pub(crate) fn vm_to_storage_json(val: &VmValue) -> serde_json::Value {
         VmValue::Dict(map) => {
             let obj: serde_json::Map<String, serde_json::Value> = map
                 .iter()
-                .map(|(k, v)| (k.clone(), vm_to_storage_json(v)))
+                .map(|(k, v)| (k.to_string(), vm_to_storage_json(v)))
                 .collect();
             serde_json::Value::Object(obj)
         }

--- a/crates/harn-vm/src/vm/debug.rs
+++ b/crates/harn-vm/src/vm/debug.rs
@@ -271,7 +271,11 @@ impl Vm {
     /// `completions` (#109) so the REPL autocomplete surfaces
     /// everything the unified evaluator can reach.
     pub fn identifiers_in_scope(&self, _frame_id: usize) -> Vec<String> {
-        let mut out: Vec<String> = self.visible_variables().keys().cloned().collect();
+        let mut out: Vec<String> = self
+            .visible_variables()
+            .keys()
+            .map(|k| k.to_string())
+            .collect();
         out.extend(self.builtins.keys().cloned());
         out.extend(self.async_builtins.keys().cloned());
         out.sort();

--- a/crates/harn-vm/src/vm/iter.rs
+++ b/crates/harn-vm/src/vm/iter.rs
@@ -221,7 +221,7 @@ impl VmIter {
             VmIter::Dict { entries, keys, idx } => {
                 if *idx < keys.len() {
                     let k = &keys[*idx];
-                    let v = entries.get(k).cloned().unwrap_or(VmValue::Nil);
+                    let v = entries.get(k.as_str()).cloned().unwrap_or(VmValue::Nil);
                     *idx += 1;
                     Ok(Some(VmValue::Pair(std::sync::Arc::new((
                         VmValue::String(arcstr::ArcStr::from(k.as_str())),
@@ -1171,7 +1171,7 @@ pub fn iter_from_value(v: VmValue) -> Result<VmValue, VmError> {
             idx: 0,
         },
         VmValue::Dict(entries) => {
-            let keys: Vec<String> = entries.keys().cloned().collect();
+            let keys: Vec<String> = entries.keys().map(|k| k.to_string()).collect();
             VmIter::Dict {
                 entries,
                 keys,

--- a/crates/harn-vm/src/vm/methods/dict.rs
+++ b/crates/harn-vm/src/vm/methods/dict.rs
@@ -26,9 +26,14 @@ impl crate::vm::Vm {
             ))),
             "entries" => Ok(VmValue::List(std::sync::Arc::new(Self::dict_entries(map)))),
             "count" => Ok(VmValue::Int(map.len() as i64)),
-            "has" => Ok(VmValue::Bool(map.contains_key(
-                &args.first().map(|a| a.display()).unwrap_or_default(),
-            ))),
+            "has" => Ok(VmValue::Bool(
+                map.contains_key(
+                    args.first()
+                        .map(|a| a.display())
+                        .unwrap_or_default()
+                        .as_str(),
+                ),
+            )),
             "merge" => {
                 if let Some(VmValue::Dict(other)) = args.first() {
                     if map.is_empty() {
@@ -53,13 +58,13 @@ impl crate::vm::Vm {
             "remove" => {
                 let key = args.first().map(|a| a.display()).unwrap_or_default();
                 let mut result = (**map).clone();
-                result.remove(&key);
+                result.remove(key.as_str());
                 Ok(VmValue::dict(result))
             }
             "get" => {
                 let key = args.first().map(|a| a.display()).unwrap_or_default();
                 let default = args.get(1).cloned().unwrap_or(VmValue::Nil);
-                Ok(map.get(&key).cloned().unwrap_or(default))
+                Ok(map.get(key.as_str()).cloned().unwrap_or(default))
             }
             "to_dict" => Ok(VmValue::Dict(Arc::clone(map))),
             "to_list" => Ok(VmValue::List(std::sync::Arc::new(Self::dict_entries(map)))),

--- a/crates/harn-vm/src/vm/methods/list.rs
+++ b/crates/harn-vm/src/vm/methods/list.rs
@@ -344,8 +344,11 @@ impl crate::vm::Vm {
                             break;
                         }
                     };
-                    let current = counts.get(&bucket).and_then(|v| v.as_int()).unwrap_or(0);
-                    counts.insert(bucket, VmValue::Int(current + 1));
+                    let current = counts
+                        .get(bucket.as_str())
+                        .and_then(|v| v.as_int())
+                        .unwrap_or(0);
+                    counts.insert(crate::value::intern_key(&bucket), VmValue::Int(current + 1));
                 }
                 if let Some(err) = error {
                     Err(err)
@@ -526,7 +529,12 @@ impl crate::vm::Vm {
                 }
                 let result: crate::value::DictMap = groups
                     .into_iter()
-                    .map(|(k, v)| (k, VmValue::List(std::sync::Arc::new(v))))
+                    .map(|(k, v)| {
+                        (
+                            crate::value::intern_key(&k),
+                            VmValue::List(std::sync::Arc::new(v)),
+                        )
+                    })
                     .collect();
                 Ok(VmValue::dict(result))
             }
@@ -604,7 +612,7 @@ impl crate::vm::Vm {
             }
             "count_by" => {
                 let Some(callable) = args.first().filter(|v| Self::is_callable_value(v)) else {
-                    return Ok(VmValue::dict(BTreeMap::new()));
+                    return Ok(VmValue::dict_map(Default::default()));
                 };
                 let mut counts: BTreeMap<String, i64> = BTreeMap::new();
                 for item in items.iter() {
@@ -616,7 +624,7 @@ impl crate::vm::Vm {
                 Ok(VmValue::dict(
                     counts
                         .into_iter()
-                        .map(|(k, v)| (k, VmValue::Int(v)))
+                        .map(|(k, v)| (crate::value::intern_key(&k), VmValue::Int(v)))
                         .collect::<crate::value::DictMap>(),
                 ))
             }

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -388,9 +388,10 @@ impl super::super::Vm {
             (MethodCacheTarget::DictCount, VmValue::Dict(map)) => {
                 Some(VmValue::Int(map.len() as i64))
             }
-            (MethodCacheTarget::DictHas, VmValue::Dict(map)) => Some(VmValue::Bool(
-                map.contains_key(&args.first().map(|arg| arg.display()).unwrap_or_default()),
-            )),
+            (MethodCacheTarget::DictHas, VmValue::Dict(map)) => {
+                let key = args.first().map(|arg| arg.display()).unwrap_or_default();
+                Some(VmValue::Bool(map.contains_key(key.as_str())))
+            }
             (MethodCacheTarget::RangeCount | MethodCacheTarget::RangeLen, VmValue::Range(r)) => {
                 Some(VmValue::Int(r.len()))
             }

--- a/crates/harn-vm/src/vm/ops/collections.rs
+++ b/crates/harn-vm/src/vm/ops/collections.rs
@@ -299,7 +299,10 @@ impl super::super::Vm {
             (VmValue::Dict(map), VmValue::String(key)) => {
                 map.get(key.as_str()).cloned().unwrap_or(VmValue::Nil)
             }
-            (VmValue::Dict(map), _) => map.get(&idx.display()).cloned().unwrap_or(VmValue::Nil),
+            (VmValue::Dict(map), _) => map
+                .get(idx.display().as_str())
+                .cloned()
+                .unwrap_or(VmValue::Nil),
             (VmValue::Range(r), VmValue::Int(i)) => {
                 let len = r.len();
                 let pos = if *i < 0 { len + *i } else { *i };
@@ -500,7 +503,7 @@ impl super::super::Vm {
             match obj {
                 VmValue::Dict(map) => {
                     let mut new_map = (*map).clone();
-                    new_map.insert(prop_name.to_string(), new_value);
+                    new_map.insert(crate::value::intern_key(prop_name), new_value);
                     assign_value(self, VmValue::dict(new_map))?;
                 }
                 VmValue::StructInstance(_) => {
@@ -554,7 +557,7 @@ impl super::super::Vm {
                     return Ok(());
                 }
                 VmValue::Dict(map) => {
-                    let key = index.display();
+                    let key = crate::value::intern_key(&index.display());
                     if let Some(previous) = Arc::make_mut(map).insert(key, new_value) {
                         crate::value::recursion::dismantle(previous);
                     }
@@ -583,7 +586,7 @@ impl super::super::Vm {
                         .assign(var_name, VmValue::List(std::sync::Arc::new(new_items)))?;
                 }
                 VmValue::Dict(map) => {
-                    let key = index.display();
+                    let key = crate::value::intern_key(&index.display());
                     let mut new_map = Arc::try_unwrap(map).unwrap_or_else(|map| (*map).clone());
                     new_map.insert(key, new_value);
                     self.env.assign(var_name, VmValue::dict(new_map))?;
@@ -625,7 +628,9 @@ impl super::super::Vm {
         }
 
         if let VmValue::Dict(map) = &mut slot.value {
-            if let Some(previous) = Arc::make_mut(map).insert(prop_name.to_string(), new_value) {
+            if let Some(previous) =
+                Arc::make_mut(map).insert(crate::value::intern_key(prop_name), new_value)
+            {
                 crate::value::recursion::dismantle(previous);
             }
             slot.synced = false;
@@ -688,7 +693,7 @@ impl super::super::Vm {
                 Ok(())
             }
             VmValue::Dict(map) => {
-                let key = index.display();
+                let key = crate::value::intern_key(&index.display());
                 if let Some(previous) = Arc::make_mut(map).insert(key, new_value) {
                     crate::value::recursion::dismantle(previous);
                 }

--- a/crates/harn-vm/src/vm/ops/comparison.rs
+++ b/crates/harn-vm/src/vm/ops/comparison.rs
@@ -33,7 +33,7 @@ impl super::super::Vm {
             VmValue::List(items) => items.iter().any(|v| values_equal(v, &item)),
             VmValue::Dict(map) => {
                 let key = item.display();
-                map.contains_key(&key)
+                map.contains_key(key.as_str())
             }
             VmValue::Set(items) => items.iter().any(|v| values_equal(v, &item)),
             VmValue::Range(r) => match &item {

--- a/crates/harn-vm/src/vm/ops/iter.rs
+++ b/crates/harn-vm/src/vm/ops/iter.rs
@@ -39,7 +39,7 @@ impl super::super::Vm {
                     .push(super::super::IterState::Vec { items, idx: 0 });
             }
             VmValue::Dict(map) => {
-                let keys = map.keys().cloned().collect();
+                let keys = map.keys().map(|k| k.to_string()).collect();
                 self.iterators.push(super::super::IterState::Dict {
                     entries: map,
                     keys,
@@ -131,13 +131,13 @@ impl super::super::Vm {
             Some(super::super::IterState::Dict { entries, keys, idx }) => {
                 if *idx < keys.len() {
                     let key = &keys[*idx];
-                    let value = entries.get(key).cloned().unwrap_or(VmValue::Nil);
+                    let value = entries.get(key.as_str()).cloned().unwrap_or(VmValue::Nil);
                     let entry_key = VmValue::String(arcstr::ArcStr::from(key.as_str()));
                     *idx += 1;
                     self.stack
                         .push(VmValue::dict(crate::value::DictMap::from_iter([
-                            ("key".to_string(), entry_key),
-                            ("value".to_string(), value),
+                            (crate::value::intern_key("key"), entry_key),
+                            (crate::value::intern_key("value"), value),
                         ])));
                 } else {
                     self.iterators.pop();
@@ -374,8 +374,8 @@ mod tests {
     fn iter_init_dict_keeps_shared_entries_and_snapshots_keys() {
         run_iter_init_test(async {
             let entries = Arc::new(crate::value::DictMap::from_iter([
-                ("a".to_string(), VmValue::Int(1)),
-                ("b".to_string(), VmValue::Int(2)),
+                (crate::value::intern_key("a"), VmValue::Int(1)),
+                (crate::value::intern_key("b"), VmValue::Int(2)),
             ]));
             let mut vm = Vm::new();
             vm.stack.push(VmValue::Dict(entries.clone()));

--- a/crates/harn-vm/src/vm/ops/stack.rs
+++ b/crates/harn-vm/src/vm/ops/stack.rs
@@ -87,7 +87,7 @@ impl super::super::Vm {
                 all_vars.entry(k.clone()).or_insert_with(|| v.clone());
             }
             // Include builtin names so typos on builtin refs get suggestions.
-            let mut candidates: Vec<String> = all_vars.keys().cloned().collect();
+            let mut candidates: Vec<String> = all_vars.keys().map(|k| k.to_string()).collect();
             candidates.extend(self.builtins.keys().cloned());
             candidates.extend(self.async_builtins.keys().cloned());
             if let Some(suggestion) =

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -466,7 +466,7 @@ impl Vm {
         };
         for (slot, info) in frame.local_slots.iter().zip(frame.chunk.local_slots.iter()) {
             if slot.initialized && info.scope_depth <= frame.local_scope_depth {
-                vars.insert(info.name.clone(), slot.value.clone());
+                vars.insert(crate::value::intern_key(&info.name), slot.value.clone());
             }
         }
         vars
@@ -851,7 +851,7 @@ impl Vm {
     /// Set a global constant (e.g. `pi`, `e`).
     /// Stored separately from the environment so user-defined variables can shadow them.
     pub fn set_global(&mut self, name: &str, value: VmValue) {
-        Arc::make_mut(&mut self.globals).insert(name.to_string(), value);
+        Arc::make_mut(&mut self.globals).insert(crate::value::intern_key(name), value);
     }
 
     /// Read a previously-installed global (the value `set_global` /

--- a/crates/harn-vm/src/workspace_anchor.rs
+++ b/crates/harn-vm/src/workspace_anchor.rs
@@ -271,7 +271,7 @@ mod tests {
 
     #[test]
     fn parse_anchor_dict_rejects_missing_primary() {
-        let dict = VmValue::dict(BTreeMap::new());
+        let dict = VmValue::dict_map(Default::default());
         let err = parse_anchor_dict(&dict).expect_err("missing primary should fail");
         assert!(err.contains("primary"));
     }

--- a/perf/llm/bench_llm_options_roundtrip.rs
+++ b/perf/llm/bench_llm_options_roundtrip.rs
@@ -37,30 +37,36 @@ fn override_value(index: usize) -> VmValue {
 
 fn provider_overrides() -> VmValue {
     let mut overrides = harn_vm::value::DictMap::new();
-    overrides.insert("override_000".to_string(), override_value(0));
+    overrides.insert(
+        harn_vm::value::intern_key("override_000"),
+        override_value(0),
+    );
     dict(overrides)
 }
 
 fn build_options(key_count: usize) -> harn_vm::value::DictMap {
     let mut options = harn_vm::value::DictMap::new();
-    options.insert("provider".to_string(), string("mock"));
+    options.insert(harn_vm::value::intern_key("provider"), string("mock"));
 
     if key_count >= 2 {
-        options.insert("model".to_string(), string("gpt-4o-mini"));
+        options.insert(harn_vm::value::intern_key("model"), string("gpt-4o-mini"));
     }
     if key_count >= 3 {
-        options.insert("stream".to_string(), VmValue::Bool(false));
+        options.insert(harn_vm::value::intern_key("stream"), VmValue::Bool(false));
     }
     if key_count >= 4 {
-        options.insert("max_tokens".to_string(), VmValue::Int(512));
+        options.insert(harn_vm::value::intern_key("max_tokens"), VmValue::Int(512));
     }
     if key_count >= 5 {
-        options.insert("mock".to_string(), provider_overrides());
+        options.insert(harn_vm::value::intern_key("mock"), provider_overrides());
     }
 
     while options.len() < key_count {
         let index = options.len();
-        options.insert(format!("passthrough_{index:03}"), override_value(index));
+        options.insert(
+            harn_vm::value::intern_key(&format!("passthrough_{index:03}")),
+            override_value(index),
+        );
     }
 
     options


### PR DESCRIPTION
## What

The map backing every `VmValue::Dict` changes from `OrdMap<String, VmValue>` to **`OrdMap<HarnStr, VmValue>`** (the thin one-word `arcstr::ArcStr` introduced by the value shrink), and keys flow through a new **bounded interner**, `harn_vm::value::intern_key`.

Agent workloads are dict-heavy — the same field names (`role`, `content`, `arguments`, `tool_calls`, …) recur across thousands of message/JSON dicts. Each recurring key now shares a single allocation (a refcount bump) instead of allocating a fresh `String` per key, and dict tree nodes hold an 8-byte key instead of a 24-byte one.

## Safety: the interner is bounded

Keys up to 64 bytes, at most 8192 distinct entries. High-cardinality or adversarial keys (UUIDs, user-controlled keys) fall back to a plain allocation and **can never grow the table without bound**.

## Ergonomics preserved

`VmValue::dict(...)` keeps accepting the `BTreeMap<String, _>` / `DictMap` maps callers already build, via a new `IntoDictKey` trait — it interns owned `String`/`&str` keys on the way in and passes an already-shared `HarnStr` straight through (no re-intern). Reads by `&str` literal still work (`ArcStr: Borrow<str>`); `&String` queries use `.as_str()`; dict keys crossing into `serde_json` / `String`-keyed maps convert with `.to_string()`.

No `harn` language behavior changes — this is an internal representation change. Builds on #3461 (16-byte `VmValue`).

## Validation

- Workspace builds clean; `cargo clippy --workspace --all-targets` clean (`-D warnings`).
- `harn-vm`: 3986 tests pass.
- Conformance: 1647 passed, 0 failed.
- Dependent crates (cli, serve, hostlib, dap, rules-hostlib): 2550 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)