### PR TITLE
fix(release): avoid interactive tag messages

### DIFF
--- a/changelog.d/release-tag-message.fixed.md
+++ b/changelog.d/release-tag-message.fixed.md
@@ -1,0 +1,2 @@
+- Made `release_ship.sh --finalize` create release tags with an explicit message
+  so signed-tag Git configurations cannot block on an interactive editor.

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -599,7 +599,11 @@ ensure_tag_at_head() {
     fi
     echo "Tag already exists at HEAD: $tag"
   else
-    git tag "$tag"
+    # Some developer machines set tag.gpgSign/tag.forceSignAnnotated. In that
+    # configuration even plain `git tag <name>` can become an annotated signed
+    # tag and open $EDITOR for the message. Finalization must be noninteractive,
+    # so provide the stable release message explicitly.
+    git tag -m "Release $tag" "$tag"
   fi
 }
 


### PR DESCRIPTION
## Summary
- create release tags with an explicit `Release <tag>` message during `release_ship.sh --finalize`
- prevents signed-tag Git configs such as `tag.gpgSign=true` from opening an editor and blocking noninteractive finalization

## Verification
- `bash -n scripts/release_ship.sh`
- `git diff --check`
- `npx markdownlint-cli2 changelog.d/release-tag-message.fixed.md`
- disposable git repo smoke: `GIT_EDITOR=false git tag -m "Release v0.0.0-test" v0.0.0-test` produced a signed tag without editor interaction
