### PR TITLE
[codex] Add identity provenance status helpers

### DIFF
--- a/changelog.d/identity-provenance-spine.added.md
+++ b/changelog.d/identity-provenance-spine.added.md
@@ -1,0 +1,7 @@
+- Added `std/identity` for Harn-native ActorChain validation, summaries, compact
+  formatting, and structured provenance reports. `std/disclosure` now reuses
+  those helpers for traversal and subject parsing.
+- Extended `harn.mcp.status()` and `mcp_registry_status()` entries with server
+  `transport`/`url` metadata, and added `display_identity` to
+  `harn.mcp.status()` for connected OAuth-backed MCP servers with vetted
+  identity descriptors.

--- a/conformance/tests/scenarios/mcp_status_identity_shape.expected
+++ b/conformance/tests/scenarios/mcp_status_identity_shape.expected
@@ -1,0 +1,8 @@
+identity-shape
+http
+https://identity.example.invalid/mcp
+true
+false
+true
+http
+https://identity.example.invalid/mcp

--- a/conformance/tests/scenarios/mcp_status_identity_shape.harn
+++ b/conformance/tests/scenarios/mcp_status_identity_shape.harn
@@ -1,0 +1,30 @@
+pipeline default() {
+  let name = harn.mcp
+    .spawn(
+    {name: "identity-shape", transport: "http", url: "https://identity.example.invalid/mcp"},
+    {lazy: true},
+  )
+  let status = harn.mcp.status()
+  var entry = nil
+  for item in status {
+    if item.name == name {
+      entry = item
+    }
+  }
+  require entry != nil, "status should include the lazy server"
+  __io_println(entry.name)
+  __io_println(entry.transport)
+  __io_println(entry.url)
+  __io_println(entry.display_identity == nil)
+  __io_println(entry.active)
+  __io_println(entry.lazy)
+  var registry_entry = nil
+  for item in mcp_registry_status() {
+    if item.name == name {
+      registry_entry = item
+    }
+  }
+  require registry_entry != nil, "registry status should include the lazy server"
+  __io_println(registry_entry.transport)
+  __io_println(registry_entry.url)
+}

--- a/conformance/tests/stdlib/identity_actor_chain.expected
+++ b/conformance/tests/stdlib/identity_actor_chain.expected
@@ -1,0 +1,22 @@
+true
+3
+true
+agent:reviewer
+current
+repo:read
+agent:planner
+repo:read
+user:owner
+agent:delegate
+agent:reviewer for user:owner via agent:planner
+agent:reviewer -> agent:planner -> user:owner
+agent/reviewer
+principal/root
+false
+user:solo
+false
+actor_chain.sub_type
+act.sub
+false
+actor_chain.scope_type
+$.scopes[0]

--- a/conformance/tests/stdlib/identity_actor_chain.harn
+++ b/conformance/tests/stdlib/identity_actor_chain.harn
@@ -1,0 +1,47 @@
+import {
+  actor_chain_format,
+  actor_chain_report,
+  actor_chain_subject_parts,
+  actor_chain_summary,
+} from "std/identity"
+
+pipeline default() {
+  let chain = {
+    sub: "user:owner",
+    scopes: ["repo:read", "repo:write"],
+    may_act: {sub: "agent:delegate"},
+    act: {sub: "agent:reviewer", scopes: ["repo:read"], act: {sub: "agent:planner", scope: "repo:read"}},
+  }
+  let report = actor_chain_report(chain)
+  __io_println(report.ok)
+  __io_println(report.depth)
+  __io_println(report.delegated)
+  let current = report.current
+  require current != nil, "report should expose current actor"
+  __io_println(current.subject)
+  __io_println(current.role)
+  __io_println(join(current.scopes, ","))
+  __io_println(report.prior_actors[0].subject)
+  __io_println(join(report.prior_actors[0].scopes, ","))
+  let origin = report.origin
+  require origin != nil, "report should expose origin"
+  __io_println(origin.subject)
+  __io_println(report.may_act)
+  __io_println(actor_chain_format(chain))
+  __io_println(actor_chain_format(chain, {style: "arrow"}))
+  let parts = actor_chain_subject_parts("agent:reviewer")
+  __io_println(parts.kind + "/" + parts.id)
+  let plain = actor_chain_subject_parts("root")
+  __io_println(plain.kind + "/" + plain.id)
+  let solo = actor_chain_summary({sub: "user:solo"})
+  __io_println(solo.delegated)
+  __io_println(solo.current.subject)
+  let invalid = actor_chain_report({sub: "user:owner", act: {sub: 42, scopes: "repo:read"}})
+  __io_println(invalid.ok)
+  __io_println(invalid.issues[0].code)
+  __io_println(invalid.issues[0].path)
+  let bad_scope = actor_chain_report({sub: "user:owner", scopes: [1]})
+  __io_println(bad_scope.ok)
+  __io_println(bad_scope.issues[0].code)
+  __io_println(bad_scope.issues[0].path)
+}

--- a/crates/harn-cli/assets/demo/mcp-host/scenario.harn
+++ b/crates/harn-cli/assets/demo/mcp-host/scenario.harn
@@ -7,7 +7,9 @@
  *     no eager connect, so we don't need a live MCP server bundled).
  *   - Snapshot `harn.mcp.status()` and emit a receipt that proves the
  *     registry view, supervision counters, circuit-breaker state, and
- *     cache slot all line up with a freshly-registered lazy server.
+ *     cache slot all line up with a freshly-registered lazy server. Status
+ *     entries also include transport, URL, and display_identity fields so
+ *     script-side dashboards match CLI status output.
  *   - Issue a graceful `harn.mcp.stop` against one of the registrations
  *     and re-snapshot to show the deregistration path.
  *
@@ -38,7 +40,8 @@ pipeline default(_task) {
   }
   // 2. Snapshot the host's view of every registered server. Each entry
   //    carries supervision counters (restart_count, consecutive_failures,
-  //    circuit) plus the lazy/active/ref_count registry triple.
+  //    circuit), transport/URL/identity metadata, plus the lazy/active/ref_count
+  //    registry triple.
   let after_spawn = harn.mcp.status()
   __io_println("=== status after spawn ===")
   for entry in after_spawn {

--- a/crates/harn-cli/src/commands/mcp/mod.rs
+++ b/crates/harn-cli/src/commands/mcp/mod.rs
@@ -370,14 +370,7 @@ async fn derive_server_status(server: &McpServerConfig) -> McpServerStatus {
 /// token-response payload. Returns `None` (never errors) so status reporting
 /// degrades gracefully.
 async fn server_display_identity(server: &McpServerConfig) -> Option<String> {
-    // Only descriptor-bearing servers pay for a token load.
-    harn_vm::mcp_identity::descriptor_for(&server.url)?;
-    let discovery = mcp_oauth::discover(&server.url).await.ok()?;
-    let resource = canonical_server_resource(&server.url).ok()?;
-    let token = mcp_oauth::load_token(&resource, &discovery.authorization_server_issuer, None)
-        .await
-        .ok()??;
-    harn_vm::mcp_identity::display_identity(&server.url, &token)
+    harn_vm::mcp_identity::display_identity_from_store(&server.url, None).await
 }
 
 fn print_focused_status_report(

--- a/crates/harn-mcp-rc-compat/tests/mcp_host.rs
+++ b/crates/harn-mcp-rc-compat/tests/mcp_host.rs
@@ -85,7 +85,7 @@ async fn status_reflects_active_server_and_clears_on_stop() {
         .await
         .expect("spawn should succeed");
 
-    let snap = mcp_host::status();
+    let snap = mcp_host::status().await;
     let entry = snap
         .iter()
         .find(|s| s.name == "alpha")
@@ -97,7 +97,7 @@ async fn status_reflects_active_server_and_clears_on_stop() {
     assert!(!entry.ejected);
 
     mcp_host::stop("alpha").expect("stop should succeed");
-    let snap_after = mcp_host::status();
+    let snap_after = mcp_host::status().await;
     assert!(
         snap_after.iter().all(|s| !s.active || s.name != "alpha"),
         "alpha should no longer be active after stop"
@@ -180,7 +180,7 @@ async fn reload_drops_active_connection_but_subsequent_call_reconnects() {
     // Reload — the underlying connection is dropped; the registration
     // and supervision state are reset.
     mcp_host::reload("hot").expect("reload should succeed");
-    let snap = mcp_host::status();
+    let snap = mcp_host::status().await;
     let entry = snap.iter().find(|s| s.name == "hot").expect("entry exists");
     assert_eq!(entry.restart_count, 0, "reload should reset restart_count");
     assert_eq!(entry.consecutive_failures, 0);
@@ -285,7 +285,7 @@ async fn lazy_spawn_does_not_eagerly_connect() {
         .expect("lazy spawn must not perform an eager connect");
     assert_eq!(id, "lazy");
 
-    let snap = mcp_host::status();
+    let snap = mcp_host::status().await;
     let entry = snap.iter().find(|s| s.name == "lazy").expect("registered");
     assert!(entry.lazy);
     assert!(

--- a/crates/harn-stdlib/src/lib.rs
+++ b/crates/harn-stdlib/src/lib.rs
@@ -150,6 +150,10 @@ pub const STDLIB_SOURCES: &[StdlibSource] = &[
         source: include_str!("stdlib/stdlib_schema.harn"),
     },
     StdlibSource {
+        module: "identity",
+        source: include_str!("stdlib/stdlib_identity.harn"),
+    },
+    StdlibSource {
         module: "disclosure",
         source: include_str!("stdlib/stdlib_disclosure.harn"),
     },

--- a/crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn
@@ -2,6 +2,7 @@
 //
 // Import: import { render } from "std/disclosure"
 import { deep_merge } from "std/collections"
+import { actor_chain_subject_parts, actor_chain_subjects } from "std/identity"
 
 type DisclosureRenderOptions = {project?: bool, project_root?: string, env?: bool, config?: dict}
 
@@ -130,28 +131,6 @@ fn __config(options) -> dict {
   return config
 }
 
-fn __chain_subjects(chain) -> list<string> {
-  require type_of(chain) == "dict", "std/disclosure: chain must be an ActorChain dict"
-  require chain?.sub != nil && chain.sub != "", "std/disclosure: chain.sub is required"
-  var subjects = []
-  var node = chain?.act
-  while node != nil {
-    require type_of(node) == "dict", "std/disclosure: chain.act entries must be dicts"
-    require node?.sub != nil && node.sub != "", "std/disclosure: chain.act.sub is required"
-    subjects = subjects + [to_string(node.sub)]
-    node = node?.act
-  }
-  return subjects + [to_string(chain.sub)]
-}
-
-fn __subject_parts(subject: string) -> dict {
-  let split_at = subject.index_of(":")
-  if split_at < 0 {
-    return {kind: "principal", id: subject}
-  }
-  return {kind: substring(subject, 0, split_at), id: substring(subject, split_at + 1)}
-}
-
 fn __slug(value: string) -> string {
   let lowered = lowercase(trim(value))
   let cleaned = regex_replace("[^a-z0-9._+-]+", "-", lowered)
@@ -172,7 +151,7 @@ fn __profile_for(subject: string, config: dict) -> dict {
 
 fn __principal(subject: string, config: dict, role: string, position: int) -> dict {
   let profile = __profile_for(subject, config)
-  let parts = __subject_parts(subject)
+  let parts = actor_chain_subject_parts(subject)
   let name = to_string(profile?.name ?? profile?.display_name ?? profile?.label ?? parts.id ?? subject)
   let label = to_string(profile?.label ?? profile?.slack_label ?? profile?.display_name ?? name)
   let email_domain = to_string(config?.defaults?.email_domain ?? "actors.harn.invalid")
@@ -212,18 +191,13 @@ fn __principal(subject: string, config: dict, role: string, position: int) -> di
 }
 
 fn __context(chain, config: dict) -> dict {
-  let subjects = __chain_subjects(chain)
-  let origin_index = len(subjects) - 1
+  let subject_entries = actor_chain_subjects(chain)
+  let origin_index = len(subject_entries) - 1
   var principals = []
-  for {index, value} in subjects.enumerate() {
-    let role = if index == 0 {
-      "current"
-    } else if index == origin_index {
-      "origin"
-    } else {
-      "actor"
-    }
-    principals = principals + [__principal(value, config, role, index)]
+  var subjects = []
+  for entry in subject_entries {
+    subjects = subjects + [entry.subject]
+    principals = principals + [__principal(entry.subject, config, entry.role, entry.position)]
   }
   let origin = principals[origin_index]
   let actors = if len(principals) > 1 {

--- a/crates/harn-stdlib/src/stdlib/stdlib_identity.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_identity.harn
@@ -1,0 +1,330 @@
+/**
+ * std/identity - ActorChain inspection and provenance helpers.
+ *
+ * Import: import { actor_chain_report } from "std/identity"
+ *
+ * @effects: []
+ * @errors: []
+ */
+type ActorChainIssue = {code: string, path: string, message: string}
+
+type ActorChainSubject = {
+  subject: string,
+  kind: string,
+  id: string,
+  role: string,
+  position: int,
+  path: string,
+  scopes: list<string>,
+}
+
+type ActorChainReport = {
+  ok: bool,
+  issues: list<ActorChainIssue>,
+  subjects: list<ActorChainSubject>,
+  current?: ActorChainSubject,
+  origin?: ActorChainSubject,
+  actors: list<ActorChainSubject>,
+  prior_actors: list<ActorChainSubject>,
+  depth: int,
+  delegated: bool,
+  may_act?: string,
+}
+
+type ActorChainFormatOptions = {style?: string, include_prior?: bool}
+
+fn __issue(code: string, path: string, message: string) -> ActorChainIssue {
+  return {code: code, path: path, message: message}
+}
+
+fn __append_unique(values: list<string>, value: string) -> list<string> {
+  let normalized = trim(value)
+  if normalized == "" || contains(values, normalized) {
+    return values
+  }
+  return values + [normalized]
+}
+
+fn __subject_parts(subject: string) -> dict {
+  let split_at = subject.index_of(":")
+  if split_at < 0 {
+    return {kind: "principal", id: subject}
+  }
+  return {kind: substring(subject, 0, split_at), id: substring(subject, split_at + 1)}
+}
+
+fn __scope_claims(node: dict, path: string) -> dict {
+  var issues = []
+  var scopes = []
+  if node?.scopes != nil {
+    if type_of(node.scopes) != "list" {
+      issues = issues
+        + [__issue("actor_chain.scopes_type", path + ".scopes", "scopes must be a list of strings")]
+    } else {
+      for {index, value} in node.scopes.enumerate() {
+        if type_of(value) != "string" {
+          issues = issues
+            + [
+            __issue(
+              "actor_chain.scope_type",
+              path + ".scopes[" + to_string(index) + "]",
+              "scope entries must be strings",
+            ),
+          ]
+        } else {
+          scopes = __append_unique(scopes, value)
+        }
+      }
+    }
+  }
+  if node?.scope != nil {
+    if type_of(node.scope) != "string" {
+      issues = issues
+        + [__issue("actor_chain.scope_type", path + ".scope", "scope must be a whitespace-delimited string")]
+    } else {
+      for value in split(node.scope, " ") {
+        scopes = __append_unique(scopes, value)
+      }
+    }
+  }
+  return {issues: issues, scopes: scopes}
+}
+
+fn __entry(node, path: string) -> dict {
+  var issues = []
+  if type_of(node) != "dict" {
+    return {issues: [__issue("actor_chain.node_type", path, "node must be a dict")], entry: nil}
+  }
+  if type_of(node?.sub) != "string" || trim(node.sub) == "" {
+    return {
+      issues: [__issue("actor_chain.sub_type", path + ".sub", "sub must be a non-empty string")],
+      entry: nil,
+    }
+  }
+  let scope_result = __scope_claims(node, path)
+  issues = issues + scope_result.issues
+  let subject = to_string(node.sub)
+  let parts = __subject_parts(subject)
+  return {
+    issues: issues,
+    entry: {subject: subject, kind: parts.kind, id: parts.id, path: path + ".sub", scopes: scope_result.scopes},
+  }
+}
+
+fn __may_act(chain: dict) -> dict {
+  if chain?.may_act == nil {
+    return {issues: [], value: nil}
+  }
+  if type_of(chain.may_act) != "dict" {
+    return {
+      issues: [__issue("actor_chain.may_act_type", "may_act", "may_act must be a dict with a sub string")],
+      value: nil,
+    }
+  }
+  if type_of(chain.may_act?.sub) != "string" || trim(chain.may_act.sub) == "" {
+    return {
+      issues: [__issue("actor_chain.may_act_sub_type", "may_act.sub", "may_act.sub must be a non-empty string")],
+      value: nil,
+    }
+  }
+  return {issues: [], value: to_string(chain.may_act.sub)}
+}
+
+fn __with_roles(entries: list<dict>) -> list<ActorChainSubject> {
+  var subjects = []
+  let origin_index = len(entries) - 1
+  for {index, value} in entries.enumerate() {
+    let role = if index == 0 {
+      "current"
+    } else if index == origin_index {
+      "origin"
+    } else {
+      "actor"
+    }
+    subjects = subjects + [value + {role: role, position: index}]
+  }
+  return subjects
+}
+
+fn __report(issues: list<ActorChainIssue>, entries: list<dict>, may_act) -> ActorChainReport {
+  let subjects = __with_roles(entries)
+  var current = nil
+  var origin = nil
+  var actors = []
+  var prior_actors = []
+  if len(subjects) > 0 {
+    current = subjects[0]
+    origin = subjects[len(subjects) - 1]
+  }
+  if len(subjects) > 1 {
+    actors = subjects.slice(0, len(subjects) - 1)
+  }
+  if len(actors) > 1 {
+    prior_actors = actors.slice(1, len(actors))
+  }
+  var report = {
+    ok: len(issues) == 0,
+    issues: issues,
+    subjects: subjects,
+    current: current,
+    origin: origin,
+    actors: actors,
+    prior_actors: prior_actors,
+    depth: len(subjects),
+    delegated: len(actors) > 0,
+  }
+  if may_act != nil {
+    report = report + {may_act: may_act}
+  }
+  return report
+}
+
+/**
+ * Split an ActorChain subject (`kind:id`) into displayable parts.
+ *
+ * Subjects without a colon are treated as `{kind: "principal", id: subject}`.
+ *
+ * @effects: []
+ * @errors: []
+ */
+pub fn actor_chain_subject_parts(subject: string) -> dict {
+  return __subject_parts(subject)
+}
+
+/**
+ * Validate and inspect an RFC 8693-style ActorChain dict without throwing.
+ *
+ * Returned subjects are ordered current actor first and origin last, matching
+ * Harn's Rust `ActorChain::entries()` traversal. Each subject preserves `scope`
+ * / `scopes` claims as a deduplicated list.
+ *
+ * @effects: []
+ * @errors: []
+ */
+pub fn actor_chain_report(chain) -> ActorChainReport {
+  var issues = []
+  var entries = []
+  if type_of(chain) != "dict" {
+    return __report([__issue("actor_chain.type", "$", "chain must be a dict")], [], nil)
+  }
+  var node = chain?.act
+  var path = "act"
+  while node != nil {
+    let result = __entry(node, path)
+    issues = issues + result.issues
+    if result.entry == nil {
+      return __report(issues, entries, nil)
+    }
+    entries = entries + [result.entry]
+    node = node?.act
+    path = path + ".act"
+  }
+  let origin = __entry(chain, "$")
+  issues = issues + origin.issues
+  if origin.entry != nil {
+    entries = entries + [origin.entry]
+  }
+  let may_act = __may_act(chain)
+  issues = issues + may_act.issues
+  return __report(issues, entries, may_act.value)
+}
+
+/**
+ * Validate an ActorChain and return the same report as `actor_chain_report`.
+ *
+ * Throws a concise message when the chain is malformed; use
+ * `actor_chain_report` when callers need to collect structured issues.
+ *
+ * @effects: []
+ * @errors: [TypeError, ValueError]
+ */
+pub fn actor_chain_require(chain) -> ActorChainReport {
+  let report = actor_chain_report(chain)
+  if report.ok {
+    return report
+  }
+  var messages = []
+  for issue in report.issues {
+    messages = messages + [issue.path + ": " + issue.message]
+  }
+  throw "std/identity: invalid ActorChain: " + join(messages, "; ")
+}
+
+/**
+ * Return validated ActorChain subjects ordered current-first, origin-last.
+ *
+ * @effects: []
+ * @errors: [TypeError, ValueError]
+ */
+pub fn actor_chain_subjects(chain) -> list<ActorChainSubject> {
+  return actor_chain_require(chain).subjects
+}
+
+/**
+ * Return the stable summary fields from a validated ActorChain.
+ *
+ * @effects: []
+ * @errors: [TypeError, ValueError]
+ */
+pub fn actor_chain_summary(chain) -> dict {
+  let report = actor_chain_require(chain)
+  var summary = {
+    subjects: report.subjects,
+    current: report.current,
+    origin: report.origin,
+    actors: report.actors,
+    prior_actors: report.prior_actors,
+    actor_count: len(report.actors),
+    depth: report.depth,
+    delegated: report.delegated,
+  }
+  if report.may_act != nil {
+    summary = summary + {may_act: report.may_act}
+  }
+  return summary
+}
+
+fn __subject_names(subjects: list<ActorChainSubject>) -> list<string> {
+  var names = []
+  for subject in subjects {
+    names = names + [subject.subject]
+  }
+  return names
+}
+
+/**
+ * Format an ActorChain for compact logs and status displays.
+ *
+ * Default style renders `current for origin` and includes prior actors as
+ * `via a, b`. Pass `{style: "arrow"}` for the full current-to-origin chain.
+ *
+ * @effects: []
+ * @errors: [TypeError, ValueError]
+ */
+pub fn actor_chain_format(chain, options: ActorChainFormatOptions = {}) -> string {
+  let report = actor_chain_require(chain)
+  if report.depth == 0 {
+    return ""
+  }
+  let style = lowercase(trim(to_string(options.style ?? "for")))
+  if style == "arrow" {
+    return join(__subject_names(report.subjects), " -> ")
+  }
+  let origin = report.origin
+  if origin == nil {
+    return ""
+  }
+  if !report.delegated {
+    return origin.subject
+  }
+  let current = report.current
+  if current == nil {
+    return origin.subject
+  }
+  var rendered = current.subject + " for " + origin.subject
+  let include_prior = options.include_prior ?? true
+  if include_prior && len(report.prior_actors) > 0 {
+    rendered = rendered + " via " + join(__subject_names(report.prior_actors), ", ")
+  }
+  return rendered
+}

--- a/crates/harn-vm/src/mcp/builtins.rs
+++ b/crates/harn-vm/src/mcp/builtins.rs
@@ -272,6 +272,12 @@ pub fn register_mcp_builtins(vm: &mut Vm) {
         for entry in crate::mcp_registry::snapshot_status() {
             let mut dict = BTreeMap::new();
             dict.put_str("name", entry.name.as_str());
+            dict.put_str("transport", entry.transport.as_str());
+            if let Some(url) = entry.url {
+                dict.put_str("url", url.as_str());
+            } else {
+                dict.insert("url".to_string(), VmValue::Nil);
+            }
             dict.insert("lazy".to_string(), VmValue::Bool(entry.lazy));
             dict.insert("active".to_string(), VmValue::Bool(entry.active));
             dict.insert(
@@ -845,13 +851,19 @@ pub(crate) fn register_supervised_mcp_host_builtins(vm: &mut Vm) {
         )))
     });
 
-    vm.register_builtin("harn.mcp.status", |_args, _out| {
-        let entries = crate::mcp_host::status();
+    vm.register_async_builtin("harn.mcp.status", |_ctx, _args| async move {
+        let entries = crate::mcp_host::status().await;
         let list: Vec<VmValue> = entries
             .into_iter()
             .map(|s| {
                 let mut dict = BTreeMap::new();
                 dict.put_str("name", s.name);
+                dict.put_str("transport", s.transport);
+                if let Some(url) = s.url {
+                    dict.put_str("url", url);
+                } else {
+                    dict.insert("url".to_string(), VmValue::Nil);
+                }
                 dict.insert("active".to_string(), VmValue::Bool(s.active));
                 dict.insert("lazy".to_string(), VmValue::Bool(s.lazy));
                 dict.insert("ref_count".to_string(), VmValue::Int(s.ref_count as i64));
@@ -869,6 +881,11 @@ pub(crate) fn register_supervised_mcp_host_builtins(vm: &mut Vm) {
                     "cache_entries".to_string(),
                     VmValue::Int(s.cache_entries as i64),
                 );
+                if let Some(display_identity) = s.display_identity {
+                    dict.put_str("display_identity", display_identity);
+                } else {
+                    dict.insert("display_identity".to_string(), VmValue::Nil);
+                }
                 VmValue::dict(dict)
             })
             .collect();

--- a/crates/harn-vm/src/mcp_host.rs
+++ b/crates/harn-vm/src/mcp_host.rs
@@ -241,6 +241,8 @@ pub type AllowlistGuard = Arc<dyn Fn(&str, Option<&str>) -> AllowlistDecision + 
 #[derive(Clone, Debug, Serialize)]
 pub struct McpHostStatus {
     pub name: String,
+    pub transport: String,
+    pub url: Option<String>,
     pub active: bool,
     pub lazy: bool,
     pub ref_count: usize,
@@ -251,6 +253,10 @@ pub struct McpHostStatus {
     /// Number of cached response entries for this server (across all
     /// tools).
     pub cache_entries: usize,
+    /// Human-readable authenticated identity for connected OAuth-backed HTTP
+    /// servers when a vetted identity descriptor can render from the stored
+    /// token response.
+    pub display_identity: Option<String>,
 }
 
 /// Options accepted by [`spawn`]. Mirrors the dict surface in
@@ -635,12 +641,12 @@ pub async fn discover() -> Result<Vec<JsonValue>, VmError> {
 }
 
 /// Diagnostic snapshot across all hosted servers.
-pub fn status() -> Vec<McpHostStatus> {
+pub async fn status() -> Vec<McpHostStatus> {
     let registry: BTreeMap<String, mcp_registry::RegistryStatus> = mcp_registry::snapshot_status()
         .into_iter()
         .map(|s| (s.name.clone(), s))
         .collect();
-    with_inner(|inner| {
+    let mut statuses = with_inner(|inner| {
         let mut out = Vec::new();
         let now = Instant::now();
         for (name, reg) in &registry {
@@ -664,6 +670,8 @@ pub fn status() -> Vec<McpHostStatus> {
                 .sum();
             out.push(McpHostStatus {
                 name: name.clone(),
+                transport: reg.transport.clone(),
+                url: reg.url.clone(),
                 active: reg.active,
                 lazy: reg.lazy,
                 ref_count: reg.ref_count,
@@ -672,10 +680,21 @@ pub fn status() -> Vec<McpHostStatus> {
                 circuit,
                 ejected,
                 cache_entries,
+                display_identity: None,
             });
         }
         out
-    })
+    });
+    for status in &mut statuses {
+        if !status.active || status.transport != "http" {
+            continue;
+        }
+        let Some(url) = status.url.as_deref() else {
+            continue;
+        };
+        status.display_identity = crate::mcp_identity::display_identity_from_store(url, None).await;
+    }
+    statuses
 }
 
 fn current_allowlist() -> Option<AllowlistGuard> {

--- a/crates/harn-vm/src/mcp_identity.rs
+++ b/crates/harn-vm/src/mcp_identity.rs
@@ -42,6 +42,39 @@ pub fn display_identity(server_url: &str, token: &StoredMcpToken) -> Option<Stri
     render_identity(descriptor, token.token_response_extra.as_ref())
 }
 
+/// Resolve a display-identity string from Harn's stored MCP OAuth token state.
+///
+/// This is the shared status-surface helper: callers get the same behavior in
+/// CLI status, host status, and Harn scripts without each reimplementing OAuth
+/// discovery, resource-indicator canonicalization, token lookup, and graceful
+/// fallback. Returns `None` for unknown servers, servers without token-response
+/// identity descriptors, missing tokens, discovery/storage errors, or tokens
+/// that predate captured token-response extras.
+pub async fn display_identity_from_store(
+    server_url: &str,
+    client_id_hint: Option<&str>,
+) -> Option<String> {
+    let descriptor = descriptor_for(server_url)?;
+    if descriptor.resolution == IdentityResolutionKind::None
+        || !descriptor
+            .sources
+            .iter()
+            .any(|source| source.kind == IdentityProbeKind::TokenResponse)
+    {
+        return None;
+    }
+    let discovery = crate::mcp_oauth::discover(server_url).await.ok()?;
+    let resource = crate::mcp_auth::canonical_resource_indicator(server_url).ok()?;
+    let token = crate::mcp_oauth::load_token(
+        &resource,
+        &discovery.authorization_server_issuer,
+        client_id_hint,
+    )
+    .await
+    .ok()??;
+    render_identity(descriptor, token.token_response_extra.as_ref())
+}
+
 /// Render a descriptor against an optional captured token-response payload.
 /// Tries each `token_response` source in order; returns the first non-empty
 /// render. Pure — the unit of behavior the tests exercise.
@@ -294,5 +327,12 @@ mod tests {
         let mut other = token;
         other.resource = "https://unknown.example/mcp".into();
         assert!(display_identity("https://unknown.example/mcp", &other).is_none());
+    }
+
+    #[tokio::test]
+    async fn store_lookup_skips_unknown_servers_without_discovery() {
+        let rendered =
+            display_identity_from_store("https://identity.example.invalid/mcp", None).await;
+        assert!(rendered.is_none());
     }
 }

--- a/crates/harn-vm/src/mcp_registry.rs
+++ b/crates/harn-vm/src/mcp_registry.rs
@@ -275,10 +275,20 @@ pub fn sweep_expired() {
 #[derive(Clone, Debug)]
 pub struct RegistryStatus {
     pub name: String,
+    pub transport: String,
+    pub url: Option<String>,
     pub lazy: bool,
     pub active: bool,
     pub ref_count: usize,
     pub card: Option<String>,
+}
+
+fn spec_string(spec: &serde_json::Value, key: &str) -> Option<String> {
+    spec.get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 pub fn snapshot_status() -> Vec<RegistryStatus> {
@@ -288,6 +298,8 @@ pub fn snapshot_status() -> Vec<RegistryStatus> {
         let active = guard.active.get(name);
         out.push(RegistryStatus {
             name: name.clone(),
+            transport: spec_string(&server.spec, "transport").unwrap_or_else(|| "stdio".into()),
+            url: spec_string(&server.spec, "url"),
             lazy: server.lazy,
             active: active.is_some(),
             ref_count: active.map(|a| a.ref_count).unwrap_or(0),
@@ -329,6 +341,8 @@ mod tests {
         let snap = snapshot_status();
         assert_eq!(snap.len(), 1);
         assert_eq!(snap[0].name, "x");
+        assert_eq!(snap[0].transport, "stdio");
+        assert!(snap[0].url.is_none());
         assert!(snap[0].lazy);
         assert!(!snap[0].active);
         assert_eq!(snap[0].card.as_deref(), Some("card.json"));

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -133,6 +133,7 @@
 - [Diff stdlib](./stdlib/diff.md)
 - [OAuth storage stdlib](./stdlib/oauth-storage.md)
 - [Prompt library stdlib](./stdlib/prompt-library.md)
+- [Identity stdlib](./stdlib/identity.md)
 - [Disclosure stdlib](./stdlib/disclosure.md)
 - [Human in the loop](./hitl.md)
 - [Trust graph](./trust-graph.md)

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -2142,6 +2142,12 @@ an MCP server name, or uses the explicit URL when you pass `--url` or a raw
 - falls back to dynamic client registration when supported by the server
 - stores tokens in the local OS keychain and refreshes them automatically
 
+`harn mcp status` prints the configured server state. For OAuth-backed HTTP
+servers with a vetted identity descriptor and captured token-response metadata,
+human output includes the connected account/workspace and `--json` includes
+`display_identity`. Harn scripts see the same field through `harn.mcp.status()`,
+alongside the server `transport` and `url`.
+
 Relevant flags:
 
 | Flag | Description |

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -267,7 +267,10 @@ harn mcp status notion
 stores the token in the local OS keychain. `harn mcp redirect-uri` just prints
 the default callback URI (`http://127.0.0.1:9783/oauth/callback`) for servers
 that ask you to pre-register one; you usually do not need it for built-in
-presets such as Notion.
+presets such as Notion. `harn mcp status notion` shows the connection state and,
+when the server exposes identity metadata in its OAuth token response, the
+connected account/workspace. Scripts can read the same value from
+`harn.mcp.status()[i].display_identity`.
 
 Then declare the server in `harn.toml`:
 

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -80,7 +80,7 @@ code or inside any pipeline.
 `import "std/..."` is only needed for the Harn-written helper modules
 described below (`std/text`, `std/json`, `std/math`, `std/collections`,
 `std/ansi`, `std/table`, `std/diff`, `std/path`, `std/fs`, `std/os`,
-`std/slug`, `std/edit`, `std/disclosure`, `std/artifact/web`, `std/ui_resource`, `std/cache`,
+`std/slug`, `std/edit`, `std/identity`, `std/disclosure`, `std/artifact/web`, `std/ui_resource`, `std/cache`,
 `std/llm/handlers`, `std/llm/budget`, `std/llm/prompts`, `std/vision`,
 `std/context`, `std/agent_state`, `std/agents`, `std/agent/user`,
 `std/agent/fact`, `std/agent/probe`, `std/agent/scratchpad`,
@@ -112,6 +112,7 @@ import "std/connectors/shared"
 import "std/context"
 import "std/disclosure"
 import "std/edit"
+import "std/identity"
 import "std/artifact/web"
 import "std/ui_resource"
 import "std/experiments"
@@ -486,6 +487,38 @@ import "std/slug"
 let run_name = random_slug({segments: 3})
 let stable = slug_from({repo: "harn", pr: 42}, {segments: 4, salt: "ci"})
 let id = slugify("Agent 007 / Fast Verify")
+```
+
+### std/identity
+
+ActorChain inspection helpers for provenance, logs, status displays, and
+surface adapters:
+
+| Function | Description |
+|---|---|
+| `actor_chain_report(chain)` | Validate an ActorChain dict without throwing; returns `{ok, issues, subjects, current, origin, actors, prior_actors, depth, delegated, may_act?}` |
+| `actor_chain_require(chain)` | Return the report or throw a concise `std/identity` error for malformed chains |
+| `actor_chain_subjects(chain)` | Return validated subjects ordered current actor first and origin last |
+| `actor_chain_summary(chain)` | Return the stable summary fields from a valid chain |
+| `actor_chain_format(chain, options?)` | Format `current for origin`, including prior actors by default, or use `{style: "arrow"}` for the full chain |
+| `actor_chain_subject_parts(subject)` | Split `kind:id` subjects into `{kind, id}`; subjects without `:` become `{kind: "principal", id: subject}` |
+
+```harn
+import { actor_chain_format, actor_chain_report } from "std/identity"
+
+pipeline default() {
+  let chain = {
+    sub: "user:owner",
+    scopes: ["repo:read", "repo:write"],
+    act: {sub: "agent:reviewer", scopes: ["repo:read"]},
+  }
+  let report = actor_chain_report(chain)
+  let current = report.current
+  require current != nil, "chain should have a current subject"
+  log(current.subject)                    // "agent:reviewer"
+  log(actor_chain_format(chain))          // "agent:reviewer for user:owner"
+  log(actor_chain_format(chain, {style: "arrow"})) // "agent:reviewer -> user:owner"
+}
 ```
 
 ### std/eval/stats

--- a/docs/src/stdlib/disclosure.md
+++ b/docs/src/stdlib/disclosure.md
@@ -4,6 +4,9 @@
 RFC 8693-style `ActorChain` value. Use it when a host or connector needs the
 same actor chain represented in a surface-native form such as Git trailers,
 a Slack byline, or a GitHub author-mode decision.
+Generic ActorChain validation, traversal, and compact formatting live in
+[`std/identity`](./identity.md); disclosure reuses that module and adds only
+surface-specific rendering policy.
 
 ```harn
 import { append_git_trailers, render, slack_message_disclosure } from "std/disclosure"

--- a/docs/src/stdlib/identity.md
+++ b/docs/src/stdlib/identity.md
@@ -1,0 +1,63 @@
+# Identity stdlib
+
+`std/identity` provides Harn-native helpers for inspecting RFC 8693-style
+`ActorChain` dicts. Use it when a script, connector, status surface, or audit
+receipt needs the same current-actor-through-origin view that Harn's Rust
+`ActorChain` type uses internally.
+
+```harn
+import { actor_chain_format, actor_chain_report } from "std/identity"
+
+pipeline default() {
+  let chain = {
+    sub: "user:owner",
+    scopes: ["repo:read", "repo:write"],
+    may_act: {sub: "agent:delegate"},
+    act: {
+      sub: "agent:reviewer",
+      scopes: ["repo:read"],
+      act: {sub: "agent:planner", scope: "repo:read"},
+    },
+  }
+
+  let report = actor_chain_report(chain)
+  let display = actor_chain_format(chain)
+}
+```
+
+## Report Shape
+
+`actor_chain_report(chain)` never throws. It returns:
+
+| Field | Description |
+|---|---|
+| `ok` | `true` when the chain is structurally valid |
+| `issues` | Structured `{code, path, message}` validation issues |
+| `subjects` | Current actor first, origin last |
+| `current` | The current actor, or the origin for non-delegated chains |
+| `origin` | The top-level `sub` principal |
+| `actors` | Actor entries excluding the origin |
+| `prior_actors` | Actors after `current` |
+| `depth` | Number of subjects in the chain |
+| `delegated` | `true` when the chain has one or more acting agents |
+| `may_act` | Optional authorized-actor hint from `may_act.sub` |
+
+Each subject includes `subject`, `kind`, `id`, `role`, `position`, `path`, and
+`scopes`. `scope` strings and `scopes` lists are normalized into a deduplicated
+`scopes` list.
+
+## Throwing Helpers
+
+Use `actor_chain_require(chain)` when malformed input should fail fast. The
+other convenience helpers call it:
+
+| Function | Use |
+|---|---|
+| `actor_chain_subjects(chain)` | Return current-first subject entries |
+| `actor_chain_summary(chain)` | Return only the stable summary fields |
+| `actor_chain_format(chain, options?)` | Render compact status text |
+| `actor_chain_subject_parts(subject)` | Split `kind:id` subjects |
+
+`actor_chain_format(chain)` renders `current for origin` and includes
+`via prior` actors when present. Pass `{style: "arrow"}` to render the full
+current-to-origin chain with ` -> ` separators.


### PR DESCRIPTION
## Summary

- add `std/identity` for Harn-native ActorChain validation, structured reports, summaries, and compact formatting
- refactor `std/disclosure` to reuse the shared ActorChain traversal and subject parsing helpers
- centralize MCP OAuth display-identity lookup in `harn-vm` and surface `transport`, `url`, and `display_identity` through Harn MCP status APIs
- document the new stdlib module and status fields, with conformance coverage and a changelog fragment

## Verification

- `cargo check -p harn-vm -p harn-cli -p harn-stdlib -p harn-mcp-rc-compat --tests`
- `cargo run --quiet --bin harn -- check crates/harn-stdlib/src/stdlib/stdlib_identity.harn`
- `cargo run --quiet --bin harn -- check crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn`
- `cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/stdlib_identity.harn crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn conformance/tests/stdlib/identity_actor_chain.harn conformance/tests/scenarios/mcp_status_identity_shape.harn crates/harn-cli/assets/demo/mcp-host/scenario.harn`
- `cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/stdlib_identity.harn crates/harn-stdlib/src/stdlib/stdlib_disclosure.harn conformance/tests/stdlib/identity_actor_chain.harn conformance/tests/scenarios/mcp_status_identity_shape.harn crates/harn-cli/assets/demo/mcp-host/scenario.harn`
- `cargo run --quiet --bin harn -- test conformance --filter identity_actor_chain`
- `cargo run --quiet --bin harn -- test conformance --filter mcp_status_identity_shape`
- `cargo run --quiet --bin harn -- test conformance --filter disclosure_render`
- `cargo test -p harn-vm mcp_identity -- --nocapture`
- `cargo test -p harn-vm mcp_registry -- --nocapture`
- `cargo test -p harn-mcp-rc-compat --test mcp_host -- --nocapture`
- `cargo test -p harn-cli status_report -- --nocapture`
- `make check-generated-registry && make check-highlight && make check-docs-snippets`
- `cargo run --quiet --bin harn -- test conformance`
- `make lint-harn`
- `make fmt-harn`
- `cargo fmt && make test`
- pre-commit hook
- pre-push hook
