### PR TITLE
Support archive sources in the package registry

### DIFF
--- a/changelog.d/package-archive-sources.added.md
+++ b/changelog.d/package-archive-sources.added.md
@@ -1,0 +1,3 @@
+- **Package registry archive sources.** Registry entries can now resolve to
+  checksum-verified `.tar.gz` package archives, and private HTTP(S) registries
+  can use `HARN_PACKAGE_REGISTRY_TOKEN` for both index and archive fetches.

--- a/crates/harn-cli/src/package/lockfile.rs
+++ b/crates/harn-cli/src/package/lockfile.rs
@@ -292,10 +292,14 @@ pub(crate) fn compatible_locked_entry(
         }
         let version = parse_registry_semver(&registry.version)?;
         let req = parse_registry_version_req(requirement)?;
-        return Ok(req.matches(&version)
-            && lock.source.starts_with("git+")
-            && lock.commit.is_some()
-            && lock.content_hash.is_some());
+        let resolved_source_is_locked = if lock.source.starts_with("git+") {
+            lock.commit.is_some() && lock.content_hash.is_some()
+        } else if lock.source.starts_with("archive+") {
+            lock.content_hash.is_some()
+        } else {
+            false
+        };
+        return Ok(req.matches(&version) && resolved_source_is_locked);
     }
     if let Some(url) = dependency.git_url() {
         let source = format!("git+{}", normalize_git_url(url)?);
@@ -306,6 +310,10 @@ pub(crate) fn compatible_locked_entry(
             && lock.commit.is_some()
             && lock.content_hash.is_some());
     }
+    if let Some(url) = dependency.archive_url() {
+        let source = archive_source_uri(url)?;
+        return Ok(lock.source == source && lock.content_hash.is_some());
+    }
     Ok(false)
 }
 
@@ -315,7 +323,7 @@ pub(crate) struct PendingDependency {
     dependency: Dependency,
     manifest_dir: PathBuf,
     parent: Option<String>,
-    parent_is_git: bool,
+    parent_is_remote: bool,
 }
 
 pub(crate) fn git_rev_request(
@@ -336,6 +344,19 @@ pub(crate) fn dependency_git_request(dependency: &Dependency) -> Option<&str> {
         .branch()
         .or_else(|| dependency.rev())
         .or_else(|| dependency.tag())
+}
+
+pub(crate) fn dependency_content_hash(
+    alias: &str,
+    dependency: &Dependency,
+) -> Result<String, PackageError> {
+    let Dependency::Table(table) = dependency else {
+        return Err(format!("dependency {alias} is missing checksum").into());
+    };
+    table
+        .checksum
+        .clone()
+        .ok_or_else(|| format!("archive dependency {alias} must specify checksum").into())
 }
 
 pub(crate) fn dependency_manifest_dir(source: &Path) -> Option<PathBuf> {
@@ -509,7 +530,7 @@ pub(crate) fn enqueue_manifest_dependencies(
     manifest: Manifest,
     manifest_dir: PathBuf,
     parent: String,
-    parent_is_git: bool,
+    parent_is_remote: bool,
 ) {
     let mut aliases: Vec<String> = manifest.dependencies.keys().cloned().collect();
     aliases.sort();
@@ -520,7 +541,7 @@ pub(crate) fn enqueue_manifest_dependencies(
                 dependency,
                 manifest_dir: manifest_dir.clone(),
                 parent: Some(parent.clone()),
-                parent_is_git,
+                parent_is_remote,
             });
         }
     }
@@ -537,18 +558,43 @@ fn resolve_registry_version_dependency(
     if table.version.is_none() {
         return Ok(dependency);
     }
-    if table.git.is_some()
-        || table.path.is_some()
-        || table.rev.is_some()
-        || table.tag.is_some()
-        || table.branch.is_some()
+    registry_dependency_from_manifest_constraint_in(workspace, alias, table)
+}
+
+fn validate_dependency_source_shape(
+    alias: &str,
+    dependency: &Dependency,
+) -> Result<(), PackageError> {
+    let Dependency::Table(table) = dependency else {
+        return Ok(());
+    };
+    let source_count = usize::from(table.git.is_some())
+        + usize::from(table.archive.is_some())
+        + usize::from(table.path.is_some());
+    if table.version.is_some()
+        && (source_count > 0
+            || table.rev.is_some()
+            || table.tag.is_some()
+            || table.branch.is_some())
     {
         return Err(format!(
-            "dependency {alias} uses `version`; do not combine registry version constraints with git, path, tag, rev, or branch"
+            "dependency {alias} uses `version`; do not combine registry version constraints with git, archive, path, tag, rev, or branch"
         )
         .into());
     }
-    registry_dependency_from_manifest_constraint_in(workspace, alias, table)
+    if source_count > 1 {
+        return Err(
+            format!("dependency {alias} must specify only one of git, archive, or path").into(),
+        );
+    }
+    if table.archive.is_some()
+        && (table.tag.is_some() || table.rev.is_some() || table.branch.is_some())
+    {
+        return Err(
+            format!("archive dependency {alias} cannot specify tag, rev, or branch").into(),
+        );
+    }
+    Ok(())
 }
 
 pub(crate) fn build_lockfile(
@@ -580,7 +626,7 @@ pub(crate) fn build_lockfile(
             dependency,
             manifest_dir: ctx.dir.clone(),
             parent: None,
-            parent_is_git: false,
+            parent_is_remote: false,
         });
     }
 
@@ -588,10 +634,10 @@ pub(crate) fn build_lockfile(
         let alias = next.alias;
         validate_package_alias(&alias)?;
         let dependency = next.dependency;
-        if dependency.local_path().is_some() && next.parent_is_git {
-            let parent = next.parent.as_deref().unwrap_or("a git package");
+        if dependency.local_path().is_some() && next.parent_is_remote {
+            let parent = next.parent.as_deref().unwrap_or("a remote package");
             return Err(format!(
-                "package {parent} declares local path dependency {alias}, but path dependencies are not supported inside git-installed packages; publish {alias} as a git dependency with `tag`, `rev`, or `version`"
+                "package {parent} declares local path dependency {alias}, but path dependencies are not supported inside remote-installed packages; publish {alias} as a git or registry dependency"
             ).into());
         }
         if dependency.requires_git() {
@@ -600,6 +646,7 @@ pub(crate) fn build_lockfile(
                 git_rev_request(&alias, &dependency)?;
             }
         }
+        validate_dependency_source_shape(&alias, &dependency)?;
         let refresh = refresh_all || refresh_alias == Some(alias.as_str());
         if let Some(existing_lock) = existing.and_then(|lock| lock.find(&alias)) {
             if !refresh
@@ -669,6 +716,42 @@ pub(crate) fn build_lockfile(
                             );
                         }
                     }
+                } else if entry.source.starts_with("archive+") {
+                    let url = archive_url_from_source_uri(&entry.source)?;
+                    let expected_hash = entry
+                        .content_hash
+                        .as_deref()
+                        .ok_or_else(|| format!("missing content hash for {alias}"))?;
+                    ensure_archive_cache_populated_in(
+                        workspace,
+                        url,
+                        &entry.source,
+                        expected_hash,
+                        false,
+                        offline,
+                    )?;
+                    let cache_dir = archive_cache_dir_in(workspace, &entry.source, expected_hash)?;
+                    if entry.manifest_digest.is_none()
+                        || entry.package_version.is_none()
+                        || entry.provenance.is_none()
+                    {
+                        fill_provenance(&mut entry, read_lock_entry_provenance(&cache_dir)?);
+                    }
+                    if entry.registry.is_none() {
+                        entry.registry = dependency.registry_provenance();
+                    }
+                    let inserted = replace_lock_entry(&mut lock, entry.clone())?;
+                    if inserted {
+                        if let Some(manifest) = read_package_manifest_from_dir(&cache_dir)? {
+                            enqueue_manifest_dependencies(
+                                &mut pending,
+                                manifest,
+                                cache_dir,
+                                alias,
+                                true,
+                            );
+                        }
+                    }
                 } else if entry.source.starts_with("path+") {
                     let source = path_from_source_uri(&entry.source)?;
                     let manifest_dir = dependency_manifest_dir(&source);
@@ -706,6 +789,13 @@ pub(crate) fn build_lockfile(
         }
 
         let dependency = resolve_registry_version_dependency(workspace, &alias, dependency)?;
+        validate_dependency_source_shape(&alias, &dependency)?;
+        if dependency.requires_git() {
+            ensure_git_available()?;
+            if dependency.git_url().is_some() {
+                git_rev_request(&alias, &dependency)?;
+            }
+        }
 
         if let Some(path) = dependency.local_path() {
             let source = resolve_path_dependency_source(&next.manifest_dir, path)?;
@@ -745,6 +835,46 @@ pub(crate) fn build_lockfile(
                             false,
                         );
                     }
+                }
+            }
+            continue;
+        }
+
+        if let Some(url) = dependency.archive_url() {
+            let normalized_url = normalize_archive_url(url)?;
+            let source = format!("archive+{normalized_url}");
+            let expected_hash = dependency_content_hash(&alias, &dependency)?;
+            let content_hash = ensure_archive_cache_populated_in(
+                workspace,
+                &normalized_url,
+                &source,
+                &expected_hash,
+                false,
+                offline,
+            )?;
+            let cache_dir = archive_cache_dir_in(workspace, &source, &content_hash)?;
+            let provenance = read_lock_entry_provenance(&cache_dir)?;
+            let mut entry = LockEntry {
+                name: alias.clone(),
+                source: source.clone(),
+                tag: None,
+                rev_request: None,
+                commit: None,
+                content_hash: Some(content_hash.clone()),
+                package_version: None,
+                harn_compat: None,
+                provenance: None,
+                manifest_digest: None,
+                registry: dependency.registry_provenance(),
+                exports: PackageLockExports::default(),
+                permissions: Vec::new(),
+                host_requirements: Vec::new(),
+            };
+            fill_provenance(&mut entry, provenance);
+            let inserted = replace_lock_entry(&mut lock, entry)?;
+            if inserted {
+                if let Some(manifest) = read_package_manifest_from_dir(&cache_dir)? {
+                    enqueue_manifest_dependencies(&mut pending, manifest, cache_dir, alias, true);
                 }
             }
             continue;
@@ -797,7 +927,7 @@ pub(crate) fn build_lockfile(
             continue;
         }
 
-        return Err(format!("dependency {alias} is missing a git or path source").into());
+        return Err(format!("dependency {alias} is missing a git, archive, or path source").into());
     }
     Ok(lock)
 }
@@ -824,27 +954,42 @@ pub(crate) fn materialize_dependencies_from_lock(
             continue;
         }
 
-        let commit = entry
-            .commit
-            .as_deref()
-            .ok_or_else(|| format!("missing locked commit for {alias}"))?;
         let expected_hash = entry
             .content_hash
             .as_deref()
             .ok_or_else(|| format!("missing content hash for {alias}"))?;
         let source = entry.source.clone();
-        let url = source.trim_start_matches("git+");
         let refetch_this = refetch == Some("all") || refetch == Some(alias.as_str());
-        ensure_git_cache_populated_in(
-            workspace,
-            url,
-            &source,
-            commit,
-            Some(expected_hash),
-            refetch_this,
-            offline,
-        )?;
-        let cache_dir = git_cache_dir_in(workspace, &source, commit)?;
+        let cache_dir = if source.starts_with("git+") {
+            let commit = entry
+                .commit
+                .as_deref()
+                .ok_or_else(|| format!("missing locked commit for {alias}"))?;
+            let url = source.trim_start_matches("git+");
+            ensure_git_cache_populated_in(
+                workspace,
+                url,
+                &source,
+                commit,
+                Some(expected_hash),
+                refetch_this,
+                offline,
+            )?;
+            git_cache_dir_in(workspace, &source, commit)?
+        } else if source.starts_with("archive+") {
+            let url = archive_url_from_source_uri(&source)?;
+            ensure_archive_cache_populated_in(
+                workspace,
+                url,
+                &source,
+                expected_hash,
+                refetch_this,
+                offline,
+            )?;
+            archive_cache_dir_in(workspace, &source, expected_hash)?
+        } else {
+            return Err(format!("unsupported locked package source for {alias}: {source}").into());
+        };
         let dest_dir = packages_dir.join(alias);
         if !dest_dir.exists() || !materialized_hash_matches(&dest_dir, expected_hash) {
             remove_materialized_package(&packages_dir, alias)?;
@@ -932,6 +1077,9 @@ pub(crate) fn render_dependency_line(
             if let Some(git) = table.git.as_deref() {
                 fields.push(format!("git = {}", toml_string_literal(git)?));
             }
+            if let Some(archive) = table.archive.as_deref() {
+                fields.push(format!("archive = {}", toml_string_literal(archive)?));
+            }
             if let Some(branch) = table.branch.as_deref() {
                 fields.push(format!("branch = {}", toml_string_literal(branch)?));
             } else if let Some(tag) = table.tag.as_deref() {
@@ -944,6 +1092,9 @@ pub(crate) fn render_dependency_line(
             }
             if let Some(package) = table.package.as_deref() {
                 fields.push(format!("package = {}", toml_string_literal(package)?));
+            }
+            if let Some(checksum) = table.checksum.as_deref() {
+                fields.push(format!("checksum = {}", toml_string_literal(checksum)?));
             }
             if let Some(registry) = table.registry.as_deref() {
                 fields.push(format!("registry = {}", toml_string_literal(registry)?));
@@ -1495,6 +1646,35 @@ mod tests {
     use super::*;
     use crate::package::test_support::*;
 
+    fn write_tar_gz_package_archive(root: &Path, archive_path: &Path) {
+        fn append_files(
+            builder: &mut tar::Builder<flate2::write::GzEncoder<File>>,
+            root: &Path,
+            cursor: &Path,
+        ) {
+            let mut entries = fs::read_dir(cursor)
+                .unwrap()
+                .map(|entry| entry.unwrap().path())
+                .collect::<Vec<_>>();
+            entries.sort();
+            for path in entries {
+                if path.is_dir() {
+                    append_files(builder, root, &path);
+                } else {
+                    let relative = path.strip_prefix(root).unwrap();
+                    builder.append_path_with_name(&path, relative).unwrap();
+                }
+            }
+        }
+
+        let file = File::create(archive_path).unwrap();
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+        append_files(&mut builder, root, root);
+        let encoder = builder.into_inner().unwrap();
+        encoder.finish().unwrap();
+    }
+
     #[test]
     fn lock_file_round_trips_typed_schema() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1733,6 +1913,125 @@ tag = "v0.2.0"
             .join(PKG_DIR)
             .join("acme-lib")
             .join("lib.harn")
+            .is_file());
+    }
+
+    #[test]
+    fn registry_archive_dependency_materializes_and_reinstalls_offline() {
+        let package_tmp = tempfile::tempdir().unwrap();
+        let package_root = package_tmp.path().join("acme-rules");
+        fs::create_dir_all(package_root.join("rules")).unwrap();
+        fs::write(
+            package_root.join(MANIFEST),
+            r#"
+    [package]
+    name = "acme-rules"
+    version = "1.0.0"
+
+    [rules]
+    ruleDirs = ["rules"]
+    "#,
+        )
+        .unwrap();
+        fs::write(
+            package_root.join("rules/no_todo.harn"),
+            "pub fn rule() -> string { return \"no todo\" }\n",
+        )
+        .unwrap();
+        let checksum = compute_content_hash(&package_root).unwrap();
+
+        let project_tmp = tempfile::tempdir().unwrap();
+        let root = project_tmp.path();
+        let registry_path = root.join("index.toml");
+        let archive_path = root.join("acme-rules-1.0.0.tar.gz");
+        write_tar_gz_package_archive(&package_root, &archive_path);
+        let archive = normalize_archive_url(archive_path.to_string_lossy().as_ref()).unwrap();
+        let workspace =
+            TestWorkspace::new(root).with_registry_source(registry_path.display().to_string());
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(
+            &registry_path,
+            format!(
+                r#"
+version = 1
+
+[[package]]
+name = "@acme/rules"
+description = "Rule pack"
+repository = "https://github.com/acme/rules"
+
+[package.rule_pack]
+rule_count = 1
+languages = ["harn"]
+safety_summary = ["advisory:1"]
+
+[[package.version]]
+version = "1.0.0"
+archive = "{archive}"
+package = "acme-rules"
+checksum = "{checksum}"
+"#
+            ),
+        )
+        .unwrap();
+        fs::write(
+            root.join(MANIFEST),
+            r#"
+    [package]
+    name = "workspace"
+    version = "0.1.0"
+    "#,
+        )
+        .unwrap();
+
+        let (alias, installed) = add_package_to(
+            workspace.env(),
+            "@acme/rules@1.0.0",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(alias, "acme-rules");
+        assert_eq!(installed, 1);
+        let manifest = fs::read_to_string(root.join(MANIFEST)).unwrap();
+        assert!(manifest.contains("archive = "));
+        assert!(manifest.contains(&format!("checksum = \"{checksum}\"")));
+        assert!(manifest.contains("registry_name = \"@acme/rules\""));
+        let lock_path = root.join(LOCK_FILE);
+        let lock = LockFile::load(&lock_path).unwrap().unwrap();
+        let entry = lock.find("acme-rules").unwrap();
+        assert!(entry.source.starts_with("archive+file://"));
+        assert_eq!(entry.content_hash.as_deref(), Some(checksum.as_str()));
+        assert!(entry.commit.is_none());
+        assert_eq!(
+            entry
+                .registry
+                .as_ref()
+                .map(|registry| registry.name.as_str()),
+            Some("@acme/rules")
+        );
+        assert!(root
+            .join(PKG_DIR)
+            .join("acme-rules")
+            .join("rules/no_todo.harn")
+            .is_file());
+
+        let original_lock = fs::read_to_string(&lock_path).unwrap();
+        fs::remove_dir_all(root.join(PKG_DIR)).unwrap();
+        fs::remove_file(&archive_path).unwrap();
+        let reinstalled = install_packages_in(workspace.env(), true, None, true).unwrap();
+        assert_eq!(reinstalled, 1);
+        assert_eq!(fs::read_to_string(&lock_path).unwrap(), original_lock);
+        assert!(root
+            .join(PKG_DIR)
+            .join("acme-rules")
+            .join("rules/no_todo.harn")
             .is_file());
     }
 
@@ -2135,7 +2434,7 @@ tag = "v0.2.0"
         let error = install_packages_in(workspace.env(), false, None, false).unwrap_err();
         assert!(error
             .to_string()
-            .contains("path dependencies are not supported inside git-installed packages"));
+            .contains("path dependencies are not supported inside remote-installed packages"));
     }
 
     #[test]

--- a/crates/harn-cli/src/package/manifest.rs
+++ b/crates/harn-cli/src/package/manifest.rs
@@ -903,12 +903,16 @@ pub enum Dependency {
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct DepTable {
     pub git: Option<String>,
+    #[serde(default, alias = "archive-url", alias = "archive_url")]
+    pub archive: Option<String>,
     pub tag: Option<String>,
     pub rev: Option<String>,
     pub branch: Option<String>,
     pub version: Option<String>,
     pub path: Option<String>,
     pub package: Option<String>,
+    #[serde(default)]
+    pub checksum: Option<String>,
     /// Registry index URL/path the dependency was originally added from.
     /// Persisted in the manifest so registry provenance survives
     /// round-trips and the lockfile can compare against the registry's
@@ -928,6 +932,13 @@ impl Dependency {
     pub(crate) fn git_url(&self) -> Option<&str> {
         match self {
             Dependency::Table(t) => t.git.as_deref(),
+            Dependency::Path(_) => None,
+        }
+    }
+
+    pub(crate) fn archive_url(&self) -> Option<&str> {
+        match self {
+            Dependency::Table(t) => t.archive.as_deref(),
             Dependency::Path(_) => None,
         }
     }
@@ -961,7 +972,7 @@ impl Dependency {
     }
 
     pub(crate) fn requires_git(&self) -> bool {
-        self.git_url().is_some() || self.version().is_some()
+        self.git_url().is_some()
     }
 
     pub(crate) fn local_path(&self) -> Option<&str> {

--- a/crates/harn-cli/src/package/maturity.rs
+++ b/crates/harn-cli/src/package/maturity.rs
@@ -224,6 +224,11 @@ pub(crate) fn outdated_packages_in(
                     );
                 }
             }
+            "archive" => {
+                report.status = OutdatedStatus::Skipped;
+                report.note =
+                    Some("archive dependencies are immutable content-hash pins".to_string());
+            }
             other => {
                 report.status = OutdatedStatus::Unknown;
                 report.note = Some(format!("unsupported lock kind '{other}'"));
@@ -377,7 +382,7 @@ pub(crate) fn audit_packages_in(
             }
         }
 
-        if matches!(kind, "git" | "registry") {
+        if matches!(kind, "git" | "registry" | "archive") {
             if let Err(error) = audit_git_entry_integrity(workspace, entry, skip_materialized) {
                 findings.push(AuditFinding {
                     alias: Some(alias.clone()),
@@ -584,12 +589,12 @@ fn compact_value(value: &serde_json::Value) -> String {
 fn lock_entry_kind(entry: &LockEntry) -> &'static str {
     if entry.source.starts_with("path+") {
         "path"
+    } else if entry.registry.is_some() {
+        "registry"
     } else if entry.source.starts_with("git+") {
-        if entry.registry.is_some() {
-            "registry"
-        } else {
-            "git"
-        }
+        "git"
+    } else if entry.source.starts_with("archive+") {
+        "archive"
     } else {
         "unknown"
     }

--- a/crates/harn-cli/src/package/mod.rs
+++ b/crates/harn-cli/src/package/mod.rs
@@ -18,11 +18,14 @@ const CONTENT_HASH_FILE: &str = ".harn-content-hash";
 const CACHE_METADATA_FILE: &str = ".harn-package-cache.toml";
 const HARN_CACHE_DIR_ENV: &str = "HARN_CACHE_DIR";
 const HARN_PACKAGE_REGISTRY_ENV: &str = "HARN_PACKAGE_REGISTRY";
+const HARN_PACKAGE_REGISTRY_TOKEN_ENV: &str = "HARN_PACKAGE_REGISTRY_TOKEN";
 const DEFAULT_PACKAGE_REGISTRY_URL: &str =
     "https://burin-labs.github.io/harn-cloud/package-index/harn-package-index.toml";
 const CACHE_METADATA_VERSION: u32 = 1;
 const LOCK_FILE_VERSION: u32 = 4;
 const REGISTRY_INDEX_VERSION: u32 = 1;
+const PACKAGE_ARCHIVE_MAX_BYTES: u64 = 64 * 1024 * 1024;
+const PACKAGE_ARCHIVE_MAX_UNPACKED_BYTES: u64 = 64 * 1024 * 1024;
 const PKG_DIR: &str = ".harn/packages";
 const MANIFEST: &str = "harn.toml";
 const LOCK_FILE: &str = "harn.lock";

--- a/crates/harn-cli/src/package/package_ops/validate.rs
+++ b/crates/harn-cli/src/package/package_ops/validate.rs
@@ -88,6 +88,7 @@ pub(crate) fn validate_dependencies_for_publish(
             Dependency::Table(table) => {
                 if table.version.is_some()
                     && (table.git.is_some()
+                        || table.archive.is_some()
                         || table.path.is_some()
                         || table.rev.is_some()
                         || table.tag.is_some()
@@ -96,7 +97,7 @@ pub(crate) fn validate_dependencies_for_publish(
                     push_error(
                         errors,
                         &field,
-                        "version dependencies resolve through the registry; do not combine version with git, path, tag, rev, or branch",
+                        "version dependencies resolve through the registry; do not combine version with git, archive, path, tag, rev, or branch",
                     );
                 }
                 if table.path.is_some() {
@@ -106,11 +107,21 @@ pub(crate) fn validate_dependencies_for_publish(
                         "path dependencies are not publishable; pin a git tag, git rev, or registry version",
                     );
                 }
-                if table.git.is_none() && table.path.is_none() && table.version.is_none() {
+                let source_count = usize::from(table.git.is_some())
+                    + usize::from(table.archive.is_some())
+                    + usize::from(table.path.is_some());
+                if source_count > 1 {
+                    push_error(errors, &field, "dependency must specify only one of git, archive, or path");
+                }
+                if table.git.is_none()
+                    && table.archive.is_none()
+                    && table.path.is_none()
+                    && table.version.is_none()
+                {
                     push_error(
                         errors,
                         &field,
-                        "dependency must specify git, registry version, or path",
+                        "dependency must specify git, archive, registry version, or path",
                     );
                 }
                 let git_ref_count = usize::from(table.rev.is_some())
@@ -121,6 +132,9 @@ pub(crate) fn validate_dependencies_for_publish(
                 }
                 if table.git.is_some() && git_ref_count == 0 {
                     push_error(errors, &field, "git dependency must specify tag, rev, or branch");
+                }
+                if table.archive.is_some() && git_ref_count > 0 {
+                    push_error(errors, &field, "archive dependency cannot specify tag, rev, or branch");
                 }
                 if table.branch.is_some() {
                     push_warning(
@@ -137,6 +151,18 @@ pub(crate) fn validate_dependencies_for_publish(
                 if let Some(git) = table.git.as_deref() {
                     if normalize_git_url(git).is_err() {
                         push_error(errors, &field, format!("invalid git source '{git}'"));
+                    }
+                }
+                if let Some(archive) = table.archive.as_deref() {
+                    if normalize_archive_url(archive).is_err() {
+                        push_error(errors, &field, format!("invalid archive source '{archive}'"));
+                    }
+                    match table.checksum.as_deref() {
+                        Some(checksum) if archive_cache_key(checksum).is_ok() => {}
+                        Some(checksum) => {
+                            push_error(errors, &field, format!("invalid archive checksum '{checksum}'"));
+                        }
+                        None => push_error(errors, &field, "archive dependency must specify checksum"),
                     }
                 }
             }

--- a/crates/harn-cli/src/package/registry.rs
+++ b/crates/harn-cli/src/package/registry.rs
@@ -68,7 +68,10 @@ pub(crate) struct RegistryRulePackInfo {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct RegistryPackageVersion {
     version: String,
-    git: String,
+    #[serde(default)]
+    git: Option<String>,
+    #[serde(default, alias = "archive-url", alias = "archive_url")]
+    archive: Option<String>,
     #[serde(default)]
     tag: Option<String>,
     #[serde(default)]
@@ -143,12 +146,65 @@ pub(crate) fn git_cache_lock_path_in(
         .join(format!("{}-{commit}.lock", sha256_hex(source))))
 }
 
+pub(crate) fn archive_cache_key(content_hash: &str) -> Result<&str, PackageError> {
+    let Some(value) = content_hash.strip_prefix("sha256:") else {
+        return Err(format!("archive checksum must use sha256:<hex>, got {content_hash}").into());
+    };
+    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(
+            format!("archive checksum must use sha256:<64 hex>, got {content_hash}").into(),
+        );
+    }
+    Ok(value)
+}
+
+pub(crate) fn archive_cache_dir_in(
+    workspace: &PackageWorkspace,
+    source: &str,
+    content_hash: &str,
+) -> Result<PathBuf, PackageError> {
+    Ok(workspace
+        .cache_root()?
+        .join("archive")
+        .join(sha256_hex(source))
+        .join(archive_cache_key(content_hash)?))
+}
+
+pub(crate) fn archive_cache_lock_path_in(
+    workspace: &PackageWorkspace,
+    source: &str,
+    content_hash: &str,
+) -> Result<PathBuf, PackageError> {
+    Ok(workspace.cache_root()?.join("locks").join(format!(
+        "{}-{}.lock",
+        sha256_hex(source),
+        archive_cache_key(content_hash)?
+    )))
+}
+
 pub(crate) fn acquire_git_cache_lock_in(
     workspace: &PackageWorkspace,
     source: &str,
     commit: &str,
 ) -> Result<File, PackageError> {
     let path = git_cache_lock_path_in(workspace, source, commit)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    }
+    let file = File::create(&path)
+        .map_err(|error| format!("failed to open {}: {error}", path.display()))?;
+    file.lock_exclusive()
+        .map_err(|error| format!("failed to lock {}: {error}", path.display()))?;
+    Ok(file)
+}
+
+pub(crate) fn acquire_archive_cache_lock_in(
+    workspace: &PackageWorkspace,
+    source: &str,
+    content_hash: &str,
+) -> Result<File, PackageError> {
+    let path = archive_cache_lock_path_in(workspace, source, content_hash)?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
@@ -514,6 +570,16 @@ pub(crate) fn path_from_source_uri(source: &str) -> Result<PathBuf, PackageError
     Ok(PathBuf::from(raw))
 }
 
+pub(crate) fn archive_url_from_source_uri(source: &str) -> Result<&str, PackageError> {
+    source
+        .strip_prefix("archive+")
+        .ok_or_else(|| format!("invalid archive source: {source}").into())
+}
+
+pub(crate) fn archive_source_uri(raw: &str) -> Result<String, PackageError> {
+    Ok(format!("archive+{}", normalize_archive_url(raw)?))
+}
+
 pub(crate) fn registry_file_url_or_path(raw: &str) -> Result<Option<PathBuf>, PackageError> {
     if let Ok(url) = Url::parse(raw) {
         if url.scheme() == "file" {
@@ -524,6 +590,64 @@ pub(crate) fn registry_file_url_or_path(raw: &str) -> Result<Option<PathBuf>, Pa
         return Ok(None);
     }
     Ok(Some(PathBuf::from(raw)))
+}
+
+pub(crate) fn normalize_archive_url(raw: &str) -> Result<String, PackageError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("archive URL cannot be empty".to_string().into());
+    }
+    if let Ok(url) = Url::parse(trimmed) {
+        return match url.scheme() {
+            "file" => {
+                let path = url.to_file_path().map_err(|_| {
+                    PackageError::Registry(format!(
+                        "invalid file:// package archive URL: {trimmed}"
+                    ))
+                })?;
+                if path.exists() {
+                    let canonical = path.canonicalize().map_err(|error| {
+                        format!("failed to canonicalize {}: {error}", path.display())
+                    })?;
+                    let url = Url::from_file_path(canonical)
+                        .map_err(|_| format!("failed to convert {trimmed} to file:// URL"))?;
+                    Ok(url.to_string())
+                } else {
+                    Ok(url.to_string())
+                }
+            }
+            "http" | "https" => Ok(url.to_string()),
+            other => Err(format!("unsupported package archive URL scheme: {other}").into()),
+        };
+    }
+
+    let path = PathBuf::from(trimmed);
+    if !path.exists() {
+        return Err(format!("package archive not found: {}", path.display()).into());
+    }
+    let canonical = path
+        .canonicalize()
+        .map_err(|error| format!("failed to canonicalize {}: {error}", path.display()))?;
+    let url = Url::from_file_path(canonical)
+        .map_err(|_| format!("failed to convert {trimmed} to file:// URL"))?;
+    Ok(url.to_string())
+}
+
+fn package_registry_auth_token() -> Option<String> {
+    std::env::var(HARN_PACKAGE_REGISTRY_TOKEN_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn apply_package_registry_auth(
+    request: reqwest::blocking::RequestBuilder,
+) -> reqwest::blocking::RequestBuilder {
+    if let Some(token) = package_registry_auth_token() {
+        request.bearer_auth(token)
+    } else {
+        request
+    }
 }
 
 pub(crate) fn read_registry_source(source: &str) -> Result<String, PackageError> {
@@ -557,11 +681,11 @@ pub(crate) fn read_registry_source(source: &str) -> Result<String, PackageError>
 }
 
 fn fetch_registry_blocking(url: Url, source: &str) -> Result<String, PackageError> {
-    let response = reqwest::blocking::Client::builder()
+    let client = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(20))
         .build()
-        .map_err(|error| format!("failed to build package registry client: {error}"))?
-        .get(url)
+        .map_err(|error| format!("failed to build package registry client: {error}"))?;
+    let response = apply_package_registry_auth(client.get(url))
         .send()
         .map_err(|error| format!("failed to fetch package registry {source}: {error}"))?;
     let status = response.status();
@@ -571,6 +695,78 @@ fn fetch_registry_blocking(url: Url, source: &str) -> Result<String, PackageErro
     response.text().map_err(|error| {
         PackageError::Registry(format!("failed to read package registry response: {error}"))
     })
+}
+
+pub(crate) fn read_package_archive_bytes(source: &str) -> Result<Vec<u8>, PackageError> {
+    if let Some(path) = registry_file_url_or_path(source)? {
+        let metadata = fs::metadata(&path).map_err(|error| {
+            format!("failed to stat package archive {}: {error}", path.display())
+        })?;
+        if metadata.len() > PACKAGE_ARCHIVE_MAX_BYTES {
+            return Err(format!(
+                "package archive {} is {} bytes, above the {} byte limit",
+                path.display(),
+                metadata.len(),
+                PACKAGE_ARCHIVE_MAX_BYTES
+            )
+            .into());
+        }
+        return fs::read(&path).map_err(|error| {
+            PackageError::Registry(format!(
+                "failed to read package archive {}: {error}",
+                path.display()
+            ))
+        });
+    }
+
+    let url = Url::parse(source)
+        .map_err(|error| format!("invalid package archive URL {source:?}: {error}"))?;
+    match url.scheme() {
+        "http" | "https" => {}
+        other => return Err(format!("unsupported package archive URL scheme: {other}").into()),
+    }
+    let source_owned = source.to_string();
+    std::thread::scope(|scope| {
+        scope
+            .spawn(move || fetch_package_archive_blocking(url, &source_owned))
+            .join()
+            .map_err(|_| {
+                PackageError::Registry("package archive fetch thread panicked".to_string())
+            })?
+    })
+}
+
+fn fetch_package_archive_blocking(url: Url, source: &str) -> Result<Vec<u8>, PackageError> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|error| format!("failed to build package archive client: {error}"))?;
+    let response = apply_package_registry_auth(client.get(url))
+        .send()
+        .map_err(|error| format!("failed to fetch package archive {source}: {error}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(format!("GET {source} returned HTTP {status}").into());
+    }
+    if response
+        .content_length()
+        .is_some_and(|length| length > PACKAGE_ARCHIVE_MAX_BYTES)
+    {
+        return Err(format!(
+            "package archive {source} is larger than the {PACKAGE_ARCHIVE_MAX_BYTES} byte limit"
+        )
+        .into());
+    }
+    let bytes = response
+        .bytes()
+        .map_err(|error| format!("failed to read package archive response: {error}"))?;
+    if bytes.len() as u64 > PACKAGE_ARCHIVE_MAX_BYTES {
+        return Err(format!(
+            "package archive {source} is larger than the {PACKAGE_ARCHIVE_MAX_BYTES} byte limit"
+        )
+        .into());
+    }
+    Ok(bytes.to_vec())
 }
 
 pub(crate) fn is_valid_registry_segment(segment: &str) -> bool {
@@ -689,25 +885,70 @@ pub(crate) fn validate_package_registry_index(
                 )
                 .into());
             }
-            if selected_git_ref_count(version) != 1 {
-                return Err(format!(
-                    "package registry {source} entry '{}@{}' must specify tag, rev, or branch; rev may accompany tag as a resolved commit pin",
-                    package.name, version.version
-                )
-                .into());
-            }
             parse_registry_semver(&version.version).map_err(|error| {
                 format!(
                     "package registry {source} has invalid semver for '{}@{}': {error}",
                     package.name, version.version
                 )
             })?;
-            normalize_git_url(&version.git).map_err(|error| {
-                format!(
-                    "package registry {source} has invalid git source for '{}@{}': {error}",
-                    package.name, version.version
-                )
-            })?;
+            match (version.git.as_deref(), version.archive.as_deref()) {
+                (Some(git), None) => {
+                    if selected_git_ref_count(version) != 1 {
+                        return Err(format!(
+                            "package registry {source} entry '{}@{}' must specify tag, rev, or branch; rev may accompany tag as a resolved commit pin",
+                            package.name, version.version
+                        )
+                        .into());
+                    }
+                    normalize_git_url(git).map_err(|error| {
+                        format!(
+                            "package registry {source} has invalid git source for '{}@{}': {error}",
+                            package.name, version.version
+                        )
+                    })?;
+                }
+                (None, Some(archive)) => {
+                    if version.tag.is_some() || version.rev.is_some() || version.branch.is_some() {
+                        return Err(format!(
+                            "package registry {source} entry '{}@{}' must not combine archive with tag, rev, or branch",
+                            package.name, version.version
+                        )
+                        .into());
+                    }
+                    normalize_archive_url(archive).map_err(|error| {
+                        format!(
+                            "package registry {source} has invalid archive source for '{}@{}': {error}",
+                            package.name, version.version
+                        )
+                    })?;
+                    let checksum = version.checksum.as_deref().ok_or_else(|| {
+                        format!(
+                            "package registry {source} entry '{}@{}' must specify checksum for archive source",
+                            package.name, version.version
+                        )
+                    })?;
+                    archive_cache_key(checksum).map_err(|error| {
+                        format!(
+                            "package registry {source} has invalid archive checksum for '{}@{}': {error}",
+                            package.name, version.version
+                        )
+                    })?;
+                }
+                (Some(_), Some(_)) => {
+                    return Err(format!(
+                        "package registry {source} entry '{}@{}' must specify only one of git or archive",
+                        package.name, version.version
+                    )
+                    .into());
+                }
+                (None, None) => {
+                    return Err(format!(
+                        "package registry {source} entry '{}@{}' must specify git or archive",
+                        package.name, version.version
+                    )
+                    .into());
+                }
+            }
         }
     }
     index
@@ -1043,32 +1284,19 @@ pub(crate) fn registry_dependency_from_spec_in(
     if selected.yanked {
         return Err(format!("{name}@{version} is yanked in the package registry").into());
     }
-    let git = normalize_git_url(&selected.git)?;
-    let package_name = selected
-        .package
-        .clone()
-        .map(Ok)
-        .unwrap_or_else(|| derive_repo_name_from_source(&git))?;
+    let package_name = registry_package_version_alias(&info.package.name, &selected)?;
     let alias = alias.unwrap_or(package_name.as_str()).to_string();
-    let tag = selected.tag;
-    let rev = if tag.is_some() { None } else { selected.rev };
     let resolved_version = selected.version.clone();
     Ok((
         alias.clone(),
-        Dependency::Table(Box::new(DepTable {
-            git: Some(git),
-            tag,
-            rev,
-            branch: selected.branch,
-            package: (alias != package_name).then_some(package_name),
-            registry: Some(registry_source),
-            // Store the canonical scoped registry name (e.g. `@burin/notion-sdk`)
-            // even when the user typed the bare alias (`notion-sdk-harn`) so
-            // re-resolves stay anchored to the same registry row.
-            registry_name: Some(info.package.name),
-            registry_version: Some(resolved_version),
-            ..DepTable::default()
-        })),
+        registry_dependency_table(
+            info.package.name,
+            selected,
+            package_name,
+            alias,
+            registry_source,
+            resolved_version,
+        )?,
     ))
 }
 
@@ -1092,20 +1320,96 @@ pub(crate) fn registry_dependency_from_manifest_constraint_in(
     let selected = info.selected_version.ok_or_else(|| {
         format!("package registry does not contain {registry_name} matching {requirement}")
     })?;
-    let git = normalize_git_url(&selected.git)?;
-    let tag = selected.tag;
-    let rev = if tag.is_some() { None } else { selected.rev };
-    Ok(Dependency::Table(Box::new(DepTable {
-        git: Some(git),
+    let package_name = selected
+        .package
+        .clone()
+        .or_else(|| table.package.clone())
+        .unwrap_or_else(|| alias.to_string());
+    let resolved_version = selected.version.clone();
+    registry_dependency_table(
+        registry_name.to_string(),
+        selected,
+        package_name,
+        alias.to_string(),
+        registry_source,
+        resolved_version,
+    )
+}
+
+fn registry_package_version_alias(
+    registry_name: &str,
+    selected: &RegistryPackageVersion,
+) -> Result<String, PackageError> {
+    if let Some(package) = selected.package.clone() {
+        return Ok(package);
+    }
+    if let Some(git) = selected.git.as_deref() {
+        return derive_repo_name_from_source(&normalize_git_url(git)?);
+    }
+    derive_registry_alias_from_name(registry_name)
+}
+
+fn derive_registry_alias_from_name(registry_name: &str) -> Result<String, PackageError> {
+    let alias = registry_name
+        .strip_prefix('@')
+        .and_then(|scoped| scoped.split_once('/').map(|(_, package)| package))
+        .unwrap_or(registry_name)
+        .to_string();
+    validate_package_alias(&alias)?;
+    Ok(alias)
+}
+
+fn registry_dependency_table(
+    registry_name: String,
+    selected: RegistryPackageVersion,
+    package_name: String,
+    alias: String,
+    registry_source: String,
+    resolved_version: String,
+) -> Result<Dependency, PackageError> {
+    let package = (alias != package_name).then_some(package_name);
+    let RegistryPackageVersion {
+        git,
+        archive,
         tag,
         rev,
-        branch: selected.branch,
-        package: selected.package.or_else(|| table.package.clone()),
-        registry: Some(registry_source),
-        registry_name: Some(registry_name.to_string()),
-        registry_version: Some(selected.version),
-        ..DepTable::default()
-    })))
+        branch,
+        checksum,
+        ..
+    } = selected;
+    let table = if let Some(git) = git {
+        let git = normalize_git_url(&git)?;
+        let rev = if tag.is_some() { None } else { rev };
+        DepTable {
+            git: Some(git),
+            tag,
+            rev,
+            branch,
+            package,
+            registry: Some(registry_source),
+            // Store the canonical scoped registry name (e.g. `@burin/notion-sdk`)
+            // even when the user typed the bare alias (`notion-sdk-harn`) so
+            // re-resolves stay anchored to the same registry row.
+            registry_name: Some(registry_name),
+            registry_version: Some(resolved_version),
+            ..DepTable::default()
+        }
+    } else if let Some(archive) = archive {
+        DepTable {
+            archive: Some(normalize_archive_url(&archive)?),
+            package,
+            checksum,
+            registry: Some(registry_source),
+            registry_name: Some(registry_name),
+            registry_version: Some(resolved_version),
+            ..DepTable::default()
+        }
+    } else {
+        return Err("registry package version is missing git or archive source"
+            .to_string()
+            .into());
+    };
+    Ok(Dependency::Table(Box::new(table)))
 }
 
 pub(crate) fn is_probable_shorthand_git_url(raw: &str) -> bool {
@@ -1557,26 +1861,177 @@ pub(crate) fn ensure_git_cache_populated_in(
     Ok(hash)
 }
 
+fn archive_entry_relative_path(path: &Path) -> Result<PathBuf, PackageError> {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(value) => out.push(value),
+            std::path::Component::CurDir => {}
+            _ => {
+                return Err(format!(
+                    "package archive entry must be relative and contained within the package root: {}",
+                    path.display()
+                )
+                .into());
+            }
+        }
+    }
+    if out.as_os_str().is_empty() {
+        return Err("package archive entry path cannot be empty"
+            .to_string()
+            .into());
+    }
+    Ok(out)
+}
+
+pub(crate) fn unpack_package_archive_bytes(bytes: &[u8], dest: &Path) -> Result<(), PackageError> {
+    let decoder = flate2::read::GzDecoder::new(bytes);
+    let mut archive = tar::Archive::new(decoder);
+    let entries = archive
+        .entries()
+        .map_err(|error| format!("failed to read package archive: {error}"))?;
+    let mut unpacked_bytes = 0u64;
+    for entry in entries {
+        let mut entry =
+            entry.map_err(|error| format!("failed to read package archive entry: {error}"))?;
+        let entry_type = entry.header().entry_type();
+        let raw_path = entry
+            .path()
+            .map_err(|error| format!("failed to read package archive entry path: {error}"))?;
+        let relative = archive_entry_relative_path(&raw_path)?;
+        let target = dest.join(relative);
+        if entry_type.is_dir() {
+            fs::create_dir_all(&target)
+                .map_err(|error| format!("failed to create {}: {error}", target.display()))?;
+        } else if entry_type.is_file() {
+            unpacked_bytes = unpacked_bytes
+                .checked_add(entry.size())
+                .ok_or_else(|| "package archive expanded size overflowed".to_string())?;
+            if unpacked_bytes > PACKAGE_ARCHIVE_MAX_UNPACKED_BYTES {
+                return Err(format!(
+                    "package archive expands above the {PACKAGE_ARCHIVE_MAX_UNPACKED_BYTES} byte limit"
+                )
+                .into());
+            }
+            if let Some(parent) = target.parent() {
+                fs::create_dir_all(parent)
+                    .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+            }
+            entry
+                .unpack(&target)
+                .map_err(|error| format!("failed to unpack {}: {error}", target.display()))?;
+        } else {
+            return Err(format!(
+                "package archive entry {} has unsupported type {:?}",
+                raw_path.display(),
+                entry_type
+            )
+            .into());
+        }
+    }
+    if !dest.join(MANIFEST).is_file() {
+        return Err(format!("package archive is missing {MANIFEST} at its root").into());
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_archive_cache_populated_in(
+    workspace: &PackageWorkspace,
+    url: &str,
+    source: &str,
+    expected_hash: &str,
+    refetch: bool,
+    offline: bool,
+) -> Result<String, PackageError> {
+    archive_cache_key(expected_hash)?;
+    let cache_dir = archive_cache_dir_in(workspace, source, expected_hash)?;
+    let _lock = acquire_archive_cache_lock_in(workspace, source, expected_hash)?;
+    if refetch && cache_dir.exists() {
+        fs::remove_dir_all(&cache_dir)
+            .map_err(|error| format!("failed to remove {}: {error}", cache_dir.display()))?;
+    }
+    if cache_dir.exists() {
+        verify_content_hash_or_compute(&cache_dir, expected_hash)?;
+        write_cache_metadata(&cache_dir, source, expected_hash, expected_hash)?;
+        return Ok(expected_hash.to_string());
+    }
+    if offline {
+        return Err(format!(
+            "package cache entry for {source} at {expected_hash} is missing; cannot fetch in offline mode"
+        )
+        .into());
+    }
+
+    let parent = cache_dir
+        .parent()
+        .ok_or_else(|| format!("invalid cache path {}", cache_dir.display()))?;
+    fs::create_dir_all(parent)
+        .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    let temp_dir = unique_temp_dir(parent, "tmp")?;
+    let populated = (|| -> Result<String, PackageError> {
+        fs::create_dir_all(&temp_dir)
+            .map_err(|error| format!("failed to create {}: {error}", temp_dir.display()))?;
+        let bytes = read_package_archive_bytes(url)?;
+        unpack_package_archive_bytes(&bytes, &temp_dir)?;
+        let hash = compute_content_hash(&temp_dir)?;
+        if hash != expected_hash {
+            return Err(format!(
+                "content hash mismatch for {source}: expected {expected_hash}, got {hash}"
+            )
+            .into());
+        }
+        write_cached_content_hash(&temp_dir, expected_hash)?;
+        write_cache_metadata(&temp_dir, source, expected_hash, expected_hash)?;
+        fs::rename(&temp_dir, &cache_dir).map_err(|error| {
+            format!(
+                "failed to move {} to {}: {error}",
+                temp_dir.display(),
+                cache_dir.display()
+            )
+        })?;
+        Ok(expected_hash.to_string())
+    })();
+    match populated {
+        Ok(hash) => Ok(hash),
+        Err(error) => {
+            let _ = fs::remove_dir_all(&temp_dir);
+            Err(error)
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct PackageCacheEntry {
     path: PathBuf,
+    kind: &'static str,
     source_hash: String,
     commit: String,
     metadata: Option<PackageCacheMetadata>,
 }
 
-pub(crate) fn git_cache_root_in(workspace: &PackageWorkspace) -> Result<PathBuf, PackageError> {
-    Ok(workspace.cache_root()?.join("git"))
+pub(crate) fn discover_package_cache_entries() -> Result<Vec<PackageCacheEntry>, PackageError> {
+    discover_package_cache_entries_in(&PackageWorkspace::from_current_dir()?)
 }
 
-pub(crate) fn discover_git_cache_entries() -> Result<Vec<PackageCacheEntry>, PackageError> {
-    discover_git_cache_entries_in(&PackageWorkspace::from_current_dir()?)
-}
-
-pub(crate) fn discover_git_cache_entries_in(
+pub(crate) fn discover_package_cache_entries_in(
     workspace: &PackageWorkspace,
 ) -> Result<Vec<PackageCacheEntry>, PackageError> {
-    let root = git_cache_root_in(workspace)?;
+    let mut entries = discover_cache_entries_for_kind(workspace, "git")?;
+    entries.extend(discover_cache_entries_for_kind(workspace, "archive")?);
+    entries.sort_by(|left, right| {
+        left.kind
+            .cmp(right.kind)
+            .then_with(|| left.source_hash.cmp(&right.source_hash))
+            .then_with(|| left.commit.cmp(&right.commit))
+    });
+    Ok(entries)
+}
+
+fn discover_cache_entries_for_kind(
+    workspace: &PackageWorkspace,
+    kind: &'static str,
+) -> Result<Vec<PackageCacheEntry>, PackageError> {
+    let root = workspace.cache_root()?.join(kind);
     let mut entries = Vec::new();
     let source_dirs = match fs::read_dir(&root) {
         Ok(source_dirs) => source_dirs,
@@ -1615,6 +2070,7 @@ pub(crate) fn discover_git_cache_entries_in(
             let metadata = read_cache_metadata(&commit_dir.path())?;
             entries.push(PackageCacheEntry {
                 path: commit_dir.path(),
+                kind,
                 source_hash: source_hash.clone(),
                 commit,
                 metadata,
@@ -1629,21 +2085,30 @@ pub(crate) fn discover_git_cache_entries_in(
     Ok(entries)
 }
 
-pub(crate) fn locked_git_cache_paths_in(
+pub(crate) fn locked_package_cache_paths_in(
     workspace: &PackageWorkspace,
     lock: &LockFile,
 ) -> Result<HashSet<PathBuf>, PackageError> {
     let mut keep = HashSet::new();
     for entry in &lock.packages {
         validate_package_alias(&entry.name)?;
-        if !entry.source.starts_with("git+") {
-            continue;
+        if entry.source.starts_with("git+") {
+            let commit = entry
+                .commit
+                .as_deref()
+                .ok_or_else(|| format!("missing locked commit for {}", entry.name))?;
+            keep.insert(git_cache_dir_in(workspace, &entry.source, commit)?);
+        } else if entry.source.starts_with("archive+") {
+            let expected_hash = entry
+                .content_hash
+                .as_deref()
+                .ok_or_else(|| format!("missing content hash for {}", entry.name))?;
+            keep.insert(archive_cache_dir_in(
+                workspace,
+                &entry.source,
+                expected_hash,
+            )?);
         }
-        let commit = entry
-            .commit
-            .as_deref()
-            .ok_or_else(|| format!("missing locked commit for {}", entry.name))?;
-        keep.insert(git_cache_dir_in(workspace, &entry.source, commit)?);
     }
     Ok(keep)
 }
@@ -1653,29 +2118,36 @@ pub(crate) fn verify_lock_entry_cache_in(
     entry: &LockEntry,
 ) -> Result<bool, PackageError> {
     validate_package_alias(&entry.name)?;
-    if !entry.source.starts_with("git+") {
-        if entry.source.starts_with("path+") {
-            let path = path_from_source_uri(&entry.source)?;
-            if !path.exists() {
-                return Err(format!(
-                    "path dependency {} source is missing: {}",
-                    entry.name,
-                    path.display()
-                )
-                .into());
-            }
+    if entry.source.starts_with("path+") {
+        let path = path_from_source_uri(&entry.source)?;
+        if !path.exists() {
+            return Err(format!(
+                "path dependency {} source is missing: {}",
+                entry.name,
+                path.display()
+            )
+            .into());
         }
         return Ok(false);
     }
-    let commit = entry
-        .commit
-        .as_deref()
-        .ok_or_else(|| format!("missing locked commit for {}", entry.name))?;
     let expected_hash = entry
         .content_hash
         .as_deref()
         .ok_or_else(|| format!("missing content hash for {}", entry.name))?;
-    let cache_dir = git_cache_dir_in(workspace, &entry.source, commit)?;
+    let (cache_dir, cache_key) = if entry.source.starts_with("git+") {
+        let commit = entry
+            .commit
+            .as_deref()
+            .ok_or_else(|| format!("missing locked commit for {}", entry.name))?;
+        (git_cache_dir_in(workspace, &entry.source, commit)?, commit)
+    } else if entry.source.starts_with("archive+") {
+        (
+            archive_cache_dir_in(workspace, &entry.source, expected_hash)?,
+            expected_hash,
+        )
+    } else {
+        return Ok(false);
+    };
     if !cache_dir.is_dir() {
         return Err(format!(
             "package cache entry for {} is missing: {}",
@@ -1688,14 +2160,14 @@ pub(crate) fn verify_lock_entry_cache_in(
     match read_cache_metadata(&cache_dir)? {
         Some(metadata)
             if metadata.source == entry.source
-                && metadata.commit == commit
+                && metadata.commit == cache_key
                 && metadata.content_hash == expected_hash => {}
         Some(metadata) => {
             return Err(format!(
                 "package cache metadata mismatch for {}: expected {} {} {}, got {} {} {}",
                 entry.name,
                 entry.source,
-                commit,
+                cache_key,
                 expected_hash,
                 metadata.source,
                 metadata.commit,
@@ -1703,7 +2175,7 @@ pub(crate) fn verify_lock_entry_cache_in(
             )
             .into());
         }
-        None => write_cache_metadata(&cache_dir, &entry.source, commit, expected_hash)?,
+        None => write_cache_metadata(&cache_dir, &entry.source, cache_key, expected_hash)?,
     }
     Ok(true)
 }
@@ -1727,7 +2199,7 @@ pub(crate) fn verify_materialized_lock_entry(
         }
         return Ok(true);
     }
-    if !entry.source.starts_with("git+") {
+    if !entry.source.starts_with("git+") && !entry.source.starts_with("archive+") {
         return Ok(false);
     }
     let expected_hash = entry
@@ -1779,13 +2251,13 @@ pub(crate) fn clean_package_cache_in(
     workspace: &PackageWorkspace,
     all: bool,
 ) -> Result<usize, PackageError> {
-    let entries = discover_git_cache_entries_in(workspace)?;
+    let entries = discover_package_cache_entries_in(workspace)?;
     if entries.is_empty() {
         return Ok(0);
     }
     if all {
         let root = workspace.cache_root()?;
-        for child in ["git", "locks"] {
+        for child in ["git", "archive", "locks"] {
             let path = root.join(child);
             if path.exists() {
                 fs::remove_dir_all(&path)
@@ -1799,7 +2271,7 @@ pub(crate) fn clean_package_cache_in(
     let lock = LockFile::load(&ctx.lock_path())?
         .ok_or_else(|| format!("{LOCK_FILE} is missing; pass --all to clean every cache entry"))?;
     validate_lock_matches_manifest(workspace, &ctx, &lock)?;
-    let keep = locked_git_cache_paths_in(workspace, &lock)?;
+    let keep = locked_package_cache_paths_in(workspace, &lock)?;
     let mut removed = 0usize;
     for entry in entries {
         if keep.contains(&entry.path) {
@@ -1823,17 +2295,17 @@ pub(crate) fn clean_package_cache_in(
 
 pub fn list_package_cache() {
     let result = (|| -> Result<(PathBuf, Vec<PackageCacheEntry>), PackageError> {
-        Ok((cache_root()?, discover_git_cache_entries()?))
+        Ok((cache_root()?, discover_package_cache_entries()?))
     })();
 
     match result {
         Ok((root, entries)) => {
             println!("Cache root: {}", root.display());
             if entries.is_empty() {
-                println!("No cached git packages.");
+                println!("No cached packages.");
                 return;
             }
-            println!("commit\tcontent_hash\tsource\tpath");
+            println!("kind\tkey\tcontent_hash\tsource\tpath");
             for entry in entries {
                 let (source, content_hash) = entry
                     .metadata
@@ -1841,7 +2313,8 @@ pub fn list_package_cache() {
                     .map(|metadata| (metadata.source.as_str(), metadata.content_hash.as_str()))
                     .unwrap_or(("(unknown)", "(unknown)"));
                 println!(
-                    "{}\t{}\t{}\t{}",
+                    "{}\t{}\t{}\t{}\t{}",
+                    entry.kind,
                     entry.commit,
                     content_hash,
                     source,
@@ -2010,7 +2483,12 @@ pub fn show_package_registry_info(spec: &str, registry: Option<&str>, json: bool
             }
             if let Some(version) = info.selected_version {
                 println!("selected: {}", version.version);
-                println!("git: {}", version.git);
+                if let Some(git) = version.git.as_deref() {
+                    println!("git: {git}");
+                }
+                if let Some(archive) = version.archive.as_deref() {
+                    println!("archive: {archive}");
+                }
                 if let Some(rev) = version.rev.as_deref() {
                     println!("rev: {rev}");
                 }
@@ -2279,7 +2757,7 @@ abc123abc123abc123abc123abc123abc1234567\trefs/tags/v0.0.1\n";
 
         install_packages_in(workspace.env(), false, None, false).unwrap();
         assert_eq!(
-            discover_git_cache_entries_in(workspace.env())
+            discover_package_cache_entries_in(workspace.env())
                 .unwrap()
                 .len(),
             1
@@ -2287,7 +2765,7 @@ abc123abc123abc123abc123abc123abc1234567\trefs/tags/v0.0.1\n";
 
         let removed = clean_package_cache_in(workspace.env(), true).unwrap();
         assert_eq!(removed, 1);
-        assert!(discover_git_cache_entries_in(workspace.env())
+        assert!(discover_package_cache_entries_in(workspace.env())
             .unwrap()
             .is_empty());
     }
@@ -2337,7 +2815,7 @@ abc123abc123abc123abc123abc123abc1234567\trefs/tags/v0.0.1\n";
         assert_eq!(
             info.selected_version
                 .as_ref()
-                .map(|version| version.git.as_str()),
+                .and_then(|version| version.git.as_deref()),
             Some(git.as_str())
         );
     }
@@ -2514,6 +2992,43 @@ tag = "v1.0.0"
             manifest.contains("registry_version = \"1.0.0\""),
             "semver range must resolve to the highest matching exact version: {manifest}"
         );
+    }
+
+    #[test]
+    fn registry_index_accepts_archive_versions_and_requires_checksums() {
+        let content = r#"
+version = 1
+
+[[package]]
+name = "@acme/rules"
+repository = "https://github.com/acme/rules"
+
+[[package.version]]
+version = "1.0.0"
+archive = "https://cdn.example.test/acme-rules-1.0.0.tar.gz"
+package = "acme-rules"
+checksum = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+"#;
+        let index = parse_package_registry_index("fixture", content).unwrap();
+        assert_eq!(index.packages[0].versions[0].git, None);
+        assert_eq!(
+            index.packages[0].versions[0].archive.as_deref(),
+            Some("https://cdn.example.test/acme-rules-1.0.0.tar.gz")
+        );
+
+        let missing_checksum = r#"
+version = 1
+
+[[package]]
+name = "@acme/rules"
+repository = "https://github.com/acme/rules"
+
+[[package.version]]
+version = "1.0.0"
+archive = "https://cdn.example.test/acme-rules-1.0.0.tar.gz"
+"#;
+        let error = parse_package_registry_index("fixture", missing_checksum).unwrap_err();
+        assert!(error.to_string().contains("must specify checksum"));
     }
 
     #[test]

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -2349,6 +2349,14 @@ harn package search --registry ./harn-package-index.toml --json
 
 The registry source comes from `--registry`, `HARN_PACKAGE_REGISTRY`,
 `[registry].url` in `harn.toml`, or Harn's default hosted index.
+Private HTTP(S) registries can be accessed with
+`HARN_PACKAGE_REGISTRY_TOKEN`; Harn sends it as a bearer token when fetching
+the index and any archive URLs listed by that index.
+
+Registry versions may resolve to either a git source or an archive source.
+Archive versions use `archive = "<url>"` plus `checksum = "sha256:<tree>"`;
+Harn expands `.tar.gz` archives into the package cache and verifies the
+expanded tree hash before writing `harn.lock`.
 
 ## harn rule publish / search
 


### PR DESCRIPTION
## Summary
- allow package registry versions to resolve to checksum-verified .tar.gz archives
- reuse HARN_PACKAGE_REGISTRY_TOKEN for private registry and archive fetches
- cache/materialize archive packages and support offline reinstall from the verified cache

## Verification
- CARGO_TARGET_DIR="/Users/ksinder/.codex/worktrees/d3e8/harn-package-archive/.target" cargo fmt --all -- --check
- CARGO_TARGET_DIR="/Users/ksinder/.codex/worktrees/d3e8/harn-package-archive/.target" cargo test -p harn-cli package::lockfile::tests -- --nocapture
- CARGO_TARGET_DIR="/Users/ksinder/.codex/worktrees/d3e8/harn-package-archive/.target" cargo test -p harn-cli package::registry::tests -- --nocapture
- CARGO_TARGET_DIR="/Users/ksinder/.codex/worktrees/d3e8/harn-package-archive/.target" cargo clippy --locked -p harn-cli --all-targets -- -D warnings

Supports burin-labs/harn-cloud#548.