### PR TITLE
perf(vm): dispatch synchronous builtins on the fast call path

### DIFF
--- a/changelog.d/builtin-call-sync-dispatch.changed.md
+++ b/changelog.d/builtin-call-sync-dispatch.changed.md
@@ -1,0 +1,12 @@
+- **Synchronous builtin calls now dispatch on the fast (sync) interpreter
+  path.** A bare builtin call such as `abs(x)` / `len(xs)` previously fell
+  through `Op::CallBuiltin`'s sync handler to the async handler, which re-ran
+  name resolution (a second local-slot scan, env walk, and — inside imported
+  modules — the `module_functions` + `module_state` mutexes) and spun up the
+  async state machine only to reach the same synchronous builtin. The sync
+  handler now dispatches synchronous builtins directly once it has confirmed the
+  name is not a user closure, eliminating the redundant resolution and the async
+  hop; asynchronous builtins are unchanged. Resolution semantics are identical —
+  a user `fn` that shadows a builtin name still wins — and the change holds one
+  fewer lock per call inside imported modules, so it is friendly to the
+  multi-threaded runtime. No `harn` language behavior changes.

--- a/crates/harn-vm/Cargo.toml
+++ b/crates/harn-vm/Cargo.toml
@@ -186,6 +186,10 @@ harness = false
 name = "fs_find_text"
 harness = false
 
+[[bench]]
+name = "vm_name_resolution"
+harness = false
+
 [lints]
 workspace = true
 

--- a/crates/harn-vm/benches/vm_name_resolution.rs
+++ b/crates/harn-vm/benches/vm_name_resolution.rs
@@ -1,0 +1,162 @@
+//! Benchmarks isolating variable/builtin *name resolution* on the VM hot
+//! path: function-local slot reads (the fast O(1) path) versus module-level
+//! ("global") reads and builtin references/calls, which fall through
+//! `execute_get_var` / `resolve_named_closure` (local-slot scan -> env walk
+//! -> `module_state` mutex -> globals -> builtin registry).
+//!
+//! Each fixture reads its target name ten times per iteration over a long
+//! loop so the per-read resolution cost dominates the one-time VM
+//! construction. The `*_many_locals` variant widens the enclosing function's
+//! local-slot table so the linear, string-comparing scan that every
+//! non-local access pays in `active_local_slot_index` is visible.
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use harn_vm::{compile_source, register_vm_stdlib, Chunk, Vm};
+
+fn run_chunk(rt: &tokio::runtime::Runtime, chunk: &Chunk) -> String {
+    rt.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let mut vm = Vm::new();
+                register_vm_stdlib(&mut vm);
+                let result = vm.execute(chunk).await.expect("bench script runs");
+                black_box(result);
+                vm.output().to_string()
+            })
+            .await
+    })
+}
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime")
+}
+
+/// `work` reads a *function-local* `a` ten times per iteration: the compiler
+/// resolves `a` to a `GetLocalSlot`, the O(1) fast path.
+const LOCAL_READ: &str = r"pipeline t(task) {
+  fn work() {
+    let a = 1
+    var total = 0
+    var i = 0
+    while i < 50000 {
+      total = total + a + a + a + a + a + a + a + a + a + a
+      i = i + 1
+    }
+    return total
+  }
+  return work()
+}";
+
+/// `work` reads a *module-level* `a` ten times per iteration: the compiler
+/// emits `GetVar`, so each read runs the dead local-slot scan + env walk +
+/// `module_state` mutex before hitting the binding.
+const GLOBAL_READ: &str = r"pipeline t(task) {
+  let a = 1
+  fn work() {
+    var total = 0
+    var i = 0
+    while i < 50000 {
+      total = total + a + a + a + a + a + a + a + a + a + a
+      i = i + 1
+    }
+    return total
+  }
+  return work()
+}";
+
+/// Same global read, but `work` carries many local slots so the linear
+/// `active_local_slot_index` scan each `GetVar` pays is wide.
+const GLOBAL_READ_MANY_LOCALS: &str = r"pipeline t(task) {
+  let a = 1
+  fn work() {
+    let l0 = 0
+    let l1 = 1
+    let l2 = 2
+    let l3 = 3
+    let l4 = 4
+    let l5 = 5
+    let l6 = 6
+    let l7 = 7
+    let l8 = 8
+    let l9 = 9
+    let l10 = 10
+    let l11 = 11
+    let l12 = 12
+    let l13 = 13
+    let l14 = 14
+    let l15 = 15
+    let l16 = 16
+    let l17 = 17
+    let l18 = 18
+    let l19 = 19
+    var total = l0 + l19
+    var i = 0
+    while i < 50000 {
+      total = total + a + a + a + a + a + a + a + a + a + a
+      i = i + 1
+    }
+    return total
+  }
+  return work()
+}";
+
+fn bench(c: &mut Criterion, name: &str, src: &str) {
+    let chunk = compile_source(src).expect("compile name-resolution fixture");
+    let rt = rt();
+    c.bench_function(name, |b| b.iter(|| black_box(run_chunk(&rt, &chunk))));
+}
+
+/// Hot loop calling a builtin (`abs`) by bare name ten times per iteration.
+/// The sync call path runs `resolve_named_closure` — local-slot scan, env
+/// walk, and the `module_functions` + `module_state` mutexes (both missing) —
+/// before the builtin finally dispatches by id.
+const BUILTIN_CALL: &str = r"pipeline t(task) {
+  fn work() {
+    var total = 0
+    var i = 0
+    while i < 50000 {
+      total = abs(i) + abs(i) + abs(i) + abs(i) + abs(i) + abs(i) + abs(i) + abs(i) + abs(i) + abs(i)
+      i = i + 1
+    }
+    return total
+  }
+  return work()
+}";
+
+/// Hot loop calling a sibling module-level function ten times per iteration:
+/// `resolve_named_closure` re-resolves through the module-function/module-state
+/// mutexes every call even though the DirectCall cache is "warm".
+const USER_FN_CALL: &str = r"pipeline t(task) {
+  fn dbl(x) { return x + x }
+  fn work() {
+    var total = 0
+    var i = 0
+    while i < 50000 {
+      total = dbl(i) + dbl(i) + dbl(i) + dbl(i) + dbl(i) + dbl(i) + dbl(i) + dbl(i) + dbl(i) + dbl(i)
+      i = i + 1
+    }
+    return total
+  }
+  return work()
+}";
+
+fn benches_group(c: &mut Criterion) {
+    bench(c, "name_res_local_read", LOCAL_READ);
+    bench(c, "name_res_global_read", GLOBAL_READ);
+    bench(
+        c,
+        "name_res_global_read_many_locals",
+        GLOBAL_READ_MANY_LOCALS,
+    );
+    bench(c, "name_res_builtin_call", BUILTIN_CALL);
+    bench(c, "name_res_user_fn_call", USER_FN_CALL);
+}
+
+criterion_group!(benches, benches_group);
+criterion_main!(benches);

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -1093,7 +1093,20 @@ impl super::super::Vm {
 
         let closure = match self.try_cached_named_direct_call(cached_state.as_ref(), name, argc) {
             Some(closure) => closure,
-            None => self.resolve_named_closure(name)?,
+            None => match self.resolve_named_closure(name) {
+                Some(closure) => closure,
+                // Not a user closure, so this bare call targets a builtin.
+                // Most builtins are synchronous; dispatch them right here on
+                // the sync path instead of bailing to
+                // `execute_call_builtin_async`, which would spin up the async
+                // state machine and re-run `resolve_named_closure` (a second
+                // local-slot scan + env walk + module mutexes) only to reach
+                // the same builtin. Async builtins return `None` and still take
+                // the async path. Resolution semantics are unchanged: a user
+                // `fn` of the same name is still found by `resolve_named_closure`
+                // above and wins over the builtin.
+                None => return self.try_dispatch_sync_builtin_inline(name, argc),
+            },
         };
         if !Self::direct_call_cacheable(&closure) {
             return None;
@@ -1112,6 +1125,49 @@ impl super::super::Vm {
         frame.ip += 11;
         let args_start = self.stack.len().checked_sub(argc)?;
         Some(self.push_closure_frame_from_stack_args(&closure, args_start, args_start))
+    }
+
+    /// Dispatch a synchronous builtin directly from the `Op::CallBuiltin` sync
+    /// handler, bypassing the async path for the common case.
+    ///
+    /// Returns `Some(result)` when the named builtin is synchronous — consuming
+    /// its `argc` stack arguments and advancing `ip` past the 11 operand bytes,
+    /// exactly as the closure path does. Returns `None` when the builtin is
+    /// asynchronous, bridge-backed, side-effect-gated, or otherwise not
+    /// sync-dispatchable, leaving the operand stack and `ip` untouched so
+    /// `execute_call_builtin_async` re-reads and handles it.
+    ///
+    /// Only reached after `resolve_named_closure` has already established the
+    /// name is not a user closure, so this never shadows a user `fn`.
+    fn try_dispatch_sync_builtin_inline(
+        &mut self,
+        name: &str,
+        argc: usize,
+    ) -> Option<Result<(), VmError>> {
+        let id = {
+            let frame = self.frames.last()?;
+            BuiltinId::from_raw(frame.chunk.read_u64(frame.ip))
+        };
+        let args_start = self.stack.len().checked_sub(argc)?;
+        // Dispatch straight off the operand stack — `*_from_stack_args` reads
+        // the argument slice in place (no owned `Vec`), exactly as the async
+        // handler does at its builtin branch. `None` means the builtin is not
+        // synchronously dispatchable (async / bridge / side-effect-gated); the
+        // stack is left untouched so `execute_call_builtin_async` handles it.
+        match self.try_call_sync_builtin_id_or_name_from_stack_args(Some(id), name, args_start) {
+            Some(result) => {
+                self.frames.last_mut()?.ip += 11;
+                self.stack.truncate(args_start);
+                Some(match result {
+                    Ok(value) => {
+                        self.stack.push(value);
+                        Ok(())
+                    }
+                    Err(error) => Err(error),
+                })
+            }
+            None => None,
+        }
     }
 
     fn try_cached_named_direct_call(

--- a/crates/harn-vm/tests/builtin_call_dispatch.rs
+++ b/crates/harn-vm/tests/builtin_call_dispatch.rs
@@ -1,0 +1,88 @@
+#![recursion_limit = "256"]
+//! Regression tests for the synchronous-builtin fast path on `Op::CallBuiltin`.
+//!
+//! `execute_call_builtin_sync` dispatches synchronous builtins directly instead
+//! of bailing to the async handler (which would re-run `resolve_named_closure`
+//! and spin up the async state machine). These tests pin the *semantics* that
+//! optimization must preserve:
+//!   - a bare builtin call still produces the builtin's result,
+//!   - a user `fn` that shadows a builtin name still wins over the builtin,
+//!   - builtin calls keep working inside loops / collection callbacks,
+//!   - builtin argument validation still fires on the fast path.
+
+use harn_vm::value::{VmError, VmValue};
+
+fn eval(source: &str) -> Result<VmValue, String> {
+    harn_vm::reset_thread_local_state();
+    let chunk = harn_vm::compile_source(source)?;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| e.to_string())?;
+    rt.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let mut vm = harn_vm::Vm::new();
+                harn_vm::register_vm_stdlib(&mut vm);
+                vm.execute(&chunk)
+                    .await
+                    .map_err(|e: VmError| format!("{e:?}"))
+            })
+            .await
+    })
+}
+
+#[test]
+fn sync_builtin_call_dispatches_inline() {
+    // `abs` is a synchronous builtin: the fast path must return its result.
+    assert!(matches!(
+        eval("pipeline t(task) { return abs(-5) }"),
+        Ok(VmValue::Int(5))
+    ));
+}
+
+#[test]
+fn user_fn_shadowing_a_builtin_name_still_wins() {
+    // The sync fast path is only reached *after* `resolve_named_closure`
+    // confirms the name is not a user closure. A module-level `fn` named like a
+    // builtin must therefore still take precedence over the builtin.
+    let result = eval(
+        r"pipeline t(task) {
+            fn abs(x) { return 999 }
+            return abs(-5)
+        }",
+    );
+    assert!(
+        matches!(result, Ok(VmValue::Int(999))),
+        "user fn must shadow the builtin, got {result:?}"
+    );
+}
+
+#[test]
+fn builtin_calls_work_inside_a_loop() {
+    let result = eval(
+        r"pipeline t(task) {
+            var s = 0
+            for x in [-1, -2, 3] {
+                s = s + abs(x)
+            }
+            return s
+        }",
+    );
+    assert!(
+        matches!(result, Ok(VmValue::Int(6))),
+        "expected sum of abs values, got {result:?}"
+    );
+}
+
+#[test]
+fn builtin_argument_validation_still_fires_on_fast_path() {
+    // Calling a numeric builtin with a wrong-typed argument must still error
+    // (validation runs inside the sync dispatch, not only on the async path).
+    let result = eval(r#"pipeline t(task) { return abs("not a number") }"#);
+    assert!(
+        result.is_err(),
+        "expected a validation error for abs(string), got {result:?}"
+    );
+}


### PR DESCRIPTION
## What

A bare builtin call (`abs(x)`, `len(xs)`, …) compiles to `Op::CallBuiltin`. Its **sync** handler resolved the name as a user closure, found none, and bailed to the **async** handler — which re-ran `resolve_named_closure` (a second local-slot scan + env walk + the `module_functions`/`module_state` mutexes inside imported modules) and drove the async state machine, only to reach the same synchronous builtin via `try_call_sync_builtin_id_or_name_from_stack_args`.

The sync handler now calls that same **in-place, no-alloc** helper directly, once `resolve_named_closure` has confirmed the name is not a user closure. Asynchronous builtins return `None` from the helper and still take the async path with the operand stack untouched.

## Why it's sound

- **Resolution semantics are identical** — a user `fn` that shadows a builtin name is still found by `resolve_named_closure` *before* the builtin path and wins (new test).
- Builtin argument validation, denial checks, and special-name (`await`/`cancel`) handling are unchanged.
- **No opcode / bytecode / compiler change** → vendored burin-code `.harnbc` is unaffected.
- **Thread-safe and holds one fewer lock per call** inside imported modules (drops the redundant `resolve_named_closure`, which acquires the `module_functions`/`module_state` mutexes) — friendlier to the multi-threaded runtime.

## Measurements

Adds `crates/harn-vm/benches/vm_name_resolution.rs` (local/global reads, builtin/user-fn calls) for regression tracking. Baseline per-op (500k-iter, low-noise run): local read ~24 ns, global read ~48 ns, **builtin call ~162 ns**, user-fn call ~248 ns — calls dominate. This removes the redundant resolution + async hop from every synchronous builtin call.

## Tests

`crates/harn-vm/tests/builtin_call_dispatch.rs` pins the preserved semantics (sync dispatch, user-fn shadowing wins, builtin-in-loop, argument validation on the fast path). Full harn-vm suite + 1647 conformance tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)