### PR TITLE
fix(llm): recover from provider context_overflow (emergency compact + retry) + set gpt-oss context windows

### DIFF
--- a/changelog.d/context-overflow-resilience.fixed.md
+++ b/changelog.d/context-overflow-resilience.fixed.md
@@ -1,0 +1,10 @@
+- The agent loop now recovers from a provider `context_overflow` error instead
+  of dying. When a provider rejects a turn because the assembled prompt exceeds
+  the model's context window, the loop emergency-compacts the transcript
+  (deterministic observation masking) and retries, bounded so a pathological
+  irreducible prompt can't loop forever; only a still-overflowing,
+  no-longer-shrinkable transcript becomes a terminal error.
+- Added the Fireworks-served `accounts/fireworks/models/gpt-oss-120b` route to
+  the model catalog with its real 131072-token context window. Without a catalog
+  row the route had no window, so auto-compaction had no budget to enforce and
+  the prompt could grow until Fireworks returned HTTP 400 `[context_overflow]`.

--- a/conformance/tests/agents/agent_loop_context_overflow_recovery.expected
+++ b/conformance/tests/agents/agent_loop_context_overflow_recovery.expected
@@ -1,0 +1,8 @@
+done
+true
+true
+true
+provider_error
+context_overflow
+provider_error
+true

--- a/conformance/tests/agents/agent_loop_context_overflow_recovery.harn
+++ b/conformance/tests/agents/agent_loop_context_overflow_recovery.harn
@@ -1,0 +1,123 @@
+import { llm_done, with_llm_script } from "std/testing"
+
+/**
+ * A provider can reject a turn with HTTP 400 [context_overflow] when the
+ * assembled prompt outgrows the model's real context window (large repo, or an
+ * under-cataloged window so auto-compaction never fired). The agent must NOT
+ * die: it emergency-compacts the live transcript (deterministic observation
+ * masking) and RETRIES the turn, bounded so a pathological irreducible prompt
+ * can't loop forever. Only a still-overflowing, no-longer-shrinkable transcript
+ * becomes a genuinely terminal error — distinct from auth / invalid-model
+ * failures which stay terminal immediately.
+ */
+fn lookup_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "lookup",
+    "Return evidence",
+    {
+      handler: { args -> "evidence for " + to_string(args?.query) },
+      parameters: {query: {type: "string"}},
+      returns: {type: "string"},
+      annotations: {kind: "read"},
+    },
+  )
+  return tools
+}
+
+fn overflow_turn() {
+  return {
+    error: {
+      status: 400,
+      reason: "context_overflow",
+      message: "fireworks HTTP 400 [context_overflow]: prompt is too long: 197467 tokens exceeds maximum context length of 131071",
+    },
+  }
+}
+
+pipeline main() {
+  // (a) Accrue several tool observations so the transcript has masking
+  // headroom, hit context_overflow, then recover: emergency compaction archives
+  // older observations and the retried turn succeeds and finishes.
+  with_llm_script(
+    [
+      {tool_calls: [{id: "lookup_1", name: "lookup", arguments: {query: "a"}}]},
+      {tool_calls: [{id: "lookup_2", name: "lookup", arguments: {query: "b"}}]},
+      {tool_calls: [{id: "lookup_3", name: "lookup", arguments: {query: "c"}}]},
+      {tool_calls: [{id: "lookup_4", name: "lookup", arguments: {query: "d"}}]},
+      overflow_turn(),
+      llm_done(),
+    ],
+    { ->
+      let result = agent_loop(
+        "Inspect evidence and finish.",
+        nil,
+        {
+          provider: "mock",
+          model: "qwen-local",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 12,
+        },
+      )
+      __io_println(result.status)
+      __io_println(contains(json_stringify(result.transcript), "context_overflow_recovery"))
+      __io_println(contains(json_stringify(result.transcript), "\"reason\":\"context_overflow\""))
+      __io_println(!contains(json_stringify(result.transcript), "agent_loop_terminal_error"))
+    },
+  )
+  // (b) Bounded: when EVERY turn overflows (nothing left to shed once the
+  // recovery budget is spent), the loop stops with a terminal context_overflow
+  // error instead of spinning forever.
+  with_llm_script(
+    [
+      {tool_calls: [{id: "lookup_1", name: "lookup", arguments: {query: "a"}}]},
+      {tool_calls: [{id: "lookup_2", name: "lookup", arguments: {query: "b"}}]},
+      overflow_turn(),
+      overflow_turn(),
+      overflow_turn(),
+      overflow_turn(),
+      overflow_turn(),
+      overflow_turn(),
+    ],
+    { ->
+      let result = agent_loop(
+        "Inspect evidence and finish.",
+        nil,
+        {
+          provider: "mock",
+          model: "qwen-local",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 12,
+        },
+      )
+      __io_println(result.status)
+      __io_println(result.error.reason)
+    },
+  )
+  // (c) A genuinely-terminal error (auth) is NOT routed through overflow
+  // recovery — it stops immediately with no recovery event.
+  with_llm_script(
+    [{error: {category: "auth", message: "missing API key"}}, llm_done()],
+    { ->
+      let result = agent_loop(
+        "Inspect evidence and finish.",
+        nil,
+        {
+          provider: "mock",
+          model: "qwen-local",
+          tools: lookup_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 12,
+        },
+      )
+      __io_println(result.status)
+      __io_println(!contains(json_stringify(result.transcript), "context_overflow_recovery"))
+    },
+  )
+}

--- a/crates/harn-stdlib/src/stdlib/agent/autocompact.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/autocompact.harn
@@ -453,3 +453,99 @@ pub fn agent_autocompact_if_needed(session, opts) {
   }
   return nil
 }
+
+/**
+ * Force an emergency compaction of the live session transcript, IGNORING the
+ * normal compaction policy/threshold gate. This is the recovery path for a
+ * provider `context_overflow` error: the prompt already exceeded the model's
+ * real context window, so we must shrink it unconditionally and retry — there
+ * is no "should we compact?" decision left to make.
+ *
+ * Uses deterministic observation masking (never an LLM round-trip, which would
+ * itself overflow) with a `compact_threshold` of 1 so masking always engages,
+ * and an `attempt`-decreasing `keep_last` so successive emergency attempts drop
+ * more of the recent tail. Returns the number of archived messages: `0` means
+ * compaction could not shrink the transcript further (irreducible — e.g. the
+ * system prompt plus a single oversized message), which the agent loop treats
+ * as a genuinely terminal overflow.
+ *
+ * @effects: [host]
+ * @errors: []
+ * @api_stability: experimental
+ */
+pub fn agent_emergency_compact(session, opts, attempt) {
+  let messages = __host_agent_session_messages(session.session_id)
+  // Shrink the preserved tail as attempts escalate: a longer tail is tried
+  // first (least lossy), collapsing toward keeping only the latest user turn so
+  // a pathological recent observation can still be masked out.
+  let base_keep = if attempt <= 1 {
+    8
+  } else if attempt == 2 {
+    4
+  } else {
+    1
+  }
+  // Clamp the preserved tail well below the live message count so masking
+  // always has a span to archive — a `keep_last` that swallows the whole
+  // transcript would make `transcript_auto_compact` a no-op (archived == 0),
+  // which the loop reads as "irreducible" and gives up on prematurely. Leaving
+  // at most a third of the messages guarantees forward progress while still
+  // dropping the smallest tail it can.
+  let one_third = to_int(len(messages) / 3)
+  let ceiling = if one_third < 1 {
+    1
+  } else {
+    one_third
+  }
+  let keep_last = if base_keep < ceiling {
+    base_keep
+  } else {
+    ceiling
+  }
+  let compact_opts = {compact_strategy: "observation_mask", compact_threshold: 1, keep_last: keep_last}
+  let pre_payload = {
+    session: {id: session.session_id},
+    reason: "context_overflow",
+    strategy: "observation_mask",
+    engine_strategy: "observation_mask",
+    message_count: len(messages),
+    keep_last: keep_last,
+    attempt: attempt,
+    estimated_tokens_before: estimate_tokens(messages),
+  }
+  __host_fire_session_hook("pre_compact", pre_payload)
+  let compacted = transcript_auto_compact(messages, compact_opts)
+  let summary = __auto_compact_summary(messages, compacted)
+  let archived = if summary != "" {
+    len(messages) - len(compacted) + 1
+  } else {
+    0
+  }
+  if archived > 0 {
+    __host_agent_session_replace_messages(session.session_id, compacted, summary)
+    let metadata = {
+      mode: "emergency",
+      reason: "context_overflow",
+      strategy: "observation_mask",
+      engine_strategy: "observation_mask",
+      archived_messages: archived,
+      new_summary_len: len(summary),
+      keep_last: keep_last,
+      attempt: attempt,
+      estimated_tokens_before: estimate_tokens(messages),
+      estimated_tokens_after: estimate_tokens(compacted),
+    }
+    agent_record_compaction(session.session_id, metadata)
+    let post_payload = pre_payload
+      + {
+      archived_messages: archived,
+      new_summary_len: len(summary),
+      remaining_messages: len(compacted),
+      summary: summary,
+      estimated_tokens_after: estimate_tokens(compacted),
+    }
+    __host_fire_session_hook("post_compact", post_payload)
+    agent_reminder_providers_fire(session.session_id, "post_compact", post_payload, opts)
+  }
+  return archived
+}

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -1,5 +1,5 @@
 // @harn-entrypoint-category agent.stdlib
-import { agent_autocompact_if_needed } from "std/agent/autocompact"
+import { agent_autocompact_if_needed, agent_emergency_compact } from "std/agent/autocompact"
 import { agent_budget_post_call_blocked, agent_budget_pre_call_blocked } from "std/agent/budget"
 import {
   agent_loop_apply_command,
@@ -319,6 +319,107 @@ fn __invoke_llm_with_autocontinue(
     call = __invoke_llm(message, turn_system, retry_opts)
   }
   return call
+}
+
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Context-overflow recovery.
+ *
+ * A provider can reject a turn with a `context_overflow` error when the
+ * assembled prompt exceeds the model's real context window — typically on a
+ * large repo where tool observations accreted past the budget, OR when the
+ * model's window is mis/under-cataloged so auto-compaction never fired. The
+ * agent must NOT die on this: it is a recoverable, self-inflicted condition.
+ *
+ * Recovery is a bounded loop: emergency-compact the live transcript
+ * (deterministic observation masking — never an LLM call, which would itself
+ * overflow), then re-issue the SAME turn. Each attempt compacts more
+ * aggressively (shorter preserved tail). We stop when either the retry
+ * succeeds, or emergency compaction can no longer shrink the transcript
+ * (`archived == 0`, i.e. an irreducible system-prompt + single oversized
+ * message), at which point the overflow is genuinely terminal.
+ */
+fn __agent_loop_is_context_overflow(error) {
+  if type_of(error) != "dict" {
+    return false
+  }
+  let reason = to_string(error?.reason ?? "")
+  if reason == "context_overflow" {
+    return true
+  }
+  // Defensive fallback: some routes surface the condition only in the message
+  // text (uncataloged provider, no structured `reason`). Match the canonical
+  // classifier tag the Rust LLM layer stamps onto the error string.
+  let message = to_string(error?.message ?? "")
+  return contains(message, "[context_overflow]")
+}
+
+fn __agent_loop_context_overflow_max_recoveries(llm_opts) {
+  let configured = llm_opts?.context_overflow_recover_max
+  if type_of(configured) == "int" && configured >= 0 {
+    return configured
+  }
+  return 3
+}
+
+/**
+ * On a `context_overflow` provider error, emergency-compact + retry (bounded).
+ * Returns a fresh `{ok, ...}` call result: `ok:true` when a retry succeeded,
+ * or the last `ok:false` result (so the caller's terminal path runs unchanged)
+ * when recovery is exhausted or the transcript is irreducible.
+ */
+fn __agent_loop_recover_context_overflow(
+  call,
+  message,
+  turn_system,
+  llm_opts,
+  turn_opts,
+  session,
+  iteration_index,
+) {
+  let max_recoveries = __agent_loop_context_overflow_max_recoveries(llm_opts)
+  var current = call
+  var attempt = 0
+  while attempt < max_recoveries && !current.ok
+    && __agent_loop_is_context_overflow(current?.error) {
+    attempt = attempt + 1
+    let archived = agent_emergency_compact(session, llm_opts, attempt)
+    agent_emit_event(
+      session.session_id,
+      "context_overflow_recovery",
+      {
+        iteration: iteration_index + 1,
+        attempt: attempt,
+        max_recoveries: max_recoveries,
+        archived_messages: archived,
+        provider_error: current?.error ?? {},
+      },
+    )
+    // Nothing left to shed: the prompt is irreducible (system prompt + a single
+    // oversized message). Re-issuing would overflow identically, so surface the
+    // original terminal error rather than spin.
+    if archived <= 0 {
+      break
+    }
+    // Rebuild the turn prompt against the now-compacted transcript and re-issue.
+    let turn_prompt = __agent_loop_build_turn_prompt(session, llm_opts, iteration_index)
+    let retry_opts = llm_opts
+      + {
+      messages: turn_prompt.messages,
+      _system_fragments: turn_prompt.fragments,
+      _context_overflow_recovery_attempt: attempt,
+    }
+    current = __invoke_llm_with_autocontinue(
+      message,
+      turn_prompt.system,
+      retry_opts,
+      turn_opts,
+      session.session_id,
+      iteration_index,
+    )
+  }
+  return current
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -2468,7 +2569,7 @@ fn __agent_loop_run(message, session, initial_opts) {
         _iteration: iteration_index + 1,
         _system_fragments: turn_prompt.fragments,
       }
-      let call = __invoke_llm_with_autocontinue(
+      var call = __invoke_llm_with_autocontinue(
         message,
         turn_prompt.system,
         llm_opts,
@@ -2476,6 +2577,17 @@ fn __agent_loop_run(message, session, initial_opts) {
         session.session_id,
         iteration_index,
       )
+      if !call.ok && __agent_loop_is_context_overflow(call?.error) {
+        call = __agent_loop_recover_context_overflow(
+          call,
+          message,
+          turn_prompt.system,
+          llm_opts,
+          turn_opts,
+          session,
+          iteration_index,
+        )
+      }
       if !call.ok {
         let failure_config = __agent_loop_consecutive_failure_config(budget)
         if __agent_loop_tracks_failure(call?.error, failure_config) {
@@ -3323,6 +3435,9 @@ fn __agent_loop_run(message, session, initial_opts) {
   return unwrap(run)
 }
 
+// Recoverable: emergency-compact the transcript and retry the turn
+// before treating overflow as a failure. The agent must keep working
+// on a large repo, not die when the prompt outgrows the window.
 // A SUCCESSFUL terminal hand-back (clean done / a passing verify_completion)
 // must not report a stale current_failure: a run can complete without ever
 // flowing a passing verification result through the fold. Clear the

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -1848,6 +1848,7 @@ async fn host_agent_emit_event(
             | "tool_call_audit"
             | "budget_exhausted"
             | "budget_circuit_breaker"
+            | "context_overflow_recovery"
             | "loop_checkpoint"
     ) {
         let role = if matches!(
@@ -2377,6 +2378,23 @@ fn build_agent_event(
                 get_usize("raised_max_tokens"),
                 get_usize("attempt"),
                 get_usize("max_continuations"),
+            ),
+        }),
+        // `context_overflow_recovery` fires when a provider rejected the turn
+        // with a context_overflow error and the loop emergency-compacted the
+        // transcript (deterministic observation masking) before re-issuing the
+        // turn — the recovery that keeps the agent working on a large repo
+        // instead of dying. Engine-emitted; surfaced on the FeedbackInjected
+        // stream like the sibling recoveries. `content` summarizes the attempt
+        // and how many messages were archived to fit under the window.
+        "context_overflow_recovery" => Ok(AgentEvent::FeedbackInjected {
+            session_id: session_id.to_string(),
+            kind: "context_overflow_recovery".to_string(),
+            content: format!(
+                "attempt {}/{} archived {} messages",
+                get_usize("attempt"),
+                get_usize("max_recoveries"),
+                get_usize("archived_messages"),
             ),
         }),
         other => Err(VmError::Runtime(format!(

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/90-hosted-gemma-cohere-xai-groq.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/90-hosted-gemma-cohere-xai-groq.toml
@@ -65,6 +65,30 @@ tier = "frontier"
 open_weight = true
 strengths = ["speed", "cheap", "tool_use", "reasoning"]
 
+# Fireworks-hosted gpt-oss routes. Without a catalog row the wire id
+# `accounts/fireworks/models/gpt-oss-*` has NO context window, so the
+# agent's auto-compaction budget falls back to a placeholder and the prompt
+# can grow until Fireworks rejects the turn with HTTP 400 [context_overflow]
+# ("maximum context length of 131071"). Cataloging the real 131072-token
+# window lets compaction trigger before the hard limit. Verified against the
+# Fireworks-served gpt-oss spec (131072 ctx; the overflow error itself names
+# the 131071 ceiling).
+[models."accounts/fireworks/models/gpt-oss-120b"]
+name = "GPT-OSS 120B (Fireworks)"
+provider = "fireworks"
+context_window = 131072
+logical_model = "openai-gpt-oss-120b"
+equivalence_group = "openai-gpt-oss-120b"
+served_variant = "fireworks"
+wire_model = "accounts/fireworks/models/gpt-oss-120b"
+api_dialect = "openai_chat"
+capabilities = ["tools", "streaming", "thinking"]
+pricing = { input_per_mtok = 0.15, output_per_mtok = 0.60 }
+architecture = { parameter_count_b = 117.0, active_parameter_count_b = 5.1, moe = true, license = "Apache-2.0", source_url = "https://developers.openai.com/api/docs/models/gpt-oss-120b", last_verified = "2026-06-19" }
+tier = "frontier"
+open_weight = true
+strengths = ["speed", "cheap", "tool_use", "reasoning"]
+
 [models."llama-3.3-70b-versatile"]
 name = "Llama 3.3 70B Versatile (Groq)"
 provider = "groq"

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -2268,6 +2268,30 @@ tier = "frontier"
 open_weight = true
 strengths = ["speed", "cheap", "tool_use", "reasoning"]
 
+# Fireworks-hosted gpt-oss routes. Without a catalog row the wire id
+# `accounts/fireworks/models/gpt-oss-*` has NO context window, so the
+# agent's auto-compaction budget falls back to a placeholder and the prompt
+# can grow until Fireworks rejects the turn with HTTP 400 [context_overflow]
+# ("maximum context length of 131071"). Cataloging the real 131072-token
+# window lets compaction trigger before the hard limit. Verified against the
+# Fireworks-served gpt-oss spec (131072 ctx; the overflow error itself names
+# the 131071 ceiling).
+[models."accounts/fireworks/models/gpt-oss-120b"]
+name = "GPT-OSS 120B (Fireworks)"
+provider = "fireworks"
+context_window = 131072
+logical_model = "openai-gpt-oss-120b"
+equivalence_group = "openai-gpt-oss-120b"
+served_variant = "fireworks"
+wire_model = "accounts/fireworks/models/gpt-oss-120b"
+api_dialect = "openai_chat"
+capabilities = ["tools", "streaming", "thinking"]
+pricing = { input_per_mtok = 0.15, output_per_mtok = 0.60 }
+architecture = { parameter_count_b = 117.0, active_parameter_count_b = 5.1, moe = true, license = "Apache-2.0", source_url = "https://developers.openai.com/api/docs/models/gpt-oss-120b", last_verified = "2026-06-19" }
+tier = "frontier"
+open_weight = true
+strengths = ["speed", "cheap", "tool_use", "reasoning"]
+
 [models."llama-3.3-70b-versatile"]
 name = "Llama 3.3 70B Versatile (Groq)"
 provider = "groq"

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -2873,6 +2873,26 @@ mod tests {
     }
 
     #[test]
+    fn fireworks_gpt_oss_route_has_real_context_window() {
+        // Regression: the Fireworks-served `accounts/fireworks/models/gpt-oss-120b`
+        // wire id had NO catalog row, so its context window resolved to None and
+        // the agent's auto-compaction budget had nothing to enforce — the prompt
+        // grew until Fireworks rejected the turn with HTTP 400 [context_overflow]
+        // (session 019ee303: 197467 tokens > 131071 max). Cataloging the real
+        // 131072 window lets compaction trigger before the hard limit.
+        reset_overrides();
+
+        let entry = model_catalog_entry("accounts/fireworks/models/gpt-oss-120b")
+            .expect("Fireworks gpt-oss-120b must be in the model catalog");
+        assert_eq!(entry.context_window, 131_072);
+        assert_eq!(entry.provider, "fireworks");
+        assert_eq!(
+            entry.equivalence_group.as_deref(),
+            Some("openai-gpt-oss-120b"),
+        );
+    }
+
+    #[test]
     fn test_user_catalog_overlay_re_homes_model_provider() {
         // Users can re-home a built-in model by overlaying a catalog row;
         // the exact-match catalog lookup must honor overlays as well as the

--- a/docs/provider-support.json
+++ b/docs/provider-support.json
@@ -444,13 +444,14 @@
         "FIREWORKS_API_KEY"
       ],
       "recommended": {
-        "selector": "fireworks:accounts/fireworks/models/gpt-oss-*",
+        "selector": "fireworks:accounts/fireworks/models/gpt-oss-120b",
         "provider": "fireworks",
-        "model": "accounts/fireworks/models/gpt-oss-*",
-        "display_name": null,
+        "model": "accounts/fireworks/models/gpt-oss-120b",
+        "display_name": "GPT-OSS 120B (Fireworks)",
         "tool_format": "json",
         "harn_options": [
           "provider = \"fireworks\"",
+          "model = \"accounts/fireworks/models/gpt-oss-120b\"",
           "tool_format = \"json\"",
           "structured_output_mode = \"native_json\""
         ]
@@ -468,7 +469,7 @@
           "reasoning_effort"
         ],
         "prompt_or_context_cache": false,
-        "usage_accounting_confidence": "provider_default"
+        "usage_accounting_confidence": "high"
       },
       "empirical": {
         "status": "not_recorded",

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -210,6 +210,7 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `deepseek` | `deepseek-reasoner` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `deepseek` | `deepseek-v4-flash` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `deepseek` | `deepseek-v4-pro` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `fireworks` | `accounts/fireworks/models/gpt-oss-120b` | `json` | `text_only` | - | - | - | - | - | `data not yet collected` |
 | `gemini` | `gemini-2.5-flash` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `gemini` | `gemini-2.5-pro` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `gemini` | `models/gemma-4-26b-a4b-it` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |

--- a/docs/src/provider-support.md
+++ b/docs/src/provider-support.md
@@ -19,7 +19,7 @@ No benchmark summary is baked into this checked-in page. To layer local empirica
 | `Dashscope` | OpenAI-compatible chat completions | `dashscope:qwen3.6*` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `provider_default` | `not_recorded` |
 | `Deepinfra` | OpenAI-compatible chat completions | `deepinfra:deepinfra/Qwen/Qwen3.6-35B-A3B` | `native` | yes | yes | `native` / `native_json` | `enabled` | no | `high` | `not_recorded` |
 | `Deepseek` | OpenAI-compatible chat completions | `deepseek:deepseek-v4-flash` | `native` | yes | yes | `native` / `native_json` | `enabled` | yes | `high` | `not_recorded` |
-| `Fireworks` | OpenAI-compatible chat completions | `fireworks:accounts/fireworks/models/gpt-oss-*` | `json` | no | yes | `none` / `native_json` | `effort,reasoning_effort` | no | `provider_default` | `not_recorded` |
+| `Fireworks` | OpenAI-compatible chat completions | `fireworks:accounts/fireworks/models/gpt-oss-120b` | `json` | no | yes | `none` / `native_json` | `effort,reasoning_effort` | no | `high` | `not_recorded` |
 | `Gemini API` | Gemini generateContent | `gemini:gemini-2.5-flash` | `native` | yes | yes | `native` / `native_json` | `adaptive,effort,enabled` | yes | `medium` | `not_recorded` |
 | `Groq` | OpenAI-compatible chat completions | `groq:llama-3.1-8b-instant` | `native` | yes | yes | `native` / `native_json` | none | no | `high` | `not_recorded` |
 | `Huggingface` | OpenAI-compatible chat completions | `huggingface:qwen/qwen3.6*` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `provider_default` | `not_recorded` |

--- a/spec/provider-catalog/HarnProviderCatalog.swift
+++ b/spec/provider-catalog/HarnProviderCatalog.swift
@@ -3386,6 +3386,88 @@ public let harnProviderCatalogJSON = #"""
       }
     },
     {
+      "id": "accounts/fireworks/models/gpt-oss-120b",
+      "name": "GPT-OSS 120B (Fireworks)",
+      "provider": "fireworks",
+      "aliases": [],
+      "context_window": 131072,
+      "logical_model": "openai-gpt-oss-120b",
+      "equivalence_group": "openai-gpt-oss-120b",
+      "served_variant": "fireworks",
+      "wire_model": "accounts/fireworks/models/gpt-oss-120b",
+      "api_dialect": "openai_chat",
+      "architecture": {
+        "parameter_count_b": 117.0,
+        "active_parameter_count_b": 5.1,
+        "moe": true,
+        "license": "Apache-2.0",
+        "source_url": "https://developers.openai.com/api/docs/models/gpt-oss-120b",
+        "last_verified": "2026-06-19"
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "preferred_format": "json",
+        "parity": "text_only",
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "reasoning_summary"
+      },
+      "reasoning": {
+        "modes": [
+          "effort"
+        ],
+        "effort_supported": true,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.15,
+        "output_per_mtok": 0.6,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "thinking",
+        "extended_thinking"
+      ],
+      "family": "openai-gpt",
+      "lineage": "openai-legacy",
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "speed",
+        "cheap",
+        "tool_use",
+        "reasoning"
+      ]
+    },
+    {
       "id": "gemini-2.5-flash",
       "name": "Gemini 2.5 Flash",
       "provider": "gemini",

--- a/spec/provider-catalog/harn-provider-catalog.ts
+++ b/spec/provider-catalog/harn-provider-catalog.ts
@@ -3122,6 +3122,88 @@ export const harnProviderCatalog: HarnProviderCatalog = {
       }
     },
     {
+      "id": "accounts/fireworks/models/gpt-oss-120b",
+      "name": "GPT-OSS 120B (Fireworks)",
+      "provider": "fireworks",
+      "aliases": [],
+      "context_window": 131072,
+      "logical_model": "openai-gpt-oss-120b",
+      "equivalence_group": "openai-gpt-oss-120b",
+      "served_variant": "fireworks",
+      "wire_model": "accounts/fireworks/models/gpt-oss-120b",
+      "api_dialect": "openai_chat",
+      "architecture": {
+        "parameter_count_b": 117.0,
+        "active_parameter_count_b": 5.1,
+        "moe": true,
+        "license": "Apache-2.0",
+        "source_url": "https://developers.openai.com/api/docs/models/gpt-oss-120b",
+        "last_verified": "2026-06-19"
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "preferred_format": "json",
+        "parity": "text_only",
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "reasoning_summary"
+      },
+      "reasoning": {
+        "modes": [
+          "effort"
+        ],
+        "effort_supported": true,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.15,
+        "output_per_mtok": 0.6,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "thinking",
+        "extended_thinking"
+      ],
+      "family": "openai-gpt",
+      "lineage": "openai-legacy",
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "speed",
+        "cheap",
+        "tool_use",
+        "reasoning"
+      ]
+    },
+    {
       "id": "gemini-2.5-flash",
       "name": "Gemini 2.5 Flash",
       "provider": "gemini",

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -2868,6 +2868,88 @@
       }
     },
     {
+      "id": "accounts/fireworks/models/gpt-oss-120b",
+      "name": "GPT-OSS 120B (Fireworks)",
+      "provider": "fireworks",
+      "aliases": [],
+      "context_window": 131072,
+      "logical_model": "openai-gpt-oss-120b",
+      "equivalence_group": "openai-gpt-oss-120b",
+      "served_variant": "fireworks",
+      "wire_model": "accounts/fireworks/models/gpt-oss-120b",
+      "api_dialect": "openai_chat",
+      "architecture": {
+        "parameter_count_b": 117.0,
+        "active_parameter_count_b": 5.1,
+        "moe": true,
+        "license": "Apache-2.0",
+        "source_url": "https://developers.openai.com/api/docs/models/gpt-oss-120b",
+        "last_verified": "2026-06-19"
+      },
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "preferred_format": "json",
+        "parity": "text_only",
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "native_json",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "reasoning_summary"
+      },
+      "reasoning": {
+        "modes": [
+          "effort"
+        ],
+        "effort_supported": true,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.15,
+        "output_per_mtok": 0.6,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "thinking",
+        "extended_thinking"
+      ],
+      "family": "openai-gpt",
+      "lineage": "openai-legacy",
+      "tier": "frontier",
+      "open_weight": true,
+      "strengths": [
+        "speed",
+        "cheap",
+        "tool_use",
+        "reasoning"
+      ]
+    },
+    {
       "id": "gemini-2.5-flash",
       "name": "Gemini 2.5 Flash",
       "provider": "gemini",


### PR DESCRIPTION
## Problem

A real dogfood run (session `019ee303`) had `fw-gpt-oss-120b` grow its prompt to **197,467 tokens** on a large repo. Fireworks returned `HTTP 400 [context_overflow]: ... exceeds maximum context length of 131071`, Harn recorded a terminal `provider_call_error`, and **the agent loop DIED** ("Agent loop ended with a provider/tool-protocol failure"). The mandate: the agent must ALWAYS work, not only when circumstances are perfect.

Two root causes, both fixed.

## Fix 1 — capability accuracy (proximate cause)

The auto-compaction budget's context window resolves from the **model catalog** (`ModelDef.context_window` via `model_catalog_entry` / `introspection::build_snapshot`), not `capabilities.toml`. The Fireworks wire id `accounts/fireworks/models/gpt-oss-120b` had **no catalog row**, so the window resolved to `None`, `budget.harn::context_window_for` fell back to a placeholder, and compaction had no real budget.

- Added the route to the catalog (source fragment `catalog_sources/60-models/90-...toml`; regenerated `providers.toml` + the `spec/provider-catalog/*` and `docs/` artifacts) with the real **131072** window.
- **Audit:** all 101 cataloged models already carry a `context_window`. The remaining latent footgun is any *uncataloged* model on a provider with zero catalog rows: `bedrock`, `tgi`, `huggingface`, `vertex`, `dashscope`, `vllm`, `azure_openai`. Fix 2 covers those regardless; per-model windows for those providers are left for a deliberate follow-up (each needs the real limit verified). The qwen3.6/3.7 eval routes already have correct windows (262144 / 1M).

## Fix 2 — resilience (the core "always works" fix)

`context_overflow` is now **recoverable**, not terminal. On such an error the loop emergency-compacts the live transcript (deterministic observation masking — never an LLM round-trip, which would itself overflow) and retries, **bounded to 3 attempts** with an escalating `keep_last` clamped below the message count so masking always has a span to archive. Only a still-overflowing, no-longer-shrinkable transcript becomes terminal. Genuinely-terminal errors (auth, invalid model) are untouched and stop immediately.

Detection handles both shapes: the structured `reason == "context_overflow"` AND the canonical `[context_overflow]` message tag, because the live provider path surfaces the error as a `CategorizedError` that the Harn `try`/catch materializes as a **string** (no structured `reason`) — relying on `reason` alone would have silently no-op'd.

**Seam:** `crates/harn-stdlib/src/stdlib/agent/loop.harn` — recovery in the `if !call.ok` arm; helpers `__agent_loop_recover_context_overflow` / `__agent_loop_is_context_overflow`. Emergency compaction: `agent_emergency_compact` in `agent/autocompact.harn`. New `context_overflow_recovery` agent event registered in `agent_session_host.rs`.

## Verification

- New conformance test `agent_loop_context_overflow_recovery` — (a) recover+retry succeeds, (b) bounded -> terminal when irreducible, (c) auth stays terminal.
- All **224** agents conformance tests pass; compaction conformance tests pass.
- Rust regression `fireworks_gpt_oss_route_has_real_context_window` + existing `context_overflow` classification tests pass.
- `cargo fmt --all --check`, `cargo clippy -p harn-vm`, `harn fmt --check`, `lint-harn`, `lint-test-patterns`, provider catalog `validate --check-artifacts`, and downstream drift checks all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)