### PR TITLE
fix: redact durable operational records

### DIFF
--- a/changelog.d/durable-redaction-boundaries.security.md
+++ b/changelog.d/durable-redaction-boundaries.security.md
@@ -1,0 +1,2 @@
+- Redact run records, action-graph updates, and agent-event durable sinks with
+  the shared redaction policy before writing operational artifacts.

--- a/crates/harn-vm/src/agent_events/sinks.rs
+++ b/crates/harn-vm/src/agent_events/sinks.rs
@@ -174,7 +174,11 @@ impl AgentEventSink for JsonlEventSink {
             frame_depth: None,
             event: event.clone(),
         };
-        if let Ok(line) = serde_json::to_string(&envelope) {
+        let Ok(mut envelope_json) = serde_json::to_value(&envelope) else {
+            return;
+        };
+        crate::redact::current_policy().redact_json_in_place(&mut envelope_json);
+        if let Ok(line) = serde_json::to_string(&envelope_json) {
             // One line, newline-terminated — JSON Lines spec.
             // Errors here are swallowed on purpose; a failing write
             // must never crash the agent loop, and the run record
@@ -213,7 +217,8 @@ impl AgentEventSink for EventLogSink {
         headers.insert("session_id".to_string(), self.session_id.clone());
         let log = self.log.clone();
         let topic = self.topic.clone();
-        let record = EventLogRecord::new(event_kind, payload).with_headers(headers);
+        let mut record = EventLogRecord::new(event_kind, payload).with_headers(headers);
+        record.redact_in_place(&crate::redact::current_policy());
         if let Ok(handle) = tokio::runtime::Handle::try_current() {
             handle.spawn(async move {
                 let _ = log.append(&topic, record).await;

--- a/crates/harn-vm/src/agent_events/tests.rs
+++ b/crates/harn-vm/src/agent_events/tests.rs
@@ -215,6 +215,98 @@ fn jsonl_sink_lines_are_durable_without_drop_or_explicit_flush() {
 }
 
 #[test]
+fn jsonl_sink_redacts_tool_payloads_before_write() {
+    let dir =
+        std::env::temp_dir().join(format!("harn-redacted-event-log-{}", uuid::Uuid::now_v7()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("event_log.jsonl");
+    let sink = JsonlEventSink::open(&path).unwrap();
+
+    sink.handle_event(&AgentEvent::ToolCall {
+        session_id: "s".into(),
+        tool_call_id: "tc-1".into(),
+        tool_name: "http".into(),
+        kind: None,
+        status: ToolCallStatus::Pending,
+        raw_input: serde_json::json!({
+            "api_key": "raw-api-key-value",
+            "url": "https://user:password@example.com/items?client_secret=raw-client-secret&ok=1"
+        }),
+        parsing: None,
+        audit: None,
+    });
+    sink.handle_event(&AgentEvent::ToolCallUpdate {
+        session_id: "s".into(),
+        tool_call_id: "tc-1".into(),
+        tool_name: "http".into(),
+        status: ToolCallStatus::Completed,
+        raw_output: Some(serde_json::json!({
+            "callback": "https://api.example.com/cb?access_token=raw-access-token&ok=1"
+        })),
+        error: None,
+        duration_ms: None,
+        execution_duration_ms: None,
+        error_category: None,
+        executor: None,
+        parsing: None,
+        raw_input: None,
+        raw_input_partial: None,
+        audit: None,
+    });
+    sink.flush().unwrap();
+
+    let text = std::fs::read_to_string(&path).unwrap();
+    assert!(text.contains("[redacted]") || text.contains("%5Bredacted%5D"));
+    for secret in [
+        "raw-api-key-value",
+        "user:password",
+        "raw-client-secret",
+        "raw-access-token",
+    ] {
+        assert!(
+            !text.contains(secret),
+            "JSONL event sink persisted secret {secret}: {text}"
+        );
+    }
+
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_dir(&dir);
+}
+
+#[test]
+fn event_log_sink_redacts_tool_payloads_before_append() {
+    use crate::event_log::{AnyEventLog, EventLog, MemoryEventLog, Topic};
+
+    let log = Arc::new(AnyEventLog::Memory(MemoryEventLog::new(8)));
+    let sink = EventLogSink::new(log.clone(), "s");
+    sink.handle_event(&AgentEvent::ToolCall {
+        session_id: "s".into(),
+        tool_call_id: "tc-1".into(),
+        tool_name: "http".into(),
+        kind: None,
+        status: ToolCallStatus::Pending,
+        raw_input: serde_json::json!({
+            "authorization": "Bearer raw-bearer-value",
+            "url": "https://user:password@example.com/items?sig=raw-signature&ok=1"
+        }),
+        parsing: None,
+        audit: None,
+    });
+
+    let topic = Topic::new("observability.agent_events.s").unwrap();
+    let events = futures::executor::block_on(log.read_range(&topic, None, 8)).unwrap();
+    assert_eq!(events.len(), 1);
+    let persisted = serde_json::to_string(&events[0].1).unwrap();
+    assert!(persisted.contains("[redacted]") || persisted.contains("%5Bredacted%5D"));
+    for secret in ["raw-bearer-value", "user:password", "raw-signature"] {
+        assert!(
+            !persisted.contains(secret),
+            "event-log sink appended secret {secret}: {persisted}"
+        );
+    }
+}
+
+#[test]
 fn structural_validator_decision_round_trips_through_jsonl_sink() {
     use std::io::{BufRead, BufReader};
     let dir = std::env::temp_dir().join(format!(

--- a/crates/harn-vm/src/orchestration/records/action_graph.rs
+++ b/crates/harn-vm/src/orchestration/records/action_graph.rs
@@ -82,12 +82,21 @@ pub async fn append_action_graph_update(
     headers: BTreeMap<String, String>,
     payload: serde_json::Value,
 ) -> Result<(), crate::event_log::LogError> {
+    append_action_graph_update_with_policy(headers, payload, crate::redact::current_policy()).await
+}
+
+async fn append_action_graph_update_with_policy(
+    headers: BTreeMap<String, String>,
+    payload: serde_json::Value,
+    policy: crate::redact::RedactionPolicy,
+) -> Result<(), crate::event_log::LogError> {
     let Some(log) = active_event_log() else {
         return Ok(());
     };
     let topic = Topic::new("observability.action_graph")
         .expect("static observability.action_graph topic should always be valid");
-    let record = EventLogRecord::new("action_graph_update", payload).with_headers(headers);
+    let mut record = EventLogRecord::new("action_graph_update", payload).with_headers(headers);
+    record.redact_in_place(&policy);
     log.append(&topic, record).await.map(|_| ())
 }
 
@@ -110,12 +119,15 @@ pub(super) fn publish_action_graph_event(
         "status": run.status,
         "observability": observability,
     });
+    let policy = crate::redact::current_policy();
     if let Ok(handle) = tokio::runtime::Handle::try_current() {
         handle.spawn(async move {
-            let _ = append_action_graph_update(headers, payload).await;
+            let _ = append_action_graph_update_with_policy(headers, payload, policy).await;
         });
     } else {
-        let _ = futures::executor::block_on(append_action_graph_update(headers, payload));
+        let _ = futures::executor::block_on(append_action_graph_update_with_policy(
+            headers, payload, policy,
+        ));
     }
 }
 

--- a/crates/harn-vm/src/orchestration/records/persistence.rs
+++ b/crates/harn-vm/src/orchestration/records/persistence.rs
@@ -457,7 +457,10 @@ pub fn save_run_record(run: &RunRecord, path: Option<&str>) -> Result<String, Vm
         std::fs::create_dir_all(parent)
             .map_err(|e| VmError::Runtime(format!("failed to create run directory: {e}")))?;
     }
-    let json = serde_json::to_string_pretty(&materialized)
+    let mut json_value = serde_json::to_value(&materialized)
+        .map_err(|e| VmError::Runtime(format!("failed to encode run record: {e}")))?;
+    crate::redact::current_policy().redact_json_in_place(&mut json_value);
+    let json = serde_json::to_string_pretty(&json_value)
         .map_err(|e| VmError::Runtime(format!("failed to encode run record: {e}")))?;
     crate::atomic_io::atomic_write(&path, json.as_bytes())
         .map_err(|e| VmError::Runtime(format!("failed to persist run record: {e}")))?;

--- a/crates/harn-vm/src/orchestration/tests.rs
+++ b/crates/harn-vm/src/orchestration/tests.rs
@@ -488,6 +488,66 @@ fn save_run_record_materializes_hitl_questions_from_active_event_log() {
 }
 
 #[test]
+fn save_run_record_redacts_secrets_before_persisting() {
+    crate::reset_thread_local_state();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let path = temp_dir.path().join("run.json");
+    let run = RunRecord {
+        id: "run_redaction".to_string(),
+        workflow_id: "wf".to_string(),
+        status: "completed".to_string(),
+        stages: vec![RunStageRecord {
+            id: "stage_secret".to_string(),
+            node_id: "stage".to_string(),
+            kind: "tool".to_string(),
+            status: "completed".to_string(),
+            outcome: "ok".to_string(),
+            visible_text: Some(
+                "https://user:password@example.com/cb?access_token=raw-stage-token".to_string(),
+            ),
+            metadata: BTreeMap::from([(
+                "api_key".to_string(),
+                serde_json::json!("raw-stage-api-key"),
+            )]),
+            ..Default::default()
+        }],
+        metadata: BTreeMap::from([
+            ("api_key".to_string(), serde_json::json!("raw-run-api-key")),
+            (
+                "callback_url".to_string(),
+                serde_json::json!(
+                    "https://user:password@example.com/items?client_secret=raw-client-secret&ok=1"
+                ),
+            ),
+        ]),
+        ..Default::default()
+    };
+
+    save_run_record(&run, Some(path.to_str().unwrap())).unwrap();
+
+    let raw = std::fs::read_to_string(&path).unwrap();
+    assert!(raw.contains("[redacted]") || raw.contains("%5Bredacted%5D"));
+    for secret in [
+        "raw-run-api-key",
+        "raw-stage-api-key",
+        "user:password",
+        "raw-stage-token",
+        "raw-client-secret",
+    ] {
+        assert!(
+            !raw.contains(secret),
+            "run record persisted secret {secret}: {raw}"
+        );
+    }
+
+    let loaded = load_run_record(&path).unwrap();
+    assert_eq!(
+        loaded.metadata.get("api_key"),
+        Some(&serde_json::json!("[redacted]"))
+    );
+}
+
+#[test]
 fn normalize_run_record_materializes_typed_handoffs_from_artifacts() {
     let value = crate::stdlib::json_to_vm_value(&serde_json::json!({
         "_type": "run_record",
@@ -917,6 +977,9 @@ async fn save_run_record_publishes_action_graph_updates_to_event_log() {
         ..Default::default()
     };
 
+    let _policy_guard = crate::redact::PolicyGuard::new(
+        crate::redact::RedactionPolicy::default().with_extra_field("workflow_id"),
+    );
     save_run_record(&run, Some(run_path.to_str().unwrap())).unwrap();
     run.status = "completed".to_string();
     save_run_record(&run, Some(run_path.to_str().unwrap())).unwrap();
@@ -931,6 +994,9 @@ async fn save_run_record_publishes_action_graph_updates_to_event_log() {
     assert!(events.iter().all(|(_, event)| {
         event.headers.get("trace_id").map(String::as_str) == Some("trace_stream")
     }));
+    assert!(events
+        .iter()
+        .all(|(_, event)| event.payload["workflow_id"] == serde_json::json!("[redacted]")));
     assert!(events.iter().any(|(_, event)| {
         event.payload["observability"]["action_graph_nodes"]
             .as_array()
@@ -940,6 +1006,48 @@ async fn save_run_record_publishes_action_graph_updates_to_event_log() {
                 })
             })
     }));
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn action_graph_update_redacts_payload_before_append() {
+    crate::reset_thread_local_state();
+    let temp_dir = tempfile::tempdir().unwrap();
+    crate::event_log::install_default_for_base_dir(temp_dir.path()).expect("install event log");
+    let log = crate::event_log::active_event_log().expect("active event log");
+    let topic = crate::event_log::Topic::new("observability.action_graph").unwrap();
+
+    append_action_graph_update(
+        BTreeMap::from([(
+            "Authorization".to_string(),
+            "Bearer raw-action-header".to_string(),
+        )]),
+        serde_json::json!({
+            "run_id": "run_action",
+            "provider_payload": {
+                "api_key": "raw-action-api-key",
+                "callback": "https://user:password@example.com/cb?access_token=raw-action-token"
+            }
+        }),
+    )
+    .await
+    .unwrap();
+
+    let events = log.read_range(&topic, None, 8).await.unwrap();
+    assert_eq!(events.len(), 1);
+    let persisted = serde_json::to_string(&events[0].1).unwrap();
+    assert!(persisted.contains("[redacted]") || persisted.contains("%5Bredacted%5D"));
+    for secret in [
+        "raw-action-header",
+        "raw-action-api-key",
+        "user:password",
+        "raw-action-token",
+    ] {
+        assert!(
+            !persisted.contains(secret),
+            "action-graph event persisted secret {secret}: {persisted}"
+        );
+    }
+    crate::event_log::reset_active_event_log();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Redacts operational persistence boundaries with Harn's shared `RedactionPolicy` before writing durable artifacts:

- `JsonlEventSink` and `EventLogSink` now redact serialized `AgentEvent` payloads before JSONL/event-log persistence.
- `save_run_record` now redacts the serialized `RunRecord` JSON before atomic write.
- action-graph updates now redact payloads and headers before append, and `save_run_record` captures the active redaction policy before spawning async action-graph publication so host-installed policy overrides are preserved across the thread boundary.

## Root Cause

The shared redactor existed, but several durable emitters serialized cloned operational payloads directly. That left raw tool inputs/outputs, run metadata, URLs, and auth-shaped fields dependent on later readers to remember to scrub them. The fix moves redaction to the write/append boundary for these operational artifacts.

Trigger inbox event logs are intentionally not scrubbed in this PR: the inbox is also the durable dispatch queue, so blindly redacting `event_ingested` payloads would change handler inputs. That needs a separate raw-queue vs redacted-observability split.

## Verification

- `cargo fmt -p harn-vm`
- `cargo test -p harn-vm redacts --lib`
- `cargo test -p harn-vm agent_events::tests:: --lib`
- `cargo test -p harn-vm orchestration::tests::save_run_record --lib`
- `make lint-md`
- pre-push hook targeted Rust checks passed
