### PR TITLE
fix(harn-vm): strip storage-only message keys at the Anthropic egress boundary

### DIFF
--- a/changelog.d/anthropic-egress-strip-stored-keys.fixed.md
+++ b/changelog.d/anthropic-egress-strip-stored-keys.fixed.md
@@ -1,0 +1,8 @@
+- Anthropic provider: strip storage-only message keys from outgoing Messages
+  API requests. A durable assistant turn persists a top-level `reasoning` key;
+  echoing it back into `messages[]` triggered a non-retryable HTTP 400
+  (`messages.N.reasoning: Extra inputs are not permitted`) that bricked
+  thinking-enabled direct-Anthropic runs. Only canonical message-level fields
+  (`role`, `content`, `cache_control`) survive the egress boundary; the
+  persisted transcript shape is unchanged, so replay and other providers'
+  adapters still see `message.reasoning`.

--- a/crates/harn-vm/src/llm/providers/anthropic.rs
+++ b/crates/harn-vm/src/llm/providers/anthropic.rs
@@ -46,6 +46,16 @@ pub(crate) fn claude_generation(model: &str) -> Option<(u32, u32)> {
     None
 }
 
+/// Canonical message-level keys the Anthropic Messages API accepts on an
+/// entry of `messages[]`. Any other key (e.g. the storage-only `reasoning`
+/// metadata that `build_assistant_response_message` stamps onto durable
+/// assistant turns, or OpenAI-shape `tool_calls`) triggers a non-retryable
+/// HTTP 400: `messages.N.<key>: Extra inputs are not permitted`. Anthropic
+/// tool turns are projected as `tool_use` content blocks, not a top-level
+/// `tool_calls` array, so this set is intentionally minimal. `cache_control`
+/// is permitted at the message level for prompt caching.
+const ANTHROPIC_MESSAGE_KEYS: &[&str] = &["role", "content", "cache_control"];
+
 /// True for Claude 4.6 and later — the generation where Anthropic
 /// deprecated the assistant-prefill feature. Opus 4.7, Sonnet 4.6/4.7,
 /// any future -4.8+ model all return 400 when the last message has
@@ -213,6 +223,18 @@ impl AnthropicProvider {
                             crate::llm::content::anthropic_content(&content),
                         );
                     }
+                    // Durable transcript turns carry storage-only metadata
+                    // keys (e.g. `reasoning` from
+                    // `build_assistant_response_message`, OpenAI-shape
+                    // `tool_calls`, `private_reasoning`). The Anthropic
+                    // Messages API rejects ANY non-canonical message key with
+                    // a non-retryable HTTP 400 (`messages.N.reasoning: Extra
+                    // inputs are not permitted`). Strip everything except the
+                    // canonical message-level fields at this egress boundary
+                    // ONLY — the persisted transcript shape is unchanged, so
+                    // replay and other providers' adapters still see
+                    // `message.reasoning`.
+                    object.retain(|key, _| ANTHROPIC_MESSAGE_KEYS.contains(&key.as_str()));
                 }
                 message
             })
@@ -547,6 +569,84 @@ mod tests {
             prefill: None,
             reminder_lifecycle: Vec::new(),
         }
+    }
+
+    #[test]
+    fn stored_reasoning_key_stripped_from_outgoing_messages() {
+        // Reproduces the eval-traced HTTP 400: a persisted assistant turn
+        // carries a top-level `reasoning` key (stamped by
+        // build_assistant_response_message) which, if echoed into the
+        // Anthropic request, returns
+        // `messages.1.reasoning: Extra inputs are not permitted`.
+        let mut opts = base_payload();
+        let stored_assistant = serde_json::json!({
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Let me start by understanding..."}],
+            "reasoning": "Let me start by understanding the task.",
+            // OpenAI-shape leakage and other storage-only metadata must also
+            // be stripped at the Anthropic egress boundary.
+            "tool_calls": [{"id": "x", "type": "function"}],
+            "private_reasoning": "hidden",
+        });
+        opts.messages = vec![
+            serde_json::json!({"role": "user", "content": "do the task"}),
+            stored_assistant.clone(),
+            serde_json::json!({"role": "user", "content": "continue"}),
+        ];
+
+        let body = AnthropicProvider::build_request_body(&opts);
+        let messages = body["messages"].as_array().expect("messages array");
+
+        // The persisted assistant turn (messages[1]) must carry ONLY
+        // canonical Anthropic message keys after projection.
+        let assistant = messages[1].as_object().expect("assistant object");
+        assert!(
+            assistant.get("reasoning").is_none(),
+            "non-canonical `reasoning` key rode into the Anthropic request: {assistant:?}"
+        );
+        assert!(assistant.get("tool_calls").is_none());
+        assert!(assistant.get("private_reasoning").is_none());
+        assert_eq!(
+            assistant.get("role").and_then(|v| v.as_str()),
+            Some("assistant")
+        );
+        assert!(
+            assistant.get("content").is_some(),
+            "content must be preserved (replay/answer continuity)"
+        );
+
+        // Replay-preservation: the SOURCE transcript shape is untouched —
+        // build_request_body must not mutate opts.messages in place.
+        assert_eq!(
+            opts.messages[1].get("reasoning").and_then(|v| v.as_str()),
+            Some("Let me start by understanding the task."),
+            "persisted transcript shape must be unchanged at the storage layer"
+        );
+
+        // Canonical round-trip: plain user/assistant turns with no stored
+        // metadata still serialize their content unchanged.
+        assert_eq!(
+            messages[0].get("content").and_then(|v| v.as_str()),
+            Some("do the task")
+        );
+    }
+
+    #[test]
+    fn cache_control_message_key_survives_anthropic_egress() {
+        // `cache_control` is a canonical message-level field for prompt
+        // caching and must NOT be stripped by the egress sanitizer.
+        let mut opts = base_payload();
+        opts.messages = vec![serde_json::json!({
+            "role": "user",
+            "content": "hello",
+            "cache_control": {"type": "ephemeral"},
+        })];
+        let body = AnthropicProvider::build_request_body(&opts);
+        let msg = body["messages"][0].as_object().expect("message object");
+        assert_eq!(
+            msg.get("cache_control"),
+            Some(&serde_json::json!({"type": "ephemeral"}))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The bug (traced to bytes)

A durable assistant turn persists a top-level `reasoning` key (stamped by `build_assistant_response_message` in `tools/messages.rs`). The Anthropic provider's `build_request_body` projected each message's `content` through `anthropic_content` but **preserved every other top-level message key verbatim**, so that stored-only `reasoning` rode straight into `messages[]` on the next request. The Messages API rejects any non-canonical message key with a non-retryable HTTP 400:

```
anthropic HTTP 400 Bad Request [invalid_request]: messages.1.reasoning: Extra inputs are not permitted
```

This bricked thinking-enabled **direct-Anthropic** runs — disabling the frontier-model signal AND the verify-triggered escalation ladder (which targets sonnet via this same adapter).

**Decisive A/B (proves adapter bug, not capability):** a zig-feat eval — `claude-sonnet-4-6` via `anthropic` FAILED in 21s, 0 files, `provider_failure {count:6, terminalCount:6, reason:"invalid_request", retryable:false}`. The **same model via OpenRouter** PASSED the same task (604s, 3 files) — OpenRouter's shim strips the extra key. Same weights, same task, same flags; only the provider egress differs.

## The fix

`crates/harn-vm/src/llm/providers/anthropic.rs` — in `build_request_body`, after projecting `content`, retain only the canonical Anthropic message-level keys (`role`, `content`, `cache_control`) per outgoing turn.

- **Egress-boundary only.** The persisted transcript shape is UNCHANGED — replay and other providers' adapters still see `message.reasoning`.
- **Strip, not map-to-thinking-block.** A synthetic text-only `thinking` block is not a valid substitute: Anthropic rejects modified thinking blocks (a replayed reasoning block needs a valid signature). Stripping is the correct and only safe transformation.
- **Other Anthropic-wire paths immune:** Bedrock's Converse builder reconstructs `{role, content}` from scratch (never copies `reasoning`); Vertex is Gemini-wire.

## Tests

- `stored_reasoning_key_stripped_from_outgoing_messages` — reproduces the 400: stored `reasoning`/`tool_calls`/`private_reasoning` are absent from the outgoing turn, content preserved, and the **source transcript is not mutated** (replay-preservation).
- `cache_control_message_key_survives_anthropic_egress` — guards the whitelist (cache_control is canonical and must survive).

`cargo fmt` + `clippy -D warnings` clean; all 29 anthropic provider tests + 135 provider-slice tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)