### PR TITLE
[codex] fix streaming receive limit accounting

### DIFF
--- a/changelog.d/stream-receive-limits.fixed.md
+++ b/changelog.d/stream-receive-limits.fixed.md
@@ -1,0 +1,2 @@
+Fixed SSE and websocket receive limits so timeout, EOF, and open-control polls
+no longer consume the configured event/message budget.

--- a/crates/harn-vm/src/http/streaming.rs
+++ b/crates/harn-vm/src/http/streaming.rs
@@ -976,7 +976,6 @@ pub(super) async fn vm_sse_receive(stream_id: &str, timeout_ms: u64) -> Result<V
                 "sse_receive: stream '{stream_id}' exceeded max_events"
             ))));
         }
-        handle.received += 1;
         let url = handle.url.clone();
         let max_message_bytes = handle.max_message_bytes;
         let kind = match &handle.kind {
@@ -1013,6 +1012,7 @@ pub(super) async fn vm_sse_receive(stream_id: &str, timeout_ms: u64) -> Result<V
                     "sse_receive: message exceeded max_message_bytes ({max_message_bytes})"
                 )));
             }
+            record_sse_event_received(stream_id)?;
             Ok(sse_event_value(&event))
         }
         SseHandleKind::Real(stream) => {
@@ -1033,10 +1033,29 @@ pub(super) async fn vm_sse_receive(stream_id: &str, timeout_ms: u64) -> Result<V
                         "sse_receive: message exceeded max_message_bytes ({max_message_bytes})"
                     )));
                 }
+                record_sse_event_received(stream_id)?;
             }
             Ok(real_sse_event_value(event))
         }
     }
+}
+
+fn record_sse_event_received(stream_id: &str) -> Result<(), VmError> {
+    SSE_HANDLES.with(|handles| {
+        let mut handles = handles.borrow_mut();
+        let Some(handle) = handles.get_mut(stream_id) else {
+            return Err(vm_error(format!(
+                "sse_receive: unknown stream '{stream_id}'"
+            )));
+        };
+        if handle.received >= handle.max_events {
+            return Err(vm_error(format!(
+                "sse_receive: stream '{stream_id}' exceeded max_events"
+            )));
+        }
+        handle.received += 1;
+        Ok(())
+    })
 }
 
 pub(super) fn register_http_streaming_builtins(vm: &mut Vm) {
@@ -1233,4 +1252,58 @@ pub(super) fn register_http_streaming_builtins(vm: &mut Vm) {
             .collect::<Vec<_>>();
         Ok(VmValue::List(std::sync::Arc::new(values)))
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn field(value: &VmValue, key: &str) -> String {
+        value
+            .as_dict()
+            .and_then(|dict| dict.get(key))
+            .map(VmValue::display)
+            .unwrap_or_default()
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn sse_receive_open_does_not_count_toward_max_events() {
+        reset_streaming_state();
+        let url = "https://events.example.test/stream";
+        SSE_MOCKS.with(|mocks| {
+            mocks.borrow_mut().push(SseMock {
+                url_pattern: url.to_string(),
+                events: vec![MockStreamEvent {
+                    event_type: "message".to_string(),
+                    data: "one".to_string(),
+                    id: None,
+                    retry_ms: None,
+                }],
+            });
+        });
+
+        let stream = vm_sse_connect(
+            "GET",
+            url,
+            &crate::value::DictMap::from_iter([("max_events".to_string(), VmValue::Int(1))]),
+        )
+        .await
+        .expect("mock stream");
+        let stream_id = handle_from_value(&stream, "test").expect("stream id");
+
+        let open = vm_sse_receive(&stream_id, 0).await.expect("open event");
+        assert_eq!(field(&open, "type"), "open");
+
+        let event = vm_sse_receive(&stream_id, 0)
+            .await
+            .expect("first data event");
+        assert_eq!(field(&event, "type"), "event");
+        assert_eq!(field(&event, "data"), "one");
+
+        let err = vm_sse_receive(&stream_id, 0)
+            .await
+            .expect_err("one data event should consume max_events=1");
+        assert!(err.to_string().contains("exceeded max_events"), "{err}");
+        reset_streaming_state();
+    }
 }

--- a/crates/harn-vm/src/http/streaming/websocket.rs
+++ b/crates/harn-vm/src/http/streaming/websocket.rs
@@ -999,7 +999,6 @@ pub(super) async fn vm_websocket_receive(
                 "websocket_receive: socket '{socket_id}' exceeded max_messages"
             ))));
         }
-        handle.received += 1;
         let max_message_bytes = handle.max_message_bytes;
         let kind = match &handle.kind {
             WebSocketHandleKind::Real(socket) => WebSocketHandleKind::Real(socket.clone()),
@@ -1032,6 +1031,7 @@ pub(super) async fn vm_websocket_receive(
             if message.message_type == "close" {
                 socket.closed = true;
             }
+            record_websocket_message_received(socket_id)?;
             Ok(ws_event_value(message))
         }
         WebSocketHandleKind::Real(socket) => {
@@ -1061,6 +1061,7 @@ pub(super) async fn vm_websocket_receive(
                 }
                 _ => {}
             }
+            record_websocket_message_received(socket_id)?;
             Ok(real_ws_event_value(message))
         }
         WebSocketHandleKind::Server(socket) => {
@@ -1092,6 +1093,7 @@ pub(super) async fn vm_websocket_receive(
                         let mut socket = socket.lock().await;
                         socket.closed = true;
                     }
+                    record_websocket_message_received(socket_id)?;
                     return Ok(ws_event_value(message));
                 }
                 if timeout_ms == 0 || started.elapsed() >= Duration::from_millis(timeout_ms) {
@@ -1101,6 +1103,24 @@ pub(super) async fn vm_websocket_receive(
             }
         }
     }
+}
+
+fn record_websocket_message_received(socket_id: &str) -> Result<(), VmError> {
+    WEBSOCKET_HANDLES.with(|handles| {
+        let mut handles = handles.borrow_mut();
+        let Some(handle) = handles.get_mut(socket_id) else {
+            return Err(vm_error(format!(
+                "websocket_receive: unknown socket '{socket_id}'"
+            )));
+        };
+        if handle.received >= handle.max_messages {
+            return Err(vm_error(format!(
+                "websocket_receive: socket '{socket_id}' exceeded max_messages"
+            )));
+        }
+        handle.received += 1;
+        Ok(())
+    })
 }
 
 pub(super) async fn vm_websocket_close(socket_id: &str) -> Result<VmValue, VmError> {
@@ -1235,4 +1255,64 @@ pub(super) fn register_websocket_builtins(vm: &mut Vm) {
         let server_id = handle_from_value(handle, "websocket_server_close")?;
         vm_websocket_server_close(&server_id)
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn field(value: &VmValue, key: &str) -> String {
+        value
+            .as_dict()
+            .and_then(|dict| dict.get(key))
+            .map(VmValue::display)
+            .unwrap_or_default()
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn websocket_receive_timeout_does_not_count_toward_max_messages() {
+        super::super::reset_streaming_state();
+        let url = "ws://mock.example.test/socket";
+        WEBSOCKET_MOCKS.with(|mocks| {
+            mocks.borrow_mut().push(WebSocketMock {
+                url_pattern: url.to_string(),
+                messages: Vec::new(),
+                echo: true,
+            });
+        });
+
+        let socket = vm_websocket_connect(
+            url,
+            &crate::value::DictMap::from_iter([("max_messages".to_string(), VmValue::Int(1))]),
+        )
+        .await
+        .expect("mock websocket");
+        let socket_id = handle_from_value(&socket, "test").expect("socket id");
+
+        for _ in 0..2 {
+            let event = vm_websocket_receive(&socket_id, 0)
+                .await
+                .expect("timeout event");
+            assert_eq!(field(&event, "type"), "timeout");
+        }
+
+        vm_websocket_send(
+            &socket_id,
+            VmValue::String(arcstr::ArcStr::from("hello")),
+            &crate::value::DictMap::new(),
+        )
+        .await
+        .expect("echo message");
+        let event = vm_websocket_receive(&socket_id, 0)
+            .await
+            .expect("first message");
+        assert_eq!(field(&event, "type"), "text");
+        assert_eq!(field(&event, "data"), "hello");
+
+        let err = vm_websocket_receive(&socket_id, 0)
+            .await
+            .expect_err("one message should consume max_messages=1");
+        assert!(err.to_string().contains("exceeded max_messages"), "{err}");
+        super::super::reset_streaming_state();
+    }
 }


### PR DESCRIPTION
## What changed

- Changed SSE receive accounting so synthetic `open`, EOF, and timeout polls do not consume `max_events`.
- Changed websocket receive accounting so timeout/closed polls do not consume `max_messages`.
- Added focused fake-transport regression tests for both code paths.

## Why

The receive counters were incremented before the transport read completed. Polling an idle SSE/websocket stream could exhaust the configured event/message budget even when no data event or websocket message had been received.

## Validation

- `cargo fmt --all -- --check`
- `env CARGO_TARGET_DIR="$PWD/.target" cargo test --locked -p harn-vm does_not_count_toward`
- `git diff --check`
- Commit hook: markdown, Rust formatting, prompt-prose ratchet, changed-package clippy
- Push hook: markdown and targeted local checks