### PR TITLE
test(conformance): mechanism-contract onramp tier + escalation progress-credit contract

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,3 +11,17 @@ gate without cancelling other in-flight checks. See
 ## Summary
 
 ## Notes for reviewers
+
+<!--
+Mechanism-contract gate (onramp tier). If this PR adds or changes a
+termination / escalation / judge / guard / routing mechanism, a mechanism
+contract must be present and GREEN — a manufactured mini-eval under
+`conformance/tests/mechanisms/*.contract.harn` proving the mechanism fires on
+its trigger, emits its observable effect, and does NOT fire on the negative
+case. This mirrors the tracked-flag reachability-probe requirement: a new lever
+must prove it engages before it ships. A GREEN contract is a precondition to
+starting an N>=5 meter run — not a replacement for it (the meter still owns
+convergence claims; see docs/eval/meter-stick.md). Delete this comment if no
+such mechanism is touched. See conformance/tests/mechanisms/README.md.
+-->
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup clean-stale-targets install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts test-agent-scripts test-pr-gate-scripts conformance protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone check-vm-rss-soak bench-llm bench-orchestration bench-cli-cold-start loadgen-postgres all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts gen-connector-schemas check-connector-schemas check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-run-view-fixtures check-run-view-fixtures gen-trigger-quickref check-trigger-quickref gen-provider-capabilities check-provider-capabilities gen-provider-matrix check-provider-matrix check-provider-support gen-provider-config check-provider-config check-provider-catalog check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-cli-flags check-docs-links check-site-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc gen-tree-sitter-keywords check-tree-sitter-keywords check-grammar-keywords check-generated-registry
+.PHONY: setup clean-stale-targets install-hooks configure-merge-drivers build build-release sign-local check fmt fmt-harn fmt-harn-fix lint lint-md lint-actions lint-harn spec-lint test test-e2e test-cargo test-fast test-harn-scripts test-agent-scripts test-pr-gate-scripts conformance mechanism-contracts protocol-conformance mcp-rc-conformance replay-oracle replay-bench eval-tool-calls bench-vm bench-vm-micro bench-vm-clone check-vm-rss-soak bench-llm bench-orchestration bench-cli-cold-start loadgen-postgres all release-gate release-smoke smoke-audit portal portal-check portal-demo gen-highlight check-highlight gen-protocol-artifacts check-protocol-artifacts gen-connector-schemas check-connector-schemas check-burin-protocol-artifacts check-bindings gen-session-bundle-schema check-session-bundle-schema gen-run-view-fixtures check-run-view-fixtures gen-trigger-quickref check-trigger-quickref gen-provider-capabilities check-provider-capabilities gen-provider-matrix check-provider-matrix check-provider-support gen-provider-config check-provider-config check-provider-catalog check-connector-matrix check-trigger-examples check-docs-model-refs check-docs-snippets check-docs-cli-flags check-docs-links check-site-snippets check-docs-workflow-quickstart sync-language-spec check-language-spec sync-diagnostics-catalog check-diagnostics-catalog lint-test-patterns lint-diagnostic-codes check-receipt-structs lint-no-rust-prompt-prose lint-no-xfail-regression check-provider-catalog-drift check-ported-handler-loc gen-tree-sitter-keywords check-tree-sitter-keywords check-grammar-keywords check-generated-registry
 
 # Full quality check: format first, then lint/test in parallel.
 # Usage: make all -j       (parallel checks after formatting)
@@ -120,6 +120,16 @@ test-fast:
 # Run Harn conformance test suite
 conformance:
 	HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test conformance
+
+# Mechanism-contract onramp tier: the manufactured mini-evals that prove a new
+# termination/escalation/judge/guard/routing mechanism ENGAGES correctly (fires
+# on its trigger, emits its effect, does NOT fire on the negative case) before
+# any N>=5 convergence gauntlet. A focused, fast filter over the
+# conformance/tests/mechanisms/*.contract.harn suite — already covered by
+# `make conformance`, broken out here for authoring and as the documented gate.
+# See conformance/tests/mechanisms/README.md.
+mechanism-contracts:
+	HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test conformance --filter '.contract'
 
 protocol-conformance:
 	HARN_LLM_CALLS_DISABLED=1 cargo run --bin harn -- test protocols

--- a/conformance/tests/mechanisms/README.md
+++ b/conformance/tests/mechanisms/README.md
@@ -1,0 +1,78 @@
+# Mechanism contracts (the onramp tier)
+
+The **first required rung below the N≥5 convergence gauntlet.** A mechanism
+contract is a _manufactured mini-eval_: a deterministic fixture, driven by a
+mock provider scripted to emit an exact event sequence, that proves a harness
+feature **engages correctly in isolation** before any convergence measurement.
+
+It exists because the team has shipped features that went straight from
+"implemented" to "measure on the full gauntlet" and only discovered _via a full
+track day_ that the mechanism never attached: the smart-escalation ladder
+masqueraded a provider failure as success (harn #3543) and cut a converging
+`swift-feat` run at 3 strikes with ~85% of its budget unused. Those are
+"does it attach?" failures — the gauntlet is the wrong, slow, expensive,
+confounded tool for them.
+
+## The contract
+
+Every new **termination / escalation / judge / guard / routing** mechanism
+declares a contract = **{trigger, effect, negative}**:
+
+- **trigger** — the condition it claims to handle, _manufactured_ by a mock
+  provider scripted to emit the exact event sequence;
+- **effect** — the observable `AgentEvent` / status it must produce;
+- **negative** — the case where it must **not** fire.
+
+A fixture drives `agent_loop` through the mock and pins each clause as a
+deterministic golden line. No real model, no cloud, milliseconds,
+exact-input → exact-output. This is **purely fitness-for-purpose** — it does not
+try to prove the feature improves convergence or doesn't regress other
+qualities. That stays the gauntlet's job.
+
+## Relationship to the meter gate
+
+A GREEN contract is a **precondition to starting a meter run, never a
+replacement** for it. The N≥5 paired-CI meter (`docs/eval/meter-stick.md`) still
+owns every convergence claim. The onramp just refuses to spend gauntlet hours on
+a mechanism that has not been shown to engage.
+
+## Authoring a contract
+
+1. Add `conformance/tests/mechanisms/<name>.contract.harn` with a
+   `pipeline default()` that drives `agent_loop` and prints one golden line per
+   clause via the `contract_effect` / `contract_negative` helpers in
+   `lib/mechanism_contract.harn`.
+2. Capture the golden into `<name>.contract.expected`.
+3. Run `make mechanism-contracts` (a fast filter over `*.contract.harn`).
+   `make conformance` already covers this directory in CI.
+
+### Fixture-authoring rule (read this)
+
+A multi-turn mock **must not** hold per-turn state in a closure `var` counter.
+The agent loop runs the `llm_caller` inside a nested execution descent with an
+isolated environment, so outer-scope `var` mutations do not persist across
+turns — a counter silently replays turn 0 forever and the run hits its budget
+instead of the behavior you scripted (a GREEN-looking but meaningless test).
+Script a turn sequence with either:
+
+- **`shared_cell` / `shared_snapshot` / `shared_set`** (scope `task_group`) —
+  the canonical cross-descent state primitive (see
+  `../agents/agent_loop_escalation_provider_error.harn`); or
+- the harness-supplied **`call.turn.iteration`** index — a stateless key the
+  loop passes to the caller each turn.
+
+## Worked example
+
+The escalation/termination contract is split across two files so neither
+duplicates the other:
+
+- **positive clauses** — escalate on genuine provider failure, **emit** the
+  `provider_error` event (not silent, the #3543 fix), degrade back to the
+  primary — are pinned by
+  `../agents/agent_loop_escalation_provider_error.harn`;
+- **negative clause** — the terminator must **not** fire while the failing
+  error set strictly **shrinks** and budget remains (the `swift-feat`
+  premature-cut regression) — is pinned by
+  `escalation_progress_credit.contract.harn` here.
+
+Together they state the full {trigger, effect, negative} for escalation.

--- a/conformance/tests/mechanisms/escalation_progress_credit.contract.expected
+++ b/conformance/tests/mechanisms/escalation_progress_credit.contract.expected
@@ -1,0 +1,2 @@
+no_premature_stop_while_shrinking=true
+ran_to_completion_not_budget_cut=true

--- a/conformance/tests/mechanisms/escalation_progress_credit.contract.harn
+++ b/conformance/tests/mechanisms/escalation_progress_credit.contract.harn
@@ -1,0 +1,78 @@
+// MECHANISM CONTRACT (onramp tier): escalation/termination PROGRESS CREDIT.
+//
+// This is the FIRST committed example of the mechanism-contract tier (the
+// required rung below the N>=5 gauntlet). It pins the NEGATIVE clause of the
+// escalation/termination contract — the half NOT covered by the merged
+// `agent_loop_escalation_provider_error.harn` (which owns the positive
+// escalate-on-failure + emit-not-silent + degrade-to-primary clauses for the
+// #3543 fix). Together the two tests state the full {trigger, effect, negative}.
+//
+//   CONTRACT (negative): the no-progress / circuit-breaker terminator must NOT
+//   fire while the agent is genuinely CONVERGING — i.e. while the set of failing
+//   errors strictly SHRINKS turn over turn and budget remains. This is the
+//   swift-feat regression: a converging run was cut at 3 strikes with ~85% of
+//   the budget unused because distinct/shrinking failures were miscounted as
+//   "no progress". The terminator keys on BYTE-IDENTICAL failing signatures, so
+//   a shrinking error set is progress and must not terminate.
+//
+// Manufactured deterministically: the mock keys its response on the
+// harness-supplied `call.turn.iteration` (see the fixture-authoring rule in
+// lib/mechanism_contract.harn) and shrinks the error set 9 -> 4 -> 1 -> DONE.
+//
+// POSITIVE clauses (escalate on genuine failure; EMIT provider_error not silent;
+// degrade to primary) are deliberately NOT duplicated here — see
+// conformance/tests/agents/agent_loop_escalation_provider_error.harn.
+import { agent_capture_events } from "std/agent/events"
+import { contract_effect, contract_negative, count_contract_events } from "./lib/mechanism_contract"
+
+fn shrinking_error_set_case() {
+  // Strictly shrinking, NON-identical failing error sets, then completion.
+  // Each turn is a real model result (ok:true) — genuine progress, not an
+  // outage — so the no-progress terminator must credit it and keep going.
+  let errs = [
+    "errors remaining: e1 e2 e3 e4 e5 e6 e7 e8 e9",
+    "errors remaining: e1 e2 e3 e4",
+    "errors remaining: e1",
+    "all clear DONE",
+  ]
+  let caller = { call ->
+    let i = call?.turn?.iteration ?? 0
+    let text = if i < len(errs) {
+      errs[i]
+    } else {
+      "all clear DONE"
+    }
+    return {
+      ok: true,
+      value: {text: text, tool_calls: [], provider: "mock", model: "cheap", input_tokens: 1, output_tokens: 1},
+    }
+  }
+  let session = "contract-shrink-" + uuid()
+  let captured = agent_capture_events(
+    session,
+    fn() { return agent_loop(
+      "fix the build",
+      nil,
+      {
+        session_id: session,
+        provider: "mock",
+        model: "cheap",
+        llm_caller: caller,
+        loop_until_done: true,
+        done_sentinel: "DONE",
+        max_nudges: 8,
+        max_iterations: 8,
+      },
+    ) },
+  )
+  let breaker_count = count_contract_events(captured.events, "budget_circuit_breaker")
+  let stuck_count = count_contract_events(captured.events, "loop_stuck")
+  // NEGATIVE: no premature circuit-break / no-progress stop while shrinking.
+  contract_negative("no_premature_stop_while_shrinking", breaker_count > 0 || stuck_count > 0)
+  // EFFECT: the run reached DONE rather than being cut at budget.
+  contract_effect("ran_to_completion_not_budget_cut", to_string(captured.result.status) == "done")
+}
+
+pipeline default() {
+  shrinking_error_set_case()
+}

--- a/conformance/tests/mechanisms/lib/mechanism_contract.harn
+++ b/conformance/tests/mechanisms/lib/mechanism_contract.harn
@@ -1,0 +1,112 @@
+// -------------------------------------------------------------------------------------------------
+
+// mechanism_contract — the onramp tier scaffold (manufactured mini-eval helper).
+//
+// PURPOSE. The first REQUIRED rung below the N>=5 convergence gauntlet. Every new
+// termination / escalation / judge / guard / routing mechanism declares a
+// MECHANISM CONTRACT = {trigger, effect, negative}:
+//
+//   trigger  — the condition the feature claims to handle, MANUFACTURED here by a
+//              mock provider scripted to emit an exact event sequence;
+//   effect   — the observable AgentEvent / status the feature must produce;
+//   negative — the case where the feature must NOT fire.
+//
+// A deterministic fixture drives `agent_loop` through the mock and asserts the
+// effect fires and the negative does not. No real model, no cloud, ~milliseconds,
+// exact-input -> exact-output. This is PURELY fitness-for-purpose: it proves the
+// mechanism ENGAGES in isolation. It does NOT attempt to prove the feature
+// improves convergence or doesn't regress other qualities — that remains the
+// gauntlet's job, and a GREEN contract is a PRECONDITION to starting a meter run,
+// never a replacement for it (see docs/eval/meter-stick.md).
+//
+// REUSE. This is a thin veneer over the established conformance seam:
+//   * `agent_capture_events(session, fn() { agent_loop(...) })` — drive + capture
+//     typed AgentEvents (the `agent_loop_budget_rails.harn` pattern);
+//   * a scripted `llm_caller` closure — manufacture the trigger;
+//   * `first_contract_event` / `count_contract_events` below — observe the effect.
+//
+
+// -------------------------------------------------------------------------------------------------
+// FIXTURE-AUTHORING RULE (READ THIS — silently-broken mocks come from ignoring it)
+// -------------------------------------------------------------------------------------------------
+
+//
+// A multi-turn mock MUST NOT hold per-turn state in a closure `var` counter. The
+// agent loop runs the `llm_caller` inside a NESTED EXECUTION DESCENT with an
+// isolated environment, so outer-scope `var` mutations DO NOT persist across
+// turns: a `var turn = 0; turn = turn + 1` counter silently replays turn 0
+// forever, the mock never advances, and the run hits its budget instead of the
+// behavior you scripted — a GREEN-looking but meaningless test.
+//
+// Use ONE of these instead to script a turn sequence deterministically:
+//   (A) `shared_cell` / `shared_snapshot` / `shared_set` (scope: "task_group") —
+//       the canonical cross-descent state primitive (see
+//       agent_loop_escalation_provider_error.harn);
+//   (B) the harness-supplied iteration index `call.turn.iteration` — a stateless
+//       key the loop passes to the caller each turn (no shared state needed).
+//
+
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * The first AgentEvent of `event_type` in capture order, or nil.
+ *
+ * @effects: []
+ * @errors: []
+ * @example: first_contract_event(captured.events, "budget_circuit_breaker")
+ */
+pub fn first_contract_event(events, event_type: string) {
+  for event in events {
+    if to_string(event?.type ?? "") == event_type {
+      return event
+    }
+  }
+  return nil
+}
+
+/**
+ * Count AgentEvents of `event_type` — for negative clauses that assert a
+ * mechanism fired ZERO times.
+ *
+ * @effects: []
+ * @errors: []
+ * @example: count_contract_events(captured.events, "loop_stuck")
+ */
+pub fn count_contract_events(events, event_type: string) -> int {
+  var n = 0
+  for event in events {
+    if to_string(event?.type ?? "") == event_type {
+      n = n + 1
+    }
+  }
+  return n
+}
+
+/**
+ * Print one deterministic golden line for a contract EFFECT clause:
+ *   "<name>: <bool>"
+ * The sibling `.expected` golden pins the booleans, so a regression that stops
+ * the mechanism from firing flips the line and RED-flags the PR. Returns `ok`.
+ *
+ * @effects: []
+ * @errors: []
+ * @example: contract_effect("trips_on_failure", breaker != nil)
+ */
+pub fn contract_effect(name: string, ok: bool) -> bool {
+  __io_println(name + "=" + to_string(ok))
+  return ok
+}
+
+/**
+ * Print one deterministic golden line for a NEGATIVE clause: asserts the
+ * mechanism did NOT fire. Prints "<name>=true" when `fired` is false (the
+ * contract holds). Returns `!fired`.
+ *
+ * @effects: []
+ * @errors: []
+ * @example: contract_negative("no_premature_stop", breaker_count > 0)
+ */
+pub fn contract_negative(name: string, fired: bool) -> bool {
+  __io_println(name + "=" + to_string(!fired))
+  return !fired
+}


### PR DESCRIPTION
## Summary

Adds the **mechanism-contract onramp tier** — the first *required* rung below the N≥5 convergence gauntlet. A mechanism contract is a manufactured mini-eval: a deterministic fixture driven by a mock provider that proves a new **termination / escalation / judge / guard / routing** mechanism *engages correctly in isolation* (fires on its trigger, emits its observable effect, does **not** fire on the negative case) before any convergence measurement. No real model, no cloud, milliseconds, exact-input→exact-output. Pure fitness-for-purpose.

**Why.** The smart-escalation ladder shipped straight from "implemented" to "measure on the gauntlet" and only a full track day revealed it never attached right — it masqueraded a provider failure as success (#3543) and cut a converging `swift-feat` run at 3 strikes with ~85% of its budget unused. Those are "does it attach?" failures; the gauntlet is the wrong, slow, expensive, confounded tool for them. A GREEN contract is a **precondition to starting a meter run, never a replacement** (the N≥5 meter still owns convergence claims; `docs/eval/meter-stick.md`).

## What's here

- **`conformance/tests/mechanisms/lib/mechanism_contract.harn`** — the reusable `{trigger, effect, negative}` scaffold (`contract_effect` / `contract_negative` / `first_contract_event` / `count_contract_events`). Documents the fixture-authoring rule prominently: a multi-turn mock must key on `shared_cell` or `call.turn.iteration`, **never** a closure `var` counter — the nested-execution descent isolates the caller env, so a counter silently replays turn 0 and the run hits budget (a green-looking, meaningless test).
- **`conformance/tests/mechanisms/escalation_progress_credit.contract.harn`** (+`.expected`) — the first committed example. It pins the **negative** clause the merged `agent_loop_escalation_provider_error.harn` (#3543) does not cover: the no-progress / circuit-breaker terminator must **not** fire while the failing error set strictly shrinks (9→4→1→DONE) and budget remains — the `swift-feat` premature-cut regression. The two tests together state the full `{trigger, effect, negative}` for escalation; neither duplicates the other.
- **`README.md`** — the methodology + meter-precondition relationship.
- **`Makefile mechanism-contracts`** — a fast `--filter .contract` target; already covered by `make conformance` in CI.
- **PR-template checklist item** — mirrors the tracked-flag reachability-probe requirement.

## Verification

- Contract **GREEN** on `origin/main` (which has #3543).
- A simulated premature-cut regression (budget starved) flips the golden `ran_to_completion_not_budget_cut=true→false` and **RED-flags** the test — the assertion bites, catching the exact swift-feat failure the gauntlet missed.
- `make mechanism-contracts` passes (builds harn-cli, 1 passed).
- `harn fmt --check` and `markdownlint-cli2` clean; pre-push hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)