### PR TITLE
fix(llm): surface tool_define'd native tool schemas in nested agent loops (judge/sub-agent tool calls)

### DIFF
--- a/changelog.d/nested-native-tool-format-parity.fixed.md
+++ b/changelog.d/nested-native-tool-format-parity.fixed.md
@@ -1,0 +1,11 @@
+`agent_loop` now steers an explicit `tool_format: "native"` pin to the route's
+safe channel when the route's `tool_mode_parity` forbids native (e.g.
+`native_unreliable` routes such as `openrouter/deepseek-v3.2`), matching the
+wire-level capability gate in `extract_llm_options`. Previously the stdlib
+resolver honored the pin verbatim while the wire silently steered to text, so
+the loop built a native-channel prompt (native instructions + native tool
+schemas) that disagreed with a text-channel request carrying no tool surface —
+the model then saw no usable tool contract and emitted unparseable prose. This
+bit nested judge / sub-agent loops that pin `native` for a native-unreliable
+route. An explicit `tool_format_override_reason` still forces the requested
+channel deliberately.

--- a/conformance/tests/agents/agent_loop_native_unreliable_prompt_wire_parity.expected
+++ b/conformance/tests/agents/agent_loop_native_unreliable_prompt_wire_parity.expected
@@ -1,0 +1,4 @@
+true
+true
+0
+done

--- a/conformance/tests/agents/agent_loop_native_unreliable_prompt_wire_parity.harn
+++ b/conformance/tests/agents/agent_loop_native_unreliable_prompt_wire_parity.harn
@@ -1,0 +1,82 @@
+import { llm_text, with_llm_script } from "std/testing"
+
+/**
+ * Regression: a route whose `tool_mode_parity` forbids the native channel
+ * (`native_unreliable`, e.g. openrouter/deepseek-v3.2) used to resolve an
+ * explicit `tool_format: "native"` pin verbatim in the stdlib loop, so the
+ * loop built a NATIVE-channel prompt (native tool-calling instructions, native
+ * tool schemas) while the Rust `extract_llm_options` capability gate silently
+ * steered the wire request to the route's safe TEXT channel — shipping no
+ * native tool schemas (`native_tool_count == 0`) and no text-format tool
+ * contract either. The model then saw no usable tool surface and improvised
+ * unparseable prose (e.g. `emit_judgment(verdict="...")`), so the tool call was
+ * lost. This bit nested judge / sub-agent loops that pin `native` for a route
+ * the matrix says is native-unreliable.
+ *
+ * The loop's `agent_tool_format_resolution` now mirrors the wire gate: a
+ * parity-forbidden explicit pin (with no `tool_format_override_reason`) is
+ * steered to the recommended channel, so the prompt and the provider request
+ * agree. The judge-shaped loop below pins `native` on a native-unreliable
+ * route and must build a TEXT-mode prompt (mentions `<tool_call>`, NOT the
+ * native channel) and accept a text-format `emit_judgment` tool call.
+ */
+fn judge_tools() {
+  let tools = tool_registry()
+  return tool_define(
+    tools,
+    "emit_judgment",
+    "Emit the final judgment exactly once",
+    {
+      handler: { args -> return {accepted: true, verdict: args?.verdict ?? "unclear"} },
+      parameters: {verdict: {type: "string", description: "complete | incomplete | unclear"}},
+      returns: {type: "object"},
+      annotations: {kind: "judgment", side_effect_level: "read_only"},
+    },
+  )
+}
+
+pipeline main() {
+  provider_capabilities_install(
+    """
+[[provider.testcatalog]]
+model_match = "native-unreliable-*"
+native_tools = true
+preferred_tool_format = "text"
+tool_mode_parity = "native_unreliable"
+""",
+  )
+  defer {
+    provider_capabilities_clear()
+  }
+  with_llm_script(
+    [
+      llm_text("<tool_call>\nemit_judgment({ verdict: \"complete\" })\n</tool_call>"),
+      llm_text("<user_response>graded</user_response>"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Judge the candidate and call emit_judgment.",
+        "You are a judge.",
+        {
+          provider: "testcatalog",
+          model: "native-unreliable-route",
+          tools: judge_tools(),
+          tool_format: "native",
+          allowed_tools: ["emit_judgment"],
+          max_iterations: 3,
+          session_id: "native-unreliable-parity-" + uuid(),
+        },
+      )
+      let calls = llm_mock_calls()
+      __io_println(contains(calls[0].system, "<tool_call>"))
+      __io_println(!contains(calls[0].system, "native tool-calling channel"))
+      __io_println(len(calls[0].tools ?? []))
+      __io_println(result.status)
+    },
+  )
+}
+// Asserts, in order: the prompt rides the steered TEXT channel (carries
+// the `<tool_call>` contract, never advertises the forbidden native
+// channel); no native tool schemas ship on the wire (consistent with the
+// steered text channel, not a silent native drop); the text-format tool
+// call parsed and dispatched (status `done`).

--- a/conformance/tests/agents/agent_loop_tool_format_capabilities.expected
+++ b/conformance/tests/agents/agent_loop_tool_format_capabilities.expected
@@ -17,7 +17,7 @@ text
 native
 interchangeable
 true
-format=native
+format=text
 1
 native
 text

--- a/crates/harn-stdlib/src/stdlib/agent/options.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/options.harn
@@ -240,6 +240,31 @@ fn __parity_recommended_tool_format(parity) {
   return nil
 }
 
+/**
+ * Pick the concrete tool_format to steer a parity-forbidden explicit pin to,
+ * mirroring the Rust `validate_tool_format_with_caps` target selection exactly:
+ * use the route's declared `preferred_tool_format` when it rides the
+ * recommended (opposite) channel, otherwise fall back to that channel's
+ * canonical name (`json` for the text channel, `native` for the native
+ * channel). Keeping these two implementations in lockstep is what guarantees
+ * the loop's prompt and the provider wire request agree on the tool dialect.
+ */
+fn __steer_tool_format(parity, preferred) {
+  let recommended_channel = __parity_recommended_tool_format(parity)
+  if recommended_channel == nil {
+    return nil
+  }
+  let recommended_is_text = __tool_format_is_text_channel(recommended_channel)
+  if preferred != nil && __tool_format_is_text_channel(preferred) == recommended_is_text {
+    return preferred
+  }
+  return if recommended_is_text {
+    "json"
+  } else {
+    "native"
+  }
+}
+
 fn __parity_conflicts_with_requested(parity, requested) {
   if parity == "native_unreliable" {
     return requested == "native"
@@ -380,23 +405,40 @@ pub fn agent_tool_format_resolution(options = nil) {
         parity = resolved_caps?.tool_mode_parity
       }
     }
-    __validate_tool_format_parity(
-      pair,
-      explicit,
-      parity,
-      __optional_text(opts?.tool_format_override_reason),
-    )
+    let override_reason = __optional_text(opts?.tool_format_override_reason)
+    __validate_tool_format_parity(pair, explicit, parity, override_reason)
+    let override_event = __tool_format_override_event(pair, explicit, preferred, parity, override_reason)
+    // Parity steering must match the wire. The Rust `extract_llm_options`
+    // capability gate silently rewrites a tool-bearing request whose channel
+    // the route's `tool_mode_parity` forbids (e.g. `native` on a
+    // `native_unreliable` route like deepseek-v3.2) to the route's safe
+    // channel. If we honored the explicit pin verbatim here, the loop would
+    // build a prompt for the requested channel (native instructions, native
+    // tool schemas) while the wire actually ships the steered channel with no
+    // matching tool surface — the model then sees no usable tool contract and
+    // improvises unparseable prose. Steer the resolved format the same way the
+    // wire does so the prompt and the provider request agree. An explicit
+    // `tool_format_override_reason` opts out (the author is forcing a known-risky
+    // channel deliberately, and the Rust gate is bypassed in mock/replay too).
+    let steered = if override_reason == nil
+      && __parity_conflicts_with_requested(__catalog_parity(parity), explicit) {
+      __steer_tool_format(__catalog_parity(parity), preferred)
+    } else {
+      nil
+    }
+    if steered != nil {
+      return {
+        tool_format: steered,
+        source: "explicit_parity_steered",
+        capability_gap_event: nil,
+        tool_format_override_event: override_event,
+      }
+    }
     return {
       tool_format: explicit,
       source: "explicit",
       capability_gap_event: nil,
-      tool_format_override_event: __tool_format_override_event(
-        pair,
-        explicit,
-        preferred,
-        parity,
-        __optional_text(opts?.tool_format_override_reason),
-      ),
+      tool_format_override_event: override_event,
     }
   }
   let pair = __tool_format_pair(opts)
@@ -438,6 +480,10 @@ pub fn agent_tool_format_resolution(options = nil) {
   return {tool_format: nil, source: "unresolved", capability_gap_event: nil, tool_format_override_event: nil}
 }
 
+// Mirror the Rust gate's target selection: prefer the route's declared
+// `preferred_tool_format` when it rides the recommended channel (so
+// deepseek-v3.2's explicit `text` carve-out is honored over a bare
+// `text`/`native` channel name), else fall back to the channel name.
 /**
  * Return the concrete tool format a prompt-building helper should use.
  *

--- a/crates/harn-vm/tests/tool_calling_bootcamp.rs
+++ b/crates/harn-vm/tests/tool_calling_bootcamp.rs
@@ -500,11 +500,19 @@ fn override_reason_forces_marked_impossible_side() {
 }
 
 #[test]
-fn unreliable_parity_warns_but_does_not_reject() {
-    // *_unreliable is recoverable, not impossible: the requested side still
-    // works (with a warning the harness author can act on), so resolution must
-    // ACCEPT it rather than reject. This is the boundary between the warn path
-    // and the hard-reject path.
+fn unreliable_parity_steers_to_safe_channel_without_rejecting() {
+    // *_unreliable is recoverable, not impossible — but "recoverable" means the
+    // resolver STEERS the explicit pin to the route's safe channel, not that it
+    // honors the forbidden side verbatim. Honoring `native` here verbatim was
+    // the deepseek-v3.2 footgun: the loop built a native-channel prompt while
+    // the Rust `extract_llm_options` capability gate silently steered the wire
+    // request to the text channel, so the model saw no usable tool surface and
+    // improvised unparseable prose. Resolution must now match the wire and
+    // steer to a text-channel format (this synthetic row declares
+    // preferred_tool_format = native, which is not on the recommended text
+    // channel, so the fallback is the canonical text format `json`). It must
+    // accept (steer) rather than hard-reject — that is the boundary between the
+    // steer path and the *_only hard-reject path.
     match resolve_with_parity(
         "bootcamp-native-unreliable-model",
         "native_unreliable",
@@ -512,8 +520,8 @@ fn unreliable_parity_warns_but_does_not_reject() {
         "native",
     ) {
         Outcome::Accepted { tool_format, .. } => assert_eq!(
-            tool_format, "native",
-            "native_unreliable should still honor an explicit native request"
+            tool_format, "json",
+            "native_unreliable must steer an explicit native pin to the safe text channel"
         ),
         Outcome::Rejected(err) => {
             panic!("native_unreliable wrongly hard-rejected the recoverable side: {err}")


### PR DESCRIPTION
## Problem

A nested `agent_loop` (Burin's agentic rubric judge, sub-agents) that pins `tool_format: "native"` for a route whose capability matrix marks the native channel unreliable (`tool_mode_parity = native_unreliable`, e.g. `openrouter/deepseek-v3.2`) **loses every tool call**.

Decisive ground truth from a real eval run: the judge calls the in-process nested `agent_loop` with `tool_define`'d tools (`emit_judgment` + `judge_*`) and `tool_format` resolving to `"native"` for `or-deepseek`. Every provider request showed `native_tool_count = 0`, and deepseek (which graded correctly) emitted the tool call as **prose** — `emit_judgment(verdict="complete", ...)` — instead of a real invocation. Net effect: grader verdict lost → judge barred → cheap grader unusable.

## Root cause (exact)

The loop's stdlib tool_format resolution and the wire-level capability gate **disagreed** for parity-forbidden explicit pins:

- `crates/harn-stdlib/src/stdlib/agent/options.harn` — `agent_tool_format_resolution` honored an explicit `tool_format` pin **verbatim** (returning `source: "explicit"`, only emitting a soft `tool_format_override` warning). So for deepseek-v3.2 + `native`, the loop built a **NATIVE-channel prompt** (native tool-calling instructions + native tool schemas).
- `crates/harn-vm/src/llm/helpers/options/extract.rs` + `capabilities.rs::validate_tool_format_with_caps` — the wire-level gate **silently steered** the request to the route's safe **TEXT channel** (`channel_forbidden(Native)` is true for `native_unreliable`), shipping `native_tools = None` (`native_tool_count = 0`) and no text-format tool contract.

The model received a native-channel instruction with no native tools attached and no text grammar to follow, so it improvised Python-call prose.

Verified empirically: pre-fix, `agent_tool_format_resolution` for `openrouter/deepseek-v3.2` + explicit `native` returned `tool_format = native` while `caps.preferred = text` / `parity = native_unreliable`.

## Fix

Make the stdlib resolution apply the **same parity steering** as the wire so prompt and request agree. A parity-forbidden explicit pin (with no `tool_format_override_reason`) is steered to the route's safe channel via a new shared `__steer_tool_format` helper that mirrors `validate_tool_format_with_caps` target selection exactly: prefer the declared `preferred_tool_format` when it rides the recommended channel, else fall back to the canonical channel name (`json` for text, `native` for native).

Post-fix resolution (verified):
- `anthropic/claude-sonnet` native → `native` (no regression)
- `openrouter/deepseek-v3.2` native → `text` (steered, prompt+wire agree)
- deepseek native + `tool_format_override_reason` → `native` (escape hatch preserved)
- deepseek `text`/auto → `text`

This is **generic** (fixes all native-unreliable routes, not just the judge), not a judge-side salvage.

## Tests

- New conformance test `agent_loop_native_unreliable_prompt_wire_parity` drives a judge-shaped loop on a `native_unreliable` route with an explicit `native` pin and asserts the prompt rides the text channel (`<tool_call>` contract, no native-channel advertisement), `native_tool_count == 0` (consistent, not a silent native drop), and the text-format `emit_judgment` call parses + dispatches. **Proven to fail pre-fix** (`false / false / 2 / done` vs `true / true / 0 / done`).
- Updated `agent_loop_tool_format_capabilities.expected` and the `tool_calling_bootcamp` parity test for the corrected steer-not-honor behavior.
- `cargo test -p harn-vm` (capabilities, tools, tool_surface, tool_calling_bootcamp) green; full `agents` conformance suite (229) green; `harn fmt --check` + `cargo fmt --all --check` + `harn check` clean.

## Note for orchestrator (not implemented here)

Burin's `text_mode_emit_judgment_args` only salvages the harmony `<invoke name="emit_judgment">` XML form, not the `emit_judgment(verdict="...")` Python-call prose deepseek produced. A Burin-side salvage extension would be defense-in-depth, but with this fix no salvage is needed — the model is now given a real text tool contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)