### PR TITLE
fix(agent): surface escalation provider_error + primary-retry fallback (C13)

### DIFF
--- a/conformance/tests/agents/agent_loop_escalation_provider_error.expected
+++ b/conformance/tests/agents/agent_loop_escalation_provider_error.expected
@@ -1,0 +1,13 @@
+esc_event_present=true
+esc_event_skip_reason=escalation_provider_failure
+esc_event_provider=escalated
+esc_event_model=frontier
+esc_event_status=provider_error
+esc_event_fallback=true
+esc_providers=mock,escalated,mock,mock,
+esc_status=done
+primary_event_present=true
+primary_event_skip_reason=provider_failure
+primary_event_fallback=false
+primary_event_count=1
+primary_status=provider_error

--- a/conformance/tests/agents/agent_loop_escalation_provider_error.harn
+++ b/conformance/tests/agents/agent_loop_escalation_provider_error.harn
@@ -1,0 +1,158 @@
+// C13: a smart-escalation turn whose escalated provider fails fast
+// (pre-dispatch `provider_error`) must NOT silently break the loop and let a
+// stale cheap-model turn masquerade as success. The non-tracked provider-error
+// branch (no `consecutive_failures` budget configured) must:
+//   (a) EMIT an observable `iteration_end` provider_error event carrying the
+//       failed provider/model/status — never an invisible `break`;
+//   (b) NOT terminate as a fake success;
+//   (c) DEGRADE the failed escalation back to the PRIMARY provider for one more
+//       turn (primary-retry fallback) so the run continues with the cheap model
+//       instead of dying.
+//
+// A second case pins the regression guard: a plain primary provider_error with
+// NO escalation in effect still surfaces an event and stops with provider_error
+// (no spurious retry), so normal handling is preserved.
+import { agent_capture_events } from "std/agent/events"
+
+fn first_event(events, event_type) {
+  for event in events {
+    if event.type == event_type {
+      return event
+    }
+  }
+  return nil
+}
+
+fn count_events(events, event_type) {
+  var n = 0
+  for event in events {
+    if event.type == event_type {
+      n = n + 1
+    }
+  }
+  return n
+}
+
+// ---------------------------------------------------------------------------
+// Case 1: failed escalation degrades to the primary provider.
+// ---------------------------------------------------------------------------
+fn escalation_fallback_case() {
+  // Records the provider seen on every LLM call, in order, so we can prove the
+  // escalated call fired then the loop retried the PRIMARY provider.
+  let seen = shared_cell({scope: "task_group", key: "esc-providers", initial: ""})
+  let turn = shared_cell({scope: "task_group", key: "esc-turn", initial: 0})
+
+  let caller = { call ->
+    let provider = to_string(call?.opts?.provider ?? "")
+    let snap = shared_snapshot(seen)
+    shared_set(seen, snap.value + provider + ",")
+    if provider == "escalated" {
+      // Fast pre-dispatch escalation failure — the C13 trigger.
+      return {
+        ok: false,
+        status: "provider_error",
+        stop_reason: "provider_error",
+        error: {status: 503, message: "escalated provider unavailable", provider: "escalated", model: "frontier"},
+      }
+    }
+    // Primary (cheap) provider. The first primary turn produces ordinary text
+    // (no completion). After the escalation has failed and we have retried the
+    // primary, complete the run so the loop terminates deterministically.
+    let count = shared_snapshot(turn)
+    if count.value >= 2 {
+      return {ok: true, value: {text: "wrapping up DONE", tool_calls: [], provider: "mock", model: "cheap"}}
+    }
+    return {ok: true, value: {text: "still working on it", tool_calls: [], provider: "mock", model: "cheap"}}
+  }
+
+  // Escalate exactly once: after the FIRST turn, switch the provider to the
+  // escalation target. Subsequent turns leave the provider as-is, so the
+  // primary-retry fallback is not re-escalated.
+  let post_turn = { _payload ->
+    let count = shared_snapshot(turn)
+    shared_set(turn, count.value + 1)
+    if count.value == 0 {
+      return {next_options: {provider: "escalated", model: "frontier"}}
+    }
+    return nil
+  }
+
+  let session = "esc-fallback-" + uuid()
+  let captured = agent_capture_events(
+    session,
+    fn() { return agent_loop(
+      "do the task",
+      nil,
+      {
+        session_id: session,
+        provider: "mock",
+        model: "cheap",
+        llm_caller: caller,
+        post_turn_callback: post_turn,
+        loop_until_done: true,
+        done_sentinel: "DONE",
+        max_iterations: 6,
+      },
+    ) },
+  )
+
+  // (a) An observable provider_error iteration_end event was emitted carrying
+  //     the failed escalated provider/model/status — not a silent break.
+  let perr = first_event(captured.events, "iteration_end")
+  __io_println("esc_event_present=" + to_string(perr != nil))
+  __io_println("esc_event_skip_reason=" + to_string(perr?.iteration_info?.skip_reason ?? ""))
+  __io_println("esc_event_provider=" + to_string(perr?.iteration_info?.provider ?? ""))
+  __io_println("esc_event_model=" + to_string(perr?.iteration_info?.model ?? ""))
+  __io_println("esc_event_status=" + to_string(perr?.iteration_info?.provider_status ?? ""))
+  __io_println("esc_event_fallback=" + to_string(perr?.iteration_info?.escalation_fallback ?? false))
+
+  // (c) The provider call sequence proves: primary -> escalated (failed) ->
+  //     primary again (the fallback retry) -> primary (completion).
+  __io_println("esc_providers=" + shared_get(seen))
+
+  // (b) The run did NOT terminate as a fake success on the failed escalation:
+  //     it converged via the primary fallback to a real "done".
+  __io_println("esc_status=" + captured.result.status)
+}
+
+// ---------------------------------------------------------------------------
+// Case 2: regression guard — a plain primary provider_error (no escalation)
+// still surfaces an event and stops, with no spurious primary-retry.
+// ---------------------------------------------------------------------------
+fn primary_provider_error_case() {
+  let caller = { _call -> return {
+    ok: false,
+    status: "provider_error",
+    stop_reason: "provider_error",
+    error: {status: 500, message: "primary down", provider: "mock", model: "cheap"},
+  } }
+  let session = "esc-primary-err-" + uuid()
+  let captured = agent_capture_events(
+    session,
+    fn() { return agent_loop(
+      "do the task",
+      nil,
+      {
+        session_id: session,
+        provider: "mock",
+        model: "cheap",
+        llm_caller: caller,
+        loop_until_done: true,
+        done_sentinel: "DONE",
+        max_iterations: 6,
+      },
+    ) },
+  )
+  let perr = first_event(captured.events, "iteration_end")
+  __io_println("primary_event_present=" + to_string(perr != nil))
+  __io_println("primary_event_skip_reason=" + to_string(perr?.iteration_info?.skip_reason ?? ""))
+  __io_println("primary_event_fallback=" + to_string(perr?.iteration_info?.escalation_fallback ?? false))
+  // Exactly one failing turn — no escalation fallback means no spurious retry.
+  __io_println("primary_event_count=" + to_string(count_events(captured.events, "iteration_end")))
+  __io_println("primary_status=" + captured.result.status)
+}
+
+pipeline default() {
+  escalation_fallback_case()
+  primary_provider_error_case()
+}

--- a/conformance/tests/agents/agent_loop_escalation_provider_error.harn
+++ b/conformance/tests/agents/agent_loop_escalation_provider_error.harn
@@ -14,10 +14,18 @@
 // (no spurious retry), so normal handling is preserved.
 import { agent_capture_events } from "std/agent/events"
 
-fn first_event(events, event_type) {
+/**
+ * The provider_error path stamps a `skip_reason` of "provider_failure" or
+ * "escalation_provider_failure" onto its `iteration_end` event; an ordinary
+ * (successful) turn end carries an empty skip_reason. Find the failure event.
+ */
+fn first_provider_error_event(events) {
   for event in events {
-    if event.type == event_type {
-      return event
+    if event.type == "iteration_end" {
+      let reason = to_string(event?.iteration_info?.skip_reason ?? "")
+      if reason == "provider_failure" || reason == "escalation_provider_failure" {
+        return event
+      }
     }
   }
   return nil
@@ -33,21 +41,20 @@ fn count_events(events, event_type) {
   return n
 }
 
-// ---------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // Case 1: failed escalation degrades to the primary provider.
-// ---------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
+
 fn escalation_fallback_case() {
   // Records the provider seen on every LLM call, in order, so we can prove the
   // escalated call fired then the loop retried the PRIMARY provider.
   let seen = shared_cell({scope: "task_group", key: "esc-providers", initial: ""})
   let turn = shared_cell({scope: "task_group", key: "esc-turn", initial: 0})
-
   let caller = { call ->
     let provider = to_string(call?.opts?.provider ?? "")
     let snap = shared_snapshot(seen)
     shared_set(seen, snap.value + provider + ",")
     if provider == "escalated" {
-      // Fast pre-dispatch escalation failure — the C13 trigger.
       return {
         ok: false,
         status: "provider_error",
@@ -55,16 +62,12 @@ fn escalation_fallback_case() {
         error: {status: 503, message: "escalated provider unavailable", provider: "escalated", model: "frontier"},
       }
     }
-    // Primary (cheap) provider. The first primary turn produces ordinary text
-    // (no completion). After the escalation has failed and we have retried the
-    // primary, complete the run so the loop terminates deterministically.
     let count = shared_snapshot(turn)
     if count.value >= 2 {
       return {ok: true, value: {text: "wrapping up DONE", tool_calls: [], provider: "mock", model: "cheap"}}
     }
     return {ok: true, value: {text: "still working on it", tool_calls: [], provider: "mock", model: "cheap"}}
   }
-
   // Escalate exactly once: after the FIRST turn, switch the provider to the
   // escalation target. Subsequent turns leave the provider as-is, so the
   // primary-retry fallback is not re-escalated.
@@ -76,7 +79,6 @@ fn escalation_fallback_case() {
     }
     return nil
   }
-
   let session = "esc-fallback-" + uuid()
   let captured = agent_capture_events(
     session,
@@ -95,30 +97,35 @@ fn escalation_fallback_case() {
       },
     ) },
   )
-
   // (a) An observable provider_error iteration_end event was emitted carrying
   //     the failed escalated provider/model/status — not a silent break.
-  let perr = first_event(captured.events, "iteration_end")
+  let perr = first_provider_error_event(captured.events)
   __io_println("esc_event_present=" + to_string(perr != nil))
   __io_println("esc_event_skip_reason=" + to_string(perr?.iteration_info?.skip_reason ?? ""))
   __io_println("esc_event_provider=" + to_string(perr?.iteration_info?.provider ?? ""))
   __io_println("esc_event_model=" + to_string(perr?.iteration_info?.model ?? ""))
   __io_println("esc_event_status=" + to_string(perr?.iteration_info?.provider_status ?? ""))
   __io_println("esc_event_fallback=" + to_string(perr?.iteration_info?.escalation_fallback ?? false))
-
   // (c) The provider call sequence proves: primary -> escalated (failed) ->
   //     primary again (the fallback retry) -> primary (completion).
   __io_println("esc_providers=" + shared_get(seen))
-
   // (b) The run did NOT terminate as a fake success on the failed escalation:
   //     it converged via the primary fallback to a real "done".
   __io_println("esc_status=" + captured.result.status)
 }
 
-// ---------------------------------------------------------------------------
+// Fast pre-dispatch escalation failure — the C13 trigger.
+// Primary (cheap) provider. The first primary turn produces ordinary text
+// (no completion); after the escalation has failed and the primary has been
+// retried, complete so the loop terminates deterministically.
+
+// -------------------------------------------------------------------------------------------------
+
 // Case 2: regression guard — a plain primary provider_error (no escalation)
 // still surfaces an event and stops, with no spurious primary-retry.
-// ---------------------------------------------------------------------------
+
+// -------------------------------------------------------------------------------------------------
+
 fn primary_provider_error_case() {
   let caller = { _call -> return {
     ok: false,
@@ -143,10 +150,12 @@ fn primary_provider_error_case() {
       },
     ) },
   )
-  let perr = first_event(captured.events, "iteration_end")
+  let perr = first_provider_error_event(captured.events)
   __io_println("primary_event_present=" + to_string(perr != nil))
   __io_println("primary_event_skip_reason=" + to_string(perr?.iteration_info?.skip_reason ?? ""))
-  __io_println("primary_event_fallback=" + to_string(perr?.iteration_info?.escalation_fallback ?? false))
+  __io_println(
+    "primary_event_fallback=" + to_string(perr?.iteration_info?.escalation_fallback ?? false),
+  )
   // Exactly one failing turn — no escalation fallback means no spurious retry.
   __io_println("primary_event_count=" + to_string(count_events(captured.events, "iteration_end")))
   __io_println("primary_status=" + captured.result.status)

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -2038,7 +2038,14 @@ fn __agent_loop_tracks_failure(error, config) {
  * that caused it. The dispatch_skipped/skip_reason shape matches the tracked
  * branch so existing consumers parse it uniformly.
  */
-fn __agent_loop_emit_provider_error(session_id, iteration_index, call, llm_opts, loop_start_ms, escalation_fallback) {
+fn __agent_loop_emit_provider_error(
+  session_id,
+  iteration_index,
+  call,
+  llm_opts,
+  loop_start_ms,
+  escalation_fallback,
+) {
   let aggregates = __agent_loop_budget_aggregates(session_id, nil, loop_start_ms)
   agent_emit_event(
     session_id,
@@ -2642,9 +2649,6 @@ fn __agent_loop_run(message, session, initial_opts) {
   var audit_background_tasks = []
   let run = try {
     opts = agent_mcp_bootstrap_if_needed(session, opts)
-    // Capture the PRIMARY provider/model once, before any post-turn escalation
-    // can rebind `opts`. A failed escalated turn falls back to this for one
-    // retry instead of unwinding the whole loop into a fake success.
     let primary_llm_opts = __agent_loop_effective_llm_options(opts)
     let primary_provider = to_string(primary_llm_opts?.provider ?? "")
     let primary_model = to_string(primary_llm_opts?.model ?? "")
@@ -2833,15 +2837,6 @@ fn __agent_loop_run(message, session, initial_opts) {
           }
           continue
         }
-        // NON-tracked provider failure. Previously this branch broke SILENTLY
-        // (no event), so a fast pre-dispatch escalation failure unwound the
-        // loop while ACP still returned the prior cheap-model text as a fake
-        // success. Two fixes, always-correct:
-        //   1. Always emit an observable provider_error `iteration_end` event.
-        //   2. If this was an ESCALATED turn (current provider/model differs
-        //      from the captured primary) and we have not already retried the
-        //      primary for this failure, degrade to the PRIMARY provider for
-        //      one more turn instead of unwinding into a fake success.
         let failed_provider = to_string(turn_llm_opts?.provider ?? "")
         let failed_model = to_string(turn_llm_opts?.model ?? "")
         let was_escalated = (primary_provider != "" || primary_model != "")
@@ -2856,7 +2851,6 @@ fn __agent_loop_run(message, session, initial_opts) {
           can_retry_primary,
         )
         if can_retry_primary {
-          // Rebind opts back to the primary provider/model and retry one turn.
           opts = opts
             + {
             provider: primary_provider,
@@ -3674,6 +3668,19 @@ fn __agent_loop_run(message, session, initial_opts) {
   return unwrap(run)
 }
 
+// Capture the PRIMARY provider/model once, before any post-turn escalation
+// can rebind `opts`. A failed escalated turn falls back to this for one
+// retry instead of unwinding the whole loop into a fake success.
+// NON-tracked provider failure. Previously this branch broke SILENTLY
+// (no event), so a fast pre-dispatch escalation failure unwound the
+// loop while ACP still returned the prior cheap-model text as a fake
+// success. Two fixes, always-correct:
+//   1. Always emit an observable provider_error `iteration_end` event.
+//   2. If this was an ESCALATED turn (current provider/model differs
+//      from the captured primary) and we have not already retried the
+//      primary for this failure, degrade to the PRIMARY provider for
+//      one more turn instead of unwinding into a fake success.
+// Rebind opts back to the primary provider/model and retry one turn.
 // Recoverable: emergency-compact the transcript and retry the turn
 // before treating overflow as a failure. The agent must keep working
 // on a large repo, not die when the prompt outgrows the window.

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -2030,6 +2030,41 @@ fn __agent_loop_tracks_failure(error, config) {
   return false
 }
 
+/**
+ * Surface a NON-tracked provider failure as an observable event instead of a
+ * silent `break`. Mirrors the tracked-failure branch's `iteration_end` event
+ * so any provider_error (including a fast pre-dispatch escalation failure) is
+ * always visible in the transcript, carrying the provider/model/status/error
+ * that caused it. The dispatch_skipped/skip_reason shape matches the tracked
+ * branch so existing consumers parse it uniformly.
+ */
+fn __agent_loop_emit_provider_error(session_id, iteration_index, call, llm_opts, loop_start_ms, escalation_fallback) {
+  let aggregates = __agent_loop_budget_aggregates(session_id, nil, loop_start_ms)
+  agent_emit_event(
+    session_id,
+    "iteration_end",
+    {
+      iteration: iteration_index + 1,
+      iteration_info: aggregates
+        + {
+        dispatch_skipped: true,
+        skip_reason: if escalation_fallback {
+          "escalation_provider_failure"
+        } else {
+          "provider_failure"
+        },
+        provider_error: call?.error ?? {},
+        provider: to_string(llm_opts?.provider ?? ""),
+        model: to_string(llm_opts?.model ?? ""),
+        provider_status: to_string(call?.status ?? ""),
+        provider_error_message: to_string(call?.error?.message ?? call?.error ?? ""),
+        consecutive_failures: 0,
+        escalation_fallback: escalation_fallback,
+      },
+    },
+  )
+}
+
 fn __agent_loop_finalize_failed(session, iteration) {
   try {
     agent_session_finalize(
@@ -2607,6 +2642,13 @@ fn __agent_loop_run(message, session, initial_opts) {
   var audit_background_tasks = []
   let run = try {
     opts = agent_mcp_bootstrap_if_needed(session, opts)
+    // Capture the PRIMARY provider/model once, before any post-turn escalation
+    // can rebind `opts`. A failed escalated turn falls back to this for one
+    // retry instead of unwinding the whole loop into a fake success.
+    let primary_llm_opts = __agent_loop_effective_llm_options(opts)
+    let primary_provider = to_string(primary_llm_opts?.provider ?? "")
+    let primary_model = to_string(primary_llm_opts?.model ?? "")
+    var escalation_retry_pending = false
     var stop_reason = nil
     var final_status = ""
     var terminal_error = nil
@@ -2791,11 +2833,47 @@ fn __agent_loop_run(message, session, initial_opts) {
           }
           continue
         }
+        // NON-tracked provider failure. Previously this branch broke SILENTLY
+        // (no event), so a fast pre-dispatch escalation failure unwound the
+        // loop while ACP still returned the prior cheap-model text as a fake
+        // success. Two fixes, always-correct:
+        //   1. Always emit an observable provider_error `iteration_end` event.
+        //   2. If this was an ESCALATED turn (current provider/model differs
+        //      from the captured primary) and we have not already retried the
+        //      primary for this failure, degrade to the PRIMARY provider for
+        //      one more turn instead of unwinding into a fake success.
+        let failed_provider = to_string(turn_llm_opts?.provider ?? "")
+        let failed_model = to_string(turn_llm_opts?.model ?? "")
+        let was_escalated = (primary_provider != "" || primary_model != "")
+          && (failed_provider != primary_provider || failed_model != primary_model)
+        let can_retry_primary = was_escalated && !escalation_retry_pending
+        __agent_loop_emit_provider_error(
+          session.session_id,
+          iteration_index,
+          call,
+          turn_llm_opts,
+          loop_start_ms,
+          can_retry_primary,
+        )
+        if can_retry_primary {
+          // Rebind opts back to the primary provider/model and retry one turn.
+          opts = opts
+            + {
+            provider: primary_provider,
+            model: primary_model,
+            llm_options: (opts?.llm_options ?? {})
+              + {provider: primary_provider, model: primary_model},
+          }
+          escalation_retry_pending = true
+          iteration = iteration + 1
+          continue
+        }
         final_status = call.status
         stop_reason = call?.stop_reason ?? call.status
         terminal_error = call?.error
         break
       }
+      escalation_retry_pending = false
       let llm_result = call.value
       consecutive_failure_count = 0
       iteration = iteration + 1


### PR DESCRIPTION
## Problem (C13, confirmed)

In the headless eval, when smart-escalation switches the model to the frontier
provider mid-trial and that escalated `llm_call` fails fast pre-dispatch
(`{ok:false, status:"provider_error"}`), the agent loop broke **silently**:

- `__agent_loop_tracks_failure` returns `false` by default (the budget's
  `consecutive_failures` config is `nil`, so no error class is "tracked").
- The non-tracked branch in `agent/loop.harn` set `final_status="provider_error"`
  and `break` while emitting **no event** — the `iteration_end`/`provider_error`
  event only existed in the *tracked*-failure branch.
- ACP then returned a normal response and the headless driver recorded
  `completed:true` reusing the prior cheap-model text. An escalation **failure**
  masqueraded as **success**, and escalation was silently inert.

## Fix (always-correct, default-ON — surfacing a silent failure is never wrong)

In `__agent_loop_run`:

1. Capture the **primary** provider/model once, before any post-turn escalation
   can rebind `opts`.
2. In the non-tracked provider-error branch, before deciding to stop:
   - **Always emit** an observable `iteration_end` provider_error event
     (`__agent_loop_emit_provider_error`) mirroring the tracked branch and
     carrying the failed **provider / model / status / error message** — so the
     next escalation run shows *why* the frontier call failed.
   - If this was an **escalated** turn (current provider/model differs from the
     captured primary) and we have not already retried for this failure,
     **degrade to the primary provider for one more turn** instead of unwinding
     into a fake success. Bounded by a one-shot `escalation_retry_pending` flag
     (resets on any successful call), so a primary that also fails stops normally.
3. Normal (non-escalation) provider_error handling is preserved: it still stops
   with `provider_error`, now with the event emitted (no silent break) and no
   spurious retry.

## Test

New conformance test `conformance/tests/agents/agent_loop_escalation_provider_error.harn`
drives `agent_loop` with an `llm_caller` that fails on the escalated provider and
a `post_turn_callback` that escalates once. It asserts:

- (a) a provider_error `iteration_end` event **is** emitted (`provider=escalated`,
  `model=frontier`, `provider_status=provider_error`,
  `skip_reason=escalation_provider_failure`) — not silent;
- (b) the run is **not** recorded as a fake success — it converges to a real
  `done` via the primary fallback;
- (c) the primary-retry fallback fires — the recorded provider sequence is
  `mock,escalated,mock,mock`;
- regression guard: a plain primary provider_error still emits an event, stops
  with `provider_error`, and does **not** spuriously retry.

### Commands / results

- `harn test conformance tests/agents` → **229 passed, 0 failed**
- `harn lint` on changed files → no issues
- `cargo test -p harn-vm --test agent_loop_steering_seams` → **6 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)