### PR TITLE
Prune runtime artifacts from code index

### DIFF
--- a/changelog.d/codeindex-runtime-prune.fixed.md
+++ b/changelog.d/codeindex-runtime-prune.fixed.md
@@ -1,0 +1,2 @@
+Prune Harn/Burin runtime artifact directories from the hostlib code index.
+Startup indexing now ignores eval transcripts and generated run state.

--- a/crates/harn-hostlib/src/code_index/walker.rs
+++ b/crates/harn-hostlib/src/code_index/walker.rs
@@ -56,8 +56,12 @@ const SKIP_DIRS: &[&str] = &[
     // Test coverage
     "coverage",
     ".nyc_output",
-    // Legacy host cache
+    // Managed host/runtime artifacts
     ".burin",
+    ".burin-evals",
+    ".burin-live-evals",
+    ".harn",
+    ".harn-runs",
     // Claude Code
     ".claude",
     // Misc
@@ -327,10 +331,18 @@ mod tests {
         fs::create_dir_all(root.join("src")).unwrap();
         fs::create_dir_all(root.join("node_modules/foo")).unwrap();
         fs::create_dir_all(root.join(".git/objects")).unwrap();
+        fs::create_dir_all(root.join(".burin-evals/run")).unwrap();
+        fs::create_dir_all(root.join(".burin-live-evals/run")).unwrap();
+        fs::create_dir_all(root.join(".harn/state")).unwrap();
+        fs::create_dir_all(root.join(".harn-runs/session")).unwrap();
         fs::write(root.join("src/main.rs"), b"fn main() {}").unwrap();
         fs::write(root.join("src/.env"), b"SECRET=x").unwrap();
         fs::write(root.join("node_modules/foo/lib.js"), b"x").unwrap();
         fs::write(root.join(".git/objects/pack"), b"git").unwrap();
+        fs::write(root.join(".burin-evals/run/transcript.jsonl"), b"{}").unwrap();
+        fs::write(root.join(".burin-live-evals/run/live.jsonl"), b"{}").unwrap();
+        fs::write(root.join(".harn/state/session.json"), b"{}").unwrap();
+        fs::write(root.join(".harn-runs/session/trace.harn"), b"fn noisy() {}").unwrap();
         fs::write(
             root.join("oversize.json"),
             vec![b'a'; (MAX_FILE_BYTES + 1) as usize],

--- a/crates/harn-hostlib/tests/code_index.rs
+++ b/crates/harn-hostlib/tests/code_index.rs
@@ -137,6 +137,70 @@ fn rebuild_then_query_returns_hits_for_indexed_substring() {
 }
 
 #[test]
+fn rebuild_prunes_managed_runtime_artifact_roots() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(
+        root.join("src/main.rs"),
+        "pub fn live_workspace_symbol() -> &'static str { \"ok\" }\n",
+    )
+    .unwrap();
+
+    for (artifact_dir, file_name) in [
+        (".burin-evals/run", "transcript.jsonl"),
+        (".burin-live-evals/run", "live.jsonl"),
+        (".harn/state", "session.json"),
+        (".harn-runs/session", "trace.harn"),
+    ] {
+        let artifact_dir = root.join(artifact_dir);
+        fs::create_dir_all(&artifact_dir).unwrap();
+        fs::write(
+            artifact_dir.join(file_name),
+            "pub fn artifact_only_symbol() -> &'static str { \"noise\" }\n",
+        )
+        .unwrap();
+    }
+
+    let (registry, _cap) = build_registry();
+    let rebuild = extract_dict(&call(
+        &registry,
+        "hostlib_code_index_rebuild",
+        dict(&[(
+            "root",
+            VmValue::String(arcstr::ArcStr::from(root.to_string_lossy().to_string())),
+        )]),
+    ));
+    assert_eq!(extract_int(rebuild.get("files_indexed").unwrap()), 1);
+
+    let stats = extract_dict(&call(&registry, "hostlib_code_index_stats", dict(&[])));
+    assert_eq!(extract_int(stats.get("indexed_files").unwrap()), 1);
+
+    let noise = extract_dict(&call(
+        &registry,
+        "hostlib_code_index_query",
+        dict(&[(
+            "needle",
+            VmValue::String(arcstr::ArcStr::from("artifact_only_symbol")),
+        )]),
+    ));
+    assert!(extract_list(noise.get("results").unwrap()).is_empty());
+
+    let live = extract_dict(&call(
+        &registry,
+        "hostlib_code_index_query",
+        dict(&[(
+            "needle",
+            VmValue::String(arcstr::ArcStr::from("live_workspace_symbol")),
+        )]),
+    ));
+    let live_results = extract_list(live.get("results").unwrap());
+    assert_eq!(live_results.len(), 1);
+    let hit = extract_dict(&live_results[0]);
+    assert_eq!(extract_str(hit.get("path").unwrap()), "src/main.rs");
+}
+
+#[test]
 fn query_respects_case_sensitive_flag() {
     let dir = write_workspace();
     let (registry, _) = build_registry();


### PR DESCRIPTION
## Summary
- prune Harn/Burin managed runtime artifact roots from the hostlib code-index walker: `.harn`, `.harn-runs`, `.burin-evals`, and `.burin-live-evals`
- keep the fix at the general hostlib indexing boundary so every embedder benefits, instead of special-casing Burin startup
- add a public rebuild/query regression proving artifact-only tokens never enter the index

## Root Cause
Burin TUI headless dogfood timed out before its first LLM/tool call. ACP trace reached `workspace.project_root`, then the in-process bootstrap went silent. The cold-start path calls `hostlib_code_index_ensure_initialised(host_project_root())`; hostlib then synchronously rebuilds the code index over every indexable file. In the Burin checkout, generated runtime roots are large enough to dominate cold start (`.burin-evals` alone was ~2.8G locally) and include many indexable transcript/state files.

The existing walker already prunes build/package/cache roots centrally, but only skipped `.burin`, not Harn run state or eval artifacts.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `CARGO_BUILD_JOBS=1 cargo test -p harn-hostlib walk_skips_pruned_dirs_and_oversize_files`
- `CARGO_BUILD_JOBS=1 cargo test -p harn-hostlib rebuild_prunes_managed_runtime_artifact_roots`
