### PR TITLE
Add vetted MCP identity descriptors

### DIFF
--- a/changelog.d/3351.added.md
+++ b/changelog.d/3351.added.md
@@ -1,0 +1,1 @@
+Add vetted identity metadata for bundled MCP presets, including documented source URLs and drift tests for descriptor shape.

--- a/crates/harn-vm/src/mcp_identity.rs
+++ b/crates/harn-vm/src/mcp_identity.rs
@@ -18,7 +18,9 @@ use std::collections::BTreeMap;
 use serde_json::Value;
 
 use crate::mcp_oauth::StoredMcpToken;
-use crate::mcp_presets::{self, IdentityProbeDescriptor, IdentityProbeKind};
+use crate::mcp_presets::{
+    self, IdentityProbeDescriptor, IdentityProbeKind, IdentityResolutionKind,
+};
 
 /// The identity descriptor for a server URL, from the preset catalog (including
 /// any runtime overlay). `None` when the server isn't a known preset or the
@@ -47,6 +49,9 @@ pub fn render_identity(
     descriptor: &IdentityProbeDescriptor,
     token_response: Option<&Value>,
 ) -> Option<String> {
+    if descriptor.resolution == IdentityResolutionKind::None {
+        return None;
+    }
     for source in &descriptor.sources {
         if source.kind != IdentityProbeKind::TokenResponse {
             // `tool` / `http` need a live session; resolved by a follow-up.
@@ -146,11 +151,16 @@ fn tidy(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mcp_presets::{IdentityProbeKind, IdentityProbeSource};
+    use crate::mcp_presets::{
+        IdentityDescriptorConfidence, IdentityProbeKind, IdentityProbeSource,
+    };
     use serde_json::json;
 
     fn notion_descriptor() -> IdentityProbeDescriptor {
         IdentityProbeDescriptor {
+            resolution: IdentityResolutionKind::User,
+            confidence: Some(IdentityDescriptorConfidence::Documented),
+            source_url: Some("https://developers.notion.com/reference/create-a-token".to_string()),
             display_template: "{name} <{email}> — {workspace}".to_string(),
             sources: vec![IdentityProbeSource {
                 kind: IdentityProbeKind::TokenResponse,
@@ -221,6 +231,9 @@ mod tests {
     #[test]
     fn skips_live_probe_only_sources() {
         let descriptor = IdentityProbeDescriptor {
+            resolution: IdentityResolutionKind::User,
+            confidence: Some(IdentityDescriptorConfidence::Observed),
+            source_url: Some("https://example.com/mcp".to_string()),
             display_template: "{name}".to_string(),
             sources: vec![IdentityProbeSource {
                 kind: IdentityProbeKind::Tool,
@@ -230,6 +243,24 @@ mod tests {
             }],
         };
         // Tool source isn't resolved synchronously yet → None even with payload.
+        let payload = json!({"name": "Jane"});
+        assert!(render_identity(&descriptor, Some(&payload)).is_none());
+    }
+
+    #[test]
+    fn none_resolution_never_renders() {
+        let descriptor = IdentityProbeDescriptor {
+            resolution: IdentityResolutionKind::None,
+            confidence: Some(IdentityDescriptorConfidence::None),
+            source_url: Some("https://example.com/mcp".to_string()),
+            display_template: "{name}".to_string(),
+            sources: vec![IdentityProbeSource {
+                kind: IdentityProbeKind::TokenResponse,
+                tool: None,
+                url: None,
+                fields: BTreeMap::from([("name".to_string(), "name".to_string())]),
+            }],
+        };
         let payload = json!({"name": "Jane"});
         assert!(render_identity(&descriptor, Some(&payload)).is_none());
     }

--- a/crates/harn-vm/src/mcp_presets.rs
+++ b/crates/harn-vm/src/mcp_presets.rs
@@ -29,11 +29,10 @@ use std::sync::OnceLock;
 use serde::{Deserialize, Serialize};
 
 /// JSON schema version for the preset catalog. Increment on any breaking
-/// shape change to [`PresetCatalog`] / [`McpPreset`]. The optional
-/// [`McpPreset::identity`] field. Bumped to 2 in harn#3349 when the first vetted
-/// identity descriptor (Notion) began shipping in the catalog, so consumers can
-/// detect that presets may now carry an `identity` recipe.
-pub const PRESET_CATALOG_SCHEMA_VERSION: u32 = 2;
+/// shape change to [`PresetCatalog`] / [`McpPreset`]. Bumped to 3 in harn#3351
+/// when identity descriptors gained explicit resolution/confidence/source
+/// metadata and the catalog expanded to vetted remote MCP servers.
+pub const PRESET_CATALOG_SCHEMA_VERSION: u32 = 3;
 
 /// Bundled default catalog. Editable here; overlayable at runtime.
 const BUILTIN_TOML: &str = include_str!("mcp_presets.toml");
@@ -69,6 +68,9 @@ pub enum PresetAuthKind {
 pub enum PresetCategory {
     Productivity,
     Development,
+    Design,
+    Finance,
+    Cloud,
     Local,
 }
 
@@ -113,14 +115,54 @@ pub enum PlaceholderTarget {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
 pub struct IdentityProbeDescriptor {
+    /// What kind of identity this descriptor can surface. Defaults to a user
+    /// identity for older overlay descriptors.
+    #[serde(default)]
+    pub resolution: IdentityResolutionKind,
+    /// Confidence level for the descriptor, based on source quality.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confidence: Option<IdentityDescriptorConfidence>,
+    /// Primary public source that documents the server URL or identity tool.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
     /// Display template referencing captured field names in braces, e.g.
     /// `"{name} <{email}> — {workspace}"`. The runner elides unresolved
     /// `{field}` placeholders (and any bracketed segment left empty).
+    #[serde(default)]
     pub display_template: String,
     /// Ordered probe sources; the runner tries each until one yields a
     /// non-empty identity.
     #[serde(default)]
     pub sources: Vec<IdentityProbeSource>,
+}
+
+/// The type of authenticated identity a descriptor represents.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IdentityResolutionKind {
+    /// Human user/workspace identity.
+    #[default]
+    User,
+    /// Account/workspace identity only; no stable human principal is exposed.
+    Account,
+    /// No known identity surface. Clients should display only the server label
+    /// or any separately configured account name.
+    None,
+}
+
+/// Confidence in a descriptor's shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IdentityDescriptorConfidence {
+    /// Directly documented by the provider's public MCP/API documentation.
+    Documented,
+    /// Empirically observed or documented by a first-party source without a
+    /// fully specified result schema.
+    Observed,
+    /// Provider only exposes account/workspace identity, not a user principal.
+    AccountOnly,
+    /// Provider has no known identity surface.
+    None,
 }
 
 /// Where the identity runner looks. A flat struct (rather than a tagged enum)
@@ -305,7 +347,7 @@ mod tests {
     #[test]
     fn bundled_catalog_parses() {
         let presets = base_presets();
-        assert_eq!(presets.len(), 4, "bundled catalog should ship 4 presets");
+        assert_eq!(presets.len(), 9, "bundled catalog should ship 9 presets");
     }
 
     #[test]
@@ -324,7 +366,17 @@ mod tests {
 
     #[test]
     fn ships_the_well_known_servers() {
-        for id in ["notion", "linear", "github", "filesystem"] {
+        for id in [
+            "notion",
+            "linear",
+            "github",
+            "sentry",
+            "figma",
+            "atlassian",
+            "stripe",
+            "cloudflare",
+            "filesystem",
+        ] {
             assert!(preset(id).is_some(), "missing preset {id}");
         }
     }
@@ -374,7 +426,7 @@ mod tests {
     #[test]
     fn json_shape_is_stable() {
         let json = serde_json::to_value(catalog()).expect("serialize catalog");
-        assert_eq!(json["schemaVersion"], serde_json::json!(2));
+        assert_eq!(json["schemaVersion"], serde_json::json!(3));
         let notion = json["presets"]
             .as_array()
             .expect("presets array")
@@ -392,6 +444,15 @@ mod tests {
             "Notion MCP does not currently expose configurable OAuth scopes"
         );
         // Notion now ships a token_response identity descriptor (harn#3349).
+        assert_eq!(notion["identity"]["resolution"], serde_json::json!("user"));
+        assert_eq!(
+            notion["identity"]["confidence"],
+            serde_json::json!("documented")
+        );
+        assert_eq!(
+            notion["identity"]["sourceUrl"],
+            serde_json::json!("https://developers.notion.com/reference/create-a-token")
+        );
         assert_eq!(
             notion["identity"]["displayTemplate"],
             serde_json::json!("{name} <{email}> — {workspace}")
@@ -400,6 +461,142 @@ mod tests {
             notion["identity"]["sources"][0]["kind"],
             serde_json::json!("token_response")
         );
+    }
+
+    #[test]
+    fn vetted_identity_descriptors_are_declared_for_well_known_servers() {
+        let presets = base_presets();
+        let expected = [
+            ("notion", IdentityResolutionKind::User),
+            ("linear", IdentityResolutionKind::User),
+            ("github", IdentityResolutionKind::User),
+            ("sentry", IdentityResolutionKind::User),
+            ("figma", IdentityResolutionKind::User),
+            ("atlassian", IdentityResolutionKind::User),
+            ("stripe", IdentityResolutionKind::Account),
+            ("cloudflare", IdentityResolutionKind::Account),
+        ];
+
+        for (id, resolution) in expected {
+            let preset = presets
+                .iter()
+                .find(|preset| preset.id == id)
+                .unwrap_or_else(|| panic!("missing preset {id}"));
+            let identity = preset
+                .identity
+                .as_ref()
+                .unwrap_or_else(|| panic!("{id} must declare an identity descriptor"));
+            assert_eq!(
+                identity.resolution, resolution,
+                "{id} identity resolution drifted"
+            );
+            assert!(
+                identity.confidence.is_some(),
+                "{id} identity must declare confidence"
+            );
+            assert!(
+                identity
+                    .source_url
+                    .as_deref()
+                    .is_some_and(|url| url.starts_with("https://")),
+                "{id} identity must cite an https source"
+            );
+            assert!(
+                !identity.display_template.trim().is_empty(),
+                "{id} identity needs a display template"
+            );
+            assert!(
+                !identity.sources.is_empty(),
+                "{id} identity needs at least one source"
+            );
+        }
+    }
+
+    #[test]
+    fn identity_source_shapes_are_coherent() {
+        for preset in base_presets() {
+            let Some(identity) = preset.identity.as_ref() else {
+                continue;
+            };
+            if identity.resolution == IdentityResolutionKind::None {
+                assert!(
+                    identity.sources.is_empty(),
+                    "{} none identity must not carry sources",
+                    preset.id
+                );
+                assert!(
+                    identity.display_template.trim().is_empty(),
+                    "{} none identity must not carry a display template",
+                    preset.id
+                );
+                continue;
+            }
+
+            assert!(
+                !identity.display_template.trim().is_empty(),
+                "{} identity must render a display template",
+                preset.id
+            );
+            for source in &identity.sources {
+                assert!(
+                    !source.fields.is_empty(),
+                    "{} identity source {:?} must map fields",
+                    preset.id,
+                    source.kind
+                );
+                for (name, path) in &source.fields {
+                    assert!(
+                        !name.trim().is_empty() && !path.trim().is_empty(),
+                        "{} identity source fields must not be blank",
+                        preset.id
+                    );
+                }
+                match source.kind {
+                    IdentityProbeKind::TokenResponse => {
+                        assert!(
+                            source.tool.is_none(),
+                            "{} token_response source must not set tool",
+                            preset.id
+                        );
+                        assert!(
+                            source.url.is_none(),
+                            "{} token_response source must not set url",
+                            preset.id
+                        );
+                    }
+                    IdentityProbeKind::Tool => {
+                        assert!(
+                            source
+                                .tool
+                                .as_deref()
+                                .is_some_and(|tool| !tool.trim().is_empty()),
+                            "{} tool source must name a tool",
+                            preset.id
+                        );
+                        assert!(
+                            source.url.is_none(),
+                            "{} tool source must not set url",
+                            preset.id
+                        );
+                    }
+                    IdentityProbeKind::Http => {
+                        assert!(
+                            source
+                                .url
+                                .as_deref()
+                                .is_some_and(|url| url.starts_with("https://")),
+                            "{} http source must cite an https url",
+                            preset.id
+                        );
+                        assert!(
+                            source.tool.is_none(),
+                            "{} http source must not set tool",
+                            preset.id
+                        );
+                    }
+                }
+            }
+        }
     }
 
     #[test]
@@ -450,9 +647,9 @@ auth_kind = "oauth"
         assert_eq!(notion.url, "https://notion.corp.example/mcp");
         assert!(
             base.iter().any(|preset| preset.id == "sentry"),
-            "new overlay preset should be appended"
+            "existing sentry preset should remain present after replacement"
         );
-        assert_eq!(base.len(), 5, "4 base + 1 appended");
+        assert_eq!(base.len(), 9, "sentry overlay replaces bundled preset");
     }
 
     #[test]
@@ -492,6 +689,9 @@ email = "person.email"
             .identity
             .as_ref()
             .expect("notion has identity descriptor");
+        assert_eq!(identity.resolution, IdentityResolutionKind::User);
+        assert!(identity.confidence.is_none());
+        assert!(identity.source_url.is_none());
         assert_eq!(identity.display_template, "{name} <{email}> — {workspace}");
         assert_eq!(identity.sources.len(), 2);
         assert_eq!(identity.sources[0].kind, IdentityProbeKind::TokenResponse);

--- a/crates/harn-vm/src/mcp_presets.toml
+++ b/crates/harn-vm/src/mcp_presets.toml
@@ -22,8 +22,12 @@ url = "https://mcp.notion.com/mcp"
 auth_kind = "oauth"
 
 # Notion returns the authorizing user + workspace inline in its OAuth token
-# response, so the "logged in as …" string needs no extra call (harn#3349).
+# response, so the primary "logged in as ..." string needs no extra call.
+# Source: https://developers.notion.com/reference/create-a-token
 [presets.identity]
+resolution = "user"
+confidence = "documented"
+source_url = "https://developers.notion.com/reference/create-a-token"
 display_template = "{name} <{email}> — {workspace}"
 
 [[presets.identity.sources]]
@@ -32,6 +36,15 @@ kind = "token_response"
 name = "owner.user.name"
 email = "owner.user.person.email"
 workspace = "workspace_name"
+
+# Fallback shape from Notion's self endpoint.
+# Source: https://developers.notion.com/reference/get-self
+[[presets.identity.sources]]
+kind = "tool"
+tool = "notion-get-self"
+[presets.identity.sources.fields]
+name = "name"
+email = "person.email"
 
 [[presets]]
 id = "linear"
@@ -43,6 +56,22 @@ transport = "http"
 url = "https://mcp.linear.app/mcp"
 auth_kind = "oauth"
 oauth_scopes = "read write"
+
+# Linear documents the remote MCP endpoint; the user identity probe is based on
+# the first-party viewer-style surface observed during #3351 vetting.
+# Source: https://linear.app/docs/mcp
+[presets.identity]
+resolution = "user"
+confidence = "observed"
+source_url = "https://linear.app/docs/mcp"
+display_template = "{name} <{email}>"
+
+[[presets.identity.sources]]
+kind = "tool"
+tool = "viewer"
+[presets.identity.sources.fields]
+name = "name"
+email = "email"
 
 [[presets]]
 id = "github"
@@ -60,6 +89,155 @@ key = "GITHUB_PERSONAL_ACCESS_TOKEN"
 label = "GitHub personal access token"
 target = "env"
 required = true
+
+# GitHub's official MCP server ships a users toolset; get_me returns the
+# authenticated GitHub user. The existing preset remains local/stdio for
+# compatibility with clients that fill GITHUB_PERSONAL_ACCESS_TOKEN.
+# Source: https://github.com/github/github-mcp-server
+[presets.identity]
+resolution = "user"
+confidence = "observed"
+source_url = "https://github.com/github/github-mcp-server"
+display_template = "{login} <{email}>"
+
+[[presets.identity.sources]]
+kind = "tool"
+tool = "get_me"
+[presets.identity.sources.fields]
+login = "login"
+name = "name"
+email = "email"
+
+[[presets]]
+id = "sentry"
+name = "Sentry"
+description = "Issues, releases, and error context from Sentry."
+icon = "exclamationmark.triangle.fill"
+category = "development"
+transport = "http"
+url = "https://mcp.sentry.dev/mcp"
+auth_kind = "oauth"
+
+# Sentry's public MCP server exposes whoami for authenticated user display.
+# Source: https://github.com/getsentry/sentry-mcp
+[presets.identity]
+resolution = "user"
+confidence = "observed"
+source_url = "https://github.com/getsentry/sentry-mcp"
+display_template = "{name} <{email}>"
+
+[[presets.identity.sources]]
+kind = "tool"
+tool = "whoami"
+[presets.identity.sources.fields]
+name = "name"
+email = "email"
+
+[[presets]]
+id = "figma"
+name = "Figma"
+description = "Design files, variables, assets, and design-context tools from Figma."
+icon = "paintpalette.fill"
+category = "design"
+transport = "http"
+url = "https://mcp.figma.com/mcp"
+auth_kind = "oauth"
+
+# Figma documents whoami as a remote-only tool returning the authenticated
+# user's email, plans, and seat types.
+# Source: https://developers.figma.com/docs/figma-mcp-server/tools-and-prompts/
+[presets.identity]
+resolution = "user"
+confidence = "documented"
+source_url = "https://developers.figma.com/docs/figma-mcp-server/tools-and-prompts/"
+display_template = "{email}"
+
+[[presets.identity.sources]]
+kind = "tool"
+tool = "whoami"
+[presets.identity.sources.fields]
+email = "email"
+name = "name"
+
+[[presets]]
+id = "atlassian"
+name = "Atlassian"
+description = "Jira, Confluence, Compass, and Bitbucket context via Rovo MCP."
+icon = "bolt.horizontal.circle.fill"
+category = "productivity"
+transport = "http"
+url = "https://mcp.atlassian.com/v1/mcp/authv2"
+auth_kind = "oauth"
+
+# Atlassian documents the Rovo MCP endpoint; atlassianUserInfo is the
+# first-party identity probe observed during #3351 vetting.
+# Source: https://support.atlassian.com/atlassian-rovo-mcp-server/docs/setting-up-ides/
+[presets.identity]
+resolution = "user"
+confidence = "observed"
+source_url = "https://support.atlassian.com/atlassian-rovo-mcp-server/docs/setting-up-ides/"
+display_template = "{name} <{email}> ({account_id})"
+
+[[presets.identity.sources]]
+kind = "tool"
+tool = "atlassianUserInfo"
+[presets.identity.sources.fields]
+name = "name"
+email = "email"
+account_id = "accountId"
+
+[[presets]]
+id = "stripe"
+name = "Stripe"
+description = "Customers, payments, billing, and account data from Stripe."
+icon = "creditcard.fill"
+category = "finance"
+transport = "http"
+url = "https://mcp.stripe.com"
+auth_kind = "oauth"
+
+# Stripe documents get_stripe_account_info as its account retrieval tool.
+# This surfaces account identity, not a stable human principal.
+# Source: https://docs.stripe.com/mcp
+[presets.identity]
+resolution = "account"
+confidence = "account_only"
+source_url = "https://docs.stripe.com/mcp"
+display_template = "{business_name} <{email}> ({account_id})"
+
+[[presets.identity.sources]]
+kind = "tool"
+tool = "get_stripe_account_info"
+[presets.identity.sources.fields]
+account_id = "id"
+business_name = "business_profile.name"
+email = "email"
+
+[[presets]]
+id = "cloudflare"
+name = "Cloudflare"
+description = "Cloudflare API access across accounts, zones, Workers, R2, DNS, and Zero Trust."
+icon = "cloud.fill"
+category = "cloud"
+transport = "http"
+url = "https://mcp.cloudflare.com/mcp"
+auth_kind = "oauth"
+
+# Cloudflare documents a managed remote API MCP endpoint. Account listing is
+# the available identity-like surface; it does not prove a human principal.
+# Source: https://developers.cloudflare.com/agents/model-context-protocol/cloudflare/servers-for-cloudflare/
+[presets.identity]
+resolution = "account"
+confidence = "account_only"
+source_url = "https://developers.cloudflare.com/agents/model-context-protocol/cloudflare/servers-for-cloudflare/"
+display_template = "{name} ({account_id})"
+
+[[presets.identity.sources]]
+kind = "tool"
+tool = "accounts_list"
+[presets.identity.sources.fields]
+name = "result.0.name"
+account_id = "result.0.id"
 
 [[presets]]
 id = "filesystem"


### PR DESCRIPTION
## Summary
- expand the bundled MCP preset catalog with vetted identity metadata for Notion, Linear, GitHub, Sentry, Figma, Atlassian, Stripe, and Cloudflare
- add explicit identity resolution/confidence/source metadata so clients can distinguish user, account-only, and no-identity surfaces
- bump the preset catalog schema to v3 and add drift tests for descriptor shape/source coverage

## Source vetting
- checked first-party/public docs or source for each server URL and identity surface: Notion token/self endpoints, Linear MCP docs, GitHub MCP server tool snapshots/source, Sentry MCP source, Figma MCP tools docs, Atlassian Rovo MCP setup docs, Stripe MCP docs, and Cloudflare managed MCP docs
- catalog currently has no bundled Slack or Google Drive preset to mark `none`; the schema/runtime now supports `resolution = "none"` and the renderer hard-fails closed for that value

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p harn-vm mcp_presets`
- `cargo test -p harn-vm mcp_identity`
- `CARGO_BUILD_JOBS=1 cargo check -p harn-cli`

Closes #3351