### PR TITLE
feat(llm): runtime tool_format fallback + (model×serving-stack)-aware resolution + equivalence-group catalog guards

### DIFF
--- a/changelog.d/tool-format-fallback-catalog-eg-guards.added.md
+++ b/changelog.d/tool-format-fallback-catalog-eg-guards.added.md
@@ -1,0 +1,12 @@
+- **Runtime tool_format fallback and equivalence-group catalog guards.** A
+  native-tool-format request whose failure fingerprint says the provider's
+  server-side tool-call parser choked (the Ollama 500 / EOF leak, or any serving
+  stack that 500s/EOFs on the native assumption) now degrades once to the text
+  channel and retries there instead of parse-looping or hard-failing — keyed on
+  the failure signature, never a model name. The provider catalog also gains two
+  build-time invariants: every active row in an `equivalence_group` must declare
+  the same `tier` (a capability of the logical model, not of who hosts it), and a
+  local-runtime row may not carry `strengths` beyond its group's conservative
+  baseline (so a local route cannot inherit a cloud peer's decoration and read as
+  already-capable). Both invariants pass on the shipping catalog and only fail the
+  build if a future change reintroduces the divergence.

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -255,6 +255,71 @@ fn is_empty_completion_retry_error(err: &VmError) -> bool {
             && lower.contains("upstream contract violation"))
 }
 
+/// A failure that looks like the *provider's native tool-call channel itself*
+/// is broken for this route — not a generic transient hiccup. The marquee case
+/// is the documented Ollama leak: the embedded qwen3-family tool-call extractor
+/// runs server-side on `/v1/chat/completions`, fails its EOF/parse on the
+/// model's output, and Ollama returns an HTTP 500 instead of degrading to raw
+/// content (ollama/ollama#14986, #14570 — no opt-out flag). The same shape
+/// appears on any serving stack that parses tool calls server-side and 500s /
+/// EOFs when the native assumption is wrong, so this is keyed on the failure
+/// SIGNATURE, never on a model or provider name.
+///
+/// Deliberately conservative: only a 5xx `ServerError` OR an EOF/stream-cut
+/// transport error carrying a tool-call-parser fingerprint qualifies. A plain
+/// 503 "service unavailable" with no parser fingerprint stays an ordinary
+/// transient retry (retrying native is the right move — the link, not the
+/// channel, hiccuped). This keeps the degrade a genuine last-resort safety net.
+fn is_native_tool_channel_failure(err: &VmError) -> bool {
+    let msg = match err {
+        VmError::Thrown(crate::value::VmValue::String(s)) => s.as_ref(),
+        VmError::CategorizedError { message, .. } => message.as_str(),
+        VmError::Runtime(s) => s.as_str(),
+        VmError::Thrown(crate::value::VmValue::Dict(d)) => {
+            return d
+                .get("message")
+                .map(|v| v.display())
+                .map(|m| message_is_native_tool_channel_failure(&m))
+                .unwrap_or(false);
+        }
+        _ => return false,
+    };
+    message_is_native_tool_channel_failure(msg)
+}
+
+/// The string-level half of [`is_native_tool_channel_failure`], split out so the
+/// dict-carrier and string-carrier paths share one fingerprint definition.
+fn message_is_native_tool_channel_failure(msg: &str) -> bool {
+    let lower = msg.to_lowercase();
+
+    // The failure must classify as a server error (5xx) or an EOF / stream cut.
+    // A tool-call parser that chokes server-side surfaces as one of these; a
+    // 4xx (bad request / auth) or a context-overflow is a different problem the
+    // degrade would not fix.
+    let server_error = lower.contains("[http_error]")
+        || lower.contains("server_error")
+        || lower.contains(" 500")
+        || lower.contains("status 500")
+        || lower.contains("status: 500")
+        || lower.contains("502")
+        || lower.contains("api_error");
+    let stream_cut = lower.contains("unexpected eof")
+        || lower.contains("eof while parsing")
+        || lower.contains("error decoding stream");
+    if !server_error && !stream_cut {
+        return false;
+    }
+
+    // ...AND it must carry a tool-call-parser fingerprint. This is what
+    // distinguishes "the native tool channel is broken for this route" from a
+    // generic 500 (a generic 500 stays an ordinary transient native retry).
+    lower.contains("tool")
+        && (lower.contains("parse")
+            || lower.contains("parser")
+            || lower.contains("extract")
+            || lower.contains("eof"))
+}
+
 /// A wire-level "success" that carries nothing at all: zero output tokens, no
 /// text, no thinking, no tool calls, and no server-side tool-search activity.
 /// Observed live (OpenRouter): a provider stall that ends with an empty 200
@@ -1151,6 +1216,30 @@ fn rand_range_inclusive<R: rand::RngExt>(max: u64, rng: &mut R) -> u64 {
     rng.random_range(0..max.saturating_add(1))
 }
 
+/// Rewrite a native-tool-format request onto the text channel for a retry,
+/// without rebuilding the whole request from scratch. Mirrors the established
+/// "text-channel request" shape (see the Ollama raw-generate test in `api.rs`):
+/// drop the provider-native tool payload, force `Text` output, and clear the
+/// structured-output mirrors so the transport serves a plain chat completion
+/// the model answers in content. The agent loop's text-tool parser then reads
+/// the calls back out of the assistant text.
+///
+/// This is the wire-level half of the runtime tool_format fallback. It does NOT
+/// re-render the system prompt's tool exemplar (that lives in the pipeline), so
+/// the goal is strictly to stop a native-channel failure from hard-failing or
+/// parse-looping the call — letting the model produce *parseable* output on a
+/// working channel — not to guarantee identical guidance to a text-pinned run.
+fn degrade_options_to_text_channel(
+    opts: &super::api::LlmCallOptions,
+) -> super::api::LlmCallOptions {
+    let mut degraded = opts.clone();
+    degraded.native_tools = None;
+    degraded.output_format = super::api::OutputFormat::Text;
+    degraded.response_format = None;
+    degraded.json_schema = None;
+    degraded
+}
+
 // ---------------------------------------------------------------------------
 // observed_llm_call — shared single-LLM-call wrapper with full observability
 // ---------------------------------------------------------------------------
@@ -1169,7 +1258,7 @@ pub(crate) async fn observed_llm_call(
     streaming_detector: Option<StreamingDetectorContext>,
 ) -> Result<super::api::LlmResult, VmError> {
     let _in_flight_guard = super::call::InFlightLlmCallGuard::enter(opts);
-    let effective_tool_format = tool_format
+    let mut effective_tool_format = tool_format
         .map(str::to_string)
         .or_else(|| {
             std::env::var("HARN_AGENT_TOOL_FORMAT")
@@ -1177,8 +1266,16 @@ pub(crate) async fn observed_llm_call(
                 .filter(|value| !value.trim().is_empty())
         })
         .unwrap_or_else(|| crate::llm_config::default_tool_format(&opts.model, &opts.provider));
+    // Working request. Starts as the caller's `opts` (zero-copy) and is only
+    // cloned when the runtime tool_format fallback degrades a native-channel
+    // request to text mid-retry (see the `Err` arm below). Once degraded, the
+    // degraded copy persists for every remaining attempt this call makes.
+    let mut working: std::borrow::Cow<'_, super::api::LlmCallOptions> =
+        std::borrow::Cow::Borrowed(opts);
+    let mut degraded_to_text = false;
     let mut attempt = 0usize;
     loop {
+        let opts: &super::api::LlmCallOptions = working.as_ref();
         // Network-only circuit breaker: if this route has seen sustained
         // NetworkError/Timeout failures, fail fast instead of burning the retry
         // budget against a dead link (laptop disconnect / DNS failure). 429s do
@@ -1476,8 +1573,24 @@ pub(crate) async fn observed_llm_call(
                 // eval layer can still classify it as infra, not capability.
                 let empty_completion_retry = is_empty_completion_retry_error(&error)
                     && attempt < empty_completion_retry_budget(retry_config, &opts.provider);
-                let can_retry =
-                    (retryable && attempt < retry_config.retries) || empty_completion_retry;
+                // Runtime tool_format fallback: a native-channel request whose
+                // failure fingerprint says the provider's *server-side tool-call
+                // parser* choked (the documented Ollama 500 / EOF leak, or any
+                // serving stack that 500s/EOFs on the native assumption) cannot
+                // be rescued by retrying native — every retry re-feeds the same
+                // broken channel. Degrade ONCE to the text channel instead and
+                // retry there, so the call yields parseable output rather than
+                // hard-failing or parse-looping. Keyed on the failure SIGNATURE
+                // (5xx/EOF + tool-parser fingerprint), never a model name; only
+                // fires when the request actually carried provider-native tools.
+                let native_tool_channel_degrade = !degraded_to_text
+                    && crate::llm_config::tool_format_channel(&effective_tool_format)
+                        == Some(crate::llm_config::ToolFormatChannel::Native)
+                    && opts.native_tools.is_some()
+                    && is_native_tool_channel_failure(&error);
+                let can_retry = (retryable && attempt < retry_config.retries)
+                    || empty_completion_retry
+                    || native_tool_channel_degrade;
                 let status = if can_retry {
                     "retrying"
                 } else if retryable {
@@ -1559,6 +1672,13 @@ pub(crate) async fn observed_llm_call(
                         },
                     );
                 }
+                // Apply the runtime tool_format degrade for the next attempt:
+                // swap the working request to its text-channel form, flip the
+                // effective format reported to telemetry, and record why. The
+                // clone severs the shared borrow of `working` so it can be
+                // reassigned; `opts` is not used again before the loop restarts.
+                let degraded_options =
+                    native_tool_channel_degrade.then(|| degrade_options_to_text_channel(opts));
                 attempt += 1;
                 let backoff = llm_retry_backoff_ms(&error, retry_config, attempt, &opts.provider);
                 crate::events::log_warn(
@@ -1568,6 +1688,38 @@ pub(crate) async fn observed_llm_call(
                         error, backoff, attempt, retry_config.retries
                     ),
                 );
+                if let Some(degraded) = degraded_options {
+                    let detail = format!(
+                        "provider {} model {} native tool channel failed (server-side tool-call \
+                         parser 500/EOF: {error}); degrading tool_format native -> json and \
+                         retrying on the text channel",
+                        degraded.provider, degraded.model
+                    );
+                    crate::events::log_warn("llm", &detail);
+                    append_llm_observability_entry(
+                        "tool_format_degrade",
+                        serde_json::Map::from_iter([
+                            (
+                                "iteration".to_string(),
+                                serde_json::json!(iteration.unwrap_or(0)),
+                            ),
+                            ("attempt".to_string(), serde_json::json!(attempt)),
+                            ("provider".to_string(), serde_json::json!(degraded.provider)),
+                            ("model".to_string(), serde_json::json!(degraded.model)),
+                            ("from".to_string(), serde_json::json!("native")),
+                            ("to".to_string(), serde_json::json!("json")),
+                            ("error".to_string(), serde_json::json!(error.to_string())),
+                        ]),
+                    );
+                    annotate_current_span(&[
+                        ("tool_format_degrade", serde_json::json!(true)),
+                        ("tool_format_degrade_from", serde_json::json!("native")),
+                        ("tool_format_degrade_to", serde_json::json!("json")),
+                    ]);
+                    effective_tool_format = "json".to_string();
+                    degraded_to_text = true;
+                    working = std::borrow::Cow::Owned(degraded);
+                }
                 if backoff > 0 {
                     crate::clock_mock::sleep(std::time::Duration::from_millis(backoff)).await;
                 }
@@ -1590,6 +1742,76 @@ mod retry_tests {
             message: msg.to_string(),
             category,
         }
+    }
+
+    // ----- runtime tool_format fallback (native -> text) ---------------------
+
+    #[test]
+    fn native_tool_channel_failure_matches_ollama_500_parser_signature() {
+        // The documented Ollama leak: the server-side qwen3 tool-call extractor
+        // EOFs and the server returns HTTP 500 instead of degrading to content.
+        assert!(is_native_tool_channel_failure(&thrown(
+            "[http_error] ollama 500: tool call parser hit unexpected EOF while parsing"
+        )));
+        // The same shape carried as a CategorizedError.
+        assert!(is_native_tool_channel_failure(&categorized(
+            "status 500: server tool extractor failed to parse tool_calls",
+            ErrorCategory::ServerError
+        )));
+        // A stream-cut EOF in the tool-call extractor (no explicit status code).
+        assert!(is_native_tool_channel_failure(&thrown(
+            "error decoding stream: EOF while parsing a tool call"
+        )));
+    }
+
+    #[test]
+    fn native_tool_channel_failure_ignores_generic_and_keyword_only_errors() {
+        // A plain 503 with no tool-parser fingerprint stays an ordinary
+        // transient retry — retrying native is correct when the LINK hiccuped.
+        assert!(!is_native_tool_channel_failure(&thrown(
+            "service unavailable (503): upstream temporarily overloaded"
+        )));
+        // A 429 rate limit is never a tool-channel failure.
+        assert!(!is_native_tool_channel_failure(&thrown(
+            "[rate_limited] too many requests"
+        )));
+        // The word "tool" alone, without a 5xx/EOF, must not trip the degrade
+        // (e.g. a 400 complaining about a malformed tool schema).
+        assert!(!is_native_tool_channel_failure(&thrown(
+            "bad request: tool schema invalid"
+        )));
+        // A 500 with no tool-parser fingerprint is a generic server error.
+        assert!(!is_native_tool_channel_failure(&thrown(
+            "[http_error] 500 internal server error"
+        )));
+    }
+
+    #[test]
+    fn degrade_options_to_text_channel_strips_native_tool_payload() {
+        let mut opts = crate::llm::api::options::base_opts("ollama");
+        opts.model = "qwen3.6-35b-a3b".to_string();
+        opts.native_tools = Some(vec![serde_json::json!({"name": "edit"})]);
+        opts.output_format = crate::llm::api::OutputFormat::JsonObject;
+        opts.response_format = Some("json".to_string());
+        opts.json_schema = Some(serde_json::json!({"type": "object"}));
+
+        let degraded = degrade_options_to_text_channel(&opts);
+
+        assert!(
+            degraded.native_tools.is_none(),
+            "the provider-native tool payload must be dropped"
+        );
+        assert!(
+            matches!(degraded.output_format, crate::llm::api::OutputFormat::Text),
+            "output must fall back to plain Text so the model answers in content"
+        );
+        assert!(degraded.response_format.is_none());
+        assert!(degraded.json_schema.is_none());
+        // The logical request is otherwise unchanged.
+        assert_eq!(degraded.provider, "ollama");
+        assert_eq!(degraded.model, "qwen3.6-35b-a3b");
+        // The original is untouched (we degrade a clone).
+        assert!(opts.native_tools.is_some());
     }
 
     #[test]
@@ -2538,6 +2760,93 @@ mod empty_completion_retry_tests {
             assert!(
                 is_retryable_llm_error(&err),
                 "the surfaced 429 should classify as retryable"
+            );
+        });
+    }
+
+    fn native_opts() -> crate::llm::api::LlmCallOptions {
+        let mut opts = fake_opts();
+        opts.native_tools = Some(vec![serde_json::json!({"name": "edit"})]);
+        opts.tools = Some(crate::value::VmValue::Nil);
+        opts
+    }
+
+    #[test]
+    fn native_tool_channel_failure_degrades_to_text_and_recovers() {
+        // The runtime tool_format fallback: a native-pinned tool call whose
+        // server-side parser 500/EOFs degrades to the text channel and recovers
+        // on the retry. Crucially this fires at retries=0 (the transient budget
+        // is spent) — retrying native would re-feed the broken parser forever;
+        // the productive move is to switch channels. The _guard drop asserts the
+        // second (text-channel) turn was actually consumed.
+        current_thread_runtime().block_on(async {
+            let _guard = install_fake_llm_script(
+                FakeLlmScript::new()
+                    .push(FakeLlmTurn::Error(crate::llm::fake::FakeLlmError::new(
+                        crate::value::ErrorCategory::ServerError,
+                        "[http_error] ollama 500: tool call parser hit unexpected EOF \
+                         while parsing tool_calls",
+                    )))
+                    .push(FakeLlmTurn::stream(vec![
+                        FakeLlmEvent::Token(
+                            "<tool_call>\nedit({ path: \"a.rs\" })\n</tool_call>".into(),
+                        ),
+                        FakeLlmEvent::Done(FakeStopReason::EndTurn),
+                    ])),
+            );
+            let result = observed_llm_call(
+                &native_opts(),
+                Some("native"),
+                None,
+                &retry_config(0),
+                None,
+                false,
+                false,
+                None,
+            )
+            .await
+            .expect("native tool-channel failure should degrade to text and recover");
+            assert!(
+                result.text.contains("edit({ path: \"a.rs\" })"),
+                "the degraded text-channel turn should be returned"
+            );
+        });
+    }
+
+    #[test]
+    fn native_tool_channel_failure_degrade_fires_at_most_once() {
+        // The degrade is one-shot per call: if the text-channel retry ALSO
+        // fails (a different problem), the loop does not keep re-degrading. With
+        // retries=0 and two failing turns scripted, only the FIRST degrade may
+        // fire; the second failure must surface as a hard error. Exactly two
+        // turns are scripted, so a third call would panic the guard on drop.
+        current_thread_runtime().block_on(async {
+            let _guard = install_fake_llm_script(
+                FakeLlmScript::new()
+                    .push(FakeLlmTurn::Error(crate::llm::fake::FakeLlmError::new(
+                        crate::value::ErrorCategory::ServerError,
+                        "[http_error] 500: tool call parser unexpected EOF",
+                    )))
+                    .push(FakeLlmTurn::Error(crate::llm::fake::FakeLlmError::new(
+                        crate::value::ErrorCategory::ServerError,
+                        "[http_error] 500: tool call parser unexpected EOF",
+                    ))),
+            );
+            let err = observed_llm_call(
+                &native_opts(),
+                Some("native"),
+                None,
+                &retry_config(0),
+                None,
+                false,
+                false,
+                None,
+            )
+            .await
+            .expect_err("a second tool-channel failure after degrade must surface");
+            assert!(
+                err.to_string().to_lowercase().contains("tool call parser"),
+                "the surfaced error is the second (post-degrade) failure"
             );
         });
     }

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -3074,6 +3074,44 @@ native_tools = true
     }
 
     #[test]
+    fn tool_format_resolution_is_serving_stack_aware_for_same_weights() {
+        // The (model x serving-stack) insight: the SAME Qwen3.6 weights resolve
+        // to DIFFERENT working tool-call channels depending on who serves them.
+        // This divergence lives in the capability matrix as data (provider rows),
+        // NOT in alias pins — so an alias refactor must not be able to regress
+        // it. Locking the three live serving stacks here makes that explicit.
+        reset();
+
+        // llama.cpp (:8001) — native is probe-validated and trusted.
+        let llamacpp = validate_tool_format("llamacpp", "qwen3.6-35b-a3b-ud-q4-k-xl", "native");
+        assert_eq!(
+            llamacpp.effective, "native",
+            "llama.cpp serves qwen3.6 native"
+        );
+        assert!(llamacpp.correction.is_none());
+
+        // Ollama (/v1) — the embedded qwen tool-call parser 500s on text-mode
+        // output, so this route is served on the text/json channel: a native
+        // request must be auto-corrected to json (never silently dropped).
+        let ollama = validate_tool_format("ollama", "qwen3.6-35b-a3b", "native");
+        assert_eq!(
+            ollama.effective, "json",
+            "ollama qwen3.6 must steer native -> json (server-side parser 500 leak)"
+        );
+        assert!(
+            ollama.correction.is_some(),
+            "the native->json steer must be explained, not silent"
+        );
+
+        // A native_unreliable cloud route (deepinfra GLM-5) carries the same
+        // serving-stack verdict via tool_mode_parity + empirical notes, and is
+        // likewise steered off native.
+        let glm = validate_tool_format("deepinfra", "deepinfra/glm-5.2", "native");
+        assert_eq!(glm.effective, "json");
+        assert!(glm.correction.is_some());
+    }
+
+    #[test]
     fn validate_tool_format_passes_through_when_no_channel_works() {
         reset();
         // A route with no working tool surface — text_only parity forbids the

--- a/crates/harn-vm/src/provider_catalog/tests.rs
+++ b/crates/harn-vm/src/provider_catalog/tests.rs
@@ -517,7 +517,7 @@ fn validation_rejects_local_strengths_inheriting_cloud_decoration() {
         })
         .expect("catalog has a local-provider model");
     victim.equivalence_group = Some(group.clone());
-    let mut grafted = cloud_strengths.clone();
+    let mut grafted = cloud_strengths;
     grafted.push(extra.clone());
     victim.strengths = grafted;
 

--- a/crates/harn-vm/src/provider_catalog/tests.rs
+++ b/crates/harn-vm/src/provider_catalog/tests.rs
@@ -383,6 +383,156 @@ fn validation_rejects_duplicate_and_dangling_aliases() {
 }
 
 #[test]
+fn live_catalog_has_one_tier_per_equivalence_group() {
+    // The shipping catalog must not tier the same logical model differently by
+    // provider/runtime — that gives identical weights different escalation
+    // eligibility by host. validate_current() runs the full live artifact; this
+    // asserts the equivalence_group tier-consistency check finds no conflict.
+    let report = validate_current();
+    assert!(
+        !report
+            .errors
+            .iter()
+            .any(|message| message.contains("conflicting tiers")),
+        "live catalog has an equivalence_group with conflicting tiers: {:?}",
+        report
+            .errors
+            .iter()
+            .filter(|m| m.contains("conflicting tiers"))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validation_rejects_conflicting_tiers_within_an_equivalence_group() {
+    // Tier is a capability of the logical model. Two active rows in the same
+    // equivalence_group declaring different tiers must fail at catalog-build
+    // time. Build the violation by grouping two non-deprecated rows that
+    // currently agree, then flipping one tier.
+    let mut catalog = artifact();
+    // Find any non-deprecated model with an equivalence_group, give a second
+    // non-deprecated model the same group + a different tier.
+    let (group, base_tier) = catalog
+        .models
+        .iter()
+        .find(|m| {
+            m.deprecation.status != DeprecationStatus::Deprecated
+                && m.equivalence_group
+                    .as_deref()
+                    .is_some_and(|g| !g.trim().is_empty())
+        })
+        .map(|m| {
+            (
+                m.equivalence_group.clone().expect("group present"),
+                m.tier.clone(),
+            )
+        })
+        .expect("catalog has at least one grouped model");
+    let conflicting_tier = if base_tier == "frontier" {
+        "mid"
+    } else {
+        "frontier"
+    };
+    let victim = catalog
+        .models
+        .iter_mut()
+        .find(|m| {
+            m.deprecation.status != DeprecationStatus::Deprecated
+                && m.equivalence_group.as_deref() != Some(group.as_str())
+        })
+        .expect("catalog has a second non-deprecated model");
+    victim.equivalence_group = Some(group.clone());
+    victim.tier = conflicting_tier.to_string();
+
+    let report = validate_artifact(&catalog);
+    assert!(
+        report.errors.iter().any(
+            |message| message.contains("conflicting tiers") && message.contains(group.as_str())
+        ),
+        "expected an equivalence_group conflicting-tiers error for {group}, got {:?}",
+        report.errors
+    );
+}
+
+#[test]
+fn live_catalog_has_no_local_strengths_decoration_over_baseline() {
+    // Gaming guard: no local-runtime route may carry strengths beyond its
+    // equivalence_group's conservative baseline (which would read as
+    // already-capable and suppress real escalations). The live artifact must be
+    // clean.
+    let report = validate_current();
+    assert!(
+        !report
+            .errors
+            .iter()
+            .any(|message| message.contains("beyond the group's conservative baseline")),
+        "live catalog has a local route decorated above its group baseline: {:?}",
+        report
+            .errors
+            .iter()
+            .filter(|m| m.contains("beyond the group's conservative baseline"))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn validation_rejects_local_strengths_inheriting_cloud_decoration() {
+    // The exact gaming vector: a local-runtime route placed in a cloud peer's
+    // equivalence_group and decorated with the cloud row's "agentic" strength
+    // it never earned locally. The guard must reject the superset.
+    let mut catalog = artifact();
+    let local_provider = catalog
+        .providers
+        .iter()
+        .find(|p| p.local_runtime.is_some())
+        .map(|p| p.id.clone())
+        .expect("catalog has a local-runtime provider");
+    // Pick any non-deprecated cloud-hosted model that already has an
+    // equivalence_group; use its group + a richer strengths set as the cloud
+    // baseline the local row must NOT exceed.
+    let (group, cloud_strengths) = catalog
+        .models
+        .iter()
+        .find(|m| {
+            m.deprecation.status != DeprecationStatus::Deprecated
+                && m.equivalence_group
+                    .as_deref()
+                    .is_some_and(|g| !g.trim().is_empty())
+                && !m.strengths.is_empty()
+        })
+        .map(|m| (m.equivalence_group.clone().unwrap(), m.strengths.clone()))
+        .expect("a grouped cloud model with strengths exists");
+    // Find a local-provider row and graft it into that group with a strict
+    // superset of the cloud strengths (cloud set + a strength it lacks).
+    let extra = ["agentic", "reasoning", "long_context", "vision", "speed"]
+        .into_iter()
+        .find(|s| !cloud_strengths.iter().any(|c| c == s))
+        .unwrap_or("agentic")
+        .to_string();
+    let victim = catalog
+        .models
+        .iter_mut()
+        .find(|m| {
+            m.provider == local_provider && m.deprecation.status != DeprecationStatus::Deprecated
+        })
+        .expect("catalog has a local-provider model");
+    victim.equivalence_group = Some(group.clone());
+    let mut grafted = cloud_strengths.clone();
+    grafted.push(extra.clone());
+    victim.strengths = grafted;
+
+    let report = validate_artifact(&catalog);
+    assert!(
+        report.errors.iter().any(|message| {
+            message.contains("beyond the group's conservative baseline")
+                && message.contains(group.as_str())
+        }),
+        "expected a local-strengths-over-baseline error for {group} (extra {extra}), got {:?}",
+        report.errors
+    );
+}
+
+#[test]
 fn validation_rejects_alias_tool_format_not_a_known_format() {
     // A typo / wrong value in an alias's tool_format pin must be caught at
     // catalog-build time, not silently degraded at call time. The known set is

--- a/crates/harn-vm/src/provider_catalog/validation.rs
+++ b/crates/harn-vm/src/provider_catalog/validation.rs
@@ -169,6 +169,122 @@ pub fn validate_artifact(artifact: &ProviderCatalogArtifact) -> ProviderCatalogV
         }
     }
 
+    // Tier is a CAPABILITY of the logical model, not of who hosts it. The
+    // model-agnostic routing/escalation layer reads `tier` to decide
+    // "already capable, do not escalate" vs "escalate me" — so if the same
+    // weights are tiered `frontier` on one provider row and `mid` on another,
+    // the identical model gets different escalation eligibility purely by host.
+    // Enforce one tier per `equivalence_group` at catalog-build time so the
+    // divergence cannot be reintroduced silently. Deprecated rows are excluded
+    // (a superseded row may legitimately keep a stale tier until removed).
+    {
+        let mut tiers_by_group: BTreeMap<&str, BTreeMap<&str, BTreeSet<&str>>> = BTreeMap::new();
+        for model in &artifact.models {
+            if model.deprecation.status == DeprecationStatus::Deprecated {
+                continue;
+            }
+            let Some(group) = model.equivalence_group.as_deref() else {
+                continue;
+            };
+            if group.trim().is_empty() {
+                continue;
+            }
+            tiers_by_group
+                .entry(group)
+                .or_default()
+                .entry(model.tier.as_str())
+                .or_default()
+                .insert(model.id.as_str());
+        }
+        for (group, tiers) in &tiers_by_group {
+            if tiers.len() > 1 {
+                let detail = tiers
+                    .iter()
+                    .map(|(tier, ids)| {
+                        format!(
+                            "{tier} ({})",
+                            ids.iter().copied().collect::<Vec<_>>().join(", ")
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                result.errors.push(format!(
+                    "equivalence_group {group} declares conflicting tiers across its \
+                     provider rows: {detail}. tier is a capability of the logical model — \
+                     give every active row in the group the same tier (the conservative \
+                     least-capable host baseline), not a per-provider value."
+                ));
+            }
+        }
+    }
+
+    // GAMING GUARD (L3): within an equivalence_group, a LOCAL-runtime host row
+    // must not be decorated with MORE strengths than the least-decorated host in
+    // the group. `strengths` feeds the routing layer's "already capable, do not
+    // escalate" verdict (a local route claiming "agentic" reads as capable and
+    // SUPPRESSES a needed escalation). If a local route inherited a decorated
+    // cloud row's strengths it would gain capability it never earned on the
+    // local serving stack and inflate apparent local convergence — so a local
+    // row's strengths must be a SUBSET of every co-grouped row's strengths (the
+    // conservative weights-intrinsic baseline), never a superset. Providers with
+    // a `local_runtime` descriptor are the local hosts; this is data-driven, not
+    // a hardcoded name list. Deprecated rows are excluded.
+    {
+        let local_provider_ids: BTreeSet<&str> = artifact
+            .providers
+            .iter()
+            .filter(|p| p.local_runtime.is_some())
+            .map(|p| p.id.as_str())
+            .collect();
+        // Group active rows by equivalence_group, keeping each row's strengths.
+        let mut rows_by_group: BTreeMap<&str, Vec<&CatalogModel>> = BTreeMap::new();
+        for model in &artifact.models {
+            if model.deprecation.status == DeprecationStatus::Deprecated {
+                continue;
+            }
+            let Some(group) = model.equivalence_group.as_deref() else {
+                continue;
+            };
+            if group.trim().is_empty() {
+                continue;
+            }
+            rows_by_group.entry(group).or_default().push(model);
+        }
+        for (group, rows) in &rows_by_group {
+            // The group's conservative baseline is the intersection of every
+            // row's strengths — what holds for the weights regardless of host.
+            let mut baseline: Option<BTreeSet<&str>> = None;
+            for model in rows {
+                let row: BTreeSet<&str> = model.strengths.iter().map(String::as_str).collect();
+                baseline = Some(match baseline {
+                    None => row,
+                    Some(acc) => acc.intersection(&row).copied().collect(),
+                });
+            }
+            let baseline = baseline.unwrap_or_default();
+            for model in rows {
+                if !local_provider_ids.contains(model.provider.as_str()) {
+                    continue;
+                }
+                let row: BTreeSet<&str> = model.strengths.iter().map(String::as_str).collect();
+                let extras: Vec<&str> = row.difference(&baseline).copied().collect();
+                if !extras.is_empty() {
+                    result.errors.push(format!(
+                        "local-runtime row {}/{} in equivalence_group {group} claims strengths \
+                         [{}] beyond the group's conservative baseline [{}]. A local route must \
+                         not inherit a cloud peer's decoration — strengths must be the \
+                         least-capable host baseline (a subset of every co-grouped row), or the \
+                         local route reads as already-capable and suppresses real escalations.",
+                        model.provider,
+                        model.id,
+                        extras.join(", "),
+                        baseline.iter().copied().collect::<Vec<_>>().join(", "),
+                    ));
+                }
+            }
+        }
+    }
+
     // Index models by (provider, id) so alias tool_format can be checked
     // against the target model's declared tool support. An alias is the one
     // place a harness author can pin `native` / `text` per model, so a typo


### PR DESCRIPTION
## What

Hardens the model-routing / tool-call-dialect path against the leaky abstractions
found in a static + live (cattrick) leak audit, in four incremental pieces. Each
is test-backed; no catalog DATA was changed and no generated artifact drifted.

### 1. Runtime tool_format fallback (robustness core) — `agent_observe.rs`
A native-tool-format request whose failure fingerprint says the provider's
**server-side tool-call parser** choked cannot be rescued by retrying native —
every retry re-feeds the same broken channel and the loop parse-loops or
hard-fails. The marquee case is the documented Ollama leak: the embedded qwen3
tool-call extractor runs server-side on `/v1/chat/completions`, EOFs on the
model's output, and Ollama returns HTTP 500 with no opt-out
(ollama/ollama#14986, #14570). `observed_llm_call` now degrades **once** to the
text channel (drop `native_tools`, force `Text` output, clear the
structured-output mirrors) and retries there, emitting a `tool_format_degrade`
observability entry + span annotation.

- Keyed on the **failure signature** (5xx/EOF + a tool-call-parser fingerprint),
  **never** a model or provider name → generalizes to any serving stack.
- Conservative: a plain 5xx with no parser fingerprint stays an ordinary
  transient native retry (the link, not the channel, hiccuped). One-shot per call.

### 2. (model × serving-stack)-aware tool_format resolution — `capabilities.rs`
This is **already** data-driven in the capability matrix: `validate_tool_format`
keys on `(provider, model)` rows (`tool_mode_parity`, `preferred_tool_format`,
`native_tools`, `text_tool_wire_format_supported`), so the same Qwen3.6 weights
resolve to different working channels by host — llama.cpp serves native, Ollama
steers `native -> json` (server-side parser leak), and a `native_unreliable`
cloud route (deepinfra GLM-5) likewise steers off native. Added a test locking
this same-weights divergence so an alias-pin refactor cannot silently regress it.
Confirmed live via a throwaway probe (removed): see the resolution table in the
review notes. The runtime fallback (#1) complements this for failures the static
matrix has not yet empirically pinned.

### 3. L1 — tier on the equivalence_group, not the provider row — `provider_catalog/validation.rs`
`tier` is a capability of the logical model (the routing layer reads it for
already-capable-vs-escalate). The build now fails if two active rows in the same
`equivalence_group` declare conflicting tiers.

> **Honesty note on the "openrouter gpt-oss mid vs frontier" finding:** the live
> catalog has **no** such divergence. The apparent mid was a per-fragment
> source-read artifact (leading bare `tier`/`strengths` defaults belong to the
> NEXT block when read in isolation). The GENERATED `providers.toml` the runtime
> loads resolves openrouter gpt-oss to **frontier** via the fragment's leading
> defaults. So **no data edit was needed** — the guard alone is the fix, and it
> passes on the shipping catalog.

### 4. L3 — local-strengths gaming guard — `provider_catalog/validation.rs`
A local-runtime row (provider with a `local_runtime` descriptor — data-driven,
not a name list) must not carry `strengths` beyond its `equivalence_group`'s
conservative baseline (the intersection of every co-grouped row). A local route
decorated with a cloud peer's `agentic` reads as already-capable and **suppresses
real escalations** — gaming the meter.

## Change classification

| Change | Class | Why it can land |
|---|---|---|
| #1 runtime fallback | **behavior-PRESERVING / robustness** | only triggers on a failure that would otherwise loop or hard-fail; never changes a successful native call |
| #2 serving-stack resolution test | **behavior-PRESERVING** | locks existing data-driven resolution; no logic change |
| #3 tier-per-eg guard | **behavior-PRESERVING** | pure build-time invariant; live catalog passes, **no catalog data changed**, no routing decision changes |
| #4 local-strengths guard | **behavior-PRESERVING** | pure build-time invariant; live catalog passes, **no catalog data changed** |

**Nothing here is convergence-changing.** The plan anticipated #3/#4 as
meter-gated *data* edits (re-tiering, backfilling strengths). On inspecting the
**runtime** catalog (not the per-fragment source) the leaks the audit described
do not exist as data divergences — local rows already carry conservative
`["coding"]` strengths and the runtime already has one tier per eg — so the
honest, lower-risk fix is the class-eliminating *guards*, which change no routing
behavior. If a future change wants to actually re-tier or re-decorate a model,
THAT edit would be convergence-changing and must go through the meter gate.

## Strengths-guard attestation (NON-NEGOTIABLE)

The L3 guard enforces that a local-runtime route's `strengths` must be a **subset**
of every co-grouped row (the least-capable host baseline), **never** a superset of
a decorated cloud row. It does not add any strengths to any local route. The live
catalog is clean: local qwen3.6 (llamacpp/mlx) carry conservative `["coding"]` /
`["coding","vision"]` and share **no** equivalence_group with a decorated cloud
row, so no local route inherits cloud "agentic". A negative test
(`validation_rejects_local_strengths_inheriting_cloud_decoration`) grafts a local
row into a cloud peer's group with a superset and confirms the build rejects it.

## Tests

- `agent_observe`: 50/50 pass incl. 5 new — signature matcher (positive +
  ignores-generic), degrade-options helper, end-to-end degrade-and-recover (fires
  at `retries=0`), one-shot guard.
- `capabilities`: 69/69 pass incl. new serving-stack-divergence lock.
- `provider_catalog`: 35/35 pass incl. 2 tier-guard + 2 strengths-guard tests
  (live-catalog-clean positives + negative violations).
- Full `harn-vm --lib`: **3934 passed, 0 failed**. (`cargo fmt --check` + `clippy`
  clean. One rate_limit concurrency-queue timing test flaked under full-parallel
  load and passes in isolation / as a module — unrelated module, untouched here.)
- **No generated-artifact drift**: `git diff origin/main` touches only the 4 Rust
  sources + 1 changelog fragment; `providers.toml` / `capabilities.toml` /
  `spec/provider-catalog/` are byte-identical, so the catalog drift CI guards do
  not trip.

## Coordination

Checked against the active Codex session: open PR #3499 (`redact/`,
`secret_patterns.rs`, `secret_scan.rs`) is **disjoint** from these files; the
flagged hot files (tool-format.harn, capabilities.toml, providers.toml, catalog
generator) are not edited here. No collision. Branch is on top of current
origin/main (`99d269be`), no rebase needed.

Does NOT bump `.harn-version` or cut a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)