### PR TITLE
fix(hostlib): wait_command must loop until its handle completes (shared-session-inbox race)

### DIFF
--- a/changelog.d/wait-command-shared-inbox-race.fixed.md
+++ b/changelog.d/wait-command-shared-inbox-race.fixed.md
@@ -1,0 +1,10 @@
+- **`wait_command` no longer falsely reports a still-running handle when a
+  sibling background command completes during the wait.** The per-`handle_id`
+  wait is layered on a per-`session_id` completion inbox, and concurrent
+  background handles can share one inbox bucket (notably the empty session id
+  under `harn test`/headless). The old code parked once, re-drained once, and
+  requeued any foreign sibling completion — falsely returning `status:
+  "running"` for the handle the caller asked about, which then got cancelled.
+  `wait_command::handle` now loops until either its own handle's result arrives
+  or the timeout deadline elapses, re-parking for the remaining budget after
+  each foreign wakeup. The `timeout_ms == 0` non-blocking poll is unchanged.

--- a/crates/harn-hostlib/src/tools/wait_command.rs
+++ b/crates/harn-hostlib/src/tools/wait_command.rs
@@ -1,6 +1,6 @@
 //! `tools/wait_command` — wait for one background command completion.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use harn_vm::VmValue;
 
@@ -23,12 +23,24 @@ pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     }
 
     if timeout_ms > 0 {
-        let _ = harn_vm::orchestration::agent_inbox::wait_sync(
-            &session_id,
-            Duration::from_millis(timeout_ms),
-        );
-        if let Some(result) = drain_matching_result(&session_id, &handle_id) {
-            return Ok(result);
+        // The inbox is keyed per-session, but multiple concurrent background
+        // handles can share one session (notably `session_id == ""` under
+        // `harn test`/headless). `wait_sync` only parks on "this session has
+        // *any* entry", so a sibling handle's completion can wake us; the
+        // single drain below would then requeue that foreign entry and report
+        // our handle as still running. Loop until either our handle's result
+        // arrives or the deadline elapses, re-parking for the remaining budget
+        // after each foreign wakeup.
+        let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            let _ = harn_vm::orchestration::agent_inbox::wait_sync(&session_id, remaining);
+            if let Some(result) = drain_matching_result(&session_id, &handle_id) {
+                return Ok(result);
+            }
         }
     }
 
@@ -76,4 +88,134 @@ fn drain_matching_result(session_id: &str, handle_id: &str) -> Option<VmValue> {
     }
 
     selected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harn_vm::orchestration::agent_inbox;
+
+    fn fresh_session_id() -> String {
+        // Each test owns its own session id so the global inbox registry
+        // doesn't need per-test wipes and concurrent test runs stay isolated.
+        format!("wait-cmd-test-{}", uuid::Uuid::now_v7())
+    }
+
+    fn result_for(handle_id: &str) -> String {
+        serde_json::json!({
+            "handle_id": handle_id,
+            "status": "completed",
+            "exit_code": 0,
+        })
+        .to_string()
+    }
+
+    fn wait_args(session_id: &str, handle_id: &str, timeout_ms: u64) -> Vec<VmValue> {
+        let request = serde_json::json!({
+            "session_id": session_id,
+            "handle_id": handle_id,
+            "timeout_ms": timeout_ms,
+        });
+        vec![harn_vm::json_to_vm_value(&request)]
+    }
+
+    fn field(value: &VmValue, key: &str) -> Option<String> {
+        let VmValue::Dict(map) = value else {
+            return None;
+        };
+        match map.get(key) {
+            Some(VmValue::String(s)) => Some(s.to_string()),
+            _ => None,
+        }
+    }
+
+    fn status_of(value: &VmValue) -> Option<String> {
+        field(value, "status")
+    }
+
+    fn handle_of(value: &VmValue) -> Option<String> {
+        field(value, "handle_id")
+    }
+
+    /// Regression test for the shared-session-inbox race.
+    ///
+    /// Two background handles (`H1`, `H2`) share one session inbox (the
+    /// empty-session case under `harn test`/headless). A sibling's completion
+    /// (`H2`) is enqueued FIRST, then our handle's completion (`H1`) arrives
+    /// from another thread *during* the wait. The old single-shot code would
+    /// drain once on the first wakeup, find only `H2`, requeue it, and falsely
+    /// report `H1` as `running`. The deadline loop must skip past `H2`'s
+    /// wakeup and return `H1`'s result.
+    #[test]
+    fn wait_skips_foreign_wakeup_and_returns_own_result() {
+        let session = fresh_session_id();
+
+        // A foreign sibling completion is already queued before we wait.
+        agent_inbox::push(&session, "tool_result", &result_for("H2"), "test");
+
+        // Our handle's completion lands shortly after the wait begins, on a
+        // separate thread — modelling the real waiter thread that pushes the
+        // `tool_result` for our handle while we are parked.
+        let push_session = session.clone();
+        let pusher = std::thread::spawn(move || {
+            // Park briefly so `handle` has entered its first `wait_sync`. The
+            // correctness of the test does not depend on this sleep being
+            // long enough: even if H1 is already present, the initial drain
+            // would return it; the sleep just steers the common case through
+            // the loop path that the old code got wrong.
+            std::thread::sleep(Duration::from_millis(50));
+            agent_inbox::push(&push_session, "tool_result", &result_for("H1"), "test");
+        });
+
+        // Generous timeout: the assertion is on the RESULT, not on timing.
+        let value = handle(&wait_args(&session, "H1", 5_000)).expect("handle ok");
+        pusher.join().expect("pusher join");
+
+        assert_eq!(
+            status_of(&value).as_deref(),
+            Some("completed"),
+            "wait must return H1's completed result, not falsely report running"
+        );
+        assert_eq!(handle_of(&value).as_deref(), Some("H1"));
+
+        // H2's foreign completion must remain queued (requeued, not consumed).
+        let leftover = agent_inbox::drain(&session);
+        assert_eq!(leftover.len(), 1, "H2's completion must still be queued");
+        let parsed: serde_json::Value = serde_json::from_str(&leftover[0].content).expect("json");
+        assert_eq!(parsed.get("handle_id").and_then(|v| v.as_str()), Some("H2"));
+    }
+
+    /// Fully deterministic variant with no cross-thread timing at all: both
+    /// completions are already in the inbox, with the foreign one (`H2`) at
+    /// the head. `drain_matching_result` must scan past `H2` and select `H1`
+    /// while requeueing `H2`. This guards the drain/requeue selection logic
+    /// the deadline loop relies on.
+    #[test]
+    fn drain_selects_own_handle_past_foreign_head() {
+        let session = fresh_session_id();
+        agent_inbox::push(&session, "tool_result", &result_for("H2"), "test");
+        agent_inbox::push(&session, "tool_result", &result_for("H1"), "test");
+
+        let value = handle(&wait_args(&session, "H1", 5_000)).expect("handle ok");
+        assert_eq!(status_of(&value).as_deref(), Some("completed"));
+        assert_eq!(handle_of(&value).as_deref(), Some("H1"));
+
+        let leftover = agent_inbox::drain(&session);
+        assert_eq!(leftover.len(), 1);
+        let parsed: serde_json::Value = serde_json::from_str(&leftover[0].content).expect("json");
+        assert_eq!(parsed.get("handle_id").and_then(|v| v.as_str()), Some("H2"));
+    }
+
+    /// The `timeout_ms == 0` non-blocking poll must not park: a missing handle
+    /// returns `running` immediately even with a foreign entry queued.
+    #[test]
+    fn zero_timeout_is_nonblocking_poll() {
+        let session = fresh_session_id();
+        agent_inbox::push(&session, "tool_result", &result_for("H2"), "test");
+        let value = handle(&wait_args(&session, "H1", 0)).expect("handle ok");
+        assert_eq!(status_of(&value).as_deref(), Some("running"));
+        assert_eq!(handle_of(&value).as_deref(), Some("H1"));
+        // The foreign entry is untouched by a poll for a different handle.
+        assert_eq!(agent_inbox::pending_count(&session), 1);
+    }
 }


### PR DESCRIPTION
## Root cause

`crates/harn-hostlib/src/tools/wait_command.rs::handle` is a per-`handle_id`
wait layered on a per-`session_id` completion inbox
(`crates/harn-vm/src/orchestration/agent_inbox.rs`). Under `harn
test`/headless, `current_agent_session_id()` is `None` → `session_id == ""`, so
ALL concurrent background handles share ONE inbox bucket.

The old `handle()` did single-shot: drain once → if empty, `agent_inbox::wait_sync(session, timeout)`
(a Condvar that parks on "session has ANY entry", not "MY handle arrived") → on
wake, drain EXACTLY ONCE more → if the arrived entry is a DIFFERENT handle,
`drain_matching_result` requeues it and returns `None` → `handle()` falsely
returns `status: "running"`. In a bulk run (Burin spawns N background commands
then waits them sequentially), a sibling's completion landing during a handle's
single park makes that handle spuriously report "still running" → it gets
cancelled. Intermittent (~1/3 cold); warm passes by scheduling luck.

## Fix

Replace the single `wait_sync` + single re-drain with a **deadline loop**: keep
the initial drain; if `timeout_ms > 0`, compute a deadline and loop —
`wait_sync` for the remaining budget, then re-drain; a foreign wakeup just
re-drains (the sibling entry is requeued by the existing
`drain_matching_result` logic) and re-parks for the remaining budget. The
`timeout_ms == 0` non-blocking poll fast-path is preserved. No change to
`drain_matching_result`, `agent_inbox`, or the spawn side — the loop alone
closes the race because non-matching entries are already requeued.

## Regression test

`wait_skips_foreign_wakeup_and_returns_own_result`: queues a foreign sibling
completion (H2) first, then pushes the awaited handle's completion (H1) from
another thread during the wait, and asserts `wait(H1)` returns H1's completed
result (not "running") with H2 still queued. **Verified it FAILS on the old
single-shot code** (`assertion failed: wait must return H1's completed result,
not falsely report running`) **and PASSES on the looped code.** Two supporting
tests cover the drain/requeue selection and the `timeout_ms == 0` poll.

## Verification

- `cargo build -p harn-hostlib` — OK
- `cargo test -p harn-hostlib` — all pass (3 new + existing)
- `cargo fmt --all` — clean
- `cargo clippy -p harn-hostlib --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)