### PR TITLE
docs: use local catalog aliases in LLM examples

### DIFF
--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1077,7 +1077,7 @@ log(response.logprobs)       // present when requested and returned
 | Option | Type | Default | Notes |
 |---|---|---|---|
 | `provider` | string | `"auto"` | Explicit provider wins. `"auto"` infers from `model`; see the resolution table below. |
-| `model` | string | (inferred) | `local:gemma-4-e4b-it` strips the `local:` transport prefix and routes through Ollama. |
+| `model` | string | (inferred) | Use catalog aliases such as `local-gemma4-e4b` for OpenAI-compatible local servers; use `ollama:gemma4:e4b` for Ollama. |
 | `model_role` | string | nil | Fill missing call options from `[model_roles.<role>]` before normal routing. Explicit options win. `model_role: "merge"` / `"fast_apply"` also reads `HARN_LLM_MERGE_*` and `HARN_LLM_FAST_APPLY_*` provider/model/route-policy overrides. |
 | `max_tokens` | int | 16384 | |
 | `temperature` | float | provider default | |
@@ -1528,7 +1528,7 @@ let schema = {
 }
 let verdict = llm_call_structured(prompt, schema, {
   provider: "auto",
-  model: "local:gemma-4-e4b-it",
+  model: "local-gemma4-e4b",
   system: "You are a strict grader.",
 })
 log(verdict.verdict)
@@ -1639,7 +1639,7 @@ trace) alongside the parsed data, call `llm_call` directly:
 ```harn
 let r = llm_call(prompt, sys, {
   provider: "auto",
-  model: "local:gemma-4-e4b-it",
+  model: "local-gemma4-e4b",
   output_schema: schema,
   output_validation: "error",
   schema_retries: 2,
@@ -1685,7 +1685,7 @@ Batch grading at bounded concurrency:
 let outcome = parallel settle paths with { max_concurrent: 4 } { path ->
   llm_call(read_file(path), GRADER_SYSTEM, {
     provider: "auto",
-    model: "local:gemma-4-e4b-it",
+    model: "local-gemma4-e4b",
     output_schema: grader_schema,
     output_validation: "error",
     schema_retries: 2,

--- a/docs/src/scripting-cheatsheet.md
+++ b/docs/src/scripting-cheatsheet.md
@@ -158,7 +158,7 @@ You are a strict grader...
 pub fn grade(path) {
   return llm_call(read_file(path), GRADER_SYSTEM, {
     provider: "auto",
-    model: "local:gemma-4-e4b-it",
+    model: "local-gemma4-e4b",
   })
 }
 ```
@@ -266,7 +266,7 @@ both support `$1`, `$2`, `${name}` backrefs from the `regex` crate.
 ```harn
 let r = llm_call(prompt, system, {
   provider: "auto",        // infers from model prefix
-  model: "local:gemma-4-e4b-it",
+  model: "local-gemma4-e4b",
   output_schema: schema,
   output_validation: "error",
   schema_retries: 2,       // retry with corrective nudge on schema mismatch


### PR DESCRIPTION
## Summary
- replace stale `local:gemma-4-e4b-it` examples with the catalog alias `local-gemma4-e4b`
- clarify the distinction between OpenAI-compatible local servers and Ollama prefixes in the LLM quickref

## Verification
- `make check-docs-snippets` (662 checked, 0 failed)
- `npx markdownlint-cli2 docs/llm/harn-quickref.md docs/src/scripting-cheatsheet.md`
