### PR TITLE
fix(llm): pin OpenRouter gpt-oss to text/heredoc tool channel (json double-escapes \\ source bodies)

### DIFF
--- a/changelog.d/openrouter-gpt-oss-tool-format-text.fixed.md
+++ b/changelog.d/openrouter-gpt-oss-tool-format-text.fixed.md
@@ -1,0 +1,9 @@
+Pin OpenRouter-hosted `openai/gpt-oss-*` to the `text` (heredoc) tool channel
+instead of `json`. The provider-native channel bills noncommittal on this
+aggregate route, so it already rode a TEXT channel; between the two text
+grammars, an empirical A/B (real OpenRouter calls, task = author a
+backslash-heavy Zig file) showed `text` beats `json` on both dispatch (3/3 vs
+2/3) and byte-fidelity (3/3 clean vs 0/3) — gpt-oss double-escapes the
+backslashes a JSON string arg requires and corrupts `\\`-heavy source bodies,
+while the escape-free heredoc carries them verbatim. Same class as the Fireworks
+GPT-OSS flip; direct Cerebras/Groq/DeepInfra GPT-OSS rows keep `native`.

--- a/conformance/tests/scenarios/provider_capabilities_basic.harn
+++ b/conformance/tests/scenarios/provider_capabilities_basic.harn
@@ -89,8 +89,8 @@ pipeline test(task) {
   let openrouter_gpt_oss = provider_capabilities("openrouter", "openai/gpt-oss-120b")
   assert(!openrouter_gpt_oss.native_tools, "OpenRouter GPT-OSS disables native tools")
   assert(
-    openrouter_gpt_oss.preferred_tool_format == "json",
-    "OpenRouter GPT-OSS defaults to JSON text tools",
+    openrouter_gpt_oss.preferred_tool_format == "text",
+    "OpenRouter GPT-OSS defaults to heredoc text tools",
   )
   assert(
     openrouter_gpt_oss.text_tool_wire_format_supported,

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -2550,18 +2550,17 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
         // reasoning-off breaks tool calling. Provider catch-all rules carry no
         // reasoning fields, so without a dedicated `*gpt-oss*` row gpt-oss
         // would fall through to reasoning-OFF and the eval loop would bill a
-        // noncommittal. Tool wire support is provider-specific: OpenRouter uses
-        // Harn's JSON text-channel tools and Fireworks uses Harn's heredoc
-        // (`text`) text-channel tools, while the direct Cerebras/DeepInfra/Groq
-        // routes still use provider-native tools. Fireworks gpt-oss is pinned to
-        // `text` (not `json`) because a JSON string arg forces the model to
-        // escape backslashes the source code already needs and gpt-oss
-        // double-escapes them — empirically corrupting `\\`-heavy bodies
-        // (e.g. Zig multiline string literals) in every json-channel sample
-        // while the escape-free heredoc body stays byte-clean (2026-06-21 A/B).
+        // noncommittal. Tool wire support is provider-specific: OpenRouter and
+        // Fireworks ride Harn's TEXT channel (their provider-native path bills
+        // noncommittal), and within that channel they use the escape-free
+        // heredoc (`text`) grammar rather than fenced-JSON, because gpt-oss
+        // double-escapes the backslashes a JSON string arg requires and corrupts
+        // `\\`-heavy code bodies (empirical A/B 2026-06-21: text beats json on
+        // both dispatch and byte-fidelity). The direct Cerebras/DeepInfra/Groq
+        // routes still use provider-native tools.
         reset();
         for (provider, model, native_tools, preferred_tool_format) in [
-            ("openrouter", "openai/gpt-oss-120b", false, "json"),
+            ("openrouter", "openai/gpt-oss-120b", false, "text"),
             (
                 "fireworks",
                 "accounts/fireworks/models/gpt-oss-120b",

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -4222,13 +4222,19 @@ thinking_block_style = "none"
 # Must NOT carry a Qwen-style `auto_reasoning_overrides = "off"`.
 #
 # OpenRouter's provider-native tool surface is not stable enough to expose as
-# the default abstraction for this aggregate route. Burin's committed-tree smoke
-# (2026-06-19, openrouter/openai/gpt-oss-120b) passes when it selects Harn's
-# JSON text-channel tools, while the old Harn row still recommended native and
-# produced misleading `recommended_format=native requested_format=json`
-# observability. Keep the quirk in the provider matrix: text tools are the
-# recommended route for OpenRouter GPT-OSS, while direct Cerebras/Groq/DeepInfra
-# GPT-OSS rows remain native.
+# the default abstraction for this aggregate route: forced native finishes
+# billed-noncommittal (0 dispatchable tool_calls). Between the two TEXT-channel
+# grammars, an empirical A/B (2026-06-21, real OpenRouter calls, task = author a
+# Zig file heavy in `\\` multiline-string literals) showed `text`/heredoc beats
+# `json` on BOTH axes: dispatch 3/3 vs 2/3, and byte-fidelity 3/3 clean vs 0/3
+# clean. The `json` arm corrupted source bodies the same way every GPT-OSS
+# serving stack does — a JSON string arg forces the model to escape the
+# backslashes the Zig source already needs, and gpt-oss double-escapes them
+# (`\\` -> `\\\\` prefixes, escaped quotes, and a run that collapsed into invalid
+# Zig) — while the escape-free heredoc body carried the source verbatim. Pin to
+# `text`. (Same class as the Fireworks GPT-OSS json->text flip; direct
+# Cerebras/Groq/DeepInfra GPT-OSS rows keep `native`, whose provider-native
+# channel does dispatch cleanly on those stacks.)
 #
 # The OpenRouter sub-provider lottery still matters. `openai/gpt-oss-120b` fans
 # out across many upstreams; even with reasoning ON, some mis-serialize Harmony
@@ -4238,7 +4244,7 @@ thinking_block_style = "none"
 [[provider.openrouter]]
 model_match = "openai/gpt-oss-*"
 native_tools = false
-preferred_tool_format = "json"
+preferred_tool_format = "text"
 structured_output = "native"
 thinking_modes = ["effort"]
 reasoning_effort_supported = true

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/99-openrouter-new-families.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/99-openrouter-new-families.toml
@@ -91,13 +91,19 @@ thinking_block_style = "none"
 # Must NOT carry a Qwen-style `auto_reasoning_overrides = "off"`.
 #
 # OpenRouter's provider-native tool surface is not stable enough to expose as
-# the default abstraction for this aggregate route. Burin's committed-tree smoke
-# (2026-06-19, openrouter/openai/gpt-oss-120b) passes when it selects Harn's
-# JSON text-channel tools, while the old Harn row still recommended native and
-# produced misleading `recommended_format=native requested_format=json`
-# observability. Keep the quirk in the provider matrix: text tools are the
-# recommended route for OpenRouter GPT-OSS, while direct Cerebras/Groq/DeepInfra
-# GPT-OSS rows remain native.
+# the default abstraction for this aggregate route: forced native finishes
+# billed-noncommittal (0 dispatchable tool_calls). Between the two TEXT-channel
+# grammars, an empirical A/B (2026-06-21, real OpenRouter calls, task = author a
+# Zig file heavy in `\\` multiline-string literals) showed `text`/heredoc beats
+# `json` on BOTH axes: dispatch 3/3 vs 2/3, and byte-fidelity 3/3 clean vs 0/3
+# clean. The `json` arm corrupted source bodies the same way every GPT-OSS
+# serving stack does — a JSON string arg forces the model to escape the
+# backslashes the Zig source already needs, and gpt-oss double-escapes them
+# (`\\` -> `\\\\` prefixes, escaped quotes, and a run that collapsed into invalid
+# Zig) — while the escape-free heredoc body carried the source verbatim. Pin to
+# `text`. (Same class as the Fireworks GPT-OSS json->text flip; direct
+# Cerebras/Groq/DeepInfra GPT-OSS rows keep `native`, whose provider-native
+# channel does dispatch cleanly on those stacks.)
 #
 # The OpenRouter sub-provider lottery still matters. `openai/gpt-oss-120b` fans
 # out across many upstreams; even with reasoning ON, some mis-serialize Harmony
@@ -107,7 +113,7 @@ thinking_block_style = "none"
 [[provider.openrouter]]
 model_match = "openai/gpt-oss-*"
 native_tools = false
-preferred_tool_format = "json"
+preferred_tool_format = "text"
 structured_output = "native"
 thinking_modes = ["effort"]
 reasoning_effort_supported = true

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -3459,13 +3459,12 @@ mod tests {
             default_tool_format("qwen/qwen3-coder-flash", "openrouter"),
             "text"
         );
-        // GPT-OSS tool defaults are provider-specific: aggregate OpenRouter
-        // uses Harn's JSON text-channel tools, Fireworks uses Harn's heredoc
-        // text-channel tools, and direct native-capable hosts stay on
-        // provider-native tool calls.
+        // GPT-OSS tool defaults are provider-specific: aggregate OpenRouter and
+        // Fireworks use Harn's heredoc text tools, while direct native-capable
+        // hosts stay on provider-native tool calls.
         assert_eq!(
             default_tool_format("openai/gpt-oss-120b", "openrouter"),
-            "json"
+            "text"
         );
         assert_eq!(
             default_tool_format("accounts/fireworks/models/gpt-oss-120b", "fireworks"),

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -180,7 +180,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `openrouter` | `minimax/minimax-m2*` | `any` | no | no | no | no | no | yes | no | `delimited` | `plain` | `none` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `openrouter` | `z-ai/glm-5*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `text` | yes | yes | `native_unreliable` | yes | yes |
 | `openrouter` | `kwaipilot/kat-coder-pro-v2` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `interchangeable` | yes | yes |
-| `openrouter` | `openai/gpt-oss-*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `json` | no | yes | `text_only` | yes | no |
+| `openrouter` | `openai/gpt-oss-*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `text` | no | yes | `text_only` | yes | no |
 | `openrouter` | `stepfun/step-3.7-flash` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `interchangeable` | yes | yes |
 | `sambanova` | `*deepseek-v3.2*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `interchangeable` | yes | no |
 | `sambanova` | `*deepseek*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
@@ -331,7 +331,7 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `openrouter` | `mistralai/mistral-small-2603` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `moonshotai/kimi-k2.6` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `moonshotai/kimi-k2.7-code` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
-| `openrouter` | `openai/gpt-oss-120b` | `json` | `text_only` | - | - | - | - | - | `data not yet collected` |
+| `openrouter` | `openai/gpt-oss-120b` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `qwen/qwen3-coder` | `text` | `native_unreliable` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `qwen/qwen3.7-max` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `openrouter` | `qwen/qwen3.7-plus` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -10151,7 +10151,7 @@
       "tool_support": {
         "native": false,
         "text": true,
-        "preferred_format": "json",
+        "preferred_format": "text",
         "parity": "text_only",
         "tool_search": []
       },


### PR DESCRIPTION
## What
Flip the OpenRouter `openai/gpt-oss-*` row from `preferred_tool_format = "json"` to `"text"`. The row already has `native_tools = false` (provider-native bills noncommittal on this aggregate route), so it rides a TEXT channel either way — this only changes which text grammar.

## Why — empirical A/B (companion to #3505)
Same probe method as #3505: forced per-run `tool_format`, single `write_zig_file` tool, task = author a Zig file heavy in `\\` multiline-string literals + Windows path + embedded JSON. Real OpenRouter calls.

| metric | native | json | text |
|---|---|---|---|
| dispatch | 0/1 (noncommittal) | 2/3 | **3/3** |
| byte-fidelity (clean Zig) | — | **0/3** | **3/3** |

The `json` arm corrupted bodies the same way every gpt-oss serving stack does — doubled `\\` prefixes, escaped quotes `\"name\"`, and one run collapsed into invalid Zig (`const ini = \{ ... for (ini) |line|`). Root cause: a JSON string tool-arg forces the model to escape the backslashes the Zig source already needs, and gpt-oss double-escapes them. The escape-free heredoc body carried the source verbatim (`\\[server]`, `C:\\app\\data`, `{"name": "svc", "retries": 3}`) in 3/3 samples.

This is the same class as the Fireworks GPT-OSS flip (#3505). Direct Cerebras/Groq/DeepInfra gpt-oss rows are correctly left on `native` — their provider-native channel dispatches 3/3 clean (confirmed in the same sweep), so they don't need a text fallback.

## Verification
- Updated the matrix test `gpt_oss_requires_reasoning_for_tools_with_provider_specific_tool_wire` to assert `text` for the OpenRouter row.
- `rustfmt --check` clean; TOML parses; targeted test run below.

Note: touches the same test fixture array as #3505 (different tuple — fireworks vs openrouter); a 3-way merge resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)