### PR TITLE
feat(tools): bound tool contract + semantic alias resolution + actionable denials (cheap-model dialect)

### DIFF
--- a/changelog.d/tool-contract-bound-and-aliases.fixed.md
+++ b/changelog.d/tool-contract-bound-and-aliases.fixed.md
@@ -1,0 +1,25 @@
+- Cheap-model tool-call dialect: three fixes that stop advertised-only-tool
+  lanes (e.g. the Burin eval lane: `look`/`search`/`edit`/`run`/
+  `read_command_output`) from denying calls models emit in another harness's
+  vocabulary. (1) The tool-calling contract (both the text and fenced-JSON
+  prompts) now states under `## Available tools` that these are the ONLY callable
+  tools and that any unlisted name is rejected — pick the closest listed tool;
+  the JSON contract's worked `## Example` no longer primes the unlisted
+  `write_file` name (it now uses an illustrative `<tool>` placeholder). (2) The
+  tool-name normalizer resolves SEMANTIC aliases to canonical Harn tools so the
+  gate, dispatch, and telemetry all see a real name: `repo_browser.*` /
+  `repository_browser.*` / `workspace_browser.*` / `file_browser.*` file/list
+  verbs → `look`, their search/find/grep verbs → `search`; `container.exec` /
+  `container_exec` / `exec` / `sh` / `shell` / `bash` → `run` (remapping a
+  `script` / `cmd` arg onto `command`); and edit-action verbs called as
+  top-level tools (`replace_range`, `replace_body`, `insert_after`,
+  `insert_function`, `delete_range`, `exact_patch`, `add_import`) →
+  `edit({ action: <verb>, … })`. Raw-write/whole-file tools (`write_file` /
+  `delete_file` / `patch_file`) are deliberately NOT aliased to `edit` — they are
+  semantically lossy — and the symbol-level edit tools (`replace_symbol` /
+  `remove_symbol`) are NOT folded into `edit` either, since `replace_symbol` is a
+  hard-kept standalone tool in the default surface; all fall through to the
+  denial feedback instead. (3) The permission-denial feedback now NAMES the active
+  policy's allowed tools (`… Available tools: look, search, edit, run,
+  read_command_output.`) so the model can self-correct in one turn. Sibling to
+  the `tool.`/`functions.` namespace-prefix strip.

--- a/crates/harn-stdlib/src/stdlib/agent/prompts/tool_contract_json.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/agent/prompts/tool_contract_json.harn.prompt
@@ -29,14 +29,16 @@ Rules the runtime enforces:
 
 ## Available tools
 
+These are the only tools you can call. Any name not listed here will be rejected — choose the closest listed tool instead.
+
 {{ expanded_schemas }}
 
-## Example
+## Example (illustrative shape only — `<tool>` stands in for a real tool from the list above)
 
-A file whose content contains a backtick code block survives untouched because it rides inside the JSON string:
+Content that contains a backtick code block survives untouched because it rides inside the JSON string:
 
 ```tool
-{ "name": "write_file", "args": { "path": "README.md", "content": "# Title\n\nUse a fenced block:\n\n```sh\necho hi\n```\n\nDone.\n" } }
+{ "name": "<tool>", "args": { "path": "README.md", "content": "# Title\n\nUse a fenced block:\n\n```sh\necho hi\n```\n\nDone.\n" } }
 ```
 {{ if done_sentinel }}
 After the work is verified, finish with plain text and the sentinel:

--- a/crates/harn-stdlib/src/stdlib/agent/prompts/tool_contract_text.harn.prompt
+++ b/crates/harn-stdlib/src/stdlib/agent/prompts/tool_contract_text.harn.prompt
@@ -28,6 +28,8 @@ Active mode: `{{ mode }}`. Follow this runtime-owned contract even if older prom
 
 {{ end }}## Available tools
 
+These are the only tools you can call. Any name not listed here (or below under "Other tools") will be rejected — choose the closest listed tool instead.
+
 {{ expanded_schemas }}
 {{ if compact_schemas }}
 ## Other tools (call directly. Parameters are intuitive, or call tool_schema for details)

--- a/crates/harn-vm/src/llm/agent_tools.rs
+++ b/crates/harn-vm/src/llm/agent_tools.rs
@@ -27,10 +27,23 @@ pub(super) fn denied_tool_result(tool_name: &str, reason: impl Into<String>) -> 
     // will be blocked again. Recoverable rejections (bad/missing arguments, an
     // empty tool name) must NOT use this body: see `recoverable_tool_result`,
     // which coaches a retry *with the correction* instead.
+    // Name the tools that ARE callable so the model can self-correct in one
+    // turn instead of re-issuing the denied call or guessing another unlisted
+    // name (live fw-gpt-oss-120b transcripts: cheap models emit Codex/container
+    // vocab they were never shown, read a bare denial, and thrash). The active
+    // policy's allowlist is the source of truth; omit the clause when the
+    // surface is unbounded (allow-all) so we never assert a misleading list.
+    let allowed = crate::orchestration::current_allowed_tool_names();
+    let available_clause = if allowed.is_empty() {
+        String::new()
+    } else {
+        format!(" Available tools: {}.", allowed.join(", "))
+    };
     let next_step = format!(
         "The `{tool_name}` tool is not permitted right now. Do not retry the same call. \
          Make progress with the tools you are allowed to use, or if this capability is \
-         essential, briefly tell the user what you need permission for and why."
+         essential, briefly tell the user what you need permission for and why.\
+         {available_clause}"
     );
     serde_json::json!({
         "error": "permission_denied",
@@ -680,6 +693,49 @@ mod tests {
             next.contains("run"),
             "next_step should name the denied tool: {next}"
         );
+        // No active policy → no allow-all list to assert, so the "Available
+        // tools:" clause is omitted rather than claiming a misleading set.
+        assert!(
+            !next.contains("Available tools:"),
+            "with no active policy the denial should not assert an allow list: {next}"
+        );
+    }
+
+    // F3: when an execution policy advertises an explicit tool allowlist, the
+    // denial must NAME those tools so a cheap model can self-correct in one turn
+    // instead of re-emitting an unlisted name. Grounded in fw-gpt-oss-120b
+    // transcripts where the model called Codex/container vocab it was never
+    // shown and only saw a bare "not permitted" denial.
+    #[test]
+    fn denied_tool_result_names_available_tools_under_policy() {
+        use crate::orchestration::{pop_execution_policy, push_execution_policy, CapabilityPolicy};
+
+        push_execution_policy(CapabilityPolicy {
+            tools: vec![
+                "look".to_string(),
+                "search".to_string(),
+                "edit".to_string(),
+                "run".to_string(),
+                "read_command_output".to_string(),
+            ],
+            ..Default::default()
+        });
+        let result = denied_tool_result("repo_browser.open_file", "tool exceeds tool ceiling");
+        pop_execution_policy();
+
+        let next = result["next_step"]
+            .as_str()
+            .expect("denial should carry a next_step string");
+        assert!(
+            next.contains("Available tools:"),
+            "next_step should name the allowed tools under an active policy: {next}"
+        );
+        for tool in ["look", "search", "edit", "run", "read_command_output"] {
+            assert!(
+                next.contains(tool),
+                "next_step should list the allowed tool {tool}: {next}"
+            );
+        }
     }
 
     // A RECOVERABLE schema/argument rejection must coach a retry WITH the

--- a/crates/harn-vm/src/llm/tools/compat.rs
+++ b/crates/harn-vm/src/llm/tools/compat.rs
@@ -73,14 +73,13 @@ pub(crate) fn normalize_tool_call_shape(
     let normalized_name = normalize_tool_name(name);
     let is_marker_wrapper = is_harmony_marker_wrapper_name(&normalized_name);
     if !is_generic_wrapper_name(&normalized_name) && !is_marker_wrapper {
-        return (recover_namespaced_name(normalized_name), arguments);
+        let recovered = recover_namespaced_name(normalized_name);
+        return resolve_semantic_alias(recovered, arguments);
     }
 
     if let Some((inner_name, inner_arguments)) = unwrap_generic_tool_arguments(&arguments) {
-        return (
-            recover_namespaced_name(normalize_tool_name(&inner_name)),
-            inner_arguments,
-        );
+        let recovered = recover_namespaced_name(normalize_tool_name(&inner_name));
+        return resolve_semantic_alias(recovered, inner_arguments);
     }
 
     if is_marker_wrapper {
@@ -90,6 +89,146 @@ pub(crate) fn normalize_tool_call_shape(
     }
 
     (normalized_name, arguments)
+}
+
+/// Canonicalize SEMANTIC tool aliases that cheap models emit even though the
+/// name was never advertised, so the gate, dispatch, and telemetry all see a
+/// real Harn tool name. Grounded in live fw-gpt-oss-120b denial transcripts:
+/// Codex `repo_browser.*` vocab, `container.exec`, and edit-action verbs called
+/// as top-level tools. The targets here (`look`, `search`, `run`, `edit`) are
+/// the canonical Harn coding tools the executor recognizes, so the rewrite is
+/// safe without a per-turn allowed-tool set.
+///
+/// NOT mapped, deliberately: `write_file` / `delete_file` / `patch_file` →
+/// `edit`. Those are semantically lossy (`edit` is a structured-patch tool with
+/// no raw-write/whole-file-create semantics); silently rewriting them would
+/// rename a call then fail arg validation. They are left UNmapped so the
+/// actionable denial feedback (naming the available tools) can guide the model.
+fn resolve_semantic_alias(
+    name: String,
+    arguments: serde_json::Value,
+) -> (String, serde_json::Value) {
+    // 1. Browser-namespace aliases (Codex / Aider-style file-explorer vocab).
+    //    Strip a known `*_browser.` prefix, then map the verb to look/search.
+    if let Some((canonical, mapped_args)) = resolve_browser_alias(&name, &arguments) {
+        return (canonical, mapped_args);
+    }
+
+    // 2. Shell/exec aliases → run. Remap a command-shaped arg key onto
+    //    `command` so the rename doesn't then fail run's arg validation.
+    if is_shell_alias(&name) {
+        return ("run".to_string(), remap_command_args(arguments));
+    }
+
+    // 3. Edit-action verbs called as top-level tools → edit({action: <verb>}).
+    if is_edit_action_verb(&name) {
+        return ("edit".to_string(), remap_edit_action_args(&name, arguments));
+    }
+
+    (name, arguments)
+}
+
+/// Known file-explorer namespace prefixes cheap models borrow from other
+/// harnesses (Codex `repo_browser.*`, plus the obvious siblings).
+const BROWSER_NAMESPACE_PREFIXES: &[&str] = &[
+    "repo_browser.",
+    "repository_browser.",
+    "workspace_browser.",
+    "file_browser.",
+];
+
+fn resolve_browser_alias(
+    name: &str,
+    arguments: &serde_json::Value,
+) -> Option<(String, serde_json::Value)> {
+    let verb = BROWSER_NAMESPACE_PREFIXES
+        .iter()
+        .find_map(|prefix| name.strip_prefix(prefix))?
+        .trim();
+    if verb.is_empty() {
+        return None;
+    }
+    let canonical = match verb {
+        "open_file" | "view_file" | "cat_file" | "read_file" | "print_tree" | "list_tree"
+        | "list_dir" | "list_directory" | "ls" => "look",
+        "search" | "find" | "grep" => "search",
+        // `*.bundle` is left for downstream recovery: `bundle` is not a
+        // universally registered tool, so rewriting to it could itself trip the
+        // ceiling. Keep the prefix-stripped bare name so the denial feedback can
+        // guide the model rather than silently producing another unknown tool.
+        _ => return Some((verb.to_string(), arguments.clone())),
+    };
+    Some((canonical.to_string(), arguments.clone()))
+}
+
+fn is_shell_alias(name: &str) -> bool {
+    matches!(
+        name,
+        "container.exec" | "container_exec" | "exec" | "sh" | "shell" | "bash"
+    )
+}
+
+/// Move a command-shaped argument (`script` / `cmd`) onto `command` so the
+/// remapped `run` call passes arg validation. Leaves an already-`command`-shaped
+/// or unrecognized object untouched.
+fn remap_command_args(arguments: serde_json::Value) -> serde_json::Value {
+    let serde_json::Value::Object(mut map) = arguments else {
+        return arguments;
+    };
+    if map.contains_key("command") {
+        return serde_json::Value::Object(map);
+    }
+    for key in ["script", "cmd"] {
+        if let Some(value) = map.remove(key) {
+            map.insert("command".to_string(), value);
+            break;
+        }
+    }
+    serde_json::Value::Object(map)
+}
+
+/// Edit-action verbs that exist ONLY as `edit({ action: <verb> })` enum values,
+/// never as standalone advertised tool names — so folding a top-level call of
+/// one into `edit` cannot shadow a real tool.
+///
+/// `replace_symbol` / `remove_symbol` are deliberately EXCLUDED: `replace_symbol`
+/// is a hard-kept standalone tool name in Harn's default agent tool surface
+/// (`__default_tool_surface_hard_keep`), so a top-level `replace_symbol` call is
+/// a LEGITIMATE call the gate allows — rewriting it to `edit` would shadow a
+/// real tool and lose the symbol-level semantics. `remove_symbol` is excluded
+/// for the same symbol-tool symmetry. Both fall through unmapped.
+const EDIT_ACTION_VERBS: &[&str] = &[
+    "replace_range",
+    "replace_body",
+    "insert_after",
+    "insert_function",
+    "delete_range",
+    "exact_patch",
+    "add_import",
+];
+
+fn is_edit_action_verb(name: &str) -> bool {
+    EDIT_ACTION_VERBS.contains(&name)
+}
+
+/// Fold an edit-action-verb-as-tool into `edit({ action: <verb>, ...rest })`.
+/// The verb's own arguments ride through unchanged under the `edit` envelope;
+/// only the `action` key is injected (an existing `action` is preserved).
+fn remap_edit_action_args(verb: &str, arguments: serde_json::Value) -> serde_json::Value {
+    let mut map = match arguments {
+        serde_json::Value::Object(map) => map,
+        serde_json::Value::Null => serde_json::Map::new(),
+        other => {
+            // Non-object args can't carry an `action` key; wrap defensively so
+            // the rename still produces a valid edit envelope shape.
+            let mut map = serde_json::Map::new();
+            map.insert("value".to_string(), other);
+            map
+        }
+    };
+    map.entry("action".to_string())
+        .or_insert_with(|| serde_json::Value::String(verb.to_string()));
+    serde_json::Value::Object(map)
 }
 
 fn is_generic_wrapper_name(name: &str) -> bool {
@@ -278,5 +417,146 @@ mod tests {
 
         assert_eq!(name, "look");
         assert_eq!(normalized_arguments, arguments);
+    }
+
+    // ── F2: semantic alias resolution (cheap-model dialect) ──────────────
+
+    #[test]
+    fn aliases_repo_browser_open_file_to_look() {
+        let args = serde_json::json!({"path": "src/lib.rs"});
+        let (name, mapped) = normalize_tool_call_shape("repo_browser.open_file", args.clone());
+        assert_eq!(name, "look");
+        assert_eq!(mapped, args);
+    }
+
+    #[test]
+    fn aliases_repo_browser_list_dir_to_look() {
+        let (name, _) = normalize_tool_call_shape("repo_browser.list_dir", serde_json::json!({}));
+        assert_eq!(name, "look");
+        // Sibling prefixes resolve the same way.
+        let (name, _) = normalize_tool_call_shape("file_browser.print_tree", serde_json::json!({}));
+        assert_eq!(name, "look");
+    }
+
+    #[test]
+    fn aliases_repo_browser_search_to_search() {
+        let args = serde_json::json!({"query": "needle"});
+        let (name, mapped) = normalize_tool_call_shape("repository_browser.grep", args.clone());
+        assert_eq!(name, "search");
+        assert_eq!(mapped, args);
+    }
+
+    #[test]
+    fn browser_bundle_is_left_for_downstream_recovery() {
+        // `bundle` is not universally registered; rewriting to it could itself
+        // trip the ceiling. The prefix is stripped but the verb is left bare so
+        // the actionable denial feedback can guide the model.
+        let (name, _) =
+            normalize_tool_call_shape("workspace_browser.bundle", serde_json::json!({}));
+        assert_eq!(name, "bundle");
+    }
+
+    #[test]
+    fn aliases_container_exec_to_run_remapping_command_arg() {
+        let (name, mapped) =
+            normalize_tool_call_shape("container.exec", serde_json::json!({"cmd": "cargo test"}));
+        assert_eq!(name, "run");
+        // `cmd` is remapped onto `command` so run's arg validation passes.
+        assert_eq!(mapped["command"], "cargo test");
+        assert!(mapped.get("cmd").is_none());
+    }
+
+    #[test]
+    fn aliases_shell_synonyms_to_run() {
+        for alias in ["exec", "sh", "shell", "bash", "container_exec"] {
+            let (name, mapped) =
+                normalize_tool_call_shape(alias, serde_json::json!({"script": "ls"}));
+            assert_eq!(name, "run", "alias {alias} should map to run");
+            assert_eq!(mapped["command"], "ls", "alias {alias} should remap script");
+        }
+    }
+
+    #[test]
+    fn run_alias_leaves_existing_command_arg_untouched() {
+        let (name, mapped) = normalize_tool_call_shape(
+            "exec",
+            serde_json::json!({"command": "ls", "cmd": "ignored"}),
+        );
+        assert_eq!(name, "run");
+        assert_eq!(mapped["command"], "ls");
+    }
+
+    #[test]
+    fn aliases_edit_action_verb_to_edit_with_action_arg() {
+        let (name, mapped) = normalize_tool_call_shape(
+            "replace_range",
+            serde_json::json!({"path": "a.go", "range_start": 3, "range_end": 5}),
+        );
+        assert_eq!(name, "edit");
+        assert_eq!(mapped["action"], "replace_range");
+        assert_eq!(mapped["path"], "a.go");
+        assert_eq!(mapped["range_start"], 3);
+    }
+
+    #[test]
+    fn edit_action_verb_preserves_explicit_action() {
+        // A pre-existing `action` is not clobbered by the verb.
+        let (name, mapped) = normalize_tool_call_shape(
+            "replace_body",
+            serde_json::json!({"action": "replace_range", "path": "a.go"}),
+        );
+        assert_eq!(name, "edit");
+        assert_eq!(mapped["action"], "replace_range");
+    }
+
+    #[test]
+    fn all_edit_action_verbs_map_to_edit() {
+        for verb in [
+            "replace_range",
+            "replace_body",
+            "insert_after",
+            "insert_function",
+            "delete_range",
+            "exact_patch",
+            "add_import",
+        ] {
+            let (name, mapped) = normalize_tool_call_shape(verb, serde_json::json!({}));
+            assert_eq!(name, "edit", "verb {verb} should map to edit");
+            assert_eq!(mapped["action"], verb);
+        }
+    }
+
+    // NEGATIVE: `replace_symbol` is a hard-kept STANDALONE tool in Harn's default
+    // surface, so a top-level call is legitimate and must NOT be folded into
+    // `edit` (which would shadow the real tool). `remove_symbol` is excluded for
+    // the same symbol-tool symmetry.
+    #[test]
+    fn does_not_alias_symbol_edit_tools() {
+        let (name, mapped) =
+            normalize_tool_call_shape("replace_symbol", serde_json::json!({"symbol": "Foo"}));
+        assert_eq!(name, "replace_symbol");
+        assert!(mapped.get("action").is_none());
+
+        let (name, _) = normalize_tool_call_shape("remove_symbol", serde_json::json!({}));
+        assert_eq!(name, "remove_symbol");
+    }
+
+    // NEGATIVE: raw-write / whole-file tools are semantically lossy against
+    // `edit` (no raw-write semantics), so they must NOT be silently rewritten.
+    // Leaving them unmapped lets the actionable denial feedback guide the model.
+    #[test]
+    fn does_not_alias_write_file_to_edit() {
+        let args = serde_json::json!({"path": "README.md", "content": "hi"});
+        let (name, mapped) = normalize_tool_call_shape("write_file", args.clone());
+        assert_eq!(name, "write_file");
+        assert_eq!(mapped, args);
+    }
+
+    #[test]
+    fn does_not_alias_delete_file_or_patch_file() {
+        let (name, _) = normalize_tool_call_shape("delete_file", serde_json::json!({}));
+        assert_eq!(name, "delete_file");
+        let (name, _) = normalize_tool_call_shape("patch_file", serde_json::json!({}));
+        assert_eq!(name, "patch_file");
     }
 }

--- a/crates/harn-vm/src/orchestration/policy/mod.rs
+++ b/crates/harn-vm/src/orchestration/policy/mod.rs
@@ -82,6 +82,23 @@ pub fn current_tool_annotations(tool: &str) -> Option<ToolAnnotations> {
     current_execution_policy().and_then(|policy| policy.tool_annotations.get(tool).cloned())
 }
 
+/// The explicit tool allowlist the active execution policy advertises, for
+/// building actionable denial feedback that names what the model *can* call.
+///
+/// Prefers `policy.tools` (the explicit ceiling — what the eval lane sets);
+/// falls back to the annotation registry keys when no explicit list is present.
+/// Returns an empty `Vec` when no policy is active or the surface is unbounded
+/// (allow-all), in which case callers keep their generic guidance.
+pub fn current_allowed_tool_names() -> Vec<String> {
+    let Some(policy) = current_execution_policy() else {
+        return Vec::new();
+    };
+    if !policy.tools.is_empty() {
+        return policy.tools;
+    }
+    policy.tool_annotations.keys().cloned().collect()
+}
+
 pub(super) fn tool_kind_participates_in_write_allowlist(tool_name: &str) -> bool {
     current_tool_annotations(tool_name)
         .map(|annotations| !annotations.kind.is_read_only())


### PR DESCRIPTION
## Why

Grounded in real fw-gpt-oss-120b eval transcripts: the Burin eval lane advertises exactly its allowed tools (`look`/`search`/`edit`/`run`/`read_command_output` + always-on), yet cheap models still emit tool names they were never shown — Codex `repo_browser.*` vocab, `container.exec`, edit-action verbs called as top-level tools — and the gate denies them with a bare `tool 'X' exceeds tool ceiling`. Two harness gaps cause this: the contract never tells the model these are the ONLY callable tools, and the gate does a raw name-equality check with no semantic alias resolution.

## What

**F1 — bound the toolset in the tool contract (both formats).** The text and fenced-JSON contracts now state under `## Available tools` that these are the only callable tools and any unlisted name is rejected (covering the expanded schemas and the optional `## Other tools` compact tier). The JSON contract's worked `## Example` no longer primes the unlisted `write_file` name; it uses an illustrative `<tool>` placeholder.

**F2 — semantic alias resolution** in `normalize_tool_call_shape` (the #3466 sibling normalizer), canonicalizing to real Harn tools so the gate, dispatch, and telemetry all see a canonical name, remapping args together with the name:
- `repo_browser.*` / `repository_browser.*` / `workspace_browser.*` / `file_browser.*`: file/list verbs → `look`, search/find/grep → `search`; `*.bundle` left bare for denial recovery (`bundle` isn't universally registered).
- `container.exec` / `container_exec` / `exec` / `sh` / `shell` / `bash` → `run` (remapping `script`/`cmd` → `command`).
- Edit-action verbs → `edit({ action: <verb> })`: `replace_range`, `replace_body`, `insert_after`, `insert_function`, `delete_range`, `exact_patch`, `add_import`.

Deliberately **NOT** aliased (lossy/colliding): `write_file` / `delete_file` / `patch_file` (no raw-write semantics in `edit`), and `replace_symbol` / `remove_symbol` — `replace_symbol` is a hard-kept standalone tool in the default surface (`__default_tool_surface_hard_keep`), so folding it would shadow a real tool. All fall through to F3's actionable denial.

**F3 — actionable denial feedback.** `denied_tool_result` now names the active policy's allowed tools (`… Available tools: look, search, edit, run, read_command_output.`) via a new `orchestration::current_allowed_tool_names()` accessor, so the model self-corrects in one turn. Omitted when the surface is unbounded (allow-all) to avoid asserting a misleading list.

## Tests

- `cargo test -p harn-vm --lib compat` — 109 pass (incl. one focused test per alias class + NEGATIVE tests that `write_file`/`delete_file`/`patch_file` and `replace_symbol`/`remove_symbol` are not rewritten).
- `cargo test -p harn-vm --lib llm::agent_tools` — 19 pass (incl. new F3 test asserting the available-tools clause under an active policy, and that no clause is asserted with no policy).
- `cargo test -p harn-vm --lib llm::tools` (229), `denied_tool_routing_tests` (6), `stdlib::template::tests` (49), `orchestration::policy` (68) — all pass.
- `cargo fmt --all --check` clean; `cargo clippy -p harn-vm --lib` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)