### PR TITLE
fix(release): guard ACP registry manifest version

### DIFF
--- a/changelog.d/acp-registry-release-guard.fixed.md
+++ b/changelog.d/acp-registry-release-guard.fixed.md
@@ -1,0 +1,4 @@
+- **Release metadata now verifies the ACP registry manifest.** The release
+  audit fails when `spec/acp-registry/harn/agent.json` or any binary archive URL
+  drifts from the Cargo package version, preventing stale editor-install
+  entries after release bumps.

--- a/scripts/tests/verify_release_metadata_test.harn
+++ b/scripts/tests/verify_release_metadata_test.harn
@@ -2,8 +2,11 @@
 // content checks against synthetic Cargo.toml / CHANGELOG.md text without
 // touching the filesystem, subprocesses, or git.
 import {
+  acp_agent_manifest_archive_versions,
+  acp_agent_manifest_version,
   changelog_section_body,
   changelog_versions,
+  check_acp_agent_manifest,
   check_metadata,
   current_version,
   detect_misformatted_headings,
@@ -17,6 +20,21 @@ import {
 let CARGO = "[workspace]\nresolver = \"2\"\n\n[workspace.package]\nversion = \"0.8.71\"\nedition = \"2021\"\n"
 
 let CHANGELOG = "# Changelog\n\nintro text\n\n## v0.8.71\n\n- Added a thing.\n\n## v0.8.70\n\n- Fixed a thing.\n"
+
+let ACP_MANIFEST = "{\n"
+  + "  \"id\": \"harn\",\n"
+  + "  \"version\": \"0.8.71\",\n"
+  + "  \"distribution\": {\n"
+  + "    \"binary\": {\n"
+  + "      \"linux-x86_64\": {\n"
+  + "        \"archive\": \"https://github.com/burin-labs/harn/releases/download/v0.8.71/harn-x86_64-unknown-linux-gnu.tar.gz\"\n"
+  + "      },\n"
+  + "      \"windows-x86_64\": {\n"
+  + "        \"archive\": \"https://github.com/burin-labs/harn/releases/download/v0.8.71/harn-x86_64-pc-windows-msvc.zip\"\n"
+  + "      }\n"
+  + "    }\n"
+  + "  }\n"
+  + "}\n"
 
 @test
 pipeline test_current_version(task) {
@@ -37,6 +55,60 @@ pipeline test_protocol_artifact_version_missing(task) {
     e
   }
   assert_eq(r, "error: missing artifactVersion in spec/protocol-artifacts/manifest.json")
+}
+
+@test
+pipeline test_acp_agent_manifest_version(task) {
+  assert_eq(acp_agent_manifest_version(ACP_MANIFEST), "0.8.71")
+}
+
+@test
+pipeline test_acp_agent_manifest_archive_versions(task) {
+  let versions = acp_agent_manifest_archive_versions(ACP_MANIFEST)
+  assert_eq(versions[0].version, "0.8.71")
+  assert_eq(
+    versions[0].archive,
+    "https://github.com/burin-labs/harn/releases/download/v0.8.71/harn-x86_64-unknown-linux-gnu.tar.gz",
+  )
+}
+
+@test
+pipeline test_check_acp_agent_manifest_ok(task) {
+  check_acp_agent_manifest(ACP_MANIFEST, "0.8.71")
+}
+
+@test
+pipeline test_check_acp_agent_manifest_rejects_stale_version(task) {
+  let manifest = regex_replace(r#""version": "0\.8\.71""#, "\"version\": \"0.8.70\"", ACP_MANIFEST)
+  let r = try {
+    check_acp_agent_manifest(manifest, "0.8.71")
+  } catch (e) {
+    e
+  }
+  assert_eq(
+    r,
+    "error: spec/acp-registry/harn/agent.json version 0.8.70 does not match Cargo.toml version 0.8.71",
+  )
+}
+
+@test
+pipeline test_check_acp_agent_manifest_rejects_stale_archive(task) {
+  let manifest = regex_replace(
+    "releases/download/v0\\.8\\.71/harn-x86_64-unknown-linux-gnu",
+    "releases/download/v0.8.70/harn-x86_64-unknown-linux-gnu",
+    ACP_MANIFEST,
+  )
+  let r = try {
+    check_acp_agent_manifest(manifest, "0.8.71")
+  } catch (e) {
+    e
+  }
+  assert_eq(
+    r,
+    "error: spec/acp-registry/harn/agent.json archive "
+      + "https://github.com/burin-labs/harn/releases/download/v0.8.70/harn-x86_64-unknown-linux-gnu.tar.gz "
+      + "points at v0.8.70 instead of Cargo.toml version v0.8.71",
+  )
 }
 
 @test

--- a/scripts/verify_release_metadata.harn
+++ b/scripts/verify_release_metadata.harn
@@ -22,6 +22,10 @@ let CHANGELOG_PATH = "CHANGELOG.md"
 
 let MANIFEST_PATH = "spec/protocol-artifacts/manifest.json"
 
+let ACP_AGENT_MANIFEST_PATH = "spec/acp-registry/harn/agent.json"
+
+type AcpArchiveVersion = {archive: string, version: string}
+
 /**
  * Pull the workspace `version = "X.Y.Z"` literal from Cargo.toml text.
  * Throws the canonical error when the line is missing.
@@ -46,6 +50,65 @@ pub fn protocol_artifact_version(manifest_text: string) -> string {
     throw "error: missing artifactVersion in " + MANIFEST_PATH
   }
   return caps[0].groups[0]
+}
+
+/**
+ * Pull the top-level ACP Agent Registry manifest version from JSON text.
+ * The manifest is the editor-installable binary distribution entry, so it
+ * must track the Cargo package version that produced the release assets.
+ */
+pub fn acp_agent_manifest_version(manifest_text: string) -> string {
+  let manifest = json_parse(manifest_text)
+  let version = json_pointer(manifest, "/version")
+  if type_of(version) != "string" {
+    throw "error: missing version in " + ACP_AGENT_MANIFEST_PATH
+  }
+  return version
+}
+
+/**
+ * Return every release version embedded in the ACP manifest's binary archive
+ * URLs, paired with the source URL for precise failure messages.
+ */
+pub fn acp_agent_manifest_archive_versions(manifest_text: string) -> list<AcpArchiveVersion> {
+  let manifest = json_parse(manifest_text)
+  let archives = jq(manifest, ".distribution.binary[] | .archive")
+  if archives.count == 0 {
+    throw "error: missing binary archive URLs in " + ACP_AGENT_MANIFEST_PATH
+  }
+  var versions = []
+  for archive in archives {
+    if type_of(archive) != "string" {
+      throw "error: non-string binary archive URL in " + ACP_AGENT_MANIFEST_PATH
+    }
+    let caps = regex_captures(r"/releases/download/v([^/]+)/", archive)
+    if caps.count == 0 {
+      throw "error: binary archive URL in " + ACP_AGENT_MANIFEST_PATH
+        + " does not include a GitHub release version: "
+        + archive
+    }
+    versions = versions + [{archive: archive, version: caps[0].groups[0]}]
+  }
+  return versions
+}
+
+/** Ensure the ACP Agent Registry manifest points at the current release. */
+pub fn check_acp_agent_manifest(manifest_text: string, version: string) {
+  let manifest_version = acp_agent_manifest_version(manifest_text)
+  if manifest_version != version {
+    throw "error: " + ACP_AGENT_MANIFEST_PATH + " version " + manifest_version
+      + " does not match Cargo.toml version "
+      + version
+  }
+  for item in acp_agent_manifest_archive_versions(manifest_text) {
+    if item.version != version {
+      throw "error: " + ACP_AGENT_MANIFEST_PATH + " archive " + item.archive
+        + " points at v"
+        + item.version
+        + " instead of Cargo.toml version v"
+        + version
+    }
+  }
 }
 
 /** Return every `## vX.Y.Z` heading version, in file order. */
@@ -320,6 +383,8 @@ pipeline main(task) {
         + "; run `make gen-protocol-artifacts` (and "
         + "scripts/sync_protocol_fixture_runtime_versions.harn) after bumping the version"
     }
+    let acp_manifest_text = harness.fs.read_text(ACP_AGENT_MANIFEST_PATH)
+    check_acp_agent_manifest(acp_manifest_text, version)
     verify_release_notes(effective_version)
     verify_tag_state(effective_version)
     __io_println(success_message(version, effective_version))

--- a/spec/acp-registry/README.md
+++ b/spec/acp-registry/README.md
@@ -17,8 +17,8 @@ ACP-speaking clients.
 ## What's here
 
 - [`harn/agent.json`](harn/agent.json) — the registry manifest entry, pinned to
-  the v0.8.133 binary distribution (GitHub release tarballs for the five
-  published targets), launching `harn serve acp`.
+  the current Cargo package version's binary distribution (GitHub release
+  tarballs for the five published targets), launching `harn serve acp`.
 - [`harn/icon.svg`](harn/icon.svg) — 16×16 `currentColor` icon.
 
 This is the agent's free editor discoverability listing. It is **not** the

--- a/spec/acp-registry/harn/agent.json
+++ b/spec/acp-registry/harn/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "harn",
   "name": "Harn",
-  "version": "0.8.137",
+  "version": "0.8.138",
   "description": "Harn runs .harn agent pipelines as a native ACP coding agent over stdio. Powers the Burin Code workbench.",
   "repository": "https://github.com/burin-labs/harn",
   "website": "https://harnlang.com",
@@ -12,7 +12,7 @@
   "distribution": {
     "binary": {
       "darwin-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.8.137/harn-aarch64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.8.138/harn-aarch64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -20,7 +20,7 @@
         ]
       },
       "darwin-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.8.137/harn-x86_64-apple-darwin.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.8.138/harn-x86_64-apple-darwin.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -28,7 +28,7 @@
         ]
       },
       "linux-aarch64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.8.137/harn-aarch64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.8.138/harn-aarch64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -36,7 +36,7 @@
         ]
       },
       "linux-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.8.137/harn-x86_64-unknown-linux-gnu.tar.gz",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.8.138/harn-x86_64-unknown-linux-gnu.tar.gz",
         "cmd": "./harn",
         "args": [
           "serve",
@@ -44,7 +44,7 @@
         ]
       },
       "windows-x86_64": {
-        "archive": "https://github.com/burin-labs/harn/releases/download/v0.8.137/harn-x86_64-pc-windows-msvc.zip",
+        "archive": "https://github.com/burin-labs/harn/releases/download/v0.8.138/harn-x86_64-pc-windows-msvc.zip",
         "cmd": "harn.exe",
         "args": [
           "serve",


### PR DESCRIPTION
## Summary
- Update `spec/acp-registry/harn/agent.json` from v0.8.137 to v0.8.138 so the checked-in editor-install manifest matches the published release assets.
- Teach `scripts/verify_release_metadata.harn` to parse the ACP registry manifest and fail when the manifest version or any archive URL drifts from Cargo.toml.
- Add pure Harn regression tests for stale manifest versions and stale archive URLs.

## Verification
- `harn fmt --check scripts/verify_release_metadata.harn scripts/tests/verify_release_metadata_test.harn`
- `harn check scripts/verify_release_metadata.harn`
- `harn test scripts/tests/verify_release_metadata_test.harn`
- `harn run scripts/verify_release_metadata.harn`
- `HARN_LLM_CALLS_DISABLED=1 cargo nextest run -p harn-cli --test acp_registry_manifest --profile e2e`

## Root cause
The v0.8.138 release commit bumped Cargo and release artifacts, but the ACP registry manifest stayed on v0.8.137. The scheduled E2E job caught this after publishing; this moves the check into the release metadata audit so stale registry entries fail before release finalization.