### PR TITLE
fix(harn-vm,agent-loop): recover unclosed-wrapper complete bare calls + cap intra-turn identical-failure fan-out

### DIFF
--- a/changelog.d/fanout-cap.fixed.md
+++ b/changelog.d/fanout-cap.fixed.md
@@ -1,0 +1,8 @@
+- Parser: recover an unclosed `<tool_call>` wrapper around a structurally
+  complete bare `name({ ... <<EOF ... EOF })` call (heredoc sentinel-closed,
+  `})` present, `stop_reason: stop`). It was discarded with a false "TOOL CALL
+  TRUNCATED" diagnostic; a genuinely cut-off body still reports truncation.
+- Agent loop: add `intra_turn_failure_fanout_cap` (default OFF). When one model
+  response fans out a batch of byte-identical *failing* tool calls, collapse the
+  tail after the Kth identical failure into a single synthetic result instead of
+  dispatching every call — the intra-turn analog of the no-progress terminator.

--- a/conformance/tests/agents/agent_loop_intra_turn_failure_fanout_cap.expected
+++ b/conformance/tests/agents/agent_loop_intra_turn_failure_fanout_cap.expected
@@ -1,0 +1,11 @@
+done
+true
+true
+true
+done
+true
+true
+done
+true
+true
+true

--- a/conformance/tests/agents/agent_loop_intra_turn_failure_fanout_cap.harn
+++ b/conformance/tests/agents/agent_loop_intra_turn_failure_fanout_cap.harn
@@ -1,0 +1,154 @@
+/**
+ * FIX A4: intra-turn failing-fan-out cap.
+ *
+ * When ONE model response fans out a batch of byte-identical FAILING tool
+ * calls, harn dispatches them all synchronously with no LLM call / progress
+ * check between, so the cross-turn no-progress terminator fires a whole turn
+ * too late. The `intra_turn_failure_fanout_cap` flag collapses the tail of an
+ * identical-failure fan-out into a single synthetic result.
+ *
+ * This test is also the flag's reachability probe: it proves that flipping the
+ * flag changes dispatch behavior end-to-end (capped vs not), and that distinct
+ * / non-failing batches are never falsely capped.
+ */
+import { llm_text, with_llm_script } from "std/testing"
+
+// `edit` always rejects with a byte-identical error, modelling the live
+// 127×`Error: missing action` fan-out.
+fn rejecting_edit_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "edit",
+    "Edit a file (always rejects in this test).",
+    {
+      handler: { _args ->
+        throw "missing action, expected one of create/patch/replace_body"
+      },
+      parameters: {action: {type: "string", description: "Edit kind"}, path: {type: "string", description: "Path"}},
+      returns: {type: "string"},
+      annotations: {kind: "edit", side_effect_level: "workspace_write"},
+    },
+  )
+  return tools
+}
+
+// A read tool that always SUCCEEDS — distinct successful calls must never trip
+// the failing-fan-out cap.
+fn reading_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "look",
+    "Read a path.",
+    {
+      handler: { args -> "contents of " + (args?.path ?? "") },
+      parameters: {path: {type: "string", description: "Path"}},
+      returns: {type: "string"},
+      annotations: {kind: "read"},
+    },
+  )
+  return tools
+}
+
+fn identical_edit_batch(n) {
+  var calls = []
+  var i = 0
+  while i < n {
+    calls = calls.push({id: "e" + to_string(i), name: "edit", arguments: {path: "a.swift"}})
+    i = i + 1
+  }
+  return calls
+}
+
+fn distinct_look_batch(n) {
+  var calls = []
+  var i = 0
+  while i < n {
+    calls = calls.push({id: "l" + to_string(i), name: "look", arguments: {path: "f" + to_string(i) + ".swift"}})
+    i = i + 1
+  }
+  return calls
+}
+
+pipeline main() {
+  // Scenario 1: 10 byte-identical failing `edit` calls in ONE response, cap=3.
+  // The first 3 dispatch (the streak that trips the cap), the remaining 7 are
+  // collapsed into one synthetic "collapsed remaining identical failing"
+  // result, so history carries the collapse marker.
+  with_llm_script(
+    [{text: "", tool_calls: identical_edit_batch(10)}, llm_text("I see the edits were rejected.")],
+    { ->
+      let result = agent_loop(
+        "Fan out identical failing edits.",
+        nil,
+        {
+          provider: "mock",
+          tools: rejecting_edit_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          done_judge: nil,
+          intra_turn_failure_fanout_cap: 3,
+        },
+      )
+      let calls = llm_mock_calls()
+      let second_turn = json_stringify(calls[1].messages)
+      __io_println(result.status)
+      __io_println(contains(result.tools.rejected, "edit"))
+      __io_println(contains(second_turn, "missing required parameter(s): action"))
+      __io_println(contains(second_turn, "collapsed remaining identical failing"))
+    },
+  )
+  // Scenario 2: same 10 identical failing edits, but flag OFF (default). No
+  // collapse marker — every call dispatched, legacy behavior preserved.
+  with_llm_script(
+    [{text: "", tool_calls: identical_edit_batch(10)}, llm_text("I see the edits were rejected.")],
+    { ->
+      let result = agent_loop(
+        "Fan out identical failing edits, flag off.",
+        nil,
+        {
+          provider: "mock",
+          tools: rejecting_edit_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          done_judge: nil,
+        },
+      )
+      let calls = llm_mock_calls()
+      let second_turn = json_stringify(calls[1].messages)
+      __io_println(result.status)
+      __io_println(contains(result.tools.rejected, "edit"))
+      __io_println(!contains(second_turn, "collapsed remaining identical failing"))
+    },
+  )
+  // Scenario 3: 6 DISTINCT successful `look` calls in ONE response with the cap
+  // flag ON. None fail, so the cap never trips — all 6 results reach history
+  // and no collapse marker appears.
+  with_llm_script(
+    [{text: "", tool_calls: distinct_look_batch(6)}, llm_text("Read them all.")],
+    { ->
+      let result = agent_loop(
+        "Fan out distinct successful reads.",
+        nil,
+        {
+          provider: "mock",
+          tools: reading_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          done_judge: nil,
+          intra_turn_failure_fanout_cap: 3,
+        },
+      )
+      let calls = llm_mock_calls()
+      let second_turn = json_stringify(calls[1].messages)
+      __io_println(result.status)
+      __io_println(contains(second_turn, "contents of f0.swift"))
+      __io_println(contains(second_turn, "contents of f5.swift"))
+      __io_println(!contains(second_turn, "collapsed remaining identical failing"))
+    },
+  )
+}

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -1286,6 +1286,99 @@ fn __resolve_max_concurrent_tools(turn_opts) {
   return 1
 }
 
+/**
+ * Resolve the intra-turn failing-fan-out cap K (#A4). When a single model
+ * response fans out a large batch of byte-identical FAILING tool calls, every
+ * call is dispatched synchronously with no LLM call or progress check between
+ * them, so the cross-turn loop-detector / no-progress terminator fire a whole
+ * turn too late — after all N drain, having burned turn/wall budget and flooded
+ * context with N identical errors (observed: 127 identical `edit` rejections in
+ * ~2.7s on swift-feat). This cap is the intra-turn analog of the cross-turn
+ * no-progress terminator: after the Kth consecutive byte-identical failing
+ * result within ONE batch, the remaining identical calls are skipped and
+ * collapsed into a single synthetic result.
+ *
+ * Default OFF: returns `0` (no cap) unless `intra_turn_failure_fanout_cap` is
+ * set to a positive int. A value of e.g. `3` collapses after 3 identical
+ * failures. Reachability is exercised by the `agent_loop_intra_turn_*`
+ * conformance tests, which prove that flipping the flag changes dispatch
+ * behavior end-to-end.
+ */
+fn __resolve_intra_turn_failure_fanout_cap(turn_opts) {
+  let raw = turn_opts?.intra_turn_failure_fanout_cap
+  if type_of(raw) == "int" && raw > 0 {
+    return raw
+  }
+  return 0
+}
+
+/**
+ * Stable signature of a FAILING dispatch result, used to detect a fan-out of
+ * byte-identical failing calls within one batch. Keyed on (tool_name,
+ * args_hash, normalized failure text) so it is polyglot — it never inspects
+ * language-specific content, only the tool identity, the exact arguments, and
+ * the exact error/observation the tool returned. Returns `nil` for a successful
+ * (or non-result) entry so successes never count toward the cap.
+ */
+fn __intra_turn_failure_signature(result) {
+  if type_of(result) != "dict" {
+    return nil
+  }
+  if __tool_result_ok(result) {
+    return nil
+  }
+  let name = to_string(result?.tool_name ?? result?.name ?? "")
+  let args = result?.arguments ?? {}
+  let failure_text = to_string(result?.error ?? result?.observation ?? result?.rendered_result ?? result?.result ?? "")
+  return sha256(json_stringify({name: name, args: args, failure: failure_text}))
+}
+
+/**
+ * Stable signature of a tool CALL (before dispatch), keyed on (tool_name,
+ * args). Used to skip the tail of a fan-out: once a streak of byte-identical
+ * failing results trips the cap, every remaining call with this same call
+ * signature is collapsed rather than executed. Polyglot — never inspects
+ * language-specific content, only tool identity and exact arguments.
+ */
+fn __intra_turn_call_signature(call) {
+  if type_of(call) != "dict" {
+    return nil
+  }
+  let name = to_string(call?.name ?? call?.tool_name ?? "")
+  let args = call?.arguments ?? {}
+  return sha256(json_stringify({name: name, args: args}))
+}
+
+/**
+ * Synthetic collapsed result that stands in for the identical failing calls
+ * skipped after the fan-out cap tripped. Mirrors the failing-result shape so
+ * downstream rollups (rejected-tool tracking, history) treat it as one failed
+ * call rather than executing N more.
+ */
+fn __intra_turn_collapsed_result(call, sample_result) {
+  let name = to_string(call?.name ?? sample_result?.tool_name ?? "")
+  let observation = "[collapsed remaining identical failing `" + name + "` call(s) "
+    + "from this turn]\n"
+    + "These calls had byte-identical arguments and produced the byte-identical "
+    + "error already shown above, so they were NOT executed. Repeating the same "
+    + "failing call cannot make progress — issue edits one at a time and inspect "
+    + "each result, or change your approach (re-read the file / fix the argument "
+    + "that was rejected) before retrying."
+  return {
+    ok: false,
+    status: "collapsed_identical_failure",
+    tool_name: name,
+    tool_call_id: to_string(call?.id ?? call?.tool_call_id ?? ""),
+    arguments: call?.arguments ?? {},
+    result: nil,
+    rendered_result: observation,
+    observation: observation,
+    error: observation,
+    error_category: "intra_turn_failure_fanout_collapsed",
+    executor: nil,
+  }
+}
+
 fn __callable(value) {
   let kind = type_of(value)
   return kind == "closure" || kind == "function" || kind == "fn"
@@ -1404,6 +1497,7 @@ fn __dispatch_tool_calls(session_id, tool_calls, turn_opts) {
     _max_concurrent_tools: cap,
     _prefetch_next_turn: turn_opts?.prefetch_next_turn ?? false,
     _stop_reason: turn_opts?._stop_reason ?? "",
+    _intra_turn_failure_fanout_cap: __resolve_intra_turn_failure_fanout_cap(turn_opts),
   }
   let caller = turn_opts?._tool_caller
   let raw_dispatch = __dispatch_tool_calls_with_middleware(tool_calls, tools, dispatch_options, cap)
@@ -1430,9 +1524,51 @@ fn __dispatch_tool_calls_with_middleware(tool_calls, tools, options, cap) {
   // completion order so text tool-call parsers that key on
   // declaration order still match.
   if cap <= 1 || len(tool_calls) <= 1 {
+    // Intra-turn failing-fan-out cap (#A4). Dispatch serially; track the count
+    // of consecutive byte-identical FAILING results. Once that streak reaches
+    // the configured cap K, skip the remaining calls whose (tool_name, args)
+    // signature matches the capped one — they would produce the same failure —
+    // and substitute a single synthetic "collapsed" result. This is the
+    // intra-turn analog of the cross-turn no-progress terminator. Default OFF
+    // (`fanout_cap == 0`): the legacy "dispatch every call" behavior is
+    // unchanged unless the flag is set. A success, or any failure/call with a
+    // DIFFERENT signature, resets the streak, so a batch of distinct or
+    // non-failing calls is never capped.
+    let fanout_cap = options?._intra_turn_failure_fanout_cap ?? 0
     var results = []
+    var streak_signature = nil
+    var streak_count = 0
+    var capped_call_signature = nil
+    var capped_sample = nil
+    var collapsed_emitted = false
     for (index, call) in iter(tool_calls).enumerate() {
-      results = results.push(__invoke_tool_with_index(call, index, tools, options))
+      if fanout_cap > 0 && capped_call_signature != nil
+        && __intra_turn_call_signature(call) == capped_call_signature {
+        // Same failing call as the one that tripped the cap — skip dispatch.
+        if !collapsed_emitted {
+          results = results.push(__intra_turn_collapsed_result(call, capped_sample))
+          collapsed_emitted = true
+        }
+        continue
+      }
+      let result = __invoke_tool_with_index(call, index, tools, options)
+      results = results.push(result)
+      if fanout_cap > 0 {
+        let signature = __intra_turn_failure_signature(result)
+        if signature == nil {
+          streak_signature = nil
+          streak_count = 0
+        } else if signature == streak_signature {
+          streak_count = streak_count + 1
+          if streak_count >= fanout_cap {
+            capped_call_signature = __intra_turn_call_signature(call)
+            capped_sample = result
+          }
+        } else {
+          streak_signature = signature
+          streak_count = 1
+        }
+      }
     }
     return results
   }

--- a/crates/harn-vm/src/llm/tools/parse/tagged.rs
+++ b/crates/harn-vm/src/llm/tools/parse/tagged.rs
@@ -235,6 +235,29 @@ pub(crate) fn parse_text_tool_calls_with_tools(
                 }
                 Ok(None) => {}
             }
+            // Canonical bare-call body with an unclosed wrapper (#A2a): the model
+            // emitted a structurally COMPLETE `name({ ... <<EOF ... EOF })` but
+            // omitted the redundant `</tool_call>` close tag. `stop_reason` is
+            // `stop`, not `length` — nothing was truncated, the close tag is just
+            // absent. The bare-call parser is heredoc-aware, so it only yields a
+            // call when the body is genuinely complete (heredoc sentinel-closed,
+            // the call's `)` balanced); a body cut off mid-argument yields no call
+            // (or a parse error) and falls through to the TRUNCATED diagnostic.
+            if let Some(call) = recover_complete_bare_call_body(body, tools_val) {
+                let name = call
+                    .get("name")
+                    .and_then(|name| name.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let args = call
+                    .get("arguments")
+                    .cloned()
+                    .unwrap_or(serde_json::json!({}));
+                canonical_parts.push(text_tool_call_block(&render_canonical_call(&name, &args)));
+                calls.push(call);
+                cursor = bytes.len();
+                continue;
+            }
             let recovered_name = leading_call_name(body, tools_val);
             match recovered_name {
                 Some(name) => errors.push(format!(
@@ -878,6 +901,35 @@ fn stray_tool_call_close_len(src: &str, cursor: usize) -> Option<usize> {
         }
     }
     None
+}
+
+/// Recover a single COMPLETE bare `name({ ... })` call from the body of an
+/// unclosed `<tool_call>` wrapper (#A2a). Value models emit a structurally
+/// complete call — heredoc sentinel-closed, the call's `)` balanced — and
+/// simply omit the redundant `</tool_call>` close tag (observed live across
+/// swift/zig/scala on fw-gpt-oss-120b with `stop_reason: stop`, i.e. the model
+/// finished its turn rather than hitting the output cap). Without this the body
+/// falls through to the "TOOL CALL TRUNCATED" diagnostic and the generated file
+/// is discarded.
+///
+/// `parse_bare_calls_in_body` is heredoc-aware, so it yields a call ONLY when
+/// the body is genuinely complete: a body cut off mid-heredoc or before the
+/// call's closing `)` parses to zero calls (or a parse error), so the caller
+/// correctly falls through to the truncation diagnostic in that case.
+///
+/// Returns `Some(call)` only when EXACTLY ONE well-formed call is present and
+/// no parse error was raised — so a malformed-but-recognizable body still
+/// surfaces its real diagnostic via the existing fall-through path, and a body
+/// carrying multiple bare calls is not silently collapsed to one.
+fn recover_complete_bare_call_body(
+    body: &str,
+    tools_val: Option<&VmValue>,
+) -> Option<serde_json::Value> {
+    let inner = parse_bare_calls_in_body(body, tools_val);
+    if !inner.errors.is_empty() || inner.calls.len() != 1 {
+        return None;
+    }
+    inner.calls.into_iter().next()
 }
 
 /// Best-effort recovery of the tool name from a truncated `<tool_call>` body:

--- a/crates/harn-vm/src/llm/tools/tests/core_parser.rs
+++ b/crates/harn-vm/src/llm/tools/tests/core_parser.rs
@@ -609,3 +609,62 @@ fn ignores_non_tool_function_calls_inside_code_examples() {
         result.errors
     );
 }
+
+// FIX A2a: an unclosed `<tool_call>` wrapper around a structurally COMPLETE
+// bare `name({ ... <<EOF ... EOF })` call (the model omitted the redundant
+// `</tool_call>` close tag, `stop_reason: stop`) must be recovered and
+// dispatched — not discarded with a false "TOOL CALL TRUNCATED" diagnostic.
+#[test]
+fn unclosed_wrapper_complete_bare_heredoc_call_recovers() {
+    let tools = sample_tool_registry();
+    // No `</tool_call>` close tag. Heredoc sentinel `EOF` present; the call's
+    // `})` is present. This is a complete call, just missing the close tag.
+    let text = "<tool_call>\nedit({ \"action\": \"create\", \"path\": \"src/main.swift\", \"content\": <<EOF\nimport Foundation\n\nstruct App {\n    static func main() {\n        print(\"hello\")\n    }\n}\nEOF\n})";
+    let parsed = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert_eq!(
+        parsed.errors,
+        Vec::<String>::new(),
+        "complete bare call should not be reported as truncated: {:?}",
+        parsed.errors
+    );
+    assert_eq!(parsed.calls.len(), 1, "calls: {:?}", parsed.calls);
+    assert_eq!(parsed.calls[0]["name"], json!("edit"));
+    assert_eq!(parsed.calls[0]["arguments"]["action"], json!("create"));
+    assert_eq!(
+        parsed.calls[0]["arguments"]["path"],
+        json!("src/main.swift")
+    );
+    let content = parsed.calls[0]["arguments"]["content"].as_str().unwrap();
+    assert!(
+        content.contains("import Foundation"),
+        "content: {content:?}"
+    );
+    assert!(content.contains("print(\"hello\")"), "content: {content:?}");
+    // The recovered call must be re-emitted in canonical tagged form so the
+    // assistant-history replay is well-formed.
+    assert!(
+        parsed.canonical.contains("edit"),
+        "canonical: {:?}",
+        parsed.canonical
+    );
+}
+
+// FIX A2a non-regression: an unclosed `<tool_call>` wrapper whose heredoc body
+// is genuinely cut off mid-argument (no closing `EOF` sentinel, no `})`) is a
+// real truncation and must STILL surface the "TOOL CALL TRUNCATED" diagnostic
+// and dispatch zero calls — never a half-written file.
+#[test]
+fn unclosed_wrapper_truncated_heredoc_still_reports_truncated() {
+    let tools = sample_tool_registry();
+    // Heredoc opened with `<<EOF` but never closed; the call's `})` never
+    // arrives. The output was cut off mid-content.
+    let text = "<tool_call>\nedit({ \"action\": \"create\", \"path\": \"src/main.swift\", \"content\": <<EOF\nimport Foundation\n\nstruct App {\n    static func ";
+    let parsed = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert_eq!(parsed.calls.len(), 0, "calls: {:?}", parsed.calls);
+    assert_eq!(parsed.errors.len(), 1, "errors: {:?}", parsed.errors);
+    assert!(
+        parsed.errors[0].contains("TRUNCATED"),
+        "truncated body should report truncation: {:?}",
+        parsed.errors
+    );
+}


### PR DESCRIPTION
Two generalizable, polyglot-safe harness-runtime fixes from a transcript swarm.

## FIX A2a — unclosed `<tool_call>` wrapper with a COMPLETE bare heredoc body discarded + mislabeled "truncated"

`crates/harn-vm/src/llm/tools/parse/tagged.rs`. The model emits a structurally COMPLETE call but omits the redundant `</tool_call>` close tag:

```
<tool_call>
edit({ "action":"create", "path":"...", "content": <<EOF
...185 lines...
EOF
})
```

Heredoc sentinel `EOF` present, `})` present, `stop_reason: stop` (NOT length) — yet the call was discarded: the unclosed-wrapper recovery had only nested-XML (`<look>{...}`) and function-markup (`<function=edit>`) arms, both of which return `Ok(None)` for a bare body, so it fell to the `leading_call_name` path that emits a false "TOOL CALL TRUNCATED" and drops the recoverable call (21 occurrences across swift/zig/scala on fw-gpt-oss-120b — the whole generated file lost + a `verify_completion` "markup as plain text" rejection).

**Fix:** a third recovery arm after the two existing `Ok(None)` fall-throughs runs the (heredoc-aware) bare-call parser on the unclosed body and dispatches a single complete well-formed call. A body cut off mid-heredoc / before the closing `)` yields no call (or a parse error), so genuine truncation still surfaces the "TRUNCATED" diagnostic.

## FIX A4 — intra-turn fan-out of identical failing calls is ungoverned

`crates/harn-stdlib/src/stdlib/agent/loop.harn`. One model response fanned out 127 distinct `edit` calls, dispatched synchronously in ~2.7s with zero LLM / progress check between, all returning the identical error. The cross-turn loop-detector + no-progress terminator are structurally one turn too late.

**Fix:** `intra_turn_failure_fanout_cap` (default OFF; reachability probed by the conformance test below). In the serial dispatch path, track consecutive byte-identical *failing* results; after the Kth, skip the remaining calls with that same `(tool_name, args)` signature and substitute one synthetic "collapsed" result. Polyglot (signature-based). A success or a different signature resets the streak, so distinct / non-failing batches are never capped.

## Tests

- `core_parser.rs`: `unclosed_wrapper_complete_bare_heredoc_call_recovers` (recovered + dispatched + canonical re-emit); `unclosed_wrapper_truncated_heredoc_still_reports_truncated` (genuine cutoff still TRUNCATED, 0 calls).
- conformance `agent_loop_intra_turn_failure_fanout_cap`: cap fires + collapse marker (cap=3, 10 identical); flag OFF -> no collapse; 6 distinct successful calls -> all execute, no false cap.

`cargo test -p harn-vm`: 3950 pass. Agent conformance: 228 pass. `cargo fmt` + `clippy -D warnings` clean; `harn fmt --check` clean.

These are HARN changes -> they reach Burin eval via the next harn version (or a local build pinned to this rev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
