### PR TITLE
fix(agent-loop): collapse every distinct intra-turn fan-out group, not just the first

### DIFF
--- a/changelog.d/intra-turn-fanout-multigroup.fixed.md
+++ b/changelog.d/intra-turn-fanout-multigroup.fixed.md
@@ -1,0 +1,8 @@
+- Agent loop: `intra_turn_failure_fanout_cap` now collapses EVERY distinct
+  identical-failure group in one response, not just the first. A single
+  `collapsed_emitted` latch let the first capped fan-out group suppress the
+  collapse marker for every later group in the same batch, silently dropping
+  those groups' tail calls from the result set with no entry at all. The latch
+  now resets whenever a new call signature trips the cap, so each group emits
+  exactly one synthetic collapsed result (regression-guarded by a two-group
+  scenario in `agent_loop_intra_turn_failure_fanout_cap`).

--- a/conformance/tests/agents/agent_loop_intra_turn_failure_fanout_cap.expected
+++ b/conformance/tests/agents/agent_loop_intra_turn_failure_fanout_cap.expected
@@ -9,3 +9,7 @@ done
 true
 true
 true
+done
+2
+true
+true

--- a/conformance/tests/agents/agent_loop_intra_turn_failure_fanout_cap.harn
+++ b/conformance/tests/agents/agent_loop_intra_turn_failure_fanout_cap.harn
@@ -61,6 +61,21 @@ fn identical_edit_batch(n) {
   return calls
 }
 
+fn two_group_edit_batch(n) {
+  var calls = []
+  var i = 0
+  while i < n {
+    calls = calls.push({id: "a" + to_string(i), name: "edit", arguments: {path: "a.swift"}})
+    i = i + 1
+  }
+  i = 0
+  while i < n {
+    calls = calls.push({id: "b" + to_string(i), name: "edit", arguments: {path: "b.swift"}})
+    i = i + 1
+  }
+  return calls
+}
+
 fn distinct_look_batch(n) {
   var calls = []
   var i = 0
@@ -149,6 +164,37 @@ pipeline main() {
       __io_println(contains(second_turn, "contents of f0.swift"))
       __io_println(contains(second_turn, "contents of f5.swift"))
       __io_println(!contains(second_turn, "collapsed remaining identical failing"))
+    },
+  )
+  // Scenario 4: TWO distinct identical-failure fan-out groups in ONE response
+  // (6×edit a.swift then 6×edit b.swift), cap=3. Each group must trip the cap
+  // and emit its OWN single collapse marker -> exactly 2 markers. Regression
+  // guard for the single-boolean `collapsed_emitted` latch that previously let
+  // group A's collapse suppress group B's, silently dropping group B's tail
+  // calls from the result set with no entry at all.
+  with_llm_script(
+    [{text: "", tool_calls: two_group_edit_batch(6)}, llm_text("I see the edits were rejected.")],
+    { ->
+      let result = agent_loop(
+        "Fan out two distinct identical failing edit groups.",
+        nil,
+        {
+          provider: "mock",
+          tools: rejecting_edit_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 3,
+          done_judge: nil,
+          intra_turn_failure_fanout_cap: 3,
+        },
+      )
+      let calls = llm_mock_calls()
+      let second_turn = json_stringify(calls[1].messages)
+      let marker = "collapsed remaining identical failing"
+      __io_println(result.status)
+      __io_println(to_string(second_turn.split(marker).count() - 1))
+      __io_println(contains(second_turn, "a.swift"))
+      __io_println(contains(second_turn, "b.swift"))
     },
   )
 }

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -1561,7 +1561,17 @@ fn __dispatch_tool_calls_with_middleware(tool_calls, tools, options, cap) {
         } else if signature == streak_signature {
           streak_count = streak_count + 1
           if streak_count >= fanout_cap {
-            capped_call_signature = __intra_turn_call_signature(call)
+            let new_capped = __intra_turn_call_signature(call)
+            // A DISTINCT fan-out group tripped the cap: reset the
+            // collapse-emitted latch so this group gets its OWN single
+            // synthetic "collapsed" result. Without this reset the latch
+            // (set by an earlier group) suppresses every collapse marker
+            // after the first, silently dropping the tail of later groups
+            // from `results` with no entry at all.
+            if new_capped != capped_call_signature {
+              collapsed_emitted = false
+            }
+            capped_call_signature = new_capped
             capped_sample = result
           }
         } else {


### PR DESCRIPTION
## Audit context

Code-quality + bug audit of the last 10 merged Harn PRs (#3517, #3519, #3520, #3523, #3530, #3534, #3535, #3536, #3538, #3542 + the v0.8.135/136/137 releases). Each code-touching PR was empirically probed, not just eyeballed. This PR ships the ONE bug that was reproduced with a failing-before/passing-after probe AND whose fix is unambiguous. Other findings are reported in the audit summary (not shipped) — see below.

## The bug (CONFIRMED, reproduced) — #3519 intra-turn fan-out cap drops later groups

`crates/harn-stdlib/src/stdlib/agent/loop.harn`. The `intra_turn_failure_fanout_cap` lever (added in #3519, default OFF) collapses the tail of an identical-failure fan-out into one synthetic result. It tracked whether the collapsed result had been emitted with a **single `collapsed_emitted` boolean**.

When ONE model response fans out **two or more distinct identical-failure groups** (e.g. `6×edit a.swift` then `6×edit b.swift`), the first group trips the cap, emits its collapse marker, and sets `collapsed_emitted = true`. The second group's tail calls then take the skip branch — but `if !collapsed_emitted` is already false, so **no collapsed result is emitted for the second group and its tail calls are dropped from the result set with no entry at all**. The model gets zero feedback for the second group and the dispatch result list is shorter than the call list.

### Reproducing probe (failing before, passing after)

Two distinct 6-call failing `edit` groups in one response, `cap=3`:

- **Before:** `collapse_marker_count=1` (group B's tail silently dropped)
- **After:** `collapse_marker_count=2` (both groups represented, each with exactly one collapsed marker)

Added as **Scenario 4** of `conformance/tests/agents/agent_loop_intra_turn_failure_fanout_cap.harn`.

### The fix

Reset `collapsed_emitted = false` whenever a **new** call signature trips the cap, so each distinct fan-out group emits exactly one synthetic collapsed result. A success or different signature still resets the streak; distinct/non-failing batches are still never capped.

## Verification

- `cargo run --bin harn -- test conformance --filter agent_loop_intra_turn_failure_fanout_cap` — PASS (original single-group, flag-off, distinct-success scenarios + new two-group Scenario 4)
- All 76 `agent_loop` conformance tests — PASS
- `harn fmt --check` on `loop.harn` — clean
- `harn lint` — only pre-existing ambient-clock (`sleep_ms`/`now_ms`) warnings at loop.harn:82/86, unrelated to this change
- Rebased onto fresh `origin/main` (incl. #3543) — fix intact, conformance green

## Other PRs audited (NOT shipped here)

- **#3519 parser arm, #3523 Anthropic egress strip, #3517 test-pairing keys, #3534 serde_yml→noyalib migration, #3538 redaction sinks/action-graph/JSONL** — probed, no shippable bug. serde_yml 0.0.13 (noyalib) coerces non-string YAML keys to strings rather than erroring, so the `String`-keyed `Mapping` migration is behavior-preserving (probed). #3517 pairing is extension-scoped and I could not manufacture a realistic false pair.
- **#3538 `save_run_record` redaction (OPEN, not fixed):** redaction is applied to the durable run record with the default (string-scanning) policy, and that record is the functional resume/replay/eval source. URL/secret/`key=value`-shaped substrings in tool results get rewritten at rest. This is INTENTIONAL and explicitly tested (`save_run_record_redacts_secrets_before_persisting`), and replay compares both baseline and candidate under the same policy, so it is symmetric going forward. The only real skew is a NEW redacted run vs an OLD raw baseline. Flagged for a design call (raw-truth vs redacted-observability split, the same split the PR deferred for the trigger inbox) rather than blind-patched.
- **#3520 missing-tool-call classifier (OPEN, not fixed):** the suppression gate `if opts?._llm_caller != nil && !has_test_classifier { return nil }` (`postturn.harn:344`) over-reaches: `_llm_caller` is a production composability seam (captain presets, retry/routing/logging), not a test signal, and the classifier dispatches via the default typed-output checkpoint and never routes through that caller — so recovery is silently OFF for the entire captain/composed-caller class on real providers, contradicting the stated default-ON. This is a real reachability gap by code-reading, but it is NOT reproducible in the offline conformance harness (`with_llm_script` only intercepts `provider: "mock"`, where the sibling mock guard already governs the path), and the fix is a default-ON cost change to a routing-adjacent path. Deferred rather than shipped unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)