### PR TITLE
fix(vm): detect compact output redirects

### DIFF
--- a/changelog.d/3513.fixed.md
+++ b/changelog.d/3513.fixed.md
@@ -1,0 +1,4 @@
+- **Command policy write-intent scanning now recognizes compact shell output
+  redirects (#3513).** The deterministic scanner now catches file writes such
+  as `cmd>out`, `1>out`, and `2>err` while leaving descriptor duplication and
+  output sinks such as `2>&1`, `>/dev/null`, and `>NUL` unflagged.

--- a/crates/harn-vm/src/orchestration/command_policy.rs
+++ b/crates/harn-vm/src/orchestration/command_policy.rs
@@ -1344,13 +1344,148 @@ fn find_deletes_workspace(args: &[&str]) -> bool {
 }
 
 fn has_write_intent(lower: &str) -> bool {
-    lower.contains(" >")
-        || lower.contains(">>")
+    has_output_redirect_write_intent(lower)
         || lower.contains(" tee ")
         || lower.starts_with("tee ")
+        || lower.contains("|tee ")
+        || lower.contains(";tee ")
         || lower.contains("sed -i")
         || lower.contains("perl -pi")
         || lower.contains("truncate ")
+}
+
+/// Detect unquoted shell output redirects that target files, including compact
+/// forms such as `cmd>out`, `1>out`, and `2>err`. POSIX shells define output
+/// redirection as `[n]>word`; cmd.exe also treats `>` as output redirection.
+/// Do not classify descriptor duplication/close (`2>&1`, `>&-`) or process
+/// device sinks (`>/dev/null`, `>nul`) as file write intent.
+fn has_output_redirect_write_intent(lower: &str) -> bool {
+    let mut quote = QuoteMode::None;
+    let mut escaped = false;
+    let chars = lower.chars().collect::<Vec<_>>();
+    let mut idx = 0;
+    while idx < chars.len() {
+        let ch = chars[idx];
+        if escaped {
+            escaped = false;
+            idx += 1;
+            continue;
+        }
+        if ch == '\\' && quote != QuoteMode::Single {
+            escaped = true;
+            idx += 1;
+            continue;
+        }
+        quote = update_quote_mode(quote, ch);
+        if quote != QuoteMode::None {
+            idx += 1;
+            continue;
+        }
+
+        let amp_redirect = ch == '&' && idx + 1 < chars.len() && chars[idx + 1] == '>';
+        let output_redirect = ch == '>';
+        if amp_redirect || output_redirect {
+            let op_start = idx;
+            let mut op_end = idx + 1;
+            if amp_redirect {
+                op_end += 1;
+            }
+            if op_end < chars.len() && matches!(chars[op_end], '>' | '|') {
+                op_end += 1;
+            }
+            let after_operator = if !amp_redirect && op_end < chars.len() && chars[op_end] == '&' {
+                op_end + 1
+            } else {
+                op_end
+            };
+            let target = redirect_target(&chars, after_operator);
+            if redirect_target_is_write(target.as_deref()) {
+                return true;
+            }
+            idx = op_end.max(op_start + 1);
+            continue;
+        }
+        idx += 1;
+    }
+    false
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum QuoteMode {
+    None,
+    Single,
+    Double,
+}
+
+fn update_quote_mode(mode: QuoteMode, ch: char) -> QuoteMode {
+    match (mode, ch) {
+        (QuoteMode::None, '\'') => QuoteMode::Single,
+        (QuoteMode::Single, '\'') => QuoteMode::None,
+        (QuoteMode::None, '"') => QuoteMode::Double,
+        (QuoteMode::Double, '"') => QuoteMode::None,
+        _ => mode,
+    }
+}
+
+fn redirect_target(chars: &[char], start: usize) -> Option<String> {
+    let mut idx = start;
+    while idx < chars.len() && chars[idx].is_whitespace() {
+        idx += 1;
+    }
+    if idx >= chars.len() {
+        return None;
+    }
+    let mut quote = QuoteMode::None;
+    let mut escaped = false;
+    let mut target = String::new();
+    while idx < chars.len() {
+        let ch = chars[idx];
+        if escaped {
+            target.push(ch);
+            escaped = false;
+            idx += 1;
+            continue;
+        }
+        if ch == '\\' && quote != QuoteMode::Single {
+            escaped = true;
+            idx += 1;
+            continue;
+        }
+        let next_quote = update_quote_mode(quote, ch);
+        if next_quote != quote {
+            quote = next_quote;
+            idx += 1;
+            continue;
+        }
+        if quote == QuoteMode::None
+            && (ch.is_whitespace() || matches!(ch, ';' | '|' | '&' | '<' | '>' | '(' | ')'))
+        {
+            break;
+        }
+        target.push(ch);
+        idx += 1;
+    }
+    let target = target.trim().to_string();
+    (!target.is_empty()).then_some(target)
+}
+
+fn redirect_target_is_write(target: Option<&str>) -> bool {
+    let Some(target) = target else {
+        return true;
+    };
+    if target == "-" || target.bytes().all(|byte| byte.is_ascii_digit()) {
+        return false;
+    }
+    !is_output_sink_target(target)
+}
+
+fn is_output_sink_target(target: &str) -> bool {
+    matches!(
+        target.trim_end_matches(':'),
+        "/dev/null" | "/dev/stdout" | "/dev/stderr" | "nul"
+    ) || target
+        .strip_prefix("/dev/fd/")
+        .is_some_and(|fd| !fd.is_empty() && fd.bytes().all(|byte| byte.is_ascii_digit()))
 }
 
 fn has_curl_pipe_shell(lower: &str) -> bool {
@@ -1685,6 +1820,68 @@ mod tests {
     fn deterministic_scan_detects_outside_workspace_paths() {
         let scan = command_risk_scan_json(&ctx(&["cat", "/etc/passwd"]), None);
         assert!(labels(&scan).contains(&"outside_workspace".to_string()));
+    }
+
+    fn has_write_label(cmd: &str) -> bool {
+        let scan = command_risk_scan_json(&ctx(&["sh", "-c", cmd]), None);
+        labels(&scan).contains(&"write_intent".to_string())
+    }
+
+    #[test]
+    fn deterministic_scan_detects_compact_output_redirect_writes() {
+        // POSIX shells define output redirection as `[n]>word`, so spaces
+        // around `>` are optional. cmd.exe follows the same compact `>file`
+        // shape for output-to-file redirection.
+        for cmd in [
+            "python gen.py>out.txt",
+            "python gen.py >out.txt",
+            "python gen.py 1>out.txt",
+            "python gen.py 2>errors.log",
+            "python gen.py>>out.txt",
+            "python gen.py 2>>errors.log",
+            "python gen.py>|out.txt",
+            "python gen.py &>combined.log",
+            "python gen.py>&combined.log",
+            "cmd /c echo hi>out.txt",
+            "cmd /c echo hi 2>errors.log",
+            "printf hi |tee out.txt",
+            "printf hi;tee out.txt",
+        ] {
+            assert!(has_write_label(cmd), "expected write_intent: {cmd}");
+        }
+    }
+
+    #[test]
+    fn deterministic_scan_allows_descriptor_redirects_and_sinks() {
+        for cmd in [
+            "python gen.py >/dev/null",
+            "python gen.py> /dev/null",
+            "python gen.py 2>/dev/null",
+            "python gen.py >/dev/stdout",
+            "python gen.py >/dev/stderr",
+            "python gen.py >/dev/fd/1",
+            "python gen.py 2>&1",
+            "python gen.py 1>&2",
+            "python gen.py >&-",
+            "cmd /c echo hi>NUL",
+            "cmd /c echo hi>NUL:",
+        ] {
+            assert!(!has_write_label(cmd), "should not be write_intent: {cmd}");
+        }
+    }
+
+    #[test]
+    fn deterministic_scan_ignores_quoted_redirect_text() {
+        for cmd in [
+            "echo 'literal > out.txt'",
+            "node -e \"if (a>b) console.log(a)\"",
+            "python -c 'print(\"a>b\")'",
+        ] {
+            assert!(
+                !has_write_label(cmd),
+                "quoted text is not a redirect: {cmd}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Harn's deterministic command-policy `write_intent` scanner only caught spaced output redirects (`" >"`) or append redirects (`">>"`). That missed compact but valid shell redirections such as:

- `python gen.py>out.txt`
- `python gen.py 1>out.txt`
- `python gen.py 2>errors.log`
- `cmd /c echo hi>out.txt`

The fix replaces the brittle spaced substring check with a small quote-aware redirect scanner over unquoted shell output redirection operators. It also preserves low-risk boundaries: descriptor duplication/close (`2>&1`, `1>&2`, `>&-`) and output sinks (`>/dev/null`, `>/dev/stdout`, `>/dev/stderr`, `>/dev/fd/1`, `>NUL`) do not get labeled as file write intent.

Primary references used:

- GNU Bash manual: output redirection is `[n]>word`, so no space is required around `>`.
  https://www.gnu.org/software/bash/manual/html_node/Redirections.html
- Microsoft Learn `cmd`: `>` redirects command output to a file in Windows command shell.
  https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd

## Why this belongs in Harn

This is a deterministic command-policy primitive shared by host products. Fixing it in `harn-vm` makes the behavior reusable across Burin-supported languages and shells instead of adding another Burin-only Harn prompt/harness heuristic.

## Verification

- `cargo fmt --all --check`
- `cargo test -p harn-vm orchestration::command_policy --lib -- --nocapture`
  - 12/12 passed, including the new compact redirect, descriptor/sink, and quoted-text regression tests.
- `git log -1 --format='%H %G? %GS'`
  - `9e6cbdddd834881e8485a6ae1bc7ef1f12b84d9e G kennethsinder@gmail.com`
- Repo pre-push checks passed.
