### PR TITLE
fix(agent): accept argv vector under run_command `command` field

### DIFF
--- a/changelog.d/run-command-argv-coercion.fixed.md
+++ b/changelog.d/run-command-argv-coercion.fixed.md
@@ -1,0 +1,8 @@
+`run_command` (the agent host `run` tool) now accepts the command vector under
+either `argv` or `command`. Models frequently send the array under `command`
+(e.g. `run({command: ["bash", "-lc", "ls"]})`) because the tool description says
+"pass argv as an array of strings"; that previously threw
+`run_command: argv must be a non-empty list of strings`. A list under `command`
+is now coerced to argv mode (and works even when shell mode is disabled), and a
+shell string passed while shell mode is disabled now returns an actionable error
+instead of the misleading argv message.

--- a/crates/harn-cli/tests/agent_run_command_argv_coercion.rs
+++ b/crates/harn-cli/tests/agent_run_command_argv_coercion.rs
@@ -1,0 +1,183 @@
+//! Regression tests for `std/agent/host_tools` `run_command` argv handling.
+//!
+//! A cheap model driving the host `run_command` tool routinely sends the
+//! command vector under the `command` field instead of `argv` (the tool
+//! description says "pass argv as an array of strings" while the schema
+//! declares `argv` as the array), e.g. `run({command: ["bash", "-lc", "ls"]})`.
+//! Before the fix that threw "run_command: argv must be a non-empty list of
+//! strings"; the tool only worked when the array was under `argv` or when a
+//! shell string was passed under `command`.
+//!
+//! These tests spawn the real binary and drive the public `run_command`
+//! handler. They use a `command_policy` that returns a string verdict, which
+//! blocks the request BEFORE it executes — so the test is hermetic (no real
+//! process spawn, no workspace/sandbox dependency) yet still asserts the
+//! shaped request the tool would have run.
+
+use std::process::Command;
+
+fn binary_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_harn"))
+}
+
+fn write_script(dir: &std::path::Path, name: &str, body: &str) -> std::path::PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, body).expect("write script");
+    path
+}
+
+fn run_script(body: &str) -> String {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let script = write_script(tmp.path(), "script.harn", body);
+    let output = Command::new(binary_path())
+        .arg("run")
+        .arg(&script)
+        .output()
+        .expect("spawn harn run");
+    assert!(
+        output.status.success(),
+        "harn run failed: status={:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// A list passed under `command` is coerced to argv mode and produces the
+/// IDENTICAL shaped request as passing the same list under `argv`.
+#[test]
+fn list_under_command_is_coerced_to_argv() {
+    let body = r#"
+import { agent_command_tools } from "std/agent/host_tools"
+
+// Returning a string from command_policy blocks the request before it runs,
+// while exposing the shaped request so we can assert its mode/argv.
+fn capture(request, args) {
+  return "MODE=" + to_string(request?.mode) + " ARGV=" + json_stringify(request?.argv)
+}
+
+pipeline main(_) {
+  let opts = {root: "/workspace", command_policy: capture, output_format: "value"}
+  let h = tool_find(agent_command_tools(tool_registry(), opts), "run_command").handler
+  let from_command = h({command: ["bash", "-lc", "ls -1"]})
+  let from_argv = h({argv: ["bash", "-lc", "ls -1"]})
+  __io_println("COMMAND_REASON=" + from_command.reason)
+  __io_println("ARGV_REASON=" + from_argv.reason)
+  __io_println("EQUAL=" + to_string(from_command.reason == from_argv.reason))
+}
+"#;
+    let stdout = run_script(body);
+    assert!(
+        stdout.contains(r#"COMMAND_REASON=MODE=argv ARGV=["bash","-lc","ls -1"]"#),
+        "list under `command` should shape into argv mode; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("EQUAL=true"),
+        "list under `command` must equal the same list under `argv`; got:\n{stdout}"
+    );
+}
+
+/// A list passed under `argv` keeps working unchanged (no regression).
+#[test]
+fn list_under_argv_still_works() {
+    let body = r#"
+import { agent_command_tools } from "std/agent/host_tools"
+
+fn capture(request, args) {
+  return "MODE=" + to_string(request?.mode)
+}
+
+pipeline main(_) {
+  let opts = {root: "/workspace", command_policy: capture, output_format: "value"}
+  let h = tool_find(agent_command_tools(tool_registry(), opts), "run_command").handler
+  let r = h({argv: ["echo", "hi"]})
+  __io_println("REASON=" + r.reason)
+}
+"#;
+    let stdout = run_script(body);
+    assert!(
+        stdout.contains("REASON=MODE=argv"),
+        "argv-mode must still shape correctly; got:\n{stdout}"
+    );
+}
+
+/// A non-empty `command` LIST routes to argv mode even when shell is disabled
+/// (argv mode never needs a shell), instead of being rejected.
+#[test]
+fn list_under_command_works_without_shell() {
+    let body = r#"
+import { agent_command_tools } from "std/agent/host_tools"
+
+fn capture(request, args) {
+  return "MODE=" + to_string(request?.mode)
+}
+
+pipeline main(_) {
+  let opts = {root: "/workspace", allow_shell: false, command_policy: capture, output_format: "value"}
+  let h = tool_find(agent_command_tools(tool_registry(), opts), "run_command").handler
+  let r = h({command: ["bash", "-lc", "ls"]})
+  __io_println("REASON=" + r.reason)
+}
+"#;
+    let stdout = run_script(body);
+    assert!(
+        stdout.contains("REASON=MODE=argv"),
+        "list under `command` must work without shell (argv mode); got:\n{stdout}"
+    );
+}
+
+/// A non-string element in the command list yields the clear list-of-strings
+/// error rather than silently coercing junk into argv.
+#[test]
+fn non_string_command_list_is_rejected() {
+    let body = r#"
+import { agent_command_tools } from "std/agent/host_tools"
+
+pipeline main(_) {
+  let opts = {root: "/workspace", allow_shell: true, output_format: "value"}
+  let h = tool_find(agent_command_tools(tool_registry(), opts), "run_command").handler
+  let r = try { h({command: ["bash", 7]}) }
+  if is_ok(r) {
+    __io_println("OUTCOME=unexpected-ok")
+  } else {
+    __io_println("OUTCOME=" + to_string(r))
+  }
+}
+"#;
+    let stdout = run_script(body);
+    assert!(
+        stdout.contains("argv must be a non-empty list of strings"),
+        "non-string list element should be rejected clearly; got:\n{stdout}"
+    );
+}
+
+/// A non-empty shell STRING under `command` with shell disabled gives an
+/// actionable error (how to pass argv) instead of the misleading
+/// "argv must be a non-empty list of strings".
+#[test]
+fn shell_string_with_shell_disabled_gives_actionable_error() {
+    let body = r#"
+import { agent_command_tools } from "std/agent/host_tools"
+
+pipeline main(_) {
+  let opts = {root: "/workspace", allow_shell: false, output_format: "value"}
+  let h = tool_find(agent_command_tools(tool_registry(), opts), "run_command").handler
+  let r = try { h({command: "echo hi"}) }
+  if is_ok(r) {
+    __io_println("OUTCOME=unexpected-ok")
+  } else {
+    __io_println("OUTCOME=" + to_string(r))
+  }
+}
+"#;
+    let stdout = run_script(body);
+    assert!(
+        stdout.contains("shell commands are disabled for this tool"),
+        "shell-disabled string command should give an actionable error; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("pass argv as a list of strings"),
+        "actionable error should tell the model to use argv; got:\n{stdout}"
+    );
+}

--- a/crates/harn-stdlib/src/stdlib/agent/host_tools.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/host_tools.harn
@@ -348,10 +348,45 @@ fn __agent_host_command_cwd(args, options) {
   return __agent_host_resolve_path(cwd, opts)
 }
 
-fn __agent_host_command_request(args, options) {
-  let opts = __agent_host_options(options)
+fn __agent_host_list_of_strings(value) {
+  if type_of(value) != "list" || len(value) == 0 {
+    return false
+  }
+  for element in value {
+    if type_of(element) != "string" {
+      return false
+    }
+  }
+  return true
+}
+
+fn __agent_host_resolve_argv(args) {
+  // Resolve the effective argv from EITHER the canonical `argv` field OR a
+  // list passed in `command`. The schema declares `argv` as the array and
+  // `command` as a string, but the tool description tells the model to "pass
+  // argv as an array of strings", so models routinely conflate the two and
+  // send the array under `command`. Accept both spellings so the tool works
+  // regardless of which field carries the list; a string `command` still
+  // routes to shell mode below.
   let argv = args?.argv
   if type_of(argv) == "list" && len(argv) > 0 {
+    return argv
+  }
+  if (argv == nil || (type_of(argv) == "list" && len(argv) == 0))
+    && type_of(args?.command) == "list" {
+    return args.command
+  }
+  return nil
+}
+
+fn __agent_host_command_request(args, options) {
+  let opts = __agent_host_options(options)
+  let resolved_argv = __agent_host_resolve_argv(args)
+  if resolved_argv != nil {
+    if !__agent_host_list_of_strings(resolved_argv) {
+      throw "run_command: argv must be a non-empty list of strings"
+    }
+    let argv = resolved_argv
     if !__agent_host_argv_allowed(argv, opts) {
       return __agent_host_blocked_command(argv, opts)
     }
@@ -379,6 +414,12 @@ fn __agent_host_command_request(args, options) {
       req = req + {interactive: args.interactive}
     }
     return __agent_host_apply_command_policy(__agent_host_command_request_common(req, args, opts), args, opts)
+  }
+  if type_of(args?.command) == "string" && trim(args.command) != "" {
+    // A non-empty shell string was supplied, but shell mode is disabled for
+    // this tool. Tell the model exactly how to recover instead of claiming
+    // the (absent) argv is malformed.
+    throw "run_command: shell commands are disabled for this tool; pass argv as a list of strings, e.g. argv: [\"bash\", \"-lc\", \"...\"]"
   }
   throw "run_command: argv must be a non-empty list of strings"
 }
@@ -699,7 +740,7 @@ pub fn agent_command_tools(registry = nil, options = nil) {
       __agent_host_description(
         opts,
         key,
-        "Run one argv-based command from the configured cwd. Pass argv as an array of strings. Output is capped inline; use the returned command_id with the command-output reader tools for full stdout/stderr. Background progress can be enabled per call or through agent_command_tools command_behavior.",
+        "Run one argv-based command from the configured cwd. Pass argv as an array of strings (an array passed under `command` is also accepted as argv). Output is capped inline; use the returned command_id with the command-output reader tools for full stdout/stderr. Background progress can be enabled per call or through agent_command_tools command_behavior.",
       ),
       __agent_host_config(
         opts,


### PR DESCRIPTION
## Problem

A self-maintenance dogfood (cheap model `fw-gpt-oss-120b` driving `burin-headless`) failed because the host `run` tool (`run_command` in `std/agent/host_tools`) rejects the command vector when it arrives under the `command` field instead of `argv`:

- `run({command: ["bash", "-lc", "ls -1"]})` → **`Runtime error: run_command: argv must be a non-empty list of strings`**
- `run({command: "bash -lc \"printf hello\""})` (string) → worked
- `run({argv: ["bash", "-lc", "ls -1"]})` → worked

Root cause (`crates/harn-stdlib/src/stdlib/agent/host_tools.harn`, `__agent_host_command_request`): a list under `command` skips argv-mode (because `argv` is nil) and skips shell-mode (the guard requires `type_of(args?.command) == "string"`), so it falls through to the terminal `throw`. The tool **description** literally says "Pass argv as an array of strings" while the **schema** declares `command` as a string and `argv` as the array — so models conflate the two fields and put the array under `command`.

## Fix (generalize, don't band-aid)

`__agent_host_command_request` now resolves the effective argv from **either** `argv` **or** a list-valued `command`, coercing the latter to argv mode. Concretely:

- A list under `command` (with `argv` absent or `[]`) is treated as argv. It works even when shell mode is disabled — argv mode never needs a shell.
- A non-string list element still yields the clear `argv must be a non-empty list of strings` error.
- A shell **string** passed while shell mode is disabled now returns an actionable error (`shell commands are disabled for this tool; pass argv as a list of strings, e.g. argv: ["bash", "-lc", "..."]`) instead of the misleading "argv must be a list" message.
- The tool description notes that an array under `command` is also accepted.

Net: `run({command:[...]})` and `run({argv:[...]})` both work and shape into the **identical** argv request. (Confirmed on HEAD `d7ae0dd4` there is no longer an unguarded `.trim()` on a list — line 365 already guards `type_of==string`; the remaining issue was the throw, which the coercion fixes.)

## Verification

Reproduced the exact failing call before/after by driving the public `run_command` handler:

- Before: `LIST-IN-COMMAND ERR => run_command: argv must be a non-empty list of strings`
- After: `LIST-IN-COMMAND OK` (stdout `hello-from-list`); `argv`/string forms unchanged; **PARITY = true** (list-under-`command` shapes the same argv request as `argv`).

Added 5 hermetic regression tests (`crates/harn-cli/tests/agent_run_command_argv_coercion.rs`) — a `command_policy` that returns a string blocks the request *before* exec, so the tests assert the shaped request with no real process spawn or workspace dependency: list→argv coercion + parity, argv still works, list works without shell, non-string list rejected, shell-disabled-string actionable error. All pass.

Also green: `cargo fmt --all --check`, `harn check`/`harn lint` on the changed file, `cargo test -p harn-stdlib` (21), `cargo test -p harn-hostlib --test process_tools --test process_tools_e2e` (46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)