### PR TITLE
[codex] Optimize list push accumulator assignment

### DIFF
--- a/changelog.d/list-push-fusion.fixed.md
+++ b/changelog.d/list-push-fusion.fixed.md
@@ -1,0 +1,3 @@
+- **VM compiler list append optimization.** `x = x.push(item)` on local list
+  accumulators now uses the same fused append bytecode as `x = x + [item]`,
+  avoiding accidental quadratic cloning while preserving immutable aliasing.

--- a/crates/harn-vm/src/compiler/statements.rs
+++ b/crates/harn-vm/src/compiler/statements.rs
@@ -69,6 +69,33 @@ impl Compiler {
                         }
                     }
                 }
+                // `x = x.push(v)` is the method spelling of the same list
+                // accumulator append. When the receiver is statically known to
+                // be a list and the target is a local slot, lower it through
+                // the same fused concat opcode as `x = x + [v]`.
+                if let Node::MethodCall {
+                    object,
+                    method,
+                    args,
+                } = &value.node
+                {
+                    if method == "push" && args.len() == 1 {
+                        if let Node::Identifier(oname) = &object.node {
+                            if oname == name {
+                                let left_type = self.infer_expr_type(target);
+                                let value_type = self.infer_expr_type(value);
+                                if self.try_emit_list_push_assign(
+                                    name,
+                                    &args[0],
+                                    left_type.as_ref(),
+                                )? {
+                                    self.assign_type_fact(name, value_type);
+                                    return Ok(());
+                                }
+                            }
+                        }
+                    }
+                }
                 let value_type = self.infer_expr_type(value);
                 self.compile_node(value)?;
                 self.emit_set_binding(name);
@@ -377,6 +404,40 @@ impl Compiler {
         self.emit_set_binding(name); // [x, e]  binding <- nil; x uniquely held if unaliased
         self.chunk.emit(Op::Add, self.line); // [x + e]  in-place extend when unique
         self.emit_set_binding(name); // []
+        Ok(true)
+    }
+
+    /// Emit the fused local concat form for `x = x.push(item)`.
+    ///
+    /// This deliberately stays narrower than the runtime method: it only fires
+    /// for a local receiver that is statically list-like and for exactly one
+    /// non-spread argument. The optimized bytecode evaluates `item` while the
+    /// original slot is still live, builds `[item]`, then lets
+    /// `ConcatAssignLocal` perform the same immutable list append as
+    /// `x = x + [item]`, including alias-safe fallback cloning.
+    fn try_emit_list_push_assign(
+        &mut self,
+        name: &str,
+        item: &SNode,
+        left_type: Option<&TypeExpr>,
+    ) -> Result<bool, CompileError> {
+        fn is_list(t: Option<&TypeExpr>) -> bool {
+            matches!(t, Some(TypeExpr::List(_)))
+                || matches!(t, Some(TypeExpr::Named(n)) if n == "list")
+        }
+        if !self.options.optimizations_enabled() || !is_list(left_type) {
+            return Ok(false);
+        }
+        if matches!(item.node, Node::Spread(_)) {
+            return Ok(false);
+        }
+        let Some(binding) = self.resolve_local_slot(name) else {
+            return Ok(false);
+        };
+        self.compile_node(item)?;
+        self.chunk.emit_u16(Op::BuildList, 1, self.line);
+        self.chunk
+            .emit_u16(Op::ConcatAssignLocal, binding.slot, self.line);
         Ok(true)
     }
 

--- a/crates/harn-vm/src/compiler/tests.rs
+++ b/crates/harn-vm/src/compiler/tests.rs
@@ -743,6 +743,23 @@ fn inplace_list_concat_uses_fused_opcode() {
 }
 
 #[test]
+fn list_push_assign_uses_fused_concat_opcode() {
+    // `x = x.push(i)` is the method spelling of an immutable list append, so a
+    // local list accumulator should use the same fused concat opcode as
+    // `x = x + [i]` instead of dispatching through the cloning list method.
+    let chunk = compile_source("pipeline t(task) {\n  var x = []\n  x = x.push(1)\n}");
+    let d = chunk.disassemble("t");
+    assert!(
+        d.contains("CONCAT_ASSIGN_LOCAL"),
+        "list push assignment should emit the fused opcode:\n{d}"
+    );
+    assert!(
+        !d.contains("METHOD_CALL"),
+        "optimized list push assignment should skip method dispatch:\n{d}"
+    );
+}
+
+#[test]
 fn inplace_list_concat_compound_assign_form() {
     // `x += [i]` gets the same fused opcode as `x = x + [i]`.
     let chunk = compile_source("pipeline t(task) {\n  var x = []\n  x += [1]\n}");

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -2900,6 +2900,22 @@ pipeline t(task) {
 }
 
 #[test]
+fn list_push_assign_preserves_alias_immutability() {
+    // The compiler lowers `x = x.push(v)` through the same fused concat opcode
+    // as `x = x + [v]`. Rebinding `x` must still leave an existing alias `y`
+    // pointing at the original immutable list.
+    let source = r#"
+pipeline t(task) {
+  var x = []
+  x = x.push(1)
+  let y = x
+  x = x.push(2)
+  log("${x} ${y}")
+}"#;
+    assert_eq!(run_output(source), "[harn] [1, 2] [1]");
+}
+
+#[test]
 fn inplace_concat_preserves_binding_when_add_throws() {
     // The fused opcode only takes the slot in place for List/Dict values. A
     // scalar accumulator hit with an incompatible `+=` throws, and the binding


### PR DESCRIPTION
## Summary

- Lower `x = x.push(item)` on local, statically-list accumulators through the existing `CONCAT_ASSIGN_LOCAL` opcode.
- Keep the optimization narrow: exactly one non-spread argument, local slot receiver, and list-like static receiver type.
- Add compiler disassembly and runtime aliasing tests, plus a changelog fragment.

## Root Cause

`x = x + [item]` and `x += [item]` already compile to fused append bytecode, but `x = x.push(item)` still dispatched to the list method. The list method clones the receiver before appending, so accumulator loops using `.push()` could accidentally become quadratic compared with the concat spelling.

## Semantics

The new lowering builds `[item]` while the original binding is still live, then reuses `ConcatAssignLocal`. That preserves immutable value semantics: aliases keep seeing the old list, and the opcode falls back to cloning when the list buffer is shared.

## Verification

- `CARGO_TARGET_DIR=/tmp/harn-list-push-fusion-target cargo test -p harn-vm list_push_assign_uses_fused_concat_opcode`
- `CARGO_TARGET_DIR=/tmp/harn-list-push-fusion-target cargo test -p harn-vm list_push_assign_preserves_alias_immutability`
- `CARGO_TARGET_DIR=/tmp/harn-list-push-fusion-target cargo test -p harn-vm inplace_concat`
- pre-commit hook: markdown lint, Rust formatting, prompt-prose ratchet, clippy on `harn-vm`
- pre-push hook: markdown lint and targeted local checks