### PR TITLE
fix(agent): emit LLM call start checkpoints

### DIFF
--- a/changelog.d/llm-call-start.fixed.md
+++ b/changelog.d/llm-call-start.fixed.md
@@ -1,0 +1,3 @@
+- Agent loops now emit a typed `llm_call_start` checkpoint before each
+  blocking model call so thin hosts can keep liveness timers and run monitors
+  honest during long prompt/model phases.

--- a/conformance/tests/agents/agent_loop_context_overflow_recovery.harn
+++ b/conformance/tests/agents/agent_loop_context_overflow_recovery.harn
@@ -36,6 +36,10 @@ fn overflow_turn() {
   }
 }
 
+fn transcript_has_event_kind(transcript, kind) {
+  return len(transcript_events_by_kind(transcript, kind)) > 0
+}
+
 pipeline main() {
   // (a) Accrue several tool observations so the transcript has masking
   // headroom, hit context_overflow, then recover: emergency compaction archives
@@ -63,9 +67,9 @@ pipeline main() {
         },
       )
       __io_println(result.status)
-      __io_println(contains(json_stringify(result.transcript), "context_overflow_recovery"))
+      __io_println(transcript_has_event_kind(result.transcript, "context_overflow_recovery"))
       __io_println(contains(json_stringify(result.transcript), "\"reason\":\"context_overflow\""))
-      __io_println(!contains(json_stringify(result.transcript), "agent_loop_terminal_error"))
+      __io_println(!transcript_has_event_kind(result.transcript, "agent_loop_terminal_error"))
     },
   )
   // (b) Bounded: when EVERY turn overflows (nothing left to shed once the
@@ -117,7 +121,7 @@ pipeline main() {
         },
       )
       __io_println(result.status)
-      __io_println(!contains(json_stringify(result.transcript), "context_overflow_recovery"))
+      __io_println(!transcript_has_event_kind(result.transcript, "context_overflow_recovery"))
     },
   )
 }

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -149,6 +149,26 @@ fn __llm_provider_error(err, llm_opts) {
   }
 }
 
+fn __agent_loop_emit_llm_call_start(llm_opts) {
+  let session_id = to_string(llm_opts?.session_id ?? "")
+  if session_id == "" {
+    return nil
+  }
+  let checkpoint = {
+    kind: "llm_call_start",
+    phase: "llm_call",
+    iteration: to_int(llm_opts?._iteration ?? 0),
+    attempt: to_int(llm_opts?._truncation_auto_continue_attempt ?? 0) + 1,
+    context_overflow_recovery_attempt: to_int(llm_opts?._context_overflow_recovery_attempt ?? 0),
+    provider: to_string(llm_opts?.provider ?? ""),
+    model: to_string(llm_opts?.model ?? ""),
+    tool_format: to_string(llm_opts?.tool_format ?? ""),
+    final_wrapup: llm_opts?._final_wrapup ?? false,
+  }
+  agent_emit_event(session_id, "typed_checkpoint", checkpoint)
+  return nil
+}
+
 fn __validate_caller_result(r) {
   if type_of(r) != "dict" {
     throw "agent_loop: llm_caller must return a dict; got " + type_of(r)
@@ -165,6 +185,7 @@ fn __validate_caller_result(r) {
 }
 
 fn __invoke_llm(message, turn_system, llm_opts) {
+  __agent_loop_emit_llm_call_start(llm_opts)
   let caller = llm_opts?._llm_caller
   if caller == nil {
     return __default_invoke_llm(message, turn_system, llm_opts)

--- a/crates/harn-vm/tests/agent_loop_final_wrapup.rs
+++ b/crates/harn-vm/tests/agent_loop_final_wrapup.rs
@@ -59,6 +59,72 @@ fn out_lines(raw: &str) -> Vec<String> {
         .collect()
 }
 
+#[test]
+fn agent_loop_emits_llm_call_start_checkpoint_for_main_call() {
+    let raw = run_with_bridge(
+        r#"
+import { agent_capture_events } from "std/agent/events"
+
+fn llm_call_start_events(events) {
+  return events.filter({ event -> event.type == "typed_checkpoint" && event.checkpoint?.kind == "llm_call_start" })
+}
+
+pipeline main(task) {
+  let session = "agent-loop-llm-call-start-" + uuid()
+  let caller = { call -> return {
+    ok: true,
+    value: {
+      text: "<user_response>done</user_response>\n<done>##DONE##</done>",
+      provider: call?.opts?.provider ?? "",
+      model: call?.opts?.model ?? "",
+      input_tokens: 0,
+      output_tokens: 0,
+    },
+  } }
+  let captured = agent_capture_events(
+    session,
+    fn() { return agent_loop(
+      "finish",
+      nil,
+      {
+        provider: "mock",
+        model: "checkpoint-model",
+        session_id: session,
+        llm_caller: caller,
+        loop_until_done: true,
+        done_judge: false,
+        max_iterations: 1,
+        tool_format: "text",
+      },
+    ) },
+  )
+  let starts = llm_call_start_events(captured.events)
+  let checkpoint = starts[0].checkpoint
+  log(captured.result.status)
+  log(len(starts))
+  log(checkpoint.kind)
+  log(checkpoint.iteration)
+  log(checkpoint.attempt)
+  log(checkpoint.provider)
+  log(checkpoint.model)
+  log(checkpoint.tool_format)
+  log(checkpoint.final_wrapup)
+}
+"#,
+    )
+    .expect("script must run");
+    let lines = out_lines(&raw);
+    assert_eq!(lines[0], "done", "lines: {lines:?}");
+    assert_eq!(lines[1], "1", "expected one checkpoint; lines: {lines:?}");
+    assert_eq!(lines[2], "llm_call_start", "lines: {lines:?}");
+    assert_eq!(lines[3], "1", "lines: {lines:?}");
+    assert_eq!(lines[4], "1", "lines: {lines:?}");
+    assert_eq!(lines[5], "mock", "lines: {lines:?}");
+    assert_eq!(lines[6], "checkpoint-model", "lines: {lines:?}");
+    assert_eq!(lines[7], "text", "lines: {lines:?}");
+    assert_eq!(lines[8], "false", "lines: {lines:?}");
+}
+
 /// Pipeline whose stub LLM always emits a tool call until `max_iterations`
 /// runs out. The stub distinguishes the wrap-up call via the `_final_wrapup`
 /// flag the loop sets on `llm_opts`; on that call it returns a clean


### PR DESCRIPTION
## Summary

- Emit an existing `typed_checkpoint` event with `kind: "llm_call_start"` before every agent-loop LLM call.
- Include low-cardinality run metadata: iteration, retry attempt, context-overflow recovery attempt, provider, model, tool format, and final-wrapup flag.
- Add Rust integration coverage through the existing inline Harn agent-loop harness.

## Root cause / why this is general

Dogfood showed a trivial Burin headless task timing out with `ollama-gemma4-12b` before any Ollama request reached the server logs, and the same task on local llama.cpp Qwen3.6 succeeded only after a ~233s TTFT. Thin hosts already reset liveness on inbound agent frames; the missing piece was a deterministic lifecycle frame immediately before a blocking model call, not a model-specific timeout bump.

This uses `typed_checkpoint` instead of `progress_reported` so model/tool-authored user progress streams stay clean.

External context checked while root-causing:
- Ollama has a current Gemma 4 12B slow/unreliable issue: https://github.com/ollama/ollama/issues/16562
- Qwen documents llama.cpp support for Qwen3/Qwen3MoE: https://qwen.readthedocs.io/en/latest/run_locally/llama.cpp.html

## Verification

- `target/debug/harn fmt --check crates/harn-stdlib/src/stdlib/agent/loop.harn`
- `cargo fmt --check`
- `git diff --check`
- `target/debug/deps/agent_loop_final_wrapup-3762bfd2964856b2 agent_loop_emits_llm_call_start_checkpoint_for_main_call --exact --nocapture`
- Pre-push hook passed: markdownlint, targeted local checks, affected Harn fmt/lint, generated highlight keyword check.

