### PR TITLE
fix(llm): escalate max_tokens on structured-output truncation retry

### DIFF
--- a/changelog.d/structured-truncation-budget-escalation.fixed.md
+++ b/changelog.d/structured-truncation-budget-escalation.fixed.md
@@ -1,0 +1,11 @@
+A structured/`llm_call`-with-schema retry that failed because the response was
+truncated by `max_tokens` mid-JSON now doubles the output-token budget (capped
+at 32,768) before the retry instead of replaying the same under-budget call.
+Reasoning models (gpt-oss/Harmony, DeepSeek-R, o-series) bill their analysis
+channel against the same output budget while it stays invisible in the parsed
+text, so a budget that comfortably fits a non-reasoning model's JSON gets
+consumed entirely by reasoning — truncating the visible JSON to empty and, once
+schema-retry slots are exhausted, returning a DEAD `length_truncation` envelope
+(an empty judge verdict that silently falls through to the deterministic
+grader). The escalation is provider-agnostic, keyed off the existing
+`is_length_truncation` truncation marker.

--- a/crates/harn-vm/src/llm/call.rs
+++ b/crates/harn-vm/src/llm/call.rs
@@ -551,6 +551,7 @@ async fn execute_routing_schema_retry_loop(
 
         let more_attempts = attempt < schema_retries;
         if more_attempts {
+            escalate_max_tokens_on_truncation(&mut opts, &errors);
             let nudge = build_schema_nudge(&errors, opts.output_schema.as_ref(), &nudge_mode);
             emit_agent_event(AgentTraceEvent::SchemaRetry {
                 attempt: attempt + 1,
@@ -730,6 +731,7 @@ pub(crate) async fn execute_schema_retry_loop(
 
         let more_attempts = attempt < schema_retries;
         if more_attempts {
+            escalate_max_tokens_on_truncation(&mut opts, &errors);
             let nudge = build_schema_nudge(&errors, opts.output_schema.as_ref(), &nudge_mode);
             emit_agent_event(AgentTraceEvent::SchemaRetry {
                 attempt: attempt + 1,
@@ -764,6 +766,49 @@ pub(crate) async fn execute_schema_retry_loop(
         });
     }
     unreachable!("schema retry loop exited without returning");
+}
+
+/// Hard ceiling for an auto-escalated structured-output retry budget. A
+/// single doubling step is usually enough to clear a reasoning model's
+/// hidden-channel spend; the ceiling stops a pathological loop from
+/// requesting an unbounded completion when the model never converges.
+const MAX_TOKENS_RETRY_CEILING: i64 = 32_768;
+
+/// When a structured/schema attempt failed because the response ran out of
+/// output-token budget mid-JSON (`is_length_truncation` -> the canonical
+/// "hit the token limit" marker `structured_output_errors` appends), grow
+/// `opts.max_tokens` before the retry so the next attempt has room to emit a
+/// complete object.
+///
+/// This is the generalizing fix for reasoning models (gpt-oss/Harmony,
+/// DeepSeek-R, o-series): their reasoning/analysis channel is billed against
+/// the same output budget but is invisible in the parsed text, so a
+/// `max_tokens` that comfortably fits a non-reasoning model's JSON is consumed
+/// entirely by reasoning, truncating the visible JSON to empty. Replaying the
+/// identical under-budget just re-truncates — burning a retry slot and, once
+/// the slots are exhausted, returning a DEAD `length_truncation` envelope (an
+/// empty judge verdict that silently falls through to the deterministic
+/// grader). Returns `true` when the budget was grown so the caller can trace
+/// the escalation.
+fn escalate_max_tokens_on_truncation(opts: &mut api::LlmCallOptions, errors: &[String]) -> bool {
+    let truncated = errors.iter().any(|e| e.contains("hit the token limit"));
+    if !truncated || opts.max_tokens >= MAX_TOKENS_RETRY_CEILING {
+        return false;
+    }
+    let before = opts.max_tokens;
+    let grown = before
+        .saturating_mul(2)
+        .clamp(before + 1, MAX_TOKENS_RETRY_CEILING);
+    opts.max_tokens = grown;
+    crate::events::log_info(
+        "llm",
+        &format!(
+            "structured retry: response truncated at max_tokens={before}; \
+             escalating retry budget to max_tokens={grown} \
+             (reasoning channel can consume the output budget)"
+        ),
+    );
+    true
 }
 
 /// Render the schema-stream abort as a validation-style error string so
@@ -1260,5 +1305,53 @@ mod schema_stream_abort_retry_tests {
 
             reset_agent_trace_state();
         });
+    }
+
+    // A structured retry after a token-limit truncation must grow the
+    // output-token budget so a reasoning model (whose analysis channel is
+    // billed against the same budget but invisible in parsed text) gets room
+    // to emit complete JSON instead of re-truncating to empty.
+    #[test]
+    fn truncation_retry_escalates_max_tokens() {
+        let mut opts = api::options::base_opts("fake");
+        opts.max_tokens = 640;
+        let errors =
+            vec!["response hit the token limit before producing complete JSON".to_string()];
+        let grew = escalate_max_tokens_on_truncation(&mut opts, &errors);
+        assert!(grew, "truncation marker should escalate the budget");
+        assert_eq!(opts.max_tokens, 1280, "640 should double to 1280");
+    }
+
+    // A non-truncation failure (e.g. a schema-validation miss) must NOT touch
+    // the budget — escalation is reserved for the under-budget root cause.
+    #[test]
+    fn non_truncation_failure_leaves_max_tokens_unchanged() {
+        let mut opts = api::options::base_opts("fake");
+        opts.max_tokens = 640;
+        let errors = vec!["data.age: expected integer, got string".to_string()];
+        let grew = escalate_max_tokens_on_truncation(&mut opts, &errors);
+        assert!(!grew, "non-truncation failure must not escalate");
+        assert_eq!(opts.max_tokens, 640);
+    }
+
+    // The escalation is clamped at the retry ceiling so a pathological
+    // never-converging loop can't request an unbounded completion.
+    #[test]
+    fn truncation_retry_clamps_at_ceiling() {
+        let mut opts = api::options::base_opts("fake");
+        opts.max_tokens = MAX_TOKENS_RETRY_CEILING - 100;
+        let errors =
+            vec!["response hit the token limit before producing complete JSON".to_string()];
+        let grew = escalate_max_tokens_on_truncation(&mut opts, &errors);
+        assert!(grew, "below the ceiling, the budget should still grow");
+        assert_eq!(opts.max_tokens, MAX_TOKENS_RETRY_CEILING);
+
+        // Already at the ceiling: no further growth, no wasted retry signal.
+        let grew_again = escalate_max_tokens_on_truncation(&mut opts, &errors);
+        assert!(
+            !grew_again,
+            "at the ceiling the budget must not grow further"
+        );
+        assert_eq!(opts.max_tokens, MAX_TOKENS_RETRY_CEILING);
     }
 }


### PR DESCRIPTION
## Problem

A structured / `llm_call`-with-schema retry that fails because the response is
truncated by `max_tokens` mid-JSON (the provider-agnostic `is_length_truncation`
marker) replays the **identical** under-budget call. Both schema-retry loops in
`call.rs` rebuild `opts.messages` for the corrective nudge but never touch
`opts.max_tokens`.

For reasoning models (gpt-oss/Harmony, DeepSeek-R, o-series) the reasoning /
analysis channel is billed against the same output budget while staying
invisible in the parsed text. A `max_tokens` that comfortably fits a
non-reasoning model's JSON gets consumed entirely by reasoning, so the visible
JSON truncates to empty — and the retry re-truncates. Once the schema-retry
slots are exhausted, the structured envelope returns a DEAD `length_truncation`
verdict (an empty judge result that silently falls through to the deterministic
grader).

## Evidence

Mined from a gpt-oss-120b (Fireworks) meter-holdout gauntlet. **Every**
`stop_reason: "length"` response in the run was the completion / rubric judge
doing structured output:

| case | output_tokens | visible text | reasoning (thinking) |
|------|---------------|--------------|----------------------|
| code-explore-pr-review-code-bundle t1 | 640 | 0 chars | 3045 chars |
| code-explore-pr-review-tools t2 | 640 | 0 chars | 2997 chars |
| swift-feat t2 (call 1) | 640 | 0 chars | 2828 chars |
| swift-feat t2 (call 2) | 640 | 412 chars | 2352 chars |

`output_tokens` is pinned at the caller's 640-token cap, the Harmony analysis
channel ("We need to decide if the assistant's latest response is a final
answer…") eats the whole budget, and the visible JSON is empty. swift-feat t2
burned two truncated calls before a third finally produced a verdict.

## Fix

`escalate_max_tokens_on_truncation` doubles `opts.max_tokens` (capped at 32,768)
before a retry whose prior attempt carried the token-limit marker. Wired into
both `execute_routing_schema_retry_loop` and `execute_schema_retry_loop`.
Provider-agnostic (keys off the existing `is_length_truncation` marker, not a
per-provider branch). Non-truncation failures leave the budget untouched.

## Tests

- `truncation_retry_escalates_max_tokens` — 640 → 1280
- `non_truncation_failure_leaves_max_tokens_unchanged` — schema-validation miss does not grow the budget
- `truncation_retry_clamps_at_ceiling` — clamps at 32,768 and does not grow once there

`cargo test -p harn-vm --lib schema_stream_abort_retry_tests` → 8 passed.
`cargo fmt -p harn-vm --check` and `cargo clippy -p harn-vm --lib` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)