### PR TITLE
fix(llm): make context-overflow detection provider-agnostic + transparent single-shot surfacing

### DIFF
--- a/changelog.d/3479.fixed.md
+++ b/changelog.d/3479.fixed.md
@@ -1,0 +1,13 @@
+- Context-overflow detection is now provider-agnostic. The agent loop's
+  recover-and-retry path (and the error classifier it depends on) now recognize
+  the way Gemini, Moonshot/Kimi, Together, Cerebras, and Groq phrase a
+  "prompt exceeds the context window" error — several of which omit the word
+  "context" and were previously misclassified as a generic invalid request, so
+  the loop died on a large prompt instead of compacting and retrying. Genuine
+  tokens-per-minute rate limits are explicitly excluded so they still back off
+  rather than being mistaken for an overflow.
+- Single-shot structured calls (judges, routers, classifiers, cached lookups)
+  have no transcript to compact, but they now surface a context overflow
+  transparently as `status: "context_overflow"` — via the new exported
+  `is_context_overflow_error` helper — instead of an opaque generic error that
+  looked like a dead judge.

--- a/conformance/tests/stdlib/safe_structured_call_context_overflow.expected
+++ b/conformance/tests/stdlib/safe_structured_call_context_overflow.expected
@@ -1,0 +1,8 @@
+false
+context_overflow
+context_overflow
+true
+true
+true
+true
+false

--- a/conformance/tests/stdlib/safe_structured_call_context_overflow.harn
+++ b/conformance/tests/stdlib/safe_structured_call_context_overflow.harn
@@ -1,0 +1,85 @@
+// A single-shot structured call (judge, router, classifier, cached lookup) has
+// no live session transcript, so it cannot emergency-compact-and-retry the way
+// the agent loop does. It must still surface a provider context-overflow
+// TRANSPARENTLY — a distinct `status: "context_overflow"` — instead of an
+// opaque generic `error` that masquerades as a dead judge or a flaky 400.
+//
+// This guards the no-session transparency path that complements the agent
+// loop's recovery path: detection mirrors the Rust classifier's
+// `[context_overflow]` reason tag and is provider-agnostic.
+import { is_context_overflow_error, safe_structured_call } from "std/llm/safe"
+import { with_llm_script } from "std/testing"
+
+pipeline main() {
+  let schema = {type: "object", required: ["verdict"], properties: {verdict: {type: "string"}}}
+  // (a) A provider 400 [context_overflow] on a single-shot structured call is
+  // surfaced with a distinct, machine-readable status (not "ok", not a generic
+  // "error"/"missing_json"), so a harness author can SEE the window was blown.
+  with_llm_script(
+    [
+      {
+        error: {
+          status: 400,
+          reason: "context_overflow",
+          message: "fireworks HTTP 400 [context_overflow]: prompt is too long: 197467 tokens exceeds maximum context length of 131071",
+        },
+      },
+    ],
+    { ->
+      let envelope = safe_structured_call(
+        "Grade this output.",
+        schema,
+        {provider: "mock", model: "mock-model", max_tokens: 200},
+      )
+      __io_println(envelope.ok)
+      __io_println(envelope.status)
+    },
+  )
+  // (b) A different provider's phrasing (Gemini, no "context" word) is detected
+  // the same way — provider-agnostic.
+  with_llm_script(
+    [
+      {
+        error: {
+          status: 400,
+          message: "gemini HTTP 400 [context_overflow]: The input token count (1052431) exceeds the maximum number of tokens allowed (1048576).",
+        },
+      },
+    ],
+    { ->
+      let envelope = safe_structured_call(
+        "Grade this output.",
+        schema,
+        {provider: "mock", model: "mock-model", max_tokens: 200},
+      )
+      __io_println(envelope.status)
+    },
+  )
+  // (c) An UNRELATED provider error (rate limit) is NOT mislabeled as overflow —
+  // it keeps its own category so callers can still back off rather than
+  // (futilely) trying to shrink the prompt.
+  with_llm_script(
+    [
+      {
+        error: {
+          status: 429,
+          reason: "rate_limited",
+          message: "anthropic HTTP 429 [rate_limited]: quota exceeded (retry-after: 12)",
+        },
+      },
+    ],
+    { ->
+      let envelope = safe_structured_call(
+        "Grade this output.",
+        schema,
+        {provider: "mock", model: "mock-model", max_tokens: 200},
+      )
+      __io_println(envelope.status != "context_overflow")
+    },
+  )
+  // (d) The exported detector works on both a dict error and a bare string.
+  __io_println(is_context_overflow_error({reason: "context_overflow"}))
+  __io_println(is_context_overflow_error({error_category: "context_overflow"}))
+  __io_println(is_context_overflow_error("x HTTP 400 [context_overflow]: too long"))
+  __io_println(is_context_overflow_error("x HTTP 429 [rate_limited]: slow down"))
+}

--- a/crates/harn-stdlib/src/stdlib/llm/safe.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/safe.harn
@@ -357,9 +357,47 @@ fn __apply_judge_defaults(schema, options) {
   return resolved + {repair: repair}
 }
 
+/**
+ * Single-shot context-overflow detection on a structured/llm error.
+ *
+ * A single-shot structured call (judge, router, classifier, cached lookup) has
+ * NO live session transcript, so it cannot emergency-compact-and-retry the way
+ * the agent loop does — there is nothing to mask. The least-surprising thing we
+ * CAN do is surface the condition TRANSPARENTLY so a harness author sees
+ * "this call overflowed the model's window" instead of a generic `error` that
+ * looks like a dead judge or a flaky 400.
+ *
+ * Mirrors the Rust classifier's `[context_overflow]` reason tag and the
+ * structured `reason`/`error_category` fields, so detection stays consistent
+ * with the agent-loop recovery path and is provider-agnostic.
+ *
+ * @effects: []
+ * @errors: []
+ */
+pub fn is_context_overflow_error(err) {
+  if type_of(err) == "dict" {
+    let reason = to_string(err?.reason ?? "")
+    if reason == "context_overflow" {
+      return true
+    }
+    let category = to_string(err?.error_category ?? "")
+    if category == "context_overflow" {
+      return true
+    }
+    let message = to_string(err?.message ?? "") + " " + to_string(err?.error ?? "")
+    return contains(message, "[context_overflow]")
+  }
+  return contains(to_string(err), "[context_overflow]")
+}
+
 fn __augment_envelope(envelope) {
   if type_of(envelope) != "dict" {
-    return {ok: false, status: "exception", value: {}, error: envelope}
+    let exc_status = if is_context_overflow_error(envelope) {
+      "context_overflow"
+    } else {
+      "exception"
+    }
+    return {ok: false, status: exc_status, value: {}, error: envelope}
   }
   let ok_flag = envelope?.ok ?? false
   let data = if type_of(envelope?.data) == "dict" {
@@ -370,6 +408,8 @@ fn __augment_envelope(envelope) {
   let normalized = with_case_insensitive_keys(data)
   let status = if ok_flag {
     "ok"
+  } else if is_context_overflow_error(envelope) {
+    "context_overflow"
   } else {
     let category = envelope?.error_category
     if category != nil {
@@ -380,3 +420,7 @@ fn __augment_envelope(envelope) {
   }
   return envelope + {value: normalized, status: status}
 }
+// Distinct, machine-readable status so callers/harness authors can SEE that
+// a no-session single-shot call hit the context window (vs. a generic 400 or
+// a dead judge). The agent loop recovers overflow via compaction; this path
+// cannot, but it must never be silent.

--- a/crates/harn-vm/src/llm/api/errors.rs
+++ b/crates/harn-vm/src/llm/api/errors.rs
@@ -323,19 +323,93 @@ fn classify_error_message_taxonomy(msg: &str) -> Option<(LlmErrorKind, LlmErrorR
     None
 }
 
+/// Provider-agnostic detection of a "the assembled prompt is bigger than the
+/// model's context window" error.
+///
+/// This is the single point that decides whether the agent loop is allowed to
+/// recover (emergency-compact + retry) instead of treating the turn as a
+/// terminal failure, so it must catch the condition no matter which provider's
+/// 400/413/429 phrasing arrives. Every provider funnels its FULL raw error body
+/// through here, so we match on substrings of the whole body rather than any
+/// single parsed field; adding a new provider's phrasing is a one-line edit.
+///
+/// Known provider phrasings covered (see the table in the conformance tests):
+/// - OpenAI / OpenRouter / Fireworks / Azure / Nvidia / SambaNova / DeepInfra
+///   (OpenAI-compatible): `context_length_exceeded`, "maximum context length".
+/// - Anthropic: "prompt is too long: N tokens > M maximum".
+/// - vLLM: "this model's maximum context length is …".
+/// - Ollama: "model context exceeded".
+/// - Google / Gemini: "input token count (N) exceeds the maximum number of
+///   tokens allowed (M)" / "the input token count … exceeds …".
+/// - Cerebras: "please reduce the length of the messages or completion".
+/// - Moonshot / Kimi: "exceeded model token limit" / "max tokens per request".
+/// - Together: "input validation error: `inputs` tokens + `max_new_tokens` …".
+/// - Groq: "request too large" / "reduce the length …" (TPM-style 413/429 — see
+///   the `throttle` veto below so a genuine rate-limit is not stolen).
 fn is_context_overflow(lower: &str) -> bool {
-    lower.contains("maximum context length")
+    // Unambiguous signatures — the body explicitly names the context window or a
+    // canonical OpenAI-style code, so no co-occurrence gate is needed.
+    let explicit = lower.contains("maximum context length")
         || lower.contains("context length")
         || lower.contains("model context exceeded")
         || lower.contains("context exceeded")
         || lower.contains("context_length_exceeded")
         || lower.contains("context_overflow")
+        || lower.contains("context window")
         || lower.contains("prompt is too long")
+        || lower.contains("input is too long")
+        || lower.contains("input too long")
         || lower.contains("prompt_tokens_exceeded")
         || lower.contains("this model's maximum context")
         || lower.contains("exceeds the maximum")
         || (lower.contains("context") && lower.contains("exceed"))
-        || (lower.contains("max_tokens") && lower.contains("exceed"))
+        || (lower.contains("max_tokens") && lower.contains("exceed"));
+    if explicit {
+        return true;
+    }
+
+    // Token-shaped signatures that DON'T name "context" explicitly. These are
+    // genuinely about prompt size on several providers, but a couple of the
+    // phrasings ("request too large", "reduce the length …") are also emitted
+    // by some providers for tokens-per-minute rate limits. To avoid stealing a
+    // real rate-limit (whose correct reaction is back-off, not compaction), only
+    // treat them as overflow when the body also talks about tokens/length AND
+    // does NOT look like a per-minute / quota throttle.
+    let throttle = lower.contains("per minute")
+        || lower.contains("per-minute")
+        || lower.contains("per day")
+        || lower.contains("requests per")
+        || lower.contains("tokens per minute")
+        || lower.contains("tpm")
+        || lower.contains("rpm")
+        || lower.contains("quota")
+        || lower.contains("retry-after")
+        || lower.contains("retry after")
+        || lower.contains("rate_limit")
+        || lower.contains("rate limit")
+        || lower.contains("insufficient_quota");
+    if throttle {
+        return false;
+    }
+
+    let mentions_tokens =
+        lower.contains("token") || lower.contains("length") || lower.contains("messages");
+    if !mentions_tokens {
+        return false;
+    }
+
+    // Provider-specific size phrasings, only after the throttle veto above.
+    lower.contains("token limit")          // Moonshot / Kimi: "exceeded model token limit"
+        || lower.contains("token count")    // Gemini: "input token count … exceeds …"
+        || lower.contains("too many tokens")
+        || lower.contains("request too large") // Groq (non-throttle 413)
+        || lower.contains("too large for")
+        || lower.contains("input validation error") // Together
+        || lower.contains("reduce the length")       // Cerebras
+        || lower.contains("reduce the number of tokens")
+        || lower.contains("please reduce")
+        || (lower.contains("token") && lower.contains("exceed"))
+        || (lower.contains("token") && lower.contains("limit") && lower.contains("exceed"))
 }
 
 fn extract_token_count_hint(body: &str) -> Option<u64> {
@@ -485,6 +559,102 @@ mod tests {
         assert_eq!(info.reason, LlmErrorReason::ContextOverflow);
         assert!(info.message.contains("[context_overflow]"));
         assert!(info.message.contains("offending_tokens: 49152"));
+    }
+
+    /// Helper: assert that a provider's HTTP-error body classifies as a
+    /// recoverable context overflow with the `[context_overflow]` tag stamped.
+    fn assert_overflow(provider: &str, status: reqwest::StatusCode, body: &str) {
+        let info = classify_provider_http_error(provider, status, None, body);
+        assert_eq!(
+            info.reason,
+            LlmErrorReason::ContextOverflow,
+            "expected context_overflow for {provider}; body={body}; msg={}",
+            info.message
+        );
+        assert_eq!(info.kind, LlmErrorKind::Terminal);
+        assert!(
+            info.message.contains("[context_overflow]"),
+            "missing tag for {provider}: {}",
+            info.message
+        );
+    }
+
+    fn assert_not_overflow(provider: &str, status: reqwest::StatusCode, body: &str) {
+        let info = classify_provider_http_error(provider, status, None, body);
+        assert_ne!(
+            info.reason,
+            LlmErrorReason::ContextOverflow,
+            "unexpectedly classified as context_overflow for {provider}; body={body}; msg={}",
+            info.message
+        );
+    }
+
+    #[test]
+    fn classify_gemini_token_count_exceeds_as_context_overflow() {
+        // Gemini phrases overflow without the word "context".
+        assert_overflow(
+            "gemini",
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":{"code":400,"message":"The input token count (1052431) exceeds the maximum number of tokens allowed (1048576).","status":"INVALID_ARGUMENT"}}"#,
+        );
+    }
+
+    #[test]
+    fn classify_moonshot_token_limit_as_context_overflow() {
+        assert_overflow(
+            "moonshot",
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":{"type":"invalid_request_error","message":"Your request exceeded model token limit: 262144"}}"#,
+        );
+    }
+
+    #[test]
+    fn classify_together_input_validation_error_as_context_overflow() {
+        assert_overflow(
+            "together",
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":{"message":"Input validation error: `inputs` tokens + `max_new_tokens` must be <= 131073. Given: 198342 `inputs` tokens","type":"invalid_request_error"}}"#,
+        );
+    }
+
+    #[test]
+    fn classify_cerebras_reduce_length_as_context_overflow() {
+        assert_overflow(
+            "cerebras",
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"message":"Please reduce the length of the messages or completion.","type":"invalid_request_error"}"#,
+        );
+    }
+
+    #[test]
+    fn classify_groq_request_too_large_as_context_overflow() {
+        // Groq's non-throttle 413 for a single oversized request.
+        assert_overflow(
+            "groq",
+            reqwest::StatusCode::PAYLOAD_TOO_LARGE,
+            r#"{"error":{"message":"Request too large for model with 131072 tokens. Reduce the number of tokens.","type":"invalid_request_error","code":"request_too_large"}}"#,
+        );
+    }
+
+    #[test]
+    fn classify_groq_tpm_rate_limit_is_not_context_overflow() {
+        // The SAME "request too large" phrasing, but a per-minute throttle: must
+        // NOT be stolen as context_overflow (correct reaction is back-off).
+        assert_not_overflow(
+            "groq",
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            r#"{"error":{"message":"Rate limit reached: Request too large. Limit 6000 tokens per minute. Please try again.","type":"tokens","code":"rate_limit_exceeded"}}"#,
+        );
+    }
+
+    #[test]
+    fn classify_openai_quota_is_not_context_overflow() {
+        // insufficient_quota mentions tokens but is a billing throttle, not overflow.
+        assert_not_overflow(
+            "openai",
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            r#"{"error":{"code":"insufficient_quota","message":"You exceeded your current quota, please check your plan and billing details."}}"#,
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/api/errors.rs
+++ b/crates/harn-vm/src/llm/api/errors.rs
@@ -648,6 +648,18 @@ mod tests {
     }
 
     #[test]
+    fn classify_explicit_overflow_wins_even_with_throttle_words() {
+        // An explicit "maximum context length" signature must classify as
+        // overflow even if the body coincidentally also mentions a rate limit —
+        // the explicit branch returns before the throttle veto.
+        assert_overflow(
+            "openai",
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":{"code":"context_length_exceeded","message":"This model's maximum context length is 8192 tokens. (rate limit note: unrelated)"}}"#,
+        );
+    }
+
+    #[test]
     fn classify_openai_quota_is_not_context_overflow() {
         // insufficient_quota mentions tokens but is a billing throttle, not overflow.
         assert_not_overflow(


### PR DESCRIPTION
## Context

PR #3475 made provider `context_overflow` **recoverable** in the agent loop (emergency-compact + bounded retry) and set the Fireworks gpt-oss window. This PR takes full ownership of the *general* story: confirming the recovery generalizes to **every** provider and closing the detection + transparency gaps so it is not gpt-oss-shaped.

## Audit findings

**Classification (already centralized, but under-covered).** `is_context_overflow` (`crates/harn-vm/src/llm/api/errors.rs`) is the single point that decides whether the agent loop recovers vs. dies. It reads the *full raw body* of every provider's error and is checked **before** auth/rate-limit/model-unavailable in both classifier paths — so it's architecturally sound. But the literal list only covered OpenAI/Anthropic/vLLM/Ollama phrasings. Providers that phrase overflow **without the word "context"** were misclassified as generic `invalid_request` → hard agent-loop death:

| Provider | 400 phrasing | Before | After |
|---|---|---|---|
| Gemini | "input token count (N) exceeds the maximum number of tokens allowed" | MISSED | caught |
| Moonshot/Kimi | "exceeded model token limit" | MISSED | caught |
| Together | "input validation error: \`inputs\` tokens + \`max_new_tokens\` …" | MISSED | caught |
| Cerebras | "please reduce the length of the messages or completion" | MISSED | caught |
| Groq | "request too large" (non-throttle 413) | MISSED | caught |
| OpenAI/OpenRouter/Fireworks/Azure/Nvidia/SambaNova/DeepInfra | `context_length_exceeded` / "maximum context length" | caught | caught |
| Anthropic | "prompt is too long" | caught | caught |

**Threading.** Recovery is correctly threaded through the main agent loop **and sub-agents** (which route through `__agent_loop_run`). Single-shot / judge / nested-structured calls (`safe_structured_call`, `cached_structured_call`, the done/step/scope judges) have **no live session transcript**, so they structurally cannot emergency-compact — but they were failing **opaquely**, indistinguishable from a dead judge.

**Catalog.** Per the #3475 caveat, all cataloged models carry correct windows; the only residual is uncataloged routes on zero-row providers (bedrock/tgi/vertex/etc.) hitting the 8192 fallback — Fix 2 (recovery) covers those regardless. No window value is wrong, so no catalog edit is needed here. (Burin's `.harn-version` pin lag is tracked separately — it needs a repin once a release contains #3475 + this PR.)

## Changes

1. **`errors.rs` — provider-agnostic detection.** Broaden the centralized `is_context_overflow` with the missing phrasings. Token-shaped signatures that don't name "context" are gated behind a `throttle` veto (per-minute / quota / retry-after / rate_limit) so a genuine tokens-per-minute rate limit (which must back off, not compact) is **never stolen** as a context overflow. Adding a provider stays a one-line edit.

2. **`safe.harn` — transparent single-shot surfacing.** `safe_structured_call` now returns a distinct `status: "context_overflow"` instead of a generic `error`, and a new exported `is_context_overflow_error` mirrors the Rust `[context_overflow]` tag and the structured `reason`/`error_category` fields. A harness author can now *see* a single-shot window blowout. (Recovery itself stays loop-only by design — no transcript to mask.)

## Tests

- **errors.rs**: 8 new classifier tests — Gemini/Moonshot/Together/Cerebras/Groq overflow phrasings classify as `context_overflow` with the tag stamped; the same "request too large" wording under a per-minute throttle, and an `insufficient_quota` body, are NOT stolen as overflow.
- **`conformance/tests/stdlib/safe_structured_call_context_overflow.harn`**: a single-shot 400 (two provider phrasings) surfaces `status=context_overflow`; a rate-limit keeps its own category; the exported detector works on dict and string errors.
- All **225** agents conformance tests, all `safe.*` conformance tests, and the harn-vm errors suite pass. `cargo fmt --all --check`, `cargo clippy -p harn-vm`, `harn fmt --check`, and `lint-harn` all clean.

This is pure robustness hardening — nothing is weakened, and the existing #3475 loop recovery is preserved (its conformance test still passes unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)