### PR TITLE
fix(llm): pin Fireworks gpt-oss to text/heredoc tool channel (json double-escapes \\ source bodies)

### DIFF
--- a/changelog.d/gpt-oss-fireworks-tool-format-text.fixed.md
+++ b/changelog.d/gpt-oss-fireworks-tool-format-text.fixed.md
@@ -1,0 +1,8 @@
+Pin Fireworks-hosted `gpt-oss-*` to the `text` (heredoc) tool channel instead
+of `json`. An empirical A/B (real Fireworks calls, 3 samples per arm, task =
+author a backslash-heavy Zig file) showed the `json` channel corrupts source
+bodies in every sample — gpt-oss double-escapes the backslashes a JSON string
+arg requires (`\\` becomes `\\\\` Zig multiline prefixes, escaped quotes, and
+one run leaked literal `\n`/`\"` for the whole file) — while the escape-free
+heredoc body stayed byte-clean in every sample. Tool-call dispatch succeeded on
+both channels (no heredoc-wrapper regression).

--- a/conformance/tests/scenarios/provider_capabilities_basic.harn
+++ b/conformance/tests/scenarios/provider_capabilities_basic.harn
@@ -99,8 +99,8 @@ pipeline test(task) {
   let fireworks_gpt_oss = provider_capabilities("fireworks", "accounts/fireworks/models/gpt-oss-120b")
   assert(!fireworks_gpt_oss.native_tools, "Fireworks GPT-OSS disables native tools")
   assert(
-    fireworks_gpt_oss.preferred_tool_format == "json",
-    "Fireworks GPT-OSS defaults to JSON text tools",
+    fireworks_gpt_oss.preferred_tool_format == "text",
+    "Fireworks GPT-OSS defaults to heredoc text tools",
   )
   assert(
     fireworks_gpt_oss.text_tool_wire_format_supported,

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -2550,9 +2550,15 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
         // reasoning-off breaks tool calling. Provider catch-all rules carry no
         // reasoning fields, so without a dedicated `*gpt-oss*` row gpt-oss
         // would fall through to reasoning-OFF and the eval loop would bill a
-        // noncommittal. Tool wire support is provider-specific: OpenRouter and
-        // Fireworks use Harn's JSON text-channel tools, while the direct
-        // Cerebras/DeepInfra/Groq routes still use provider-native tools.
+        // noncommittal. Tool wire support is provider-specific: OpenRouter uses
+        // Harn's JSON text-channel tools and Fireworks uses Harn's heredoc
+        // (`text`) text-channel tools, while the direct Cerebras/DeepInfra/Groq
+        // routes still use provider-native tools. Fireworks gpt-oss is pinned to
+        // `text` (not `json`) because a JSON string arg forces the model to
+        // escape backslashes the source code already needs and gpt-oss
+        // double-escapes them — empirically corrupting `\\`-heavy bodies
+        // (e.g. Zig multiline string literals) in every json-channel sample
+        // while the escape-free heredoc body stays byte-clean (2026-06-21 A/B).
         reset();
         for (provider, model, native_tools, preferred_tool_format) in [
             ("openrouter", "openai/gpt-oss-120b", false, "json"),
@@ -2560,7 +2566,7 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
                 "fireworks",
                 "accounts/fireworks/models/gpt-oss-120b",
                 false,
-                "json",
+                "text",
             ),
             ("cerebras", "gpt-oss-120b", true, "native"),
             ("deepinfra", "openai/gpt-oss-120b", true, "native"),

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -1566,7 +1566,7 @@ thinking_block_style = "inline"
 # multiline-string literals) showed `json` corrupts the file body in 3/3 runs
 # (doubled `\\` -> `\\\\` multiline prefixes, escaped quotes `\"name\"`, and one
 # run leaked literal `\n`/`\"` for the whole file) while `text`/heredoc emitted
-# byte-clean Zig in 3/3 — because a JSON string arg forces the model to escape
+# byte-clean Zig in 3/3 because a JSON string arg forces the model to escape
 # the backslashes the Zig source already needs, and gpt-oss double-escapes them.
 # Tool-call dispatch was 3/3 on BOTH channels (no heredoc-wrapper regression).
 # Pin to `text` so escape-free heredoc bodies carry source verbatim.

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -1558,14 +1558,22 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
 
-# Fireworks-hosted GPT-OSS (`accounts/fireworks/models/gpt-oss-120b`) currently
-# bills empty native completions with no dispatchable tool calls in eval JSONL.
-# Keep this route on Harn's fenced-JSON text channel until Fireworks' native
-# tool-call path is proven clean.
+# Fireworks-hosted GPT-OSS (`accounts/fireworks/models/gpt-oss-120b`) bills
+# empty native completions with no dispatchable tool calls in eval JSONL, so it
+# stays off the provider-native channel. Between the two TEXT-channel grammars
+# (`json` fenced-block vs `text` heredoc), an empirical A/B (2026-06-21, real
+# Fireworks calls, 3 samples per arm, task = author a Zig file heavy in `\\`
+# multiline-string literals) showed `json` corrupts the file body in 3/3 runs
+# (doubled `\\` -> `\\\\` multiline prefixes, escaped quotes `\"name\"`, and one
+# run leaked literal `\n`/`\"` for the whole file) while `text`/heredoc emitted
+# byte-clean Zig in 3/3 — because a JSON string arg forces the model to escape
+# the backslashes the Zig source already needs, and gpt-oss double-escapes them.
+# Tool-call dispatch was 3/3 on BOTH channels (no heredoc-wrapper regression).
+# Pin to `text` so escape-free heredoc bodies carry source verbatim.
 [[provider.fireworks]]
 model_match = "accounts/fireworks/models/gpt-oss-*"
 native_tools = false
-preferred_tool_format = "json"
+preferred_tool_format = "text"
 text_tool_wire_format_supported = true
 thinking_modes = ["effort"]
 reasoning_effort_supported = true

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/30-qwen-routed.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/30-qwen-routed.toml
@@ -47,14 +47,22 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
 
-# Fireworks-hosted GPT-OSS (`accounts/fireworks/models/gpt-oss-120b`) currently
-# bills empty native completions with no dispatchable tool calls in eval JSONL.
-# Keep this route on Harn's fenced-JSON text channel until Fireworks' native
-# tool-call path is proven clean.
+# Fireworks-hosted GPT-OSS (`accounts/fireworks/models/gpt-oss-120b`) bills
+# empty native completions with no dispatchable tool calls in eval JSONL, so it
+# stays off the provider-native channel. Between the two TEXT-channel grammars
+# (`json` fenced-block vs `text` heredoc), an empirical A/B (2026-06-21, real
+# Fireworks calls, 3 samples per arm, task = author a Zig file heavy in `\\`
+# multiline-string literals) showed `json` corrupts the file body in 3/3 runs
+# (doubled `\\` -> `\\\\` multiline prefixes, escaped quotes `\"name\"`, and one
+# run leaked literal `\n`/`\"` for the whole file) while `text`/heredoc emitted
+# byte-clean Zig in 3/3 because a JSON string arg forces the model to escape
+# the backslashes the Zig source already needs, and gpt-oss double-escapes them.
+# Tool-call dispatch was 3/3 on BOTH channels (no heredoc-wrapper regression).
+# Pin to `text` so escape-free heredoc bodies carry source verbatim.
 [[provider.fireworks]]
 model_match = "accounts/fireworks/models/gpt-oss-*"
 native_tools = false
-preferred_tool_format = "json"
+preferred_tool_format = "text"
 text_tool_wire_format_supported = true
 thinking_modes = ["effort"]
 reasoning_effort_supported = true

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -3460,15 +3460,16 @@ mod tests {
             "text"
         );
         // GPT-OSS tool defaults are provider-specific: aggregate OpenRouter
-        // and Fireworks routes use Harn's JSON text-channel tools, while direct
-        // native-capable hosts stay on provider-native tool calls.
+        // uses Harn's JSON text-channel tools, Fireworks uses Harn's heredoc
+        // text-channel tools, and direct native-capable hosts stay on
+        // provider-native tool calls.
         assert_eq!(
             default_tool_format("openai/gpt-oss-120b", "openrouter"),
             "json"
         );
         assert_eq!(
             default_tool_format("accounts/fireworks/models/gpt-oss-120b", "fireworks"),
-            "json"
+            "text"
         );
         assert_eq!(default_tool_format("gpt-oss-120b", "cerebras"), "native");
         assert_eq!(

--- a/docs/provider-support.json
+++ b/docs/provider-support.json
@@ -448,18 +448,18 @@
         "provider": "fireworks",
         "model": "accounts/fireworks/models/gpt-oss-120b",
         "display_name": "GPT-OSS 120B (Fireworks)",
-        "tool_format": "json",
+        "tool_format": "text",
         "harn_options": [
           "provider = \"fireworks\"",
           "model = \"accounts/fireworks/models/gpt-oss-120b\"",
-          "tool_format = \"json\"",
+          "tool_format = \"text\"",
           "structured_output_mode = \"native_json\""
         ]
       },
       "capabilities": {
         "native_tools": false,
         "text_tools": true,
-        "preferred_tool_format": "json",
+        "preferred_tool_format": "text",
         "tool_mode_parity": "text_only",
         "structured_output_transport": "none",
         "structured_output_mode": "native_json",

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -58,7 +58,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `deepseek` | `deepseek-v4-flash*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `deepseek` | `deepseek-chat*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | yes |
 | `deepseek` | `deepseek-reasoner*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
-| `fireworks` | `accounts/fireworks/models/gpt-oss-*` | `any` | `effort` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `json` | no | yes | `text_only` | yes | no |
+| `fireworks` | `accounts/fireworks/models/gpt-oss-*` | `any` | `effort` | no | no | no | no | yes | no | no | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
 | `fireworks` | `accounts/fireworks/models/glm-5p*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `json` | yes | yes | `native_unreliable` | yes | yes |
 | `fireworks` | `accounts/fireworks/models/deepseek-v4*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `fireworks` | `accounts/fireworks/models/kimi-k2p*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
@@ -247,7 +247,7 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `deepseek` | `deepseek-v4-pro` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `fireworks` | `accounts/fireworks/models/deepseek-v4-pro` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `fireworks` | `accounts/fireworks/models/glm-5p2` | `json` | `native_unreliable` | - | - | - | - | - | `data not yet collected` |
-| `fireworks` | `accounts/fireworks/models/gpt-oss-120b` | `json` | `text_only` | - | - | - | - | - | `data not yet collected` |
+| `fireworks` | `accounts/fireworks/models/gpt-oss-120b` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
 | `fireworks` | `accounts/fireworks/models/kimi-k2p6` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `gemini` | `gemini-2.5-flash` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `gemini` | `gemini-2.5-pro` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |

--- a/docs/src/provider-support.md
+++ b/docs/src/provider-support.md
@@ -19,7 +19,7 @@ No benchmark summary is baked into this checked-in page. To layer local empirica
 | `Dashscope` | OpenAI-compatible chat completions | `dashscope:qwen3.6*` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `provider_default` | `not_recorded` |
 | `Deepinfra` | OpenAI-compatible chat completions | `deepinfra:deepinfra/Qwen/Qwen3.6-35B-A3B` | `native` | yes | yes | `native` / `native_json` | `enabled` | no | `high` | `not_recorded` |
 | `Deepseek` | OpenAI-compatible chat completions | `deepseek:deepseek-v4-flash` | `native` | yes | yes | `native` / `native_json` | `enabled` | yes | `high` | `not_recorded` |
-| `Fireworks` | OpenAI-compatible chat completions | `fireworks:accounts/fireworks/models/gpt-oss-120b` | `json` | no | yes | `none` / `native_json` | `effort,reasoning_effort` | no | `high` | `not_recorded` |
+| `Fireworks` | OpenAI-compatible chat completions | `fireworks:accounts/fireworks/models/gpt-oss-120b` | `text` | no | yes | `none` / `native_json` | `effort,reasoning_effort` | no | `high` | `not_recorded` |
 | `Gemini API` | Gemini generateContent | `gemini:gemini-2.5-flash` | `native` | yes | yes | `native` / `native_json` | `adaptive,effort,enabled` | yes | `medium` | `not_recorded` |
 | `Groq` | OpenAI-compatible chat completions | `groq:llama-3.1-8b-instant` | `native` | yes | yes | `native` / `native_json` | none | no | `high` | `not_recorded` |
 | `Huggingface` | OpenAI-compatible chat completions | `huggingface:qwen/qwen3.6*` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `provider_default` | `not_recorded` |

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -3787,7 +3787,7 @@
       "tool_support": {
         "native": false,
         "text": true,
-        "preferred_format": "json",
+        "preferred_format": "text",
         "parity": "text_only",
         "tool_search": []
       },


### PR DESCRIPTION
## What

Flip the Fireworks-hosted `gpt-oss-*` row in `capabilities.toml` from
`preferred_tool_format = "json"` to `"text"` (escape-free heredoc). The model
already rides Harn's TEXT channel either way (`native_tools = false`); this PR
only changes which TEXT grammar it uses.

## Why — empirical A/B, not a hunch

Probe: a controlled A/B where the ONLY variable is `tool_format`. Same model
(`accounts/fireworks/models/gpt-oss-120b`, real Fireworks API), same task, same
single `write_zig_file` tool. The task forces the exact failing construct — a
Zig `test` block with `\\`-prefixed multiline string literals embedding an INI
doc (`[server]`, a Windows path `C:\app\data`) and a JSON doc. The tool handler
writes the model's `content` arg verbatim to disk; we then inspect the on-disk
bytes and run `zig ast-check`. 3 samples per arm.

### Results

| metric | `json` | `text` |
|---|---|---|
| tool-call dispatched | **3/3** | **3/3** |
| escaping artifact in file body | **3/3** | **0/3** |
| `zig ast-check` clean | 1/3 | 2/3 |
| AST failures caused by channel escaping | 2/2 | 0/2 |

The single `text` AST failure was a model authoring slip (it dropped a `\\`
prefix inside the body) — not a channel escaping artifact. Every `json` AST
failure was escaping corruption.

### Raw evidence (exact on-disk bytes)

`json` arm, the `[server]` multiline line and the embedded JSON line:

```
\\\\[server]                 <- 4 backslashes; Zig multiline prefix is exactly 2
\\\\root = C:\\\\\\\\app\\\\\\\\data
\\\\{\"name\": \"svc\", \"retries\": 3}   <- escaped quotes leaked into source
```

One `json` sample emitted the ENTIRE file as a JSON-escaped blob (literal `\n`
and `\"` throughout) — `ast-check`: `expected expression, found 'invalid token'`.

`text` arm, same lines, byte-clean:

```
\\[server]                   <- correct 2-backslash Zig multiline prefix
\\root = C:\\app\\data
\\{"name": "svc", "retries": 3}   <- unescaped, exact
```

### Root cause

A JSON string tool-arg forces the model to escape the backslashes the Zig
source *already needs* (`\\` line prefixes, `\\` path separators), and gpt-oss
double-escapes them — so `\\` lands on disk as `\\\\` and the string VALUES gain
stray backslashes (and `\"`). The heredoc (`text`) body has no escaping layer,
so `\\`-heavy code (Zig/Go raw blocks, regex, Windows paths, embedded INI/JSON)
survives intact. Tool-call dispatch was 3/3 on BOTH channels, so the heredoc
wrapper does NOT regress non-edit tool mechanics.

## Verification

- `cargo test -p harn-vm --lib llm::capabilities::` — 69 passed (incl. the
  updated `gpt_oss_requires_reasoning_for_tools_with_provider_specific_tool_wire`
  matrix assertion, now expecting `text` for the Fireworks row).
- `cargo test -p harn-vm --test tool_calling_bootcamp` — 9 passed.
- `rustfmt --check` clean; TOML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)