### PR TITLE
feat(agent-loop): in-VM agent_session_push_user_message + steer mid-turn regression coverage

### DIFF
--- a/changelog.d/session-inject-steer-in-vm.added.md
+++ b/changelog.d/session-inject-steer-in-vm.added.md
@@ -1,0 +1,7 @@
+- `agent_session_push_user_message(session_id, options)` (Harn stdlib
+  `std/agent/state`): the in-VM, loop-driver equivalent of the ACP
+  `session/inject` method. Pushes a user-role message onto the running
+  session; `options.mode: "steer"` delivers it at the next tool/iteration
+  break-point (after the in-flight tool result, before the next model call),
+  `options.mode: "queue"` defers it to loop exit. Lets in-process hosts (e.g.
+  the Burin TUI) steer a turn without the ACP wire. Refs: rfd/session-inject.

--- a/crates/harn-stdlib/src/stdlib/agent/state.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/state.harn
@@ -164,6 +164,38 @@ pub fn agent_session_push_bridge_injection(session_id, options) {
 }
 
 /**
+ * agent_session_push_user_message.
+ *
+ * Queue a user-role message onto the session's host bridge. The in-VM
+ * equivalent of the ACP `session/inject` method (the user-message
+ * sibling of `agent_session_push_bridge_injection`, which mirrors
+ * `session/remind`). The message is spliced into the transcript
+ * CHRONOLOGICALLY — after the in-flight tool_result and before the next
+ * model call — at the loop checkpoint selected by `options.mode`.
+ *
+ * `options` is `{content, mode?}`. `content` is required and non-empty.
+ * `mode` defaults to `"finish_step"`:
+ *
+ *   - `"finish_step"` / `"steer"` — STEER: delivered at the next loop
+ *     checkpoint (tool boundary / iteration boundary). The model sees
+ *     the message before its next call, mid-turn. This is the default
+ *     and the canonical steer path.
+ *   - `"interrupt_immediate"` — preempt the next pending tool batch at
+ *     the `pre_tool_dispatch` checkpoint.
+ *   - `"audit_only"` / `"queue"` — drained only at `loop_exit`; lands in
+ *     the transcript audit but is never rendered into a model prompt.
+ *
+ * Returns the message id so callers can correlate later events.
+ *
+ * @effects: [host]
+ * @api_stability: experimental
+ * @example: agent_session_push_user_message(session_id, {content: "use auth_v2.go", mode: "steer"})
+ */
+pub fn agent_session_push_user_message(session_id, options) {
+  return __host_agent_session_push_user_message(session_id, options)
+}
+
+/**
  * agent_session_pending_injections.
  *
  * Return a FIFO snapshot of queued bridge injections for `session_id`.

--- a/crates/harn-stdlib/src/stdlib/agent/state.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/state.harn
@@ -188,6 +188,7 @@ pub fn agent_session_push_bridge_injection(session_id, options) {
  * Returns the message id so callers can correlate later events.
  *
  * @effects: [host]
+ * @errors: [runtime]
  * @api_stability: experimental
  * @example: agent_session_push_user_message(session_id, {content: "use auth_v2.go", mode: "steer"})
  */

--- a/crates/harn-vm/src/bridge.rs
+++ b/crates/harn-vm/src/bridge.rs
@@ -275,7 +275,12 @@ impl QueuedUserMessageMode {
     fn from_str(value: &str) -> Self {
         match value {
             "interrupt_immediate" | "interrupt" => Self::InterruptImmediate,
-            "finish_step" | "after_current_operation" => Self::FinishStep,
+            // `steer` is the ACP `session/inject` alias for mid-turn
+            // user-message delivery at the next tool boundary; it maps to
+            // the same `FinishStep` checkpoint as `finish_step`.
+            "finish_step" | "after_current_operation" | "steer" => Self::FinishStep,
+            // `queue` is the explicit ACP alias for the audit-only path.
+            "queue" => Self::AuditOnly,
             // Unknown / missing modes fall through to the safest option:
             // record for audit, do not preempt the loop. Pre-#2212 hosts
             // that send `wait_for_completion` are caught by this arm —

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -32,6 +32,7 @@ const HOST_SESSION_RECORD_USAGE: &str = "__host_agent_session_record_usage";
 const HOST_SESSION_DRAIN_FEEDBACK: &str = "__host_agent_session_drain_feedback";
 const HOST_SESSION_DRAIN_BRIDGE_INJECTIONS: &str = "__host_agent_session_drain_bridge_injections";
 const HOST_SESSION_PUSH_BRIDGE_INJECTION: &str = "__host_agent_session_push_bridge_injection";
+const HOST_SESSION_PUSH_USER_MESSAGE: &str = "__host_agent_session_push_user_message";
 const HOST_SESSION_PENDING_INJECTIONS: &str = "__host_agent_session_pending_injections";
 const HOST_SESSION_REVOKE_REMINDER: &str = "__host_agent_session_revoke_reminder";
 const HOST_SESSION_TOTALS: &str = "__host_agent_session_totals";
@@ -2910,6 +2911,68 @@ async fn host_agent_session_push_bridge_injection(
     Ok(VmValue::String(arcstr::ArcStr::from(reminder_id)))
 }
 
+/// Push a user-role message onto the session's host bridge queue. The
+/// in-VM equivalent of the ACP `session/inject` JSON-RPC method (the
+/// user-message sibling of `__host_agent_session_push_bridge_injection`,
+/// which is the in-VM equivalent of `session/remind`). Exposed so a Harn
+/// script driving the loop (custom CLI host, conformance test, etc.) can
+/// enqueue a steer mid-turn without going through ACP.
+///
+/// Expects `options.content` (string, required, non-empty) and an
+/// optional `options.mode` (string, default `"finish_step"`). The mode
+/// follows `QueuedUserMessageMode::from_str`: `"finish_step"` /
+/// `"after_current_operation"` / `"steer"` deliver at the next loop
+/// checkpoint (tool boundary / iteration boundary); `"interrupt_immediate"`
+/// / `"interrupt"` preempt the next tool batch; `"audit_only"` / `"queue"`
+/// land in the transcript at `loop_exit` only. Returns the message id so
+/// callers can correlate with later events / revoke the message.
+#[harn_builtin(
+    sig = "__host_agent_session_push_user_message(session_id: string, options: dict) -> string",
+    kind = "async",
+    category = "agent.host",
+    runtime_only = true
+)]
+async fn host_agent_session_push_user_message(
+    _ctx: crate::vm::AsyncBuiltinCtx,
+    args: Vec<VmValue>,
+) -> Result<VmValue, VmError> {
+    let session_id = args.first().map(|v| v.display()).unwrap_or_default();
+    if session_id.trim().is_empty() {
+        return Err(VmError::Runtime(format!(
+            "{HOST_SESSION_PUSH_USER_MESSAGE}: session_id must be a non-empty string"
+        )));
+    }
+    let options = args.get(1).cloned().unwrap_or(VmValue::Nil);
+    let params = vm_to_json(&options);
+    if !params.is_object() {
+        return Err(VmError::Runtime(format!(
+            "{HOST_SESSION_PUSH_USER_MESSAGE}: options must be a dict"
+        )));
+    }
+    let content = params
+        .get("content")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string();
+    if content.trim().is_empty() {
+        return Err(VmError::Runtime(format!(
+            "{HOST_SESSION_PUSH_USER_MESSAGE}: options.content must be a non-empty string"
+        )));
+    }
+    let mode = params
+        .get("mode")
+        .and_then(|value| value.as_str())
+        .unwrap_or("finish_step")
+        .to_string();
+    let Some(bridge) = host_bridge_for_session(&session_id, HOST_SESSION_PUSH_USER_MESSAGE) else {
+        return Err(VmError::Runtime(format!(
+            "{HOST_SESSION_PUSH_USER_MESSAGE}: no host bridge attached to session `{session_id}`"
+        )));
+    };
+    let message_id = bridge.push_queued_user_message(content, &mode).await;
+    Ok(VmValue::String(arcstr::ArcStr::from(message_id)))
+}
+
 /// Return a FIFO snapshot of pending bridge user-message and reminder injections.
 #[harn_builtin(
     sig = "__host_agent_session_pending_injections(session_id: string) -> list",
@@ -3329,6 +3392,7 @@ const HOST_SESSION_BUILTINS: &[&VmBuiltinDef] = &[
     &HOST_AUTONOMY_BUDGET_CHECK_DEF,
     &HOST_AGENT_SESSION_DRAIN_BRIDGE_INJECTIONS_DEF,
     &HOST_AGENT_SESSION_PUSH_BRIDGE_INJECTION_DEF,
+    &HOST_AGENT_SESSION_PUSH_USER_MESSAGE_DEF,
     &HOST_AGENT_SESSION_PENDING_INJECTIONS_DEF,
     &HOST_AGENT_SESSION_REVOKE_REMINDER_DEF,
     &HOST_AGENT_DAEMON_WAIT_DEF,

--- a/crates/harn-vm/tests/agent_loop_steering_seams.rs
+++ b/crates/harn-vm/tests/agent_loop_steering_seams.rs
@@ -18,6 +18,22 @@
 //! transcript records the reminder, the loop's LLM call count is
 //! unchanged versus a control run, and the `loop_exit` checkpoint
 //! reports the delivery.
+//!
+//! Steer coverage (rfd/session-inject) — `mode: "steer"` (an alias for
+//! `finish_step`) queues a USER-role message via the in-VM
+//! `agent_session_push_user_message` primitive (the loop-driver
+//! equivalent of the ACP `session/inject` method). Unlike `audit_only`,
+//! the steer message is delivered MID-TURN at the next loop checkpoint
+//! (a tool boundary / iteration boundary), NOT at `loop_exit`, so the
+//! model sees it before its next call. The `steer_*` tests below prove
+//! three claims: (a) mid-turn pickup at a tool boundary — a
+//! non-`loop_exit` checkpoint reports `delivered >= 1` and NO `loop_exit`
+//! checkpoint delivers it; (b) chronological order — the steer user
+//! message is spliced AFTER the tool_result and BEFORE the final
+//! assistant message in transcript message order; (c) eval-safety — a
+//! control variant that does not push the steer produces an identical
+//! LLM-call count and tool_result count and no extra user message and no
+//! mid-turn delivery.
 
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
@@ -302,5 +318,234 @@ fn audit_only_control_run_records_no_audit_reminder() {
     assert_eq!(
         lines[3], "0",
         "control run should report zero loop_exit deliveries; lines: {lines:?}"
+    );
+}
+
+/// Harn pipeline that exercises the steer path (rfd/session-inject). On
+/// iteration 0 the stub LLM caller — BEFORE returning a `would_force_push`
+/// tool call — queues a USER-role steer via the in-VM
+/// `agent_session_push_user_message` primitive with `mode: "steer"` (the
+/// loop-driver equivalent of the ACP `session/inject` method). On
+/// iteration 1 the model returns `##DONE##`. The `mode: "steer"` string is
+/// passed verbatim through the builtin, which maps `steer` ->
+/// `finish_step` (delivered at the next loop checkpoint, i.e. the tool
+/// boundary), NOT `loop_exit`.
+///
+/// The script logs seven fields, identical between the steer and control
+/// variants so the no-inject control is directly comparable:
+///
+///   0. final status
+///   1. LLM call count observed by the caller stub
+///   2. tool_result message count
+///   3. mid-turn deliveries: count of `loop_checkpoint` events whose
+///      `kind` is NOT `loop_exit` and whose `delivered` is `>= 1`
+///   4. loop_exit deliveries: count of `loop_checkpoint` events whose
+///      `kind` IS `loop_exit` and whose `delivered` is `>= 1`
+///   5. count of `user`-role transcript messages whose content equals the
+///      steer text
+///   6. chronological-order verdict — `"ok"` iff the steer user message
+///      sits strictly after the tool_result and strictly before the final
+///      assistant message in transcript message order; otherwise a
+///      diagnostic string `"<toolIdx>/<steerIdx>/<asstIdx>"`.
+fn steer_pipeline(session_id: &str, push_steer_mid_turn: bool) -> String {
+    let push_line = if push_steer_mid_turn {
+        format!(
+            r#"      agent_session_push_user_message(
+        "{session_id}",
+        {{content: "actually use auth_v2.go", mode: "steer"}},
+      )"#
+        )
+    } else {
+        String::new()
+    };
+    format!(
+        r#"
+import {{ agent_session_push_user_message }} from "std/agent/state"
+
+pipeline main(task) {{
+  clear_tool_hooks()
+  let registry = tool_registry()
+  let tools = tool_define(
+    registry,
+    "would_force_push",
+    "Test stand-in for an irreversible side-effect tool.",
+    {{parameters: {{}}, handler: {{ _args -> return "would have force-pushed" }}}},
+  )
+  let iteration_state = shared_cell({{scope: "task_group", key: "steer-iter-{session_id}", initial: 0}})
+  let call_counter = shared_cell({{scope: "task_group", key: "steer-calls-{session_id}", initial: 0}})
+  let mock_llm = {{ _call ->
+    let csnap = shared_snapshot(call_counter)
+    shared_cas(call_counter, csnap, csnap.value + 1)
+    let snap = shared_snapshot(iteration_state)
+    let n = snap.value
+    shared_cas(iteration_state, snap, n + 1)
+    if n == 0 {{
+{push_line}
+      return {{
+        ok: true,
+        value: {{
+          text: "",
+          tool_calls: [{{id: "call_1", name: "would_force_push", arguments: {{}}}}],
+          provider: "mock",
+          model: "mock",
+        }},
+      }}
+    }}
+    return {{
+      ok: true,
+      value: {{text: "acknowledged ##DONE##", tool_calls: [], provider: "mock", model: "mock"}},
+    }}
+  }}
+  let result = agent_loop(
+    "do the push",
+    nil,
+    {{
+      provider: "mock",
+      tools: tools,
+      tool_format: "native",
+      max_iterations: 4,
+      loop_until_done: true,
+      session_id: "{session_id}",
+      llm_caller: mock_llm,
+    }},
+  )
+  log(result.status)
+  log(shared_get(call_counter))
+  let stats = transcript_stats(result.transcript)
+  log(stats.tool_result_message_count)
+
+  let checkpoints = transcript_events_by_kind(result.transcript, "loop_checkpoint")
+  var mid_turn_deliveries = 0
+  var loop_exit_deliveries = 0
+  for event in checkpoints {{
+    let delivered = event?.metadata?.delivered ?? 0
+    if delivered >= 1 {{
+      if event?.metadata?.kind == "loop_exit" {{
+        loop_exit_deliveries = loop_exit_deliveries + 1
+      }} else {{
+        mid_turn_deliveries = mid_turn_deliveries + 1
+      }}
+    }}
+  }}
+  log(mid_turn_deliveries)
+  log(loop_exit_deliveries)
+
+  // Walk the transcript messages IN ORDER to prove chronological splice:
+  // the steer user message must land after the tool_result and before the
+  // final assistant message.
+  let messages = transcript_messages(result.transcript)
+  var steer_user_count = 0
+  var tool_result_idx = -1
+  var steer_idx = -1
+  var last_assistant_idx = -1
+  var idx = 0
+  for message in messages {{
+    let role = message?.role ?? ""
+    let content = message?.content ?? ""
+    if (role == "tool_result" || role == "tool") && tool_result_idx == -1 {{
+      tool_result_idx = idx
+    }}
+    if role == "user" && content == "actually use auth_v2.go" {{
+      steer_user_count = steer_user_count + 1
+      if steer_idx == -1 {{
+        steer_idx = idx
+      }}
+    }}
+    if role == "assistant" {{
+      last_assistant_idx = idx
+    }}
+    idx = idx + 1
+  }}
+  log(steer_user_count)
+  if tool_result_idx >= 0 && steer_idx > tool_result_idx && last_assistant_idx > steer_idx {{
+    log("ok")
+  }} else {{
+    log("${{tool_result_idx}}/${{steer_idx}}/${{last_assistant_idx}}")
+  }}
+}}
+"#
+    )
+}
+
+#[test]
+fn steer_user_message_delivered_mid_turn_at_tool_boundary() {
+    let raw = run_with_bridge(&steer_pipeline("steer-mid-turn", true)).expect("script must run");
+    let lines = out_lines(&raw);
+    // Status: done (model returned `##DONE##` on the second iteration).
+    assert_eq!(lines[0], "done", "lines: {lines:?}");
+    // Two LLM calls: iteration 0 emits the tool call (after queuing the
+    // steer), iteration 1 sees the spliced steer + tool_result and
+    // returns ##DONE##.
+    assert_eq!(lines[1], "2", "expected two LLM calls; lines: {lines:?}");
+    // The tool dispatched once.
+    assert_eq!(
+        lines[2], "1",
+        "expected one tool dispatch; lines: {lines:?}"
+    );
+    // (a) MID-TURN PICKUP AT TOOL BOUNDARY: a non-`loop_exit` checkpoint
+    // (post_tool_dispatch / iteration_start of iteration 1) reported the
+    // steer delivery during the running turn.
+    assert!(
+        lines[3].parse::<i64>().unwrap_or(0) >= 1,
+        "expected >= 1 mid-turn delivery at a tool boundary; lines: {lines:?}"
+    );
+    // NO `loop_exit` checkpoint delivered the steer — this distinguishes
+    // steer (finish_step) from audit_only/queue.
+    assert_eq!(
+        lines[4], "0",
+        "steer must NOT be delivered at loop_exit; lines: {lines:?}"
+    );
+    // The steer user message landed in the transcript exactly once.
+    assert_eq!(
+        lines[5], "1",
+        "expected exactly one steer user message in the transcript; lines: {lines:?}"
+    );
+    // (b) CHRONOLOGICAL ORDER: tool_result_idx < steer_idx <
+    // last_assistant_idx, proven by walking transcript_messages in order.
+    assert_eq!(
+        lines[6], "ok",
+        "steer user message must sit chronologically after the tool_result \
+         and before the final assistant message (verdict is \
+         tool_result_idx/steer_idx/last_assistant_idx on failure); lines: {lines:?}"
+    );
+}
+
+#[test]
+fn steer_control_run_without_inject_is_eval_safe() {
+    let raw = run_with_bridge(&steer_pipeline("steer-control", false)).expect("script must run");
+    let lines = out_lines(&raw);
+    // (c) NO-INJECT PATH UNCHANGED: same status, same LLM-call count, and
+    // same tool_result count as the steer variant — the no-inject path is
+    // byte-identical from the loop's perspective (eval-safe).
+    assert_eq!(lines[0], "done", "lines: {lines:?}");
+    assert_eq!(
+        lines[1], "2",
+        "control must make the same two LLM calls as the steer variant; lines: {lines:?}"
+    );
+    assert_eq!(
+        lines[2], "1",
+        "control must dispatch the tool exactly once, same as the steer variant; lines: {lines:?}"
+    );
+    // No mid-turn deliveries and no loop_exit deliveries — nothing was
+    // queued.
+    assert_eq!(
+        lines[3], "0",
+        "control run should report zero mid-turn deliveries; lines: {lines:?}"
+    );
+    assert_eq!(
+        lines[4], "0",
+        "control run should report zero loop_exit deliveries; lines: {lines:?}"
+    );
+    // No steer user message in the transcript.
+    assert_eq!(
+        lines[5], "0",
+        "control run should not record a steer user message; lines: {lines:?}"
+    );
+    // No steer message exists, so the ordering verdict is the diagnostic
+    // form (steer_idx stays -1) — confirming the control differs from the
+    // steer variant only by the absence of the steer message.
+    assert_ne!(
+        lines[6], "ok",
+        "control run has no steer message to order; lines: {lines:?}"
     );
 }

--- a/crates/harn-vm/tests/builtin_registry_alignment.rs
+++ b/crates/harn-vm/tests/builtin_registry_alignment.rs
@@ -110,6 +110,7 @@ const RUNTIME_ONLY_EXCEPTIONS: &[&str] = &[
     "__host_agent_session_drain_feedback",
     "__host_agent_session_pending_injections",
     "__host_agent_session_push_bridge_injection",
+    "__host_agent_session_push_user_message",
     "__host_agent_session_revoke_reminder",
     "__host_agent_session_finalize",
     "__host_agent_session_init",


### PR DESCRIPTION
Implements the loop-driver half of the ACP [`session/inject`](https://github.com/agentclientprotocol/agent-client-protocol) RFD (`rfd/session-inject`, "Mid-turn input: queue and steer") for the in-process Harn agent loop.

The ACP wire lifecycle for `session/inject` (accept / pending / revoke / replace, `crates/harn-serve/src/adapters/acp/inject.rs`) already landed in #2096 (`ksinder/2079-pending-injects`), and replay-steering records landed in #1177 (`ksinder/issue-932-replay-steering`). This builds on that foundation — it does **not** duplicate it — by adding the in-VM primitive that callers driving the loop directly (e.g. the Burin TUI, which links the runtime in-process and has no ACP wire) use to steer a running turn, plus the regression coverage the steer path was missing.

## What this adds

- **`agent_session_push_user_message(session_id, options)`** — Harn stdlib `std/agent/state` + the `__host_agent_session_push_user_message` async builtin. The loop-driver equivalent of the ACP `session/inject` method and the user-message sibling of `agent_session_push_bridge_injection` (`session/remind`). Validates `options.content`, defaults `options.mode` to `finish_step`, and calls `HostBridge::push_queued_user_message`.
- **`steer` / `queue` aliases** in `QueuedUserMessageMode::from_str`: `steer` -> `FinishStep` (deliver at the next tool/iteration boundary, before the next model call), `queue` -> `AuditOnly` (deliver at loop_exit), matching the ACP vocabulary.
- **Regression tests** in `agent_loop_steering_seams.rs` proving the steer contract:
  - **mid-turn pickup at a tool boundary** — a non-`loop_exit` checkpoint reports `delivered >= 1` and NO `loop_exit` checkpoint delivers the steer.
  - **chronological splice** — walking `transcript_messages` in order: `tool_result_idx < steer_idx < last_assistant_idx`.
  - **eval-safety** — a no-inject control variant produces the same LLM-call count, the same tool_result count, no extra user message, and no mid-turn delivery (headless/eval path byte-unchanged).

## Verification

- `cargo test -p harn-vm --test agent_loop_steering_seams` — 6/6 pass (incl. the 3 steer contracts above).
- `cargo test -p harn-vm --test builtin_registry_alignment` — 6/6 (primitive registered, parser/runtime aligned).
- `cargo test -p harn-vm --lib bridge::` — 25/25 (queue/steer/revoke/replace plumbing).
- `cargo fmt -p harn-vm -p harn-stdlib --check` clean; `cargo clippy -p harn-vm` clean.

Refs: rfd/session-inject

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>