### PR TITLE
security(redaction): reuse shared policy across orchestration records

### DIFF
--- a/changelog.d/shared-redaction-policy.security.md
+++ b/changelog.d/shared-redaction-policy.security.md
@@ -1,0 +1,5 @@
+- **Redaction-sensitive orchestration surfaces now share Harn's provider-aware
+  secret policy.** Crystallization bundles and friction/context-pack records
+  reuse the central redaction catalog for provider tokens, JWTs, private keys,
+  and sensitive key/value assignments while still preserving logical secret
+  references such as `github/webhook-secret`.

--- a/conformance/tests/stdlib/friction_context_pack.harn
+++ b/conformance/tests/stdlib/friction_context_pack.harn
@@ -82,7 +82,11 @@ pipeline main() {
     },
   )
   __io_println(first.recorded && first.sink == "memory")
-  __io_println(len(events) == 2 && contains(events[0].redacted_summary, "[redacted]"))
+  __io_println(
+    len(events) == 2
+      && contains(events[0].redacted_summary, "redacted")
+      && !contains(events[0].redacted_summary, "token=secret"),
+  )
   __io_println(events[0].metadata.api_key == "[redacted]")
   __io_println(len(suggestions) == 1 && suggestions[0].recommended_artifact == "context_pack")
   __io_println(suggestions[0].candidate_manifest.capabilities[0] == "splunk.search")

--- a/crates/harn-vm/src/orchestration/crystallize/bundle.rs
+++ b/crates/harn-vm/src/orchestration/crystallize/bundle.rs
@@ -1,6 +1,6 @@
 //! Crystallization bundle: types, build/write/load/validate, shadow replay, and redaction helpers.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Component, Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -18,6 +18,7 @@ use super::types::{
     BUNDLE_SCHEMA_VERSION, BUNDLE_SKILL_DIR, BUNDLE_SKILL_FILE, BUNDLE_SKILL_GATE_FILE,
     BUNDLE_WORKFLOW_FILE, DEFAULT_ROLLOUT_POLICY, SKILL_GATE_RECEIPT_SCHEMA,
 };
+use crate::redact::{RedactionPolicy, REDACTED_PLACEHOLDER};
 use crate::skills::{parse_frontmatter, split_frontmatter};
 use crate::value::VmError;
 
@@ -1142,30 +1143,35 @@ fn candidate_is_plan_only(candidate: &WorkflowCandidate) -> bool {
 }
 
 pub(super) fn redact_trace_for_bundle(trace: &mut CrystallizationTrace) {
+    let policy = RedactionPolicy::default();
     for action in &mut trace.actions {
-        redact_bundle_value(&mut action.inputs);
+        policy.redact_json_in_place(&mut action.inputs);
         if let Some(output) = action.output.as_mut() {
-            redact_bundle_value(output);
+            policy.redact_json_in_place(output);
         }
         if let Some(observed) = action.observed_output.as_mut() {
-            redact_bundle_value(observed);
+            policy.redact_json_in_place(observed);
         }
-        for value in action.parameters.values_mut() {
-            redact_bundle_value(value);
-        }
-        for (_, value) in action.metadata.iter_mut() {
-            redact_bundle_value(value);
-        }
+        redact_bundle_map(&mut action.parameters, &policy);
+        redact_bundle_map(&mut action.metadata, &policy);
     }
-    for (_, value) in trace.metadata.iter_mut() {
-        redact_bundle_value(value);
-    }
+    redact_bundle_map(&mut trace.metadata, &policy);
     if let Some(run) = trace.replay_run.as_mut() {
-        redact_replay_run_for_bundle(run);
+        redact_replay_run_for_bundle(run, &policy);
     }
 }
 
-fn redact_replay_run_for_bundle(run: &mut ReplayTraceRun) {
+fn redact_bundle_map(map: &mut BTreeMap<String, JsonValue>, policy: &RedactionPolicy) {
+    for (key, value) in map {
+        if policy.field_is_sensitive(key) {
+            *value = JsonValue::String(REDACTED_PLACEHOLDER.to_string());
+        } else {
+            policy.redact_json_in_place(value);
+        }
+    }
+}
+
+fn redact_replay_run_for_bundle(run: &mut ReplayTraceRun, policy: &RedactionPolicy) {
     for value in run
         .event_log_entries
         .iter_mut()
@@ -1178,59 +1184,11 @@ fn redact_replay_run_for_bundle(run: &mut ReplayTraceRun) {
         .chain(run.final_artifacts.iter_mut())
         .chain(run.policy_decisions.iter_mut())
     {
-        redact_bundle_value(value);
+        policy.redact_json_in_place(value);
     }
-}
-
-fn redact_bundle_value(value: &mut JsonValue) {
-    match value {
-        JsonValue::String(text) if looks_like_secret_value(text) => {
-            *text = "[redacted]".to_string();
-        }
-        JsonValue::Array(items) => {
-            for item in items {
-                redact_bundle_value(item);
-            }
-        }
-        JsonValue::Object(map) => {
-            for (key, child) in map.iter_mut() {
-                if is_sensitive_bundle_key(key) {
-                    *child = JsonValue::String("[redacted]".to_string());
-                } else {
-                    redact_bundle_value(child);
-                }
-            }
-        }
-        _ => {}
-    }
-}
-
-fn is_sensitive_bundle_key(key: &str) -> bool {
-    let lower = key.to_ascii_lowercase();
-    lower.contains("secret")
-        || lower.contains("token")
-        || lower.contains("password")
-        || lower.contains("api_key")
-        || lower.contains("apikey")
-        || lower == "authorization"
-        || lower == "cookie"
-        || lower == "set-cookie"
-}
-
-fn looks_like_secret_value(value: &str) -> bool {
-    let trimmed = value.trim();
-    trimmed.starts_with("sk-")
-        || trimmed.starts_with("ghp_")
-        || trimmed.starts_with("ghs_")
-        || trimmed.starts_with("xoxb-")
-        || trimmed.starts_with("xoxp-")
-        || trimmed.starts_with("AKIA")
-        || (trimmed.len() > 48
-            && trimmed
-                .chars()
-                .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-'))
 }
 
 fn secret_id_looks_logical(value: &str) -> bool {
-    !looks_like_secret_value(value) && !value.trim().is_empty()
+    let trimmed = value.trim();
+    !trimmed.is_empty() && !RedactionPolicy::default().looks_like_secret_value(trimmed)
 }

--- a/crates/harn-vm/src/orchestration/crystallize_tests.rs
+++ b/crates/harn-vm/src/orchestration/crystallize_tests.rs
@@ -604,6 +604,24 @@ fn validate_rejects_unsupported_schema_version() {
 }
 
 #[test]
+fn validate_rejects_raw_required_secret_values() {
+    let traces = version_traces(3);
+    let artifacts = crystallize_traces(traces.clone(), CrystallizeOptions::default()).unwrap();
+    let mut bundle =
+        build_crystallization_bundle(artifacts, &traces, BundleOptions::default()).unwrap();
+    bundle.manifest.required_secrets = vec!["sk-live-secret".to_string()];
+    let dir = tempfile::tempdir().unwrap();
+    write_crystallization_bundle(&bundle, dir.path()).unwrap();
+
+    let validation = validate_crystallization_bundle(dir.path()).unwrap();
+    assert!(!validation.is_ok());
+    assert!(validation
+        .problems
+        .iter()
+        .any(|problem| problem.contains("required_secrets")));
+}
+
+#[test]
 fn redacts_secret_like_values_in_fixtures() {
     // Build secret-shaped strings at runtime so we exercise the
     // redaction prefixes (`xoxb-`, `ghp_`, `sk-`) without checking in
@@ -615,6 +633,7 @@ fn redacts_secret_like_values_in_fixtures() {
     let slack_secret = format!("{slack_prefix}1234567890-{pad}");
     let github_secret = format!("{github_prefix}{pad}");
     let openai_secret = format!("{openai_prefix}{pad}");
+    let huggingface_secret = format!("hf_{}", "B".repeat(24));
 
     let mut secret_action = CrystallizationAction {
         id: "secret".to_string(),
@@ -633,6 +652,10 @@ fn redacts_secret_like_values_in_fixtures() {
     secret_action
         .metadata
         .insert("api_key".to_string(), json!(openai_secret));
+    secret_action.metadata.insert(
+        "freeform_note".to_string(),
+        json!(format!("fallback model token {huggingface_secret}")),
+    );
 
     let mut trace = CrystallizationTrace {
         id: "trace_secret".to_string(),
@@ -650,6 +673,13 @@ fn redacts_secret_like_values_in_fixtures() {
     assert_eq!(inputs.get("authorization"), Some(&json!("[redacted]")));
     assert_eq!(inputs.get("version"), Some(&json!("0.7.1")));
     assert_eq!(action.metadata.get("api_key"), Some(&json!("[redacted]")));
+    let note = action
+        .metadata
+        .get("freeform_note")
+        .and_then(|value| value.as_str())
+        .unwrap();
+    assert!(note.contains("<redacted:huggingface_token:"));
+    assert!(!note.contains(&huggingface_secret));
 }
 
 #[test]

--- a/crates/harn-vm/src/orchestration/friction.rs
+++ b/crates/harn-vm/src/orchestration/friction.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{new_id, now_rfc3339, parse_json_payload};
 use crate::llm::vm_value_to_json;
+use crate::redact::{RedactionPolicy, REDACTED_PLACEHOLDER};
 use crate::value::{VmError, VmValue};
 
 pub const FRICTION_SCHEMA_VERSION: u32 = 1;
@@ -298,9 +299,7 @@ pub fn normalize_friction_event_json(json: serde_json::Value) -> Result<Friction
             "friction_event: missing redacted_summary".to_string(),
         ));
     }
-    for value in event.metadata.values_mut() {
-        redact_json_value(value);
-    }
+    redact_metadata_map(&mut event.metadata);
     Ok(event)
 }
 
@@ -418,8 +417,8 @@ fn normalize_context_pack_manifest_record(
         ));
     }
     for secret in &manifest.secrets {
-        if looks_like_secret_value(&secret.name)
-            || looks_like_secret_value(secret.capability.as_deref().unwrap_or(""))
+        if value_looks_secret(&secret.name)
+            || value_looks_secret(secret.capability.as_deref().unwrap_or(""))
         {
             return Err(VmError::Runtime(
                 "context_pack_manifest: secrets must be capability references, not raw secret values"
@@ -787,65 +786,27 @@ fn metadata_string_map(event: &FrictionEvent, key: &str) -> BTreeMap<String, Str
 }
 
 fn redact_json_value(value: &mut serde_json::Value) {
-    match value {
-        serde_json::Value::String(text) => *text = redact_text(text),
-        serde_json::Value::Array(items) => {
-            for item in items {
-                redact_json_value(item);
-            }
+    RedactionPolicy::default().redact_json_in_place(value);
+}
+
+fn redact_metadata_map(map: &mut BTreeMap<String, serde_json::Value>) {
+    let policy = RedactionPolicy::default();
+    for (key, value) in map {
+        if policy.field_is_sensitive(key) {
+            *value = serde_json::Value::String(REDACTED_PLACEHOLDER.to_string());
+        } else {
+            policy.redact_json_in_place(value);
         }
-        serde_json::Value::Object(map) => {
-            for (key, value) in map.iter_mut() {
-                if is_sensitive_key(key) {
-                    *value = serde_json::Value::String("[redacted]".to_string());
-                } else {
-                    redact_json_value(value);
-                }
-            }
-        }
-        _ => {}
     }
 }
 
 fn redact_text(text: &str) -> String {
-    text.split_whitespace()
-        .map(|word| {
-            let lower = word.to_ascii_lowercase();
-            if looks_like_secret_value(word)
-                || lower.contains("token=")
-                || lower.contains("password=")
-                || lower.contains("api_key=")
-                || lower.contains("apikey=")
-            {
-                "[redacted]".to_string()
-            } else {
-                word.to_string()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
+    RedactionPolicy::default().redact_string(text).into_owned()
 }
 
-fn is_sensitive_key(key: &str) -> bool {
-    let lower = key.to_ascii_lowercase();
-    lower.contains("secret")
-        || lower.contains("token")
-        || lower.contains("password")
-        || lower.contains("api_key")
-        || lower.contains("apikey")
-        || lower == "authorization"
-}
-
-fn looks_like_secret_value(value: &str) -> bool {
+fn value_looks_secret(value: &str) -> bool {
     let trimmed = value.trim();
-    trimmed.starts_with("sk-")
-        || trimmed.starts_with("ghp_")
-        || trimmed.starts_with("xoxb-")
-        || trimmed.starts_with("AKIA")
-        || trimmed.len() > 48
-            && trimmed
-                .chars()
-                .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+    !trimmed.is_empty() && RedactionPolicy::default().looks_like_secret_value(trimmed)
 }
 
 fn normalize_words(text: &str) -> String {
@@ -896,7 +857,8 @@ mod tests {
 
         assert_eq!(event.schema_version, FRICTION_SCHEMA_VERSION);
         assert!(event.id.starts_with("friction_"));
-        assert!(event.redacted_summary.contains("[redacted]"));
+        assert!(event.redacted_summary.contains("<redacted:"));
+        assert!(!event.redacted_summary.contains("token=abc123"));
         assert_eq!(event.metadata["api_key"], json!("[redacted]"));
     }
 

--- a/crates/harn-vm/src/redact/mod.rs
+++ b/crates/harn-vm/src/redact/mod.rs
@@ -279,6 +279,22 @@ impl RedactionPolicy {
         }
     }
 
+    /// Conservative predicate for fields that must contain logical
+    /// secret references rather than raw credential material.
+    ///
+    /// This is intentionally broader than [`redact_string`]: short
+    /// fake-looking values such as `sk-live-secret` are useful test
+    /// sentinels and should be rejected from `required_secrets` /
+    /// context-pack manifests even though the free-form string
+    /// redactor avoids replacing such short text globally.
+    pub fn looks_like_secret_value(&self, value: &str) -> bool {
+        let trimmed = value.trim();
+        !trimmed.is_empty()
+            && (self.redact_string(trimmed).as_ref() != trimmed
+                || has_secret_prefix(trimmed)
+                || is_long_bare_secret_candidate(trimmed))
+    }
+
     /// If `value` is a single URL with credentials or sensitive query
     /// params, return the redacted form. Standalone URLs are common in
     /// logged request envelopes; we don't try to walk arbitrary text
@@ -425,6 +441,22 @@ fn compact_secret_name(lower: &str) -> String {
         .chars()
         .filter(|ch| *ch != '_' && *ch != '-')
         .collect()
+}
+
+fn has_secret_prefix(trimmed: &str) -> bool {
+    trimmed.starts_with("sk-")
+        || trimmed.starts_with("ghp_")
+        || trimmed.starts_with("ghs_")
+        || trimmed.starts_with("xoxb-")
+        || trimmed.starts_with("xoxp-")
+        || trimmed.starts_with("AKIA")
+}
+
+fn is_long_bare_secret_candidate(trimmed: &str) -> bool {
+    trimmed.len() > 48
+        && trimmed
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
 }
 
 thread_local! {
@@ -635,5 +667,14 @@ mod tests {
         assert!(out.contains("<redacted:aws_access_key:"));
         assert!(!out.contains("AKIAABCDEFGHIJKLMNOP"));
         assert!(!out.contains("sk-proj-abcdefghijklmnopqrstuvwxyz0123456789ABCD"));
+    }
+
+    #[test]
+    fn looks_like_secret_value_accepts_logical_secret_references() {
+        let policy = RedactionPolicy::default();
+        assert!(policy.looks_like_secret_value("sk-live-secret"));
+        assert!(policy.looks_like_secret_value("AKIAABCDEFGHIJKLMNOP"));
+        assert!(!policy.looks_like_secret_value("github/webhook-secret"));
+        assert!(!policy.looks_like_secret_value("SPLUNK_READ_TOKEN"));
     }
 }

--- a/crates/harn-vm/src/redact/patterns.rs
+++ b/crates/harn-vm/src/redact/patterns.rs
@@ -347,6 +347,16 @@ mod tests {
     }
 
     #[test]
+    fn replaces_sensitive_assignments_inside_text() {
+        run_clean();
+        let input = "retry with token=abc123 and max_tokens=200";
+        let out = scan_secret_patterns(input, crate::redact::REDACTED_PLACEHOLDER);
+        assert!(out.contains("<redacted:sensitive_assignment:"));
+        assert!(!out.contains("token=abc123"));
+        assert!(out.contains("max_tokens=200"));
+    }
+
+    #[test]
     fn replaces_jwt_tokens() {
         run_clean();
         let input = "token=eyJabcd.eyJefgh.signature_pad here";
@@ -468,5 +478,6 @@ mod tests {
         assert!(names.contains(&"google_api_key"));
         assert!(names.contains(&"private_key_block"));
         assert!(names.contains(&"bearer_token"));
+        assert!(names.contains(&"sensitive_assignment"));
     }
 }

--- a/crates/harn-vm/src/secret_patterns.rs
+++ b/crates/harn-vm/src/secret_patterns.rs
@@ -115,4 +115,11 @@ pub(crate) const DEFAULT_SECRET_PATTERN_SPECS: &[SecretPatternSpec] = &[
         title: "Bearer token",
         regex: r"(?i)\bBearer\s+[A-Za-z0-9._\-+/=]{12,}",
     },
+    SecretPatternSpec {
+        redaction_name: "sensitive_assignment",
+        detector: "sensitive-assignment",
+        source: "detect-secrets-keyword-detector",
+        title: "Sensitive key/value assignment",
+        regex: r#"(?i)\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|password|passwd|secret|token)\s*[:=]\s*["']?[A-Za-z0-9._\-+/=]{6,}["']?"#,
+    },
 ];

--- a/crates/harn-vm/src/stdlib/secret_scan.rs
+++ b/crates/harn-vm/src/stdlib/secret_scan.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::sync::LazyLock;
 
 use regex::Regex;
@@ -95,14 +95,24 @@ pub fn scan_content(content: &str) -> Vec<SecretFinding> {
             .then(left.end_offset.cmp(&right.end_offset))
             .then(left.detector.cmp(&right.detector))
     });
-    let specific_spans: BTreeSet<(usize, usize)> = findings
+    let higher_specificity_spans = findings
         .iter()
-        .filter(|finding| finding.detector != "high-entropy-credential-assignment")
-        .map(|finding| (finding.start_offset, finding.end_offset))
-        .collect();
+        .map(|finding| {
+            (
+                finding.start_offset,
+                finding.end_offset,
+                detector_specificity(&finding.detector),
+            )
+        })
+        .collect::<Vec<_>>();
     findings.retain(|finding| {
-        finding.detector != "high-entropy-credential-assignment"
-            || !specific_spans.contains(&(finding.start_offset, finding.end_offset))
+        let specificity = detector_specificity(&finding.detector);
+        !higher_specificity_spans
+            .iter()
+            .any(|(start, end, other_specificity)| {
+                *other_specificity > specificity
+                    && spans_overlap((finding.start_offset, finding.end_offset), (*start, *end))
+            })
     });
     findings.dedup_by(|left, right| {
         left.detector == right.detector
@@ -110,6 +120,18 @@ pub fn scan_content(content: &str) -> Vec<SecretFinding> {
             && left.end_offset == right.end_offset
     });
     findings
+}
+
+fn detector_specificity(detector: &str) -> u8 {
+    match detector {
+        "sensitive-assignment" => 0,
+        "high-entropy-credential-assignment" => 1,
+        _ => 2,
+    }
+}
+
+fn spans_overlap(left: (usize, usize), right: (usize, usize)) -> bool {
+    left.0 < right.1 && right.0 < left.1
 }
 
 pub async fn append_secret_scan_audit<L: EventLog + ?Sized>(
@@ -310,6 +332,7 @@ mod tests {
     use super::*;
 
     use crate::event_log::{EventLog, MemoryEventLog};
+    use std::collections::BTreeSet;
 
     #[test]
     fn scan_content_detects_specific_rules_and_entropy_rule() {
@@ -326,6 +349,23 @@ config = { client_secret: "QWxhZGRpbjpPcGVuU2VzYW1lQWNjZXNzVG9rZW4=" }
         assert!(findings
             .iter()
             .any(|finding| finding.detector == "high-entropy-credential-assignment"));
+        assert!(!findings
+            .iter()
+            .any(|finding| finding.detector == "sensitive-assignment"));
+    }
+
+    #[test]
+    fn scan_content_deduplicates_generic_assignment_overlaps() {
+        let findings = scan_content(r#"token = "ghp_1234567890abcdefghijklmnopqrstuvwxyzAB""#);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].detector, "github-token");
+    }
+
+    #[test]
+    fn scan_content_keeps_generic_assignment_without_specific_detector() {
+        let findings = scan_content(r#"token = "secret123""#);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].detector, "sensitive-assignment");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replaces duplicate crystallization/friction secret walkers with Harn's shared `RedactionPolicy`.
- Adds a shared `sensitive_assignment` secret pattern for narrow `token=...` / `api_key=...` style text without matching operational counters such as `max_tokens=...`.
- Adds `RedactionPolicy::looks_like_secret_value` for fields that must contain logical secret references, so bundle/context-pack manifests reject raw-looking tokens while preserving IDs like `github/webhook-secret`.

## Why this shape

I checked current secret-scanner practice before adding another generic assignment pattern:
- detect-secrets has a keyword-detector family for secret-named values: https://github.com/Yelp/detect-secrets
- Gitleaks issue #1578 documents false positives from broad `key|api|token|secret|...` generic matching near random-looking strings, so this PR keeps Harn's pattern exact-key + assignment-shaped + minimum-value-length: https://github.com/gitleaks/gitleaks/issues/1578
- TruffleHog's project/docs emphasize provider-specific detectors and verification over loose generic catches; this PR keeps existing provider-specific patterns and only adds a constrained assignment fallback: https://github.com/trufflesecurity/trufflehog

## Verification

- `cargo test -p harn-vm replaces_sensitive_assignments_inside_text --lib`
- `cargo test -p harn-vm looks_like_secret_value_accepts_logical_secret_references --lib`
- `cargo test -p harn-vm friction_event_normalizes_and_redacts_sensitive_metadata --lib`
- `cargo test -p harn-vm redacts_secret_like_values_in_fixtures --lib`
- `cargo test -p harn-vm validate_rejects_raw_required_secret_values --lib`
- `cargo test -p harn-vm context_pack_manifest_rejects_raw_secret_values --lib`
- `cargo test -p harn-vm default_pattern_names_are_stable --lib`
- `cargo test -p harn-vm redact --lib` (56 passed)
- `npx markdownlint-cli2 changelog.d/shared-redaction-policy.security.md`
- `git diff --check`
- pre-push hook: markdownlint + targeted local checks passed
