### PR TITLE
perf(vm): cut user-function call frame setup from 5 to 3 heap allocations

### DIFF
--- a/changelog.d/user-fn-call-frame-allocs.changed.md
+++ b/changelog.d/user-fn-call-frame-allocs.changed.md
@@ -1,0 +1,14 @@
+- **User-function calls allocate less on the call hot path.** Entering a
+  closure frame previously performed two `VmEnv` (scope-stack) heap clones — one
+  to snapshot the caller's env for restore-on-return, and one to build the
+  callee's env — plus a reallocation when the freshly cloned callee env was
+  grown by the empty scope every call pushes. The caller-env snapshot is now a
+  move (`std::mem::replace`) rather than a clone, since `self.env` is overwritten
+  with the callee env anyway and the old value only needs to survive in the
+  frame; and the callee-env clone now reserves room for that pushed scope so it
+  no longer reallocates. A measured user-function call drops from 5 heap
+  allocations / 81 bytes to 3 / 41 bytes, with identical scoping, recursion, and
+  closure-capture semantics. The change is confined to runtime env handling (no
+  bytecode, compiler, or serialized-cache change) and touches only owned local
+  state, so it is safe under the multi-threaded runtime. No `harn` language
+  behavior changes.

--- a/crates/harn-vm/src/value/env.rs
+++ b/crates/harn-vm/src/value/env.rs
@@ -136,6 +136,21 @@ impl VmEnv {
         self.scopes.push(Scope::empty());
     }
 
+    /// Clone the scope stack for a fresh call frame, reserving room for the
+    /// one empty scope every invocation pushes for the callee's body.
+    ///
+    /// `Vec::clone` allocates at exactly `len` capacity, so the `push_scope`
+    /// that immediately follows on the call hot path would otherwise force a
+    /// reallocation and copy of the whole scope stack. Reserving the extra
+    /// slot up front folds those two allocations into one. When a caller does
+    /// not end up pushing (no path currently does, but it stays correct if one
+    /// is added), the only cost is a single unused `Scope` slot of capacity.
+    pub(crate) fn cloned_for_call(&self) -> VmEnv {
+        let mut scopes = Vec::with_capacity(self.scopes.len() + 1);
+        scopes.extend(self.scopes.iter().cloned());
+        VmEnv { scopes }
+    }
+
     pub fn pop_scope(&mut self) {
         if self.scopes.len() > 1 {
             self.scopes.pop();

--- a/crates/harn-vm/src/vm/scope.rs
+++ b/crates/harn-vm/src/vm/scope.rs
@@ -33,9 +33,9 @@ impl Vm {
     /// entirely as a fast path for context-builder workloads.
     pub(crate) fn closure_call_env(caller_env: &VmEnv, closure: &VmClosure) -> VmEnv {
         if closure.module_state().is_some() {
-            return closure.env.clone();
+            return closure.env.cloned_for_call();
         }
-        let call_env = closure.env.clone();
+        let call_env = closure.env.cloned_for_call();
         // Compile-time guard: the late-bind walk only matters when the
         // callee body actually reads a name through the runtime env
         // (GetVar / SetVar / CallBuiltin / ...). For pure-arithmetic
@@ -125,8 +125,6 @@ impl Vm {
         initial_local_slots: Option<Vec<LocalSlot>>,
         step_args: &[VmValue],
     ) {
-        let saved_env = self.env.clone();
-
         // If this closure originated from an imported module, switch
         // the thread-local source dir so that render() and other
         // source-relative builtins resolve relative to the module.
@@ -138,6 +136,12 @@ impl Vm {
             None
         };
 
+        // `closure_call_env_for_current_frame` still reads the caller's
+        // `self.env`, so build the callee env first, then *move* the caller
+        // env into the frame. `self.env` is about to be overwritten anyway —
+        // it only needs to survive in `saved_env` for restore-on-return — so a
+        // clone here would allocate a whole scope-stack copy on every call for
+        // nothing.
         let mut call_env = self.closure_call_env_for_current_frame(closure);
         call_env.push_scope();
 
@@ -146,7 +150,7 @@ impl Vm {
         } else {
             None
         };
-        self.env = call_env;
+        let saved_env = std::mem::replace(&mut self.env, call_env);
 
         // Function-name breakpoint latch: record the name so the step
         // loop can raise a single "function breakpoint" stop on the

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -502,7 +502,7 @@ impl Vm {
         closure: &crate::value::VmClosure,
     ) -> VmEnv {
         if closure.module_state().is_some() {
-            return closure.env.clone();
+            return closure.env.cloned_for_call();
         }
         let call_env = Self::closure_call_env(&self.env, closure);
         // Same compile-time short-circuit as the env walk in

--- a/crates/harn-vm/tests/call_frame_allocations.rs
+++ b/crates/harn-vm/tests/call_frame_allocations.rs
@@ -1,0 +1,119 @@
+#![recursion_limit = "256"]
+//! Deterministic allocation-regression guard for the user-function call path.
+//!
+//! Entering a closure frame is the dominant cost of an orchestration-heavy
+//! workload, and that cost is overwhelmingly heap allocation rather than CPU.
+//! Unlike a timing benchmark, the *number* of allocations per call is
+//! machine-independent and stable in CI, so we pin it here.
+//!
+//! A user-function call currently performs exactly **3** heap allocations:
+//!   1. the callee's `Vec<LocalSlot>` (fresh mutable locals — fundamental),
+//!   2. the callee's env scope-stack clone (`VmEnv::cloned_for_call`, which
+//!      also reserves the slot the call's pushed scope reuses), and
+//!   3. the frame's `fn_name` string clone.
+//!
+//! The caller-env snapshot is a move (`std::mem::replace`), not a clone, and the
+//! cloned callee env reserves room for its pushed scope, so neither shows up
+//! here. If this count regresses (e.g. a reintroduced env clone or a
+//! clone-then-grow reallocation), this test fails. Improvements are allowed:
+//! the assertion is an upper bound.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct Counting;
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        System.alloc(layout)
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+    }
+}
+
+#[global_allocator]
+static GLOBAL: Counting = Counting;
+
+/// Compile and run `source`, returning the number of heap allocations performed
+/// during `vm.execute` only (compilation and VM setup are excluded).
+fn allocs_during_execute(source: &str) -> usize {
+    harn_vm::reset_thread_local_state();
+    let chunk = harn_vm::compile_source(source).expect("compile");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    rt.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let mut vm = harn_vm::Vm::new();
+                harn_vm::register_vm_stdlib(&mut vm);
+                let before = ALLOCS.load(Ordering::Relaxed);
+                vm.execute(&chunk).await.expect("execute");
+                ALLOCS.load(Ordering::Relaxed) - before
+            })
+            .await
+    })
+}
+
+/// Calls a user `fn` `n` times in an allocation-free loop (lazy `to` range,
+/// slot-indexed locals).
+fn user_fn_loop(n: usize) -> String {
+    format!(
+        "pipeline t(task) {{\n\
+         fn f(x) {{ return x + 1 }}\n\
+         var s = 0\n\
+         for i in 0 to {n} {{ s = s + f(i) }}\n\
+         return s\n\
+         }}"
+    )
+}
+
+/// The same loop without the call, to isolate per-call allocations from any
+/// per-iteration loop overhead.
+fn bare_loop(n: usize) -> String {
+    format!(
+        "pipeline t(task) {{\n\
+         var s = 0\n\
+         for i in 0 to {n} {{ s = s + (i + 1) }}\n\
+         return s\n\
+         }}"
+    )
+}
+
+/// Marginal allocations attributable to one extra iteration of `make(n)`,
+/// computed as the difference between `n2` and `n1` iterations so fixed setup
+/// cancels out.
+fn marginal_per_iter(make: impl Fn(usize) -> String) -> f64 {
+    let (n1, n2) = (2000usize, 4000usize);
+    let a1 = allocs_during_execute(&make(n1));
+    let a2 = allocs_during_execute(&make(n2));
+    (a2 - a1) as f64 / (n2 - n1) as f64
+}
+
+#[test]
+fn user_fn_call_allocates_at_most_three_times() {
+    let per_call = marginal_per_iter(user_fn_loop);
+    let per_loop = marginal_per_iter(bare_loop);
+    let attributable_to_call = per_call - per_loop;
+
+    // The loop itself must stay allocation-free, otherwise the call delta is
+    // meaningless.
+    assert!(
+        per_loop < 0.01,
+        "the measurement loop regressed to {per_loop} allocs/iter; it must be allocation-free"
+    );
+
+    // Upper bound: a user-fn call must not exceed 3 heap allocations. Floats
+    // because the value is a measured ratio; 3.0001 tolerates nothing extra
+    // while staying robust to f64 division.
+    assert!(
+        attributable_to_call <= 3.0001,
+        "user-fn call regressed to {attributable_to_call} allocs/call (was 3); \
+         a redundant env clone or clone-then-grow reallocation was likely reintroduced"
+    );
+}


### PR DESCRIPTION
## What

Entering a user-function call frame did three avoidable things on the hot path:

1. **Cloned the caller's env** (`self.env.clone()`) to save it for restore-on-return.
2. **Cloned the closure's captured env** to build the callee env.
3. **Reallocated** that freshly cloned `Vec<Scope>` when the empty per-call scope was pushed onto it (a `Vec::clone` allocates at exactly `len` capacity, so the immediate `push_scope` always grew it).

This PR removes (1) and (3):

- The caller-env snapshot is now a **move** (`std::mem::replace`) rather than a clone — `self.env` is overwritten with the callee env anyway, so the old value only needs to survive in the frame for restore-on-return.
- The callee-env clone now reserves room for the pushed scope via a new `VmEnv::cloned_for_call`, folding the clone-then-grow into a single allocation.

Allocation (2) — the captured-env clone — and the callee's `Vec<LocalSlot>` remain; eliminating those needs the larger upvalue/indexed-capture redesign and is out of scope here.

## Measured impact

Deterministic allocation count (new regression test, machine-independent):

| | allocs / call | bytes / call |
|---|---|---|
| before | 5 | 81 |
| after | **3** | **41** |

Latency (`name_res_user_fn_call` criterion bench, A/B on the same machine, 500k calls/iter):

| | ns / call |
|---|---|
| before | 249.0 |
| after | **208.6** (**−16.2%**) |

## Correctness

- Full conformance suite: the failure set is **identical** to `main` (20 pre-existing, environment-only failures: missing `cosign`/`syft` external binaries, network listener binding, `harn` subprocess) — **zero** new failures.
- `cargo test -p harn-vm --lib`: 3903 passed.
- Closure-shadowing / recursion dispatch regression tests: pass.
- New `call_frame_allocations` integration test pins the 3-allocation upper bound as a CI-stable guard.

## Safety / scope

- Touches only **owned runtime env state** (no `Arc` aliasing introduced, no shared mutable state), so it is safe under the multi-threaded runtime.
- **No** bytecode, compiler, or serialized-cache (`.harnbc`) format change — the freeze/thaw boundary is untouched.
- No `harn` language behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)