### PR TITLE
feat(acp): expose MCP status

### DIFF
--- a/.github/actions/configure-cargo-sccache/action.yml
+++ b/.github/actions/configure-cargo-sccache/action.yml
@@ -1,0 +1,25 @@
+name: Configure Cargo sccache
+description: Enable Cargo's sccache wrapper only when it can proxy rustc cleanly.
+
+runs:
+  using: composite
+  steps:
+    - name: Enable healthy sccache wrapper
+      if: env.SCCACHE_PATH != ''
+      shell: bash
+      run: |
+        set -u
+        rustc_bin="${RUSTC:-rustc}"
+        if "${SCCACHE_PATH}" "${rustc_bin}" -vV >/dev/null; then
+          echo "RUSTC_WRAPPER=${SCCACHE_PATH}" >> "${GITHUB_ENV}"
+          echo "sccache is healthy; Cargo will use RUSTC_WRAPPER=${SCCACHE_PATH}"
+        else
+          echo "::warning::sccache could not proxy '${rustc_bin} -vV'; continuing without RUSTC_WRAPPER"
+          echo "RUSTC_WRAPPER=" >> "${GITHUB_ENV}"
+        fi
+    - name: Skip missing sccache wrapper
+      if: env.SCCACHE_PATH == ''
+      shell: bash
+      run: |
+        echo "::notice::SCCACHE_PATH is empty; continuing without RUSTC_WRAPPER"
+        echo "RUSTC_WRAPPER=" >> "${GITHUB_ENV}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,7 @@ jobs:
         # events with "Bad credentials" when api.github.com gates the release
         # lookup; a cold build is a fine fallback, but the job shouldn't fail.
         continue-on-error: true
-      - name: Configure Cargo to use sccache
-        if: env.SCCACHE_PATH != ''
-        run: echo "RUSTC_WRAPPER=${SCCACHE_PATH}" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/configure-cargo-sccache
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         continue-on-error: true
         with:
@@ -234,9 +232,7 @@ jobs:
         # cold compile is a valid fallback; the audit result should not hinge
         # on cache-service availability.
         continue-on-error: true
-      - name: Configure Cargo to use sccache
-        if: env.SCCACHE_PATH != ''
-        run: echo "RUSTC_WRAPPER=${SCCACHE_PATH}" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/configure-cargo-sccache
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         continue-on-error: true
         with:
@@ -481,10 +477,7 @@ jobs:
           components: clippy
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         continue-on-error: true
-      - name: Configure Cargo to use sccache
-        if: env.SCCACHE_PATH != ''
-        shell: bash
-        run: echo "RUSTC_WRAPPER=${SCCACHE_PATH}" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/configure-cargo-sccache
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         continue-on-error: true
         with:
@@ -595,9 +588,7 @@ jobs:
         # events with "Bad credentials" when api.github.com gates the release
         # lookup; a cold build is a fine fallback, but the job shouldn't fail.
         continue-on-error: true
-      - name: Configure Cargo to use sccache
-        if: env.SCCACHE_PATH != ''
-        run: echo "RUSTC_WRAPPER=${SCCACHE_PATH}" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/configure-cargo-sccache
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         continue-on-error: true
         with:

--- a/changelog.d/3350.added.md
+++ b/changelog.d/3350.added.md
@@ -1,0 +1,3 @@
+- Added the ACP `mcp/status` request so clients can read active MCP host
+  status, including authenticated display identity, through the same Harn-owned
+  status source as `harn.mcp.status()`.

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts/constants.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts/constants.rs
@@ -95,6 +95,8 @@ pub(super) const ACP_DISPATCHED_METHODS: &[&str] = &[
     "harn.workflow.resume",
     "mcp/catalog",
     "harn.mcp.catalog",
+    "mcp/status",
+    "harn.mcp.status",
     "mcp/authorize",
     "harn.mcp.authorize",
     "mcp/authorize_batch",

--- a/crates/harn-serve/src/adapters/acp/dispatch.rs
+++ b/crates/harn-serve/src/adapters/acp/dispatch.rs
@@ -284,6 +284,12 @@ impl AcpServer {
                 }
                 self.handle_mcp_catalog(&id, &params);
             }
+            "mcp/status" | "harn.mcp.status" => {
+                if self.reject_unauthenticated(&id) {
+                    return;
+                }
+                self.handle_mcp_status(&id).await;
+            }
             "mcp/authorize" | "harn.mcp.authorize" => {
                 if self.reject_unauthenticated(&id) {
                     return;

--- a/crates/harn-serve/src/adapters/acp/integrations.rs
+++ b/crates/harn-serve/src/adapters/acp/integrations.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+const ACP_MCP_STATUS_SCHEMA_VERSION: u32 = 1;
+
 impl AcpServer {
     pub(super) fn handle_agent_resume(&self, params: &serde_json::Value) {
         let session_id = params
@@ -51,6 +53,15 @@ impl AcpServer {
                 &format!("failed to encode mcp catalog: {error}"),
             ),
         }
+    }
+
+    /// `mcp/status`: expose the active Harn MCP host status to thin clients.
+    /// Harn owns the supervision and identity resolution; ACP only projects the
+    /// reusable VM status into the camelCase wire shape used by integration
+    /// requests.
+    pub(super) async fn handle_mcp_status(&self, id: &serde_json::Value) {
+        let report = mcp_status_report(harn_vm::mcp_host::status().await);
+        self.send_response(id, report);
     }
 
     /// `mcp/authorize`: begin an interactive OAuth authorization for an MCP
@@ -598,6 +609,34 @@ fn authorize_batch_response(
     serde_json::json!({ "flows": flows, "skipped": skipped, "failed": failed })
 }
 
+fn mcp_status_report(statuses: Vec<harn_vm::mcp_host::McpHostStatus>) -> serde_json::Value {
+    let servers = statuses
+        .into_iter()
+        .map(mcp_status_server)
+        .collect::<Vec<_>>();
+    serde_json::json!({
+        "schemaVersion": ACP_MCP_STATUS_SCHEMA_VERSION,
+        "servers": servers,
+    })
+}
+
+fn mcp_status_server(status: harn_vm::mcp_host::McpHostStatus) -> serde_json::Value {
+    serde_json::json!({
+        "name": status.name,
+        "transport": status.transport,
+        "url": status.url,
+        "active": status.active,
+        "lazy": status.lazy,
+        "refCount": status.ref_count,
+        "restartCount": status.restart_count,
+        "consecutiveFailures": status.consecutive_failures,
+        "circuit": status.circuit.as_str(),
+        "ejected": status.ejected,
+        "cacheEntries": status.cache_entries,
+        "displayIdentity": status.display_identity,
+    })
+}
+
 /// Project a driver status event into the camelCase params of an
 /// `mcp/authorize_status` notification (kept camelCase for ACP wire consistency
 /// even though the shared type serializes snake_case for the CLI `--json`).
@@ -619,6 +658,7 @@ mod authorize_batch_tests {
     use harn_vm::mcp_bulk_auth::{
         BulkAuthMode, McpAuthPhase, McpAuthStatus, PrepareOutcome, PreparedFlow,
     };
+    use harn_vm::mcp_host::{BreakerState, McpHostStatus};
     use tokio::sync::mpsc;
 
     #[test]
@@ -740,6 +780,36 @@ mod authorize_batch_tests {
         assert_eq!(with_detail["detail"], "discovery failed");
     }
 
+    #[test]
+    fn mcp_status_report_projects_camelcase_identity_fields() {
+        let report = mcp_status_report(vec![McpHostStatus {
+            name: "Notion".to_string(),
+            transport: "http".to_string(),
+            url: Some("https://mcp.notion.com/mcp".to_string()),
+            active: true,
+            lazy: false,
+            ref_count: 2,
+            restart_count: 1,
+            consecutive_failures: 0,
+            circuit: BreakerState::Closed,
+            ejected: false,
+            cache_entries: 3,
+            display_identity: Some("Jane Doe <jane@acme.com> - Acme".to_string()),
+        }]);
+        assert_eq!(report["schemaVersion"], 1);
+        let server = &report["servers"][0];
+        assert_eq!(server["name"], "Notion");
+        assert_eq!(server["transport"], "http");
+        assert_eq!(server["url"], "https://mcp.notion.com/mcp");
+        assert_eq!(server["refCount"], 2);
+        assert_eq!(server["restartCount"], 1);
+        assert_eq!(server["consecutiveFailures"], 0);
+        assert_eq!(server["circuit"], "closed");
+        assert_eq!(server["cacheEntries"], 3);
+        assert_eq!(server["displayIdentity"], "Jane Doe <jane@acme.com> - Acme");
+        assert!(server.get("display_identity").is_none());
+    }
+
     async fn recv_value(rx: &mut mpsc::UnboundedReceiver<String>) -> serde_json::Value {
         let line = rx.recv().await.expect("a frame");
         serde_json::from_str(&line).expect("valid json frame")
@@ -763,6 +833,25 @@ mod authorize_batch_tests {
         assert_eq!(frame["result"]["flows"].as_array().unwrap().len(), 0);
         assert_eq!(frame["result"]["skipped"].as_array().unwrap().len(), 0);
         assert_eq!(frame["result"]["failed"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn mcp_status_method_returns_versioned_report() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut server =
+            AcpServer::new_with_output(AcpServerConfig::new(None), AcpOutput::Channel(tx));
+        server
+            .handle_incoming_message(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "mcp/status",
+                "params": {}
+            }))
+            .await;
+        let frame = recv_value(&mut rx).await;
+        assert_eq!(frame["id"], 5);
+        assert_eq!(frame["result"]["schemaVersion"], 1);
+        assert!(frame["result"]["servers"].is_array());
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/spec/protocol-artifacts/harn-protocol.rs
+++ b/spec/protocol-artifacts/harn-protocol.rs
@@ -108,6 +108,8 @@ pub const ACP_DISPATCHED_METHOD_WORKFLOW_RESUME: &str = "workflow/resume";
 pub const ACP_DISPATCHED_METHOD_HARN_WORKFLOW_RESUME: &str = "harn.workflow.resume";
 pub const ACP_DISPATCHED_METHOD_MCP_CATALOG: &str = "mcp/catalog";
 pub const ACP_DISPATCHED_METHOD_HARN_MCP_CATALOG: &str = "harn.mcp.catalog";
+pub const ACP_DISPATCHED_METHOD_MCP_STATUS: &str = "mcp/status";
+pub const ACP_DISPATCHED_METHOD_HARN_MCP_STATUS: &str = "harn.mcp.status";
 pub const ACP_DISPATCHED_METHOD_MCP_AUTHORIZE: &str = "mcp/authorize";
 pub const ACP_DISPATCHED_METHOD_HARN_MCP_AUTHORIZE: &str = "harn.mcp.authorize";
 pub const ACP_DISPATCHED_METHOD_MCP_AUTHORIZE_BATCH: &str = "mcp/authorize_batch";
@@ -166,6 +168,8 @@ pub const ACP_DISPATCHED_METHODS: &[&str] = &[
     "harn.workflow.resume",
     "mcp/catalog",
     "harn.mcp.catalog",
+    "mcp/status",
+    "harn.mcp.status",
     "mcp/authorize",
     "harn.mcp.authorize",
     "mcp/authorize_batch",


### PR DESCRIPTION
## Summary
- add authenticated ACP `mcp/status` / `harn.mcp.status` dispatch
- project `harn_vm::mcp_host::status()` into a versioned camelCase ACP report
- include `displayIdentity` so thin clients can show connected-account identity from Harn-owned MCP status

Closes #3350.

## Root cause
Harn main already had CLI JSON schema v3 and the Harn script `harn.mcp.status()` field, but ACP only exposed catalog/authorize/import-token paths. Burin clients using ACP could receive identity after OAuth completion, but had no general status request to refresh active MCP state.

## Validation
- `cargo test -p harn-serve mcp_status --lib`
- `cargo fmt --check`
- `cargo clippy -p harn-serve --lib -- -D warnings`
- pre-push: markdownlint + targeted local checks passed
