### PR TITLE
fix(release): label version bump PRs

### DIFF
--- a/changelog.d/release-bump-changelog-label.fixed.md
+++ b/changelog.d/release-bump-changelog-label.fixed.md
@@ -1,0 +1,4 @@
+- **Release bump PRs now satisfy the changelog-fragment gate automatically.**
+  The legacy `release_ship.sh --bump` recovery path labels pure version-bump
+  PRs with `no-changelog-needed` before enabling auto-merge, matching the
+  gate's documented bypass for version-only release paperwork.

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -501,6 +501,9 @@ EOF
       --body-file "$body_file")"
     echo "$pr_url"
 
+    log_step "Label bump PR"
+    gh pr edit "$pr_url" --add-label "no-changelog-needed"
+
     log_step "Enable bump PR auto-merge"
     gh pr merge "$pr_url" --auto --squash
   else


### PR DESCRIPTION
## Summary
- label legacy release version-bump PRs with `no-changelog-needed` immediately after creation
- keep the changelog-fragment gate strict while avoiding false failures on pure release paperwork
- add a release-hygiene changelog fragment for this maintainer-facing fix

## Root Cause
`release_ship.sh --bump` opens pure version-bump recovery PRs that touch `Cargo.toml`/`Cargo.lock`; the changelog-fragment gate correctly treats those as potentially user-visible unless the documented bypass label is present. The script armed auto-merge without applying that label, so #3509 failed the gate until labeled manually.

## Validation
- `bash -n scripts/release_ship.sh`
- `git diff --check`