### PR TITLE
fix: make release publish recovery idempotent

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -353,7 +353,10 @@ jobs:
       - name: Select publish ref
         run: |
           set -euo pipefail
-          cp scripts/release_ship.sh "$RUNNER_TEMP/release_ship.sh"
+          mkdir -p "$RUNNER_TEMP/release-tools"
+          cp scripts/release_ship.sh "$RUNNER_TEMP/release-tools/release_ship.sh"
+          cp scripts/release_gate.sh "$RUNNER_TEMP/release-tools/release_gate.sh"
+          cp scripts/publish.sh "$RUNNER_TEMP/release-tools/publish.sh"
           publish_ref="${{ needs.detect-drift.outputs.publish_ref }}"
           if [[ "$publish_ref" != "main" ]]; then
             git fetch --force --tags origin
@@ -443,4 +446,7 @@ jobs:
           if [[ "${{ inputs.skip_dry_run }}" == "true" ]]; then
             args+=(--skip-dry-run)
           fi
-          HARN_RELEASE_ROOT="$PWD" bash "$RUNNER_TEMP/release_ship.sh" "${args[@]}"
+          HARN_RELEASE_ROOT="$PWD" \
+            HARN_RELEASE_GATE_SCRIPT="$RUNNER_TEMP/release-tools/release_gate.sh" \
+            HARN_PUBLISH_SCRIPT="$RUNNER_TEMP/release-tools/publish.sh" \
+            bash "$RUNNER_TEMP/release-tools/release_ship.sh" "${args[@]}"

--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,7 @@ test-agent-scripts:
 
 test-pr-gate-scripts:
 	./scripts/tests/changelog_fragment_check_test.sh
+	./scripts/tests/publish_script_test.sh
 
 # Format check (no changes, for CI)
 fmt-check:

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -66,27 +66,6 @@ RETRY_DELAY=120  # seconds to wait on rate limit
 INDEX_SETTLE_DELAY=30  # seconds to wait for index propagation between retries
 MAX_ATTEMPTS=3
 
-# Crates to publish, in dependency order. Used by the per-crate fallback
-# when `cargo publish --workspace` bails out partway through.
-WORKSPACE_CRATES=(
-  harn-glob
-  harn-lexer
-  harn-parser
-  harn-ir
-  harn-stdlib
-  harn-fmt
-  harn-modules
-  harn-vm
-  harn-lint
-  harn-dap
-  harn-serve
-  harn-lsp
-  harn-hostlib
-  harn-rules
-  harn-rules-hostlib
-  harn-cli
-)
-
 # Cargo classifies several non-fatal conditions as fatal exits, so the
 # bare `cargo publish --workspace` can fail mid-stream without actually
 # being broken. We retry on:
@@ -94,7 +73,9 @@ WORKSPACE_CRATES=(
 #   - "unexpected cargo internal error"    — known cargo bug where it gives
 #   - "packages remain in plan"              up waiting on index propagation
 #                                            after a successful upload
-#   - "already exists on crates.io index"  — crate succeeded on an earlier
+#   - "already exists on crates.io index" /
+#     "crate version ... is already uploaded"
+#                                          — crate succeeded on an earlier
 #                                            attempt; nothing to do
 #   - "timeout while waiting for published  — a dependency was uploaded but the
 #      dependencies" / "timed out waiting     index hadn't propagated before
@@ -103,7 +84,82 @@ WORKSPACE_CRATES=(
 #                                            Pure propagation lag: retrying or the
 #                                            per-crate fallback (which skips the
 #                                            already-uploaded crates) completes it.
-RETRYABLE_PATTERN='429|Too Many Requests|unexpected cargo internal error|packages remain in plan|already exists on crates.io index|timeout while waiting for published dependencies|timed out waiting for'
+ALREADY_PUBLISHED_PATTERN='already exists on crates\.io index|crate version .* is already uploaded'
+RETRYABLE_PATTERN="429|Too Many Requests|unexpected cargo internal error|packages remain in plan|${ALREADY_PUBLISHED_PATTERN}|timeout while waiting for published dependencies|timed out waiting for"
+
+workspace_publish_crates() {
+  cargo metadata --format-version 1 --no-deps | python3 -c '
+import json
+import sys
+
+meta = json.load(sys.stdin)
+workspace = set(meta.get("workspace_members", []))
+packages = [
+    pkg
+    for pkg in meta.get("packages", [])
+    if pkg.get("id") in workspace
+    and (pkg.get("publish") is None or "crates-io" in pkg.get("publish", []))
+]
+by_name = {pkg["name"]: pkg for pkg in packages}
+deps = {
+    pkg["name"]: sorted(
+        {
+            dep["name"]
+            for dep in pkg.get("dependencies", [])
+            if dep.get("source") is None and dep.get("name") in by_name
+        }
+    )
+    for pkg in packages
+}
+
+visiting = set()
+visited = set()
+ordered = []
+
+
+def visit(name):
+    if name in visited:
+        return
+    if name in visiting:
+        cycle = " -> ".join(sorted(visiting | {name}))
+        raise SystemExit(f"workspace publish dependency cycle: {cycle}")
+    visiting.add(name)
+    for dep in deps[name]:
+        visit(dep)
+    visiting.remove(name)
+    visited.add(name)
+    ordered.append(name)
+
+
+for name in sorted(by_name):
+    visit(name)
+
+print("\n".join(ordered))
+'
+}
+
+publish_output_means_already_published() {
+  local output="$1"
+  grep -Eiq "$ALREADY_PUBLISHED_PATTERN" <<<"$output"
+}
+
+crate_version_exists() {
+  local crate="$1"
+  if ! command -v curl &>/dev/null; then
+    return 1
+  fi
+  curl \
+    --fail \
+    --silent \
+    --show-error \
+    --location \
+    --retry 3 \
+    --retry-delay 2 \
+    --header "User-Agent: harn-release-publish" \
+    --output /dev/null \
+    "https://crates.io/api/v1/crates/${crate}/${CURRENT_VERSION}" \
+    >/dev/null 2>&1
+}
 
 attempt_workspace_publish() {
   local attempt=1
@@ -142,21 +198,27 @@ attempt_workspace_publish() {
 }
 
 # Per-crate fallback for the case where `cargo publish --workspace` keeps
-# bailing on the cargo internal error. Walks crates in dependency order
-# and treats "already exists on crates.io index" as success.
+# bailing on the cargo internal error. Walks publishable workspace crates in
+# dependency order and treats any crate/version already visible on crates.io as
+# success, regardless of Cargo's exact wording.
 attempt_per_crate_publish() {
   echo ""
   echo "=== Per-crate publish fallback ==="
   local crate
   local output
-  for crate in "${WORKSPACE_CRATES[@]}"; do
+  while IFS= read -r crate; do
+    [[ -n "$crate" ]] || continue
     echo ""
     echo "--- Publishing $crate ---"
+    if crate_version_exists "$crate"; then
+      echo "  $crate already published at version $CURRENT_VERSION — skipping"
+      continue
+    fi
     if output=$(cargo publish -p "$crate" $DRY_RUN $VERIFY_FLAGS $ALLOW_DIRTY 2>&1); then
       echo "$output"
       continue
     fi
-    if echo "$output" | grep -q "already exists on crates.io index"; then
+    if publish_output_means_already_published "$output" || crate_version_exists "$crate"; then
       echo "  $crate already published at this version — skipping"
       continue
     fi
@@ -168,7 +230,7 @@ attempt_per_crate_publish() {
         echo "$output"
         continue
       fi
-      if echo "$output" | grep -q "already exists on crates.io index"; then
+      if publish_output_means_already_published "$output" || crate_version_exists "$crate"; then
         echo "  $crate already published at this version — skipping"
         continue
       fi
@@ -176,7 +238,7 @@ attempt_per_crate_publish() {
     echo "$output"
     echo "  FAILED to publish $crate"
     return 1
-  done
+  done < <(workspace_publish_crates)
   return 0
 }
 

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="${HARN_RELEASE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 cd "$ROOT_DIR"
+PUBLISH_SCRIPT="${HARN_PUBLISH_SCRIPT:-./scripts/publish.sh}"
 
 usage() {
   cat <<'EOF'
@@ -433,7 +434,7 @@ cmd_publish() {
   if [[ -z "$dry_run" ]]; then
     require_clean_tree
   fi
-  ./scripts/publish.sh ${dry_run}
+  "$PUBLISH_SCRIPT" ${dry_run}
   local version
   version="$(current_version)"
   if [[ -n "$dry_run" ]]; then

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="${HARN_RELEASE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 cd "$ROOT_DIR"
+RELEASE_GATE_SCRIPT="${HARN_RELEASE_GATE_SCRIPT:-./scripts/release_gate.sh}"
 
 # ── Timing instrumentation ──────────────────────────────────────────────
 # Every `=== step ===` banner goes through `log_step`, which stamps the
@@ -423,14 +424,14 @@ run_common_gates() {
 
   if [[ "$SKIP_AUDIT" -eq 0 ]]; then
     log_step "Release audit"
-    ./scripts/release_gate.sh audit
+    "$RELEASE_GATE_SCRIPT" audit
   else
     log_step "Skipping release audit (already proved by merge-queue CI)"
   fi
 
   if [[ "$SKIP_DRY_RUN" -eq 0 ]]; then
     log_step "Publish dry run"
-    ./scripts/release_gate.sh publish --dry-run
+    "$RELEASE_GATE_SCRIPT" publish --dry-run
   fi
 }
 
@@ -459,7 +460,7 @@ open_bump_pr() {
   git switch -c "$branch"
 
   log_step "Version bump"
-  ./scripts/release_gate.sh prepare --bump "$BUMP"
+  "$RELEASE_GATE_SCRIPT" prepare --bump "$BUMP"
   local actual_next
   actual_next="$(current_version)"
   if [[ "$actual_next" != "$next" ]]; then
@@ -539,7 +540,7 @@ prepare_here() {
   run_common_gates
 
   log_step "Version bump (in place)"
-  ./scripts/release_gate.sh prepare --bump "$BUMP" --allow-dirty
+  "$RELEASE_GATE_SCRIPT" prepare --bump "$BUMP" --allow-dirty
   local actual_next
   actual_next="$(current_version)"
   if [[ "$actual_next" != "$next" ]]; then
@@ -749,7 +750,7 @@ log_step "Push tag"
 git push origin "$TAG"
 
 log_step "Publish"
-./scripts/release_gate.sh publish
+"$RELEASE_GATE_SCRIPT" publish
 
 if [[ -z "$NOTES_OUTPUT" ]]; then
   NOTES_DIR="$ROOT_DIR/.harn/release-notes"
@@ -761,7 +762,7 @@ else
 fi
 
 log_step "Release notes"
-./scripts/release_gate.sh notes --version "$TAG" --output "$NOTES_OUTPUT"
+"$RELEASE_GATE_SCRIPT" notes --version "$TAG" --output "$NOTES_OUTPUT"
 cat "$NOTES_OUTPUT"
 
 GH_RELEASE_URL=""

--- a/scripts/tests/publish_script_test.sh
+++ b/scripts/tests/publish_script_test.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+publish_script="$repo_root/scripts/publish.sh"
+
+tmp_root=$(mktemp -d)
+trap 'rm -rf "$tmp_root"' EXIT
+
+fake_bin="$tmp_root/bin"
+mkdir -p "$fake_bin"
+
+metadata_file="$tmp_root/metadata.json"
+record_file="$tmp_root/published-order.txt"
+curl_state_dir="$tmp_root/curl-state"
+mkdir -p "$curl_state_dir"
+
+cat > "$metadata_file" <<'JSON'
+{
+  "packages": [
+    {
+      "name": "gamma",
+      "version": "1.2.3",
+      "id": "path+file:///repo/gamma#1.2.3",
+      "publish": null,
+      "dependencies": [
+        {"name": "beta", "source": null},
+        {"name": "alpha", "source": null}
+      ]
+    },
+    {
+      "name": "private-helper",
+      "version": "1.2.3",
+      "id": "path+file:///repo/private-helper#1.2.3",
+      "publish": [],
+      "dependencies": []
+    },
+    {
+      "name": "alpha",
+      "version": "1.2.3",
+      "id": "path+file:///repo/alpha#1.2.3",
+      "publish": null,
+      "dependencies": []
+    },
+    {
+      "name": "beta",
+      "version": "1.2.3",
+      "id": "path+file:///repo/beta#1.2.3",
+      "publish": null,
+      "dependencies": [
+        {"name": "alpha", "source": null}
+      ]
+    }
+  ],
+  "workspace_members": [
+    "path+file:///repo/gamma#1.2.3",
+    "path+file:///repo/private-helper#1.2.3",
+    "path+file:///repo/alpha#1.2.3",
+    "path+file:///repo/beta#1.2.3"
+  ]
+}
+JSON
+
+cat > "$fake_bin/cargo" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "metadata" ]]; then
+  cat "$FAKE_CARGO_METADATA"
+  exit 0
+fi
+
+if [[ "${1:-}" == "publish" && "${2:-}" == "--workspace" ]]; then
+  echo "error: crate alpha@1.2.3 already exists on crates.io index" >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "publish" && "${2:-}" == "-p" ]]; then
+  crate="${3:-}"
+  printf '%s\n' "$crate" >> "$FAKE_CARGO_RECORD"
+  if [[ "$crate" == "private-helper" ]]; then
+    echo "private-helper should not be published" >&2
+    exit 2
+  fi
+  echo "error: failed to publish $crate v1.2.3 to registry at https://crates.io" >&2
+  echo "Caused by:" >&2
+  echo "  the remote server responded with an error (status 400 Bad Request): retryable registry response after upload" >&2
+  exit 1
+fi
+
+echo "unexpected fake cargo invocation: $*" >&2
+exit 2
+SH
+chmod +x "$fake_bin/cargo"
+
+cat > "$fake_bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url=""
+for arg in "$@"; do
+  case "$arg" in
+    https://crates.io/api/v1/crates/*)
+      url="$arg"
+      ;;
+  esac
+done
+
+if [[ -z "$url" ]]; then
+  echo "fake curl expected crates.io API URL" >&2
+  exit 2
+fi
+
+crate_version="${url#https://crates.io/api/v1/crates/}"
+crate="${crate_version%%/*}"
+state="$FAKE_CURL_STATE_DIR/$crate"
+
+if [[ -e "$state" ]]; then
+  exit 0
+fi
+
+touch "$state"
+exit 22
+SH
+chmod +x "$fake_bin/curl"
+
+cat > "$fake_bin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$fake_bin/sleep"
+
+PATH="$fake_bin:$PATH" \
+  FAKE_CARGO_METADATA="$metadata_file" \
+  FAKE_CARGO_RECORD="$record_file" \
+  FAKE_CURL_STATE_DIR="$curl_state_dir" \
+  "$publish_script" > "$tmp_root/output.txt"
+
+expected_order=$'alpha\nbeta\ngamma'
+actual_order=$(cat "$record_file")
+if [[ "$actual_order" != "$expected_order" ]]; then
+  printf 'expected publish order:\n%s\nactual:\n%s\n' "$expected_order" "$actual_order" >&2
+  exit 1
+fi
+
+if grep -q "private-helper" "$record_file"; then
+  echo "publish fallback attempted a publish=false workspace crate" >&2
+  exit 1
+fi
+
+grep -q "Workspace publish complete" "$tmp_root/output.txt"
+grep -q "already published at this version" "$tmp_root/output.txt"
+
+release_root="$tmp_root/release-root"
+mkdir -p "$release_root"
+cat > "$release_root/Cargo.toml" <<'EOF'
+[workspace]
+version = "1.2.3"
+members = []
+EOF
+
+fake_publish="$tmp_root/fake-publish.sh"
+cat > "$fake_publish" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'pwd=%s args=%s\n' "$PWD" "$*" > "$FAKE_RELEASE_GATE_RECORD"
+SH
+chmod +x "$fake_publish"
+
+release_gate_record="$tmp_root/release-gate-record.txt"
+HARN_RELEASE_ROOT="$release_root" \
+  HARN_PUBLISH_SCRIPT="$fake_publish" \
+  FAKE_RELEASE_GATE_RECORD="$release_gate_record" \
+  "$repo_root/scripts/release_gate.sh" publish --dry-run > "$tmp_root/release-gate-output.txt"
+
+expected_gate_record="pwd=$release_root args=--dry-run"
+actual_gate_record=$(cat "$release_gate_record")
+if [[ "$actual_gate_record" != "$expected_gate_record" ]]; then
+  printf 'expected release_gate to run publish script against release root:\n%s\nactual:\n%s\n' \
+    "$expected_gate_record" "$actual_gate_record" >&2
+  exit 1
+fi
+
+echo "publish_script_test: ok"


### PR DESCRIPTION
## Summary
- derive the per-crate publish fallback order from `cargo metadata` instead of a stale hard-coded list
- treat both Cargo/crates.io already-published wordings as success, and verify crate/version presence through crates.io before retrying uploads
- let workflow-dispatch recovery use fixed release scripts while keeping the release source checkout pinned to the selected tag
- add a shell test for fallback ordering, publish=false skipping, already-published recovery, and release-root script injection

## Verification
- `bash -n scripts/publish.sh scripts/release_gate.sh scripts/release_ship.sh scripts/tests/publish_script_test.sh`
- `./scripts/tests/publish_script_test.sh`
- `make test-pr-gate-scripts`

Root cause: the v0.8.137 publish tag job uploaded most crates, timed out waiting for `harn-lsp` index propagation, then the per-crate fallback stopped because crates.io returned `crate version ... is already uploaded` instead of the one string the script recognized. The fallback list was also stale, so future new publishable crates could be skipped during recovery.