### PR TITLE
fix(mlx): point local MLX route at the live Qwen3.6-35B-A3B coding MoE

### DIFF
--- a/changelog.d/mlx-qwen36-coding-moe-route.fixed.md
+++ b/changelog.d/mlx-qwen36-coding-moe-route.fixed.md
@@ -1,0 +1,14 @@
+Fix the Apple-Silicon MLX local route so `auto`/presets land on real weights.
+The MLX aliases (`mlx-qwen3.6-27b`, `mlx-qwen36-27b`, …) still pointed at
+`unsloth/Qwen3.6-27B-UD-MLX-4bit` — the dense vision model that never finished
+downloading (HF cache held only zero-byte `.incomplete` blobs) — even though
+burin #2717 switched the launcher to the coding-tuned Qwen3.6-35B-A3B MoE served
+via `mlx_lm.server`. Repoint every MLX alias (plus the `MLX_MODEL_ID` defaults
+and the install guidance) to `unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit` (q4) /
+`-8bit` (q8), add the model rows with the shared `qwen3.6-35b-a3b`
+logical_model / equivalence_group so eval aggregation compares the MLX and
+llama.cpp runtimes directly, drop the stale `vision` capability (the MoE is
+text-only), and carry `reserved_tool_call_token = true` on the MLX `*qwen3.6*`
+capability row to match the Qwen3.6 tokenizer's reserved `<tool_call>` tokens.
+The MLX runtime profile still requires a `tool_probe` before native is trusted;
+if `mlx_lm.server` returns empty OpenAI tool_calls the safe pin is fenced-json.

--- a/crates/harn-cli/data/provider_support_notes.toml
+++ b/crates/harn-cli/data/provider_support_notes.toml
@@ -216,21 +216,21 @@ id = "mlx"
 catalog_provider = "mlx"
 display_name = "MLX OpenAI-compatible server"
 endpoint_style = "OpenAI-compatible MLX server"
-recommended_model = "unsloth/Qwen3.6-27B-UD-MLX-4bit"
-recommended_selector = "mlx-qwen3.6-27b"
+recommended_model = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
+recommended_selector = "mlx-qwen3.6"
 recommended_tool_format = "native"
 usage_confidence = "medium"
 recommended_options = [
   'provider = "mlx"',
-  'model = "mlx-qwen3.6-27b"',
+  'model = "mlx-qwen3.6"',
   'tool_format = "native"',
 ]
 notes = [
   "MLX routes use native tools only after the served identity and tool probe match the cataloged model.",
 ]
 caveats = [
-  "`mlx-vlm` server flags vary by release; launch first, then verify with `harn provider-ready mlx`.",
+  "`mlx_lm.server` flags vary by release; launch first, then verify with `harn provider-ready mlx`.",
 ]
 local_setup_notes = [
-  "Run `harn models install local-qwen3.6-27b` for the venv, download, launch, and verification commands.",
+  "Run `harn models install mlx-qwen3.6` for the venv, download, launch, and verification commands.",
 ]

--- a/crates/harn-cli/src/cli/local.rs
+++ b/crates/harn-cli/src/cli/local.rs
@@ -135,7 +135,7 @@ pub(crate) struct LocalStatusArgs {
 #[derive(Debug, Args)]
 pub(crate) struct LocalSwitchArgs {
     /// Model alias or provider-native model id (e.g. `qwen36-coder`,
-    /// `ollama:llama3.2`, `mlx-qwen36-27b`).
+    /// `ollama:llama3.2`, `mlx-qwen3.6`).
     #[arg(
         value_parser = llm_model_completion_parser(),
         hide_possible_values = true

--- a/crates/harn-cli/src/cli/tests/parse_providers.rs
+++ b/crates/harn-cli/src/cli/tests/parse_providers.rs
@@ -553,7 +553,7 @@ fn test_parses_provider_ready_args() {
         "provider-ready",
         "mlx",
         "--model",
-        "mlx-qwen36-27b",
+        "mlx-qwen3.6",
         "--base-url",
         "http://127.0.0.1:8002",
         "--json",
@@ -563,7 +563,7 @@ fn test_parses_provider_ready_args() {
         panic!("expected provider-ready command");
     };
     assert_eq!(args.provider, "mlx");
-    assert_eq!(args.model.as_deref(), Some("mlx-qwen36-27b"));
+    assert_eq!(args.model.as_deref(), Some("mlx-qwen3.6"));
     assert_eq!(args.base_url.as_deref(), Some("http://127.0.0.1:8002"));
     assert!(args.json);
 }

--- a/crates/harn-cli/src/commands/models/install.rs
+++ b/crates/harn-cli/src/commands/models/install.rs
@@ -230,10 +230,10 @@ mod tests {
 
     #[test]
     fn setup_plan_exists_for_mlx_qwen_alias() {
-        let resolved = harn_vm::llm_config::resolve_model_info("local-qwen3.6-27b");
-        let plan = setup_plan_for("local-qwen3.6-27b", &resolved.provider, &resolved.id)
+        let resolved = harn_vm::llm_config::resolve_model_info("mlx-qwen3.6");
+        let plan = setup_plan_for("mlx-qwen3.6", &resolved.provider, &resolved.id)
             .expect("MLX setup plan");
-        assert_eq!(plan.title, "MLX vision-language setup");
+        assert_eq!(plan.title, "MLX local coding setup (Qwen3.6-35B-A3B MoE)");
         assert!(plan.steps.iter().any(|step| step.contains("mlx_lm.server")));
     }
 }

--- a/crates/harn-cli/src/commands/models/install.rs
+++ b/crates/harn-cli/src/commands/models/install.rs
@@ -158,11 +158,11 @@ fn llamacpp_setup_plan(selector: &str, model_id: &str) -> SetupPlan {
 
 fn mlx_setup_plan(selector: &str, _model_id: &str) -> SetupPlan {
     SetupPlan {
-        title: "MLX vision-language setup",
+        title: "MLX local coding setup (Qwen3.6-35B-A3B MoE)",
         steps: vec![
             "Create runtime: `python3 -m venv ~/.harn/mlx-lm && ~/.harn/mlx-lm/bin/pip install -U pip mlx-lm huggingface_hub`".to_string(),
-            "Download Qwen3.6 MLX: `~/.harn/mlx-lm/bin/hf download unsloth/Qwen3.6-27B-UD-MLX-4bit --local-dir ~/models/qwen3.6-27b/Qwen3.6-27B-UD-MLX-4bit`".to_string(),
-            "Launch through Harn: `harn local launch mlx-qwen36-27b --provider mlx --server-command ~/.harn/mlx-lm/bin/mlx_lm.server --model-source ~/models/qwen3.6-27b/Qwen3.6-27B-UD-MLX-4bit`".to_string(),
+            "Download Qwen3.6 MLX: `~/.harn/mlx-lm/bin/hf download unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit --local-dir ~/models/qwen3.6-35b-a3b-mlx/Qwen3.6-35B-A3B-UD-MLX-4bit`".to_string(),
+            "Launch through Harn: `harn local launch mlx-qwen3.6 --provider mlx --server-command ~/.harn/mlx-lm/bin/mlx_lm.server --model-source ~/models/qwen3.6-35b-a3b-mlx/Qwen3.6-35B-A3B-UD-MLX-4bit`".to_string(),
             "If `mlx_lm.server` is on PATH, omit `--server-command`; the provider catalog supplies that default.".to_string(),
             "Export endpoint: `export MLX_BASE_URL=http://127.0.0.1:8002`".to_string(),
             format!("Verify: `harn provider-ready mlx --model {selector}`"),

--- a/crates/harn-cli/src/commands/portal/llm.rs
+++ b/crates/harn-cli/src/commands/portal/llm.rs
@@ -131,7 +131,7 @@ fn default_model_for_provider(provider: &str) -> Option<String> {
         "mlx" => std::env::var("MLX_MODEL_ID")
             .ok()
             .filter(|value| !value.is_empty())
-            .or_else(|| Some("unsloth/Qwen3.6-27B-UD-MLX-4bit".to_string())),
+            .or_else(|| Some("unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit".to_string())),
         "openai" => Some("gpt-4o".to_string()),
         "ollama" => Some("llama3.2".to_string()),
         "openrouter" => Some("Qwen/Qwen3.5-9B".to_string()),

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -2678,8 +2678,8 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
             ("fireworks", "accounts/fireworks/models/qwen3p6-plus"),
             ("dashscope", "qwen3.6-plus"),
             ("local", "Qwen3.6-35B-A3B"),
-            ("mlx", "unsloth/Qwen3.6-27B-UD-MLX-4bit"),
-            ("mlx", "Qwen/Qwen3.6-27B"),
+            ("mlx", "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"),
+            ("mlx", "Qwen/Qwen3.6-35B-A3B"),
         ] {
             let caps = lookup(provider, model);
             assert!(

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -1462,14 +1462,26 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
 
-# Apple Silicon MLX server (mlx-vlm). OpenAI-compat with vision; honors
-# the same `chat_template_kwargs.preserve_thinking` knob as vLLM, since
-# mlx-vlm reuses HF tokenizers / chat templates.
+# Apple Silicon MLX server. Burin's local MLX route is the coding-tuned
+# Qwen3.6-35B-A3B MoE served via `mlx_lm.server` (text MoE, NOT mlx_vlm) — see
+# burin #2717, which retired the never-downloaded dense vision model
+# `unsloth/Qwen3.6-27B-UD-MLX-4bit`. OpenAI-compat; honors the same
+# `chat_template_kwargs.preserve_thinking` knob as vLLM via the HF chat template.
+# These are the SAME weights as the llama.cpp `qwen3.6-35b-a3b` route
+# (shared equivalence_group), so the same tokenizer caveat applies:
+# `reserved_tool_call_token = true` because Qwen3.6 reserves
+# `<tool_call>`/`</tool_call>` as single special tokens — reusing them as
+# heredoc-text delimiters collapses the loop into opener repetition. native is
+# kept to mirror the probe-validated llama.cpp sibling
+# (`qwen3.6-35b-a3b-ud-q4-k-xl`, validated native on 2026-06-05); the MLX
+# runtime profile still requires a `tool_probe` before native is trusted, and if
+# mlx_lm.server's OpenAI tool_calls come back empty the safe pin is fenced-json
+# (`preferred_tool_format = "json"`), matching the generic `*qwen3.6*` routes.
 [[provider.mlx]]
 model_match = "*qwen3.6*"
 native_tools = true
 preferred_tool_format = "native"
-vision = true
+reserved_tool_call_token = true
 structured_output = "native"
 thinking_modes = ["enabled"]
 auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/20-local-ollama.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/20-local-ollama.toml
@@ -361,14 +361,26 @@ prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "inline"
 
-# Apple Silicon MLX server (mlx-vlm). OpenAI-compat with vision; honors
-# the same `chat_template_kwargs.preserve_thinking` knob as vLLM, since
-# mlx-vlm reuses HF tokenizers / chat templates.
+# Apple Silicon MLX server. Burin's local MLX route is the coding-tuned
+# Qwen3.6-35B-A3B MoE served via `mlx_lm.server` (text MoE, NOT mlx_vlm) — see
+# burin #2717, which retired the never-downloaded dense vision model
+# `unsloth/Qwen3.6-27B-UD-MLX-4bit`. OpenAI-compat; honors the same
+# `chat_template_kwargs.preserve_thinking` knob as vLLM via the HF chat template.
+# These are the SAME weights as the llama.cpp `qwen3.6-35b-a3b` route
+# (shared equivalence_group), so the same tokenizer caveat applies:
+# `reserved_tool_call_token = true` because Qwen3.6 reserves
+# `<tool_call>`/`</tool_call>` as single special tokens — reusing them as
+# heredoc-text delimiters collapses the loop into opener repetition. native is
+# kept to mirror the probe-validated llama.cpp sibling
+# (`qwen3.6-35b-a3b-ud-q4-k-xl`, validated native on 2026-06-05); the MLX
+# runtime profile still requires a `tool_probe` before native is trusted, and if
+# mlx_lm.server's OpenAI tool_calls come back empty the safe pin is fenced-json
+# (`preferred_tool_format = "json"`), matching the generic `*qwen3.6*` routes.
 [[provider.mlx]]
 model_match = "*qwen3.6*"
 native_tools = true
 preferred_tool_format = "native"
-vision = true
+reserved_tool_call_token = true
 structured_output = "native"
 thinking_modes = ["enabled"]
 auto_reasoning_overrides = { agent = "off", verify = "off", code = "off" }

--- a/crates/harn-vm/src/llm/catalog_sources/30-aliases/aliases.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/30-aliases/aliases.toml
@@ -315,25 +315,42 @@ id = "qwen3.6-35b-a3b-ud-q4-k-xl"
 provider = "llamacpp"
 tool_format = "native"
 
-# MLX (Apple Silicon).
+# MLX (Apple Silicon). Burin #2717 retired the never-downloaded dense vision
+# model `unsloth/Qwen3.6-27B-UD-MLX-4bit` (HF cache held only zero-byte
+# `.incomplete` blobs) and switched the local MLX route to the coding-tuned
+# Qwen3.6-35B-A3B MoE served via `mlx_lm.server`. Point every MLX alias at the
+# live MoE so `auto`/preset selection lands on real weights. These share the
+# `qwen3.6-35b-a3b` equivalence_group with the llama.cpp GGUF route, so eval
+# aggregation compares the two runtimes directly.
+[aliases."mlx-qwen3.6"]
+id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
+provider = "mlx"
+
+[aliases."mlx-qwen3.6-q4"]
+id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
+provider = "mlx"
+
+[aliases."mlx-qwen3.6-q8"]
+id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-8bit"
+provider = "mlx"
+
+# Back-compat: the old 27B alias names now resolve to the live 35B-A3B MoE so
+# any pinned config keeps working instead of pointing at non-existent weights.
 [aliases.mlx-qwen36-27b]
-id = "unsloth/Qwen3.6-27B-UD-MLX-4bit"
+id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
 provider = "mlx"
 
 [aliases."mlx-qwen3.6-27b"]
-id = "unsloth/Qwen3.6-27B-UD-MLX-4bit"
+id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
 provider = "mlx"
-tool_format = "native"
 
 [aliases."mlx-qwen3.6-27b-q4"]
-id = "unsloth/Qwen3.6-27B-UD-MLX-4bit"
+id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
 provider = "mlx"
-tool_format = "native"
 
 [aliases."local-qwen3.6-27b"]
-id = "unsloth/Qwen3.6-27B-UD-MLX-4bit"
+id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
 provider = "mlx"
-tool_format = "native"
 
 # MiniMax direct API aliases.
 [aliases.minimax]

--- a/crates/harn-vm/src/llm/catalog_sources/30-aliases/tool-calling.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/30-aliases/tool-calling.toml
@@ -38,6 +38,18 @@ streaming_native = "pass"
 fallback_mode = "native"
 last_probe_at = "2026-06-05"
 
+# MLX route now serves the Qwen3.6-35B-A3B MoE via mlx_lm.server (burin #2717).
+# native is UNPROVEN on mlx_lm.server (the runtime profile requires a tool_probe
+# before native is trusted; the validated `native` precedent is the llama.cpp
+# sibling, a different server). Keep native = "unknown" so the readiness/probe
+# path verifies served identity + a one-tool probe before selecting native.
+[alias_tool_calling."mlx-qwen3.6"]
+native = "unknown"
+text = "unknown"
+streaming_native = "unknown"
+fallback_mode = "native"
+failure_reason = "requires_served_identity_and_tool_probe"
+
 [alias_tool_calling."mlx-qwen3.6-27b"]
 native = "unknown"
 text = "unknown"

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/80-local-runtimes.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/80-local-runtimes.toml
@@ -41,16 +41,18 @@ context_window = 262144
 runtime_context_window = 65536
 stream_timeout = 900.0
 capabilities = ["tools", "streaming", "thinking"]
+tier = "mid"
+open_weight = true
+strengths = ["coding"]
 
 # Apple Silicon MLX. Burin #2717 switched the local MLX route from the
 # never-downloaded dense vision model `unsloth/Qwen3.6-27B-UD-MLX-4bit` to the
 # coding-tuned Qwen3.6-35B-A3B MoE served via `mlx_lm.server` (text MoE, no
 # vision). Shares the `qwen3.6-35b-a3b` logical_model / equivalence_group with
 # the llama.cpp GGUF route so eval aggregation treats the two runtimes as the
-# same model and compares them directly.
-tier = "mid"
-open_weight = true
-strengths = ["coding", "agentic"]
+# same model and compares them directly. Keep strengths conservative until
+# `mlx_lm.server` has its own tool/agentic probe evidence; equivalence groups
+# use the least-decorated host baseline for escalation decisions.
 [models."unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"]
 name = "Qwen3.6 35B-A3B (MLX 4-bit)"
 provider = "mlx"
@@ -60,10 +62,10 @@ context_window = 262144
 runtime_context_window = 65536
 stream_timeout = 900.0
 capabilities = ["tools", "streaming", "thinking"]
-
 tier = "mid"
 open_weight = true
-strengths = ["coding", "agentic"]
+strengths = ["coding"]
+
 [models."unsloth/Qwen3.6-35B-A3B-UD-MLX-8bit"]
 name = "Qwen3.6 35B-A3B (MLX 8-bit)"
 provider = "mlx"
@@ -73,11 +75,11 @@ context_window = 262144
 runtime_context_window = 65536
 stream_timeout = 900.0
 capabilities = ["tools", "streaming", "thinking"]
-
-# Local OpenAI-compatible servers (vLLM / bring-your-own).
 tier = "mid"
 open_weight = true
-strengths = ["coding", "vision"]
+strengths = ["coding"]
+
+# Local OpenAI-compatible servers (vLLM / bring-your-own).
 [models."gemma-4-e2b-it"]
 name = "Gemma 4 E2B (local)"
 provider = "local"

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/80-local-runtimes.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/80-local-runtimes.toml
@@ -42,16 +42,37 @@ runtime_context_window = 65536
 stream_timeout = 900.0
 capabilities = ["tools", "streaming", "thinking"]
 
-# Apple Silicon MLX.
+# Apple Silicon MLX. Burin #2717 switched the local MLX route from the
+# never-downloaded dense vision model `unsloth/Qwen3.6-27B-UD-MLX-4bit` to the
+# coding-tuned Qwen3.6-35B-A3B MoE served via `mlx_lm.server` (text MoE, no
+# vision). Shares the `qwen3.6-35b-a3b` logical_model / equivalence_group with
+# the llama.cpp GGUF route so eval aggregation treats the two runtimes as the
+# same model and compares them directly.
 tier = "mid"
 open_weight = true
-strengths = ["coding"]
-[models."unsloth/Qwen3.6-27B-UD-MLX-4bit"]
-name = "Qwen3.6 27B (MLX 4-bit)"
+strengths = ["coding", "agentic"]
+[models."unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"]
+name = "Qwen3.6 35B-A3B (MLX 4-bit)"
 provider = "mlx"
+logical_model = "qwen3.6-35b-a3b"
+equivalence_group = "qwen3.6-35b-a3b"
 context_window = 262144
+runtime_context_window = 65536
 stream_timeout = 900.0
-capabilities = ["tools", "vision", "streaming", "thinking"]
+capabilities = ["tools", "streaming", "thinking"]
+
+tier = "mid"
+open_weight = true
+strengths = ["coding", "agentic"]
+[models."unsloth/Qwen3.6-35B-A3B-UD-MLX-8bit"]
+name = "Qwen3.6 35B-A3B (MLX 8-bit)"
+provider = "mlx"
+logical_model = "qwen3.6-35b-a3b"
+equivalence_group = "qwen3.6-35b-a3b"
+context_window = 262144
+runtime_context_window = 65536
+stream_timeout = 900.0
+capabilities = ["tools", "streaming", "thinking"]
 
 # Local OpenAI-compatible servers (vLLM / bring-your-own).
 tier = "mid"

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -998,25 +998,42 @@ id = "qwen3.6-35b-a3b-ud-q4-k-xl"
 provider = "llamacpp"
 tool_format = "native"
 
-# MLX (Apple Silicon).
+# MLX (Apple Silicon). Burin #2717 retired the never-downloaded dense vision
+# model `unsloth/Qwen3.6-27B-UD-MLX-4bit` (HF cache held only zero-byte
+# `.incomplete` blobs) and switched the local MLX route to the coding-tuned
+# Qwen3.6-35B-A3B MoE served via `mlx_lm.server`. Point every MLX alias at the
+# live MoE so `auto`/preset selection lands on real weights. These share the
+# `qwen3.6-35b-a3b` equivalence_group with the llama.cpp GGUF route, so eval
+# aggregation compares the two runtimes directly.
+[aliases."mlx-qwen3.6"]
+id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
+provider = "mlx"
+
+[aliases."mlx-qwen3.6-q4"]
+id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
+provider = "mlx"
+
+[aliases."mlx-qwen3.6-q8"]
+id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-8bit"
+provider = "mlx"
+
+# Back-compat: the old 27B alias names now resolve to the live 35B-A3B MoE so
+# any pinned config keeps working instead of pointing at non-existent weights.
 [aliases.mlx-qwen36-27b]
-id = "unsloth/Qwen3.6-27B-UD-MLX-4bit"
+id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
 provider = "mlx"
 
 [aliases."mlx-qwen3.6-27b"]
-id = "unsloth/Qwen3.6-27B-UD-MLX-4bit"
+id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
 provider = "mlx"
-tool_format = "native"
 
 [aliases."mlx-qwen3.6-27b-q4"]
-id = "unsloth/Qwen3.6-27B-UD-MLX-4bit"
+id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
 provider = "mlx"
-tool_format = "native"
 
 [aliases."local-qwen3.6-27b"]
-id = "unsloth/Qwen3.6-27B-UD-MLX-4bit"
+id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
 provider = "mlx"
-tool_format = "native"
 
 # MiniMax direct API aliases.
 [aliases.minimax]
@@ -1171,6 +1188,18 @@ text = "unknown"
 streaming_native = "pass"
 fallback_mode = "native"
 last_probe_at = "2026-06-05"
+
+# MLX route now serves the Qwen3.6-35B-A3B MoE via mlx_lm.server (burin #2717).
+# native is UNPROVEN on mlx_lm.server (the runtime profile requires a tool_probe
+# before native is trusted; the validated `native` precedent is the llama.cpp
+# sibling, a different server). Keep native = "unknown" so the readiness/probe
+# path verifies served identity + a one-tool probe before selecting native.
+[alias_tool_calling."mlx-qwen3.6"]
+native = "unknown"
+text = "unknown"
+streaming_native = "unknown"
+fallback_mode = "native"
+failure_reason = "requires_served_identity_and_tool_probe"
 
 [alias_tool_calling."mlx-qwen3.6-27b"]
 native = "unknown"
@@ -2384,16 +2413,37 @@ runtime_context_window = 65536
 stream_timeout = 900.0
 capabilities = ["tools", "streaming", "thinking"]
 
-# Apple Silicon MLX.
+# Apple Silicon MLX. Burin #2717 switched the local MLX route from the
+# never-downloaded dense vision model `unsloth/Qwen3.6-27B-UD-MLX-4bit` to the
+# coding-tuned Qwen3.6-35B-A3B MoE served via `mlx_lm.server` (text MoE, no
+# vision). Shares the `qwen3.6-35b-a3b` logical_model / equivalence_group with
+# the llama.cpp GGUF route so eval aggregation treats the two runtimes as the
+# same model and compares them directly.
 tier = "mid"
 open_weight = true
-strengths = ["coding"]
-[models."unsloth/Qwen3.6-27B-UD-MLX-4bit"]
-name = "Qwen3.6 27B (MLX 4-bit)"
+strengths = ["coding", "agentic"]
+[models."unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"]
+name = "Qwen3.6 35B-A3B (MLX 4-bit)"
 provider = "mlx"
+logical_model = "qwen3.6-35b-a3b"
+equivalence_group = "qwen3.6-35b-a3b"
 context_window = 262144
+runtime_context_window = 65536
 stream_timeout = 900.0
-capabilities = ["tools", "vision", "streaming", "thinking"]
+capabilities = ["tools", "streaming", "thinking"]
+
+tier = "mid"
+open_weight = true
+strengths = ["coding", "agentic"]
+[models."unsloth/Qwen3.6-35B-A3B-UD-MLX-8bit"]
+name = "Qwen3.6 35B-A3B (MLX 8-bit)"
+provider = "mlx"
+logical_model = "qwen3.6-35b-a3b"
+equivalence_group = "qwen3.6-35b-a3b"
+context_window = 262144
+runtime_context_window = 65536
+stream_timeout = 900.0
+capabilities = ["tools", "streaming", "thinking"]
 
 # Local OpenAI-compatible servers (vLLM / bring-your-own).
 tier = "mid"

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -2412,16 +2412,18 @@ context_window = 262144
 runtime_context_window = 65536
 stream_timeout = 900.0
 capabilities = ["tools", "streaming", "thinking"]
+tier = "mid"
+open_weight = true
+strengths = ["coding"]
 
 # Apple Silicon MLX. Burin #2717 switched the local MLX route from the
 # never-downloaded dense vision model `unsloth/Qwen3.6-27B-UD-MLX-4bit` to the
 # coding-tuned Qwen3.6-35B-A3B MoE served via `mlx_lm.server` (text MoE, no
 # vision). Shares the `qwen3.6-35b-a3b` logical_model / equivalence_group with
 # the llama.cpp GGUF route so eval aggregation treats the two runtimes as the
-# same model and compares them directly.
-tier = "mid"
-open_weight = true
-strengths = ["coding", "agentic"]
+# same model and compares them directly. Keep strengths conservative until
+# `mlx_lm.server` has its own tool/agentic probe evidence; equivalence groups
+# use the least-decorated host baseline for escalation decisions.
 [models."unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"]
 name = "Qwen3.6 35B-A3B (MLX 4-bit)"
 provider = "mlx"
@@ -2431,10 +2433,10 @@ context_window = 262144
 runtime_context_window = 65536
 stream_timeout = 900.0
 capabilities = ["tools", "streaming", "thinking"]
-
 tier = "mid"
 open_weight = true
-strengths = ["coding", "agentic"]
+strengths = ["coding"]
+
 [models."unsloth/Qwen3.6-35B-A3B-UD-MLX-8bit"]
 name = "Qwen3.6 35B-A3B (MLX 8-bit)"
 provider = "mlx"
@@ -2444,11 +2446,11 @@ context_window = 262144
 runtime_context_window = 65536
 stream_timeout = 900.0
 capabilities = ["tools", "streaming", "thinking"]
-
-# Local OpenAI-compatible servers (vLLM / bring-your-own).
 tier = "mid"
 open_weight = true
-strengths = ["coding", "vision"]
+strengths = ["coding"]
+
+# Local OpenAI-compatible servers (vLLM / bring-your-own).
 [models."gemma-4-e2b-it"]
 name = "Gemma 4 E2B (local)"
 provider = "local"

--- a/crates/harn-vm/src/llm/readiness.rs
+++ b/crates/harn-vm/src/llm/readiness.rs
@@ -499,17 +499,20 @@ mod tests {
 
     #[test]
     fn model_is_served_accepts_exact_or_prefix() {
-        let models = vec!["unsloth/Qwen3.6-27B-UD-MLX-4bit".to_string()];
-        assert!(model_is_served("unsloth/Qwen3.6-27B-UD-MLX-4bit", &models));
+        let models = vec!["unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit".to_string()];
+        assert!(model_is_served(
+            "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
+            &models
+        ));
         assert!(model_is_served("unsloth/Qwen3.6", &models));
-        assert!(!model_is_served("Qwen/Qwen3.6-27B", &models));
+        assert!(!model_is_served("Qwen/Qwen3.6-35B", &models));
     }
 
     #[tokio::test]
     async fn probe_provider_readiness_verifies_served_model() {
         let (base_url, handle) = spawn_models_stub(
             200,
-            r#"{"data":[{"id":"unsloth/Qwen3.6-27B-UD-MLX-4bit"}]}"#,
+            r#"{"data":[{"id":"unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"}]}"#,
         );
         let result = probe_provider_readiness("mlx", Some("mlx-qwen36-27b"), Some(&base_url)).await;
         handle.join().expect("stub joins");
@@ -517,7 +520,7 @@ mod tests {
         assert_eq!(result.status, ReadinessStatus::Ok);
         assert_eq!(
             result.model.as_deref(),
-            Some("unsloth/Qwen3.6-27B-UD-MLX-4bit")
+            Some("unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit")
         );
     }
 

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -1938,7 +1938,7 @@ pub fn default_model_for_provider(provider: &str) -> String {
             .or_else(|_| std::env::var("HARN_LLM_MODEL"))
             .unwrap_or_else(|_| "gemma-4-26b-a4b-it".to_string()),
         "mlx" => std::env::var("MLX_MODEL_ID")
-            .unwrap_or_else(|_| "unsloth/Qwen3.6-27B-UD-MLX-4bit".to_string()),
+            .unwrap_or_else(|_| "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit".to_string()),
         "openai" => "gpt-4o-mini".to_string(),
         "ollama" => "llama3.2".to_string(),
         "openrouter" => "anthropic/claude-sonnet-4.6".to_string(),
@@ -3242,7 +3242,7 @@ mod tests {
         );
 
         let (model, provider) = resolve_model("mlx-qwen36-27b");
-        assert_eq!(model, "unsloth/Qwen3.6-27B-UD-MLX-4bit");
+        assert_eq!(model, "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit");
         assert_eq!(provider.as_deref(), Some("mlx"));
     }
 

--- a/docs/provider-support.json
+++ b/docs/provider-support.json
@@ -883,14 +883,14 @@
       "classification": "local",
       "auth_env": [],
       "recommended": {
-        "selector": "mlx-qwen3.6-27b",
+        "selector": "mlx-qwen3.6",
         "provider": "mlx",
-        "model": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
-        "display_name": null,
+        "model": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
+        "display_name": "Qwen3.6 35B-A3B (MLX 4-bit)",
         "tool_format": "native",
         "harn_options": [
           "provider = \"mlx\"",
-          "model = \"mlx-qwen3.6-27b\"",
+          "model = \"mlx-qwen3.6\"",
           "tool_format = \"native\""
         ]
       },
@@ -924,11 +924,11 @@
         "MLX routes use native tools only after the served identity and tool probe match the cataloged model."
       ],
       "caveats": [
-        "`mlx-vlm` server flags vary by release; launch first, then verify with `harn provider-ready mlx`."
+        "`mlx_lm.server` flags vary by release; launch first, then verify with `harn provider-ready mlx`."
       ],
       "mcp_notes": [],
       "local_setup_notes": [
-        "Run `harn models install local-qwen3.6-27b` for the venv, download, launch, and verification commands."
+        "Run `harn models install mlx-qwen3.6` for the venv, download, launch, and verification commands."
       ]
     },
     {

--- a/docs/provider-support.json
+++ b/docs/provider-support.json
@@ -886,7 +886,7 @@
         "selector": "mlx-qwen3.6-27b",
         "provider": "mlx",
         "model": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
-        "display_name": "Qwen3.6 27B (MLX 4-bit)",
+        "display_name": null,
         "tool_format": "native",
         "harn_options": [
           "provider = \"mlx\"",

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1185,7 +1185,7 @@ Probe a configured provider's `/models` endpoint and optionally require a
 specific model alias or provider-native model id.
 
 ```bash
-harn provider-ready mlx --model mlx-qwen36-27b
+harn provider-ready mlx --model mlx-qwen3.6
 harn provider-ready mlx --base-url http://127.0.0.1:8002 --json
 ```
 
@@ -1221,7 +1221,7 @@ pipelines.
 
 ```bash
 harn provider-probe ollama --model devstral-small-2
-harn provider-probe mlx --model mlx-qwen36-27b --base-url http://127.0.0.1:8002
+harn provider-probe mlx --model mlx-qwen3.6 --base-url http://127.0.0.1:8002
 ```
 
 ## harn provider-tool-probe
@@ -1245,7 +1245,7 @@ Bring a local model up through Harn's provider catalog:
 ```bash
 harn local launch devstral-small-2:24b --provider ollama --json
 harn local launch local-qwen3.6 --provider llamacpp --model-source ~/models/qwen3.6/Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf --ctx 8192
-harn local launch mlx-qwen36-27b --provider mlx --model-source unsloth/Qwen3.6-27B-UD-MLX-4bit
+harn local launch mlx-qwen3.6 --provider mlx --model-source unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit
 ```
 
 Ollama launch warms the daemon and persists the active selection. llama.cpp

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -22,7 +22,7 @@ ollama-gemma4` to resolve Harn aliases and pull the matching Ollama model.
 Ollama has no working qwen3.x route — its qwen3.5-family server-side tool-call
 parser 500s on Harn's text-tool output — so use the llamacpp provider for local
 qwen3.x. For non-Ollama local runtimes, `harn models install
-local-qwen3.6-gguf` and `harn models install local-qwen3.6-27b` print concrete
+local-qwen3.6-gguf` and `harn models install mlx-qwen3.6` print concrete
 llama.cpp / MLX download, launch, context-window, endpoint, and
 `provider-ready` verification commands.
 
@@ -44,7 +44,7 @@ family-level guidance, endpoint notes, and downstream JSON support data.
 | Ollama | `OLLAMA_HOST` (optional) | `devstral-small-2` when installed, otherwise `llama3.2` |
 | Local server | `LOCAL_LLM_BASE_URL` | `LOCAL_LLM_MODEL` or explicit `model` |
 | llama.cpp server | `LLAMACPP_BASE_URL` | explicit `model` from `/v1/models` |
-| MLX OpenAI-compatible server | `MLX_BASE_URL` | `MLX_MODEL_ID` or `mlx-qwen36-27b` |
+| MLX OpenAI-compatible server | `MLX_BASE_URL` | `MLX_MODEL_ID` or `mlx-qwen3.6` |
 
 Ollama runs locally and doesn't require an API key. The default host is
 `http://localhost:11434`.
@@ -73,9 +73,9 @@ responsible for cleanup.
 
 For an Apple Silicon MLX OpenAI-compatible server, Harn uses
 `MLX_BASE_URL` with a default of `http://127.0.0.1:8002`. Run
-`harn provider-ready mlx --model mlx-qwen36-27b` to probe `/v1/models`
+`harn provider-ready mlx --model mlx-qwen3.6` to probe `/v1/models`
 and verify that the configured model or alias is currently served. `harn local
-launch mlx-qwen36-27b --provider mlx --model-source <mlx-path-or-hf-repo>`
+launch mlx-qwen3.6 --provider mlx --model-source <mlx-path-or-hf-repo>`
 uses the catalog's MLX launch shape (`mlx_lm.server`, host, port, readiness)
 and stores a tracked PID for `harn local stop`.
 
@@ -96,7 +96,7 @@ harn local status
 # Ollama warms the daemon; llama.cpp/MLX launch a tracked process.
 harn local launch devstral-small-2:24b --provider ollama
 harn local launch local-qwen3.6 --provider llamacpp --model-source ~/models/qwen3.6/Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf --ctx 8192
-harn local launch mlx-qwen36-27b --provider mlx --model-source unsloth/Qwen3.6-27B-UD-MLX-4bit
+harn local launch mlx-qwen3.6 --provider mlx --model-source unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit
 
 # Warm a model on its provider, evict conflicting local runtimes
 # (drains Ollama's loaded set, stops tracked llama.cpp/MLX PIDs), and
@@ -563,7 +563,7 @@ respects `HARN_OLLAMA_NUM_CTX` (or the catalog's
 - Endpoint: `<MLX_BASE_URL>/v1/chat/completions`
 - Readiness probe: `<MLX_BASE_URL>/v1/models`
 - Default host: `http://127.0.0.1:8002`
-- Default alias: `mlx-qwen36-27b`
+- Default alias: `mlx-qwen3.6`
 - No authentication required
 
 ## Provider resolution order

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -96,7 +96,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `mistral` | `mistral-medium-3-5*` | `any` | `effort` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
 | `mistral` | `mistral-*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `mistral` | `devstral-*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
-| `mlx` | `*qwen3.6*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `mlx` | `*qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `mlx` | `*qwen3*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `moonshot` | `*kimi-k2.7-code*` | `any` | `enabled` | yes | no | no | yes | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `json` | yes | yes | `native_unreliable` | yes | yes |
 | `moonshot` | `*kimi*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
@@ -276,7 +276,8 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `mistral` | `mistral-large-2512` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `mistral` | `mistral-medium-3-5` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `mistral` | `mistral-small-2603` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
-| `mlx` | `unsloth/Qwen3.6-27B-UD-MLX-4bit` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `mlx` | `unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `mlx` | `unsloth/Qwen3.6-35B-A3B-UD-MLX-8bit` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `moonshot` | `moonshot/kimi-k2.6` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `moonshot` | `moonshot/kimi-k2.7-code` | `json` | `native_unreliable` | - | - | - | - | - | `data not yet collected` |
 | `moonshot` | `moonshot/kimi-k2.7-code-highspeed` | `json` | `native_unreliable` | - | - | - | - | - | `data not yet collected` |

--- a/docs/src/provider-support.md
+++ b/docs/src/provider-support.md
@@ -27,7 +27,7 @@ No benchmark summary is baked into this checked-in page. To layer local empirica
 | `OpenAI-compatible local server` | OpenAI-compatible chat completions | `local-gemma4` | `text` | yes | yes | `native` / `delimited` | `enabled` | no | `low` | `not_recorded` |
 | `Minimax` | OpenAI-compatible chat completions | `minimax:MiniMax-M2.5-highspeed` | `native` | yes | yes | `delimited` / `delimited` | `enabled` | yes | `high` | `not_recorded` |
 | `Mistral via OpenRouter` | OpenAI-compatible chat completions through OpenRouter | `openrouter:mistralai/mistral-small-2603` | `native` | yes | yes | `native` / `native_json` | none | yes | `medium` | `not_recorded` |
-| `MLX OpenAI-compatible server` | OpenAI-compatible MLX server | `mlx-qwen3.6-27b` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `medium` | `not_recorded` |
+| `MLX OpenAI-compatible server` | OpenAI-compatible MLX server | `mlx-qwen3.6` | `native` | yes | yes | `native` / `delimited` | `disable_directive:/no_think,enabled` | no | `medium` | `not_recorded` |
 | `Moonshot` | OpenAI-compatible chat completions | `moonshot:moonshot/kimi-k2.6` | `native` | yes | yes | `native` / `native_json` | `enabled` | yes | `high` | `not_recorded` |
 | `Nvidia` | OpenAI-compatible chat completions | `nvidia:nvidia/minimax-m2.7` | `native` | yes | yes | `delimited` / `delimited` | `enabled` | yes | `high` | `not_recorded` |
 | `Ollama` | Ollama native chat API | `devstral-small-2` | `text` | no | yes | `format_kw` / `delimited` | none | no | `high` | `not_recorded` |
@@ -209,13 +209,13 @@ MCP notes:
 ### MLX OpenAI-compatible server
 
 - catalog provider: `mlx`
-- recommended route: `mlx-qwen3.6-27b` (`unsloth/Qwen3.6-27B-UD-MLX-4bit`)
+- recommended route: `mlx-qwen3.6` (`unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit`)
 - endpoint style: OpenAI-compatible MLX server
 - recommended Harn options:
 
 ```toml
 provider = "mlx"
-model = "mlx-qwen3.6-27b"
+model = "mlx-qwen3.6"
 tool_format = "native"
 ```
 
@@ -225,11 +225,11 @@ Notes:
 
 Caveats:
 
-- `mlx-vlm` server flags vary by release; launch first, then verify with `harn provider-ready mlx`.
+- `mlx_lm.server` flags vary by release; launch first, then verify with `harn provider-ready mlx`.
 
 Local setup:
 
-- Run `harn models install local-qwen3.6-27b` for the venv, download, launch, and verification commands.
+- Run `harn models install mlx-qwen3.6` for the venv, download, launch, and verification commands.
 
 ### Ollama
 

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -5953,21 +5953,25 @@
       ]
     },
     {
-      "id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
-      "name": "Qwen3.6 27B (MLX 4-bit)",
+      "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
+      "name": "Qwen3.6 35B-A3B (MLX 4-bit)",
       "provider": "mlx",
       "aliases": [
         "local-qwen3.6-27b",
+        "mlx-qwen3.6",
         "mlx-qwen3.6-27b",
         "mlx-qwen3.6-27b-q4",
+        "mlx-qwen3.6-q4",
         "mlx-qwen36-27b"
       ],
       "context_window": 262144,
+      "logical_model": "qwen3.6-35b-a3b",
+      "equivalence_group": "qwen3.6-35b-a3b",
+      "runtime_context_window": 65536,
       "stream_timeout": 900.0,
       "modalities": {
         "input": [
-          "text",
-          "image"
+          "text"
         ],
         "output": [
           "text"
@@ -6010,7 +6014,6 @@
       "capability_tags": [
         "streaming",
         "tools",
-        "vision",
         "thinking",
         "structured_output"
       ],
@@ -6019,8 +6022,75 @@
       "tier": "mid",
       "open_weight": true,
       "strengths": [
-        "coding",
-        "vision"
+        "coding"
+      ]
+    },
+    {
+      "id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-8bit",
+      "name": "Qwen3.6 35B-A3B (MLX 8-bit)",
+      "provider": "mlx",
+      "aliases": [
+        "mlx-qwen3.6-q8"
+      ],
+      "context_window": 262144,
+      "logical_model": "qwen3.6-35b-a3b",
+      "equivalence_group": "qwen3.6-35b-a3b",
+      "runtime_context_window": 65536,
+      "stream_timeout": 900.0,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": true
+      },
+      "prompt_cache": false,
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [
+        "local"
+      ],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "qwen",
+      "lineage": "qwen3",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "coding"
       ]
     },
     {
@@ -12541,9 +12611,8 @@
     },
     {
       "name": "local-qwen3.6-27b",
-      "model_id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
-      "provider": "mlx",
-      "tool_format": "native"
+      "model_id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
+      "provider": "mlx"
     },
     {
       "name": "local-qwen3.6-gguf",
@@ -12589,10 +12658,21 @@
       "provider": "minimax"
     },
     {
-      "name": "mlx-qwen3.6-27b",
-      "model_id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
+      "name": "mlx-qwen3.6",
+      "model_id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "provider": "mlx",
-      "tool_format": "native",
+      "tool_calling": {
+        "native": "unknown",
+        "text": "unknown",
+        "streaming_native": "unknown",
+        "fallback_mode": "native",
+        "failure_reason": "requires_served_identity_and_tool_probe"
+      }
+    },
+    {
+      "name": "mlx-qwen3.6-27b",
+      "model_id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
+      "provider": "mlx",
       "tool_calling": {
         "native": "unknown",
         "text": "unknown",
@@ -12603,13 +12683,22 @@
     },
     {
       "name": "mlx-qwen3.6-27b-q4",
-      "model_id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
-      "provider": "mlx",
-      "tool_format": "native"
+      "model_id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
+      "provider": "mlx"
+    },
+    {
+      "name": "mlx-qwen3.6-q4",
+      "model_id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
+      "provider": "mlx"
+    },
+    {
+      "name": "mlx-qwen3.6-q8",
+      "model_id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-8bit",
+      "provider": "mlx"
     },
     {
       "name": "mlx-qwen36-27b",
-      "model_id": "unsloth/Qwen3.6-27B-UD-MLX-4bit",
+      "model_id": "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit",
       "provider": "mlx"
     },
     {


### PR DESCRIPTION
## Problem
The Apple-Silicon MLX route was inert. Every MLX alias (`mlx-qwen3.6-27b`, `mlx-qwen36-27b`, `local-qwen3.6-27b`, …) and the `MLX_MODEL_ID` defaults still resolved to `unsloth/Qwen3.6-27B-UD-MLX-4bit` — the dense vision model that **never finished downloading** (its HF cache held only metadata + zero-byte `.incomplete` weight blobs). So `auto`/preset selection on Apple Silicon pointed at non-existent weights.

Burin #2717 already switched the launcher/installer to the coding-tuned **Qwen3.6-35B-A3B MoE** served via `mlx_lm.server`. This aligns the harn catalog with that intent (matching the discarded-then-lost provider-catalog edit).

## Changes
- **Aliases** repointed to `unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit` (q4) + new `mlx-qwen3.6` / `-q4` / `-q8` names; old 27B alias names kept as repointed back-compat.
- **Model rows** added for q4 + q8 with shared `logical_model` / `equivalence_group = "qwen3.6-35b-a3b"` (matches the llama.cpp GGUF route, so eval aggregation compares the two runtimes directly). Dropped the stale `vision` capability — the MoE is text-only.
- **Capability row** (`provider.mlx` `*qwen3.6*`) now carries `reserved_tool_call_token = true` (Qwen3.6 reserves `<tool_call>`/`</tool_call>` as single special tokens — same tokenizer caveat as the llama.cpp sibling). Comment updated from `mlx-vlm` to `mlx_lm.server`.
- **Defaults + guidance**: `MLX_MODEL_ID` fallback, portal fallback, and `harn models install` setup steps now reference the live MoE.
- Regenerated `capabilities.toml` + `providers.toml` from sources; both pass `build-{capabilities,config} --check`.

## tool_format — deliberately NOT flipped
The coordinator hypothesis was that a small local MoE via `mlx_lm.server` might need text/heredoc over native. I could not test it: **no `mlx_lm.server` was running** on the Mac (only Ollama on :11434), and per the conserve-hardware rule I did not start a heavy local server. So I left `preferred_tool_format = "native"`, which mirrors the **probe-validated llama.cpp sibling** (`qwen3.6-35b-a3b-ud-q4-k-xl`, validated native on 2026-06-05, same weights). The MLX runtime profile already requires a `tool_probe` before native is trusted, and the `alias_tool_calling` entry keeps `native = "unknown"` / `failure_reason = "requires_served_identity_and_tool_probe"`, so the readiness path verifies served identity + a one-tool probe before selecting native. **What a user must run** to make this route live: `harn models install` (the updated MLX steps), which downloads `unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit` and launches `mlx_lm.server` on :8002. A follow-up live `mlx_lm.server` tool-probe should confirm native vs fenced-json and pin accordingly.

## Verification
- `providers build-capabilities --check` + `build-config --check` clean (snapshots match sources).
- `cargo test -p harn-vm --lib llm::readiness::tests` + the updated `resolve_model("mlx-qwen36-27b")` / capability-matrix assertions (run on a Linux box).
- `rustfmt --check` clean; TOML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)