### PR TITLE
[codex] Share runtime SQLite WAL setup

### DIFF
--- a/changelog.d/sqlite-event-log-wal-open.fixed.md
+++ b/changelog.d/sqlite-event-log-wal-open.fixed.md
@@ -1,0 +1,1 @@
+Avoid noisy SQLite event-log startup failures when concurrent processes open an already-WAL database.

--- a/crates/harn-vm/src/durable_rate_limit.rs
+++ b/crates/harn-vm/src/durable_rate_limit.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant};
 
 use rusqlite::{params, Connection, ErrorCode, TransactionBehavior};
 
+use crate::runtime_sqlite::{configure_runtime_sqlite, RuntimeSqliteError};
 use crate::stdlib::macros::{harn_builtin, VmBuiltinDef};
 use crate::stdlib::options::{non_negative_millis_from_value, ErrorKind};
 use crate::stdlib::sandbox::{self, FsAccess};
@@ -287,23 +288,30 @@ where
 enum ReserveOnceError {
     Vm(VmError),
     Sqlite(rusqlite::Error),
+    RuntimeSqlite(RuntimeSqliteError),
 }
 
 impl ReserveOnceError {
     fn is_sqlite_busy_or_locked(&self) -> bool {
-        let Self::Sqlite(rusqlite::Error::SqliteFailure(error, _)) = self else {
-            return false;
-        };
-        matches!(
-            error.code,
-            ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked
-        )
+        match self {
+            Self::Sqlite(rusqlite::Error::SqliteFailure(error, _)) => {
+                matches!(
+                    error.code,
+                    ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked
+                )
+            }
+            Self::RuntimeSqlite(error) => error.is_busy_or_locked(),
+            Self::Vm(_) | Self::Sqlite(_) => false,
+        }
     }
 
     fn into_vm_error(self) -> VmError {
         match self {
             Self::Vm(error) => error,
             Self::Sqlite(error) => sql_error(error),
+            Self::RuntimeSqlite(error) => VmError::Runtime(format!(
+                "durable_rate_limit_acquire: sqlite setup error: {error}"
+            )),
         }
     }
 }
@@ -339,16 +347,8 @@ fn try_reserve_once_inner(
     }
 
     let mut conn = Connection::open(path)?;
-    // Set busy_timeout BEFORE the WAL pragma so the WAL-mode promotion waits
-    // out a transient SQLITE_BUSY from another session's writer instead of
-    // failing fast. WAL lets concurrent sessions sharing this project's
-    // rate-limit DB serialize on the write lock for at most busy_timeout
-    // rather than throwing "database is locked" up into the agent loop.
-    // Matches the proven event-log setup (crates/harn-vm/src/event_log/sqlite.rs).
-    conn.busy_timeout(Duration::from_millis(sqlite_busy_timeout_ms))
-        .map_err(ReserveOnceError::Sqlite)?;
-    conn.pragma_update(None, "journal_mode", "WAL")?;
-    conn.pragma_update(None, "synchronous", "NORMAL")?;
+    configure_runtime_sqlite(&conn, Duration::from_millis(sqlite_busy_timeout_ms))
+        .map_err(ReserveOnceError::RuntimeSqlite)?;
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS durable_rate_limit_entries (
             bucket_key TEXT NOT NULL,

--- a/crates/harn-vm/src/event_log/sqlite.rs
+++ b/crates/harn-vm/src/event_log/sqlite.rs
@@ -1,9 +1,12 @@
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use bytes::Bytes;
 use futures::stream::BoxStream;
 use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
+
+use crate::runtime_sqlite::{configure_runtime_sqlite, DEFAULT_BUSY_TIMEOUT};
 
 use super::util::{
     event_id_to_sqlite_i64, now_ms, prepare_event_after, sqlite_i64_to_event_id,
@@ -24,27 +27,31 @@ pub struct SqliteEventLog {
 
 impl SqliteEventLog {
     pub fn open(path: PathBuf, queue_depth: usize) -> Result<Self, LogError> {
+        Self::open_inner(path, queue_depth, DEFAULT_BUSY_TIMEOUT)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn open_with_timeout(
+        path: PathBuf,
+        queue_depth: usize,
+        busy_timeout: Duration,
+    ) -> Result<Self, LogError> {
+        Self::open_inner(path, queue_depth, busy_timeout)
+    }
+
+    fn open_inner(
+        path: PathBuf,
+        queue_depth: usize,
+        busy_timeout: Duration,
+    ) -> Result<Self, LogError> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)
                 .map_err(|error| LogError::Io(format!("event log mkdir error: {error}")))?;
         }
         let connection = Connection::open(&path)
             .map_err(|error| LogError::Sqlite(format!("event log open error: {error}")))?;
-        // Set busy_timeout BEFORE the WAL pragma so SQLite waits out transient
-        // SQLITE_BUSY from a previous test's connection that hasn't finished
-        // dropping yet (parallel `cargo test` on the same process, distinct
-        // paths, still contends on SQLite's own global mutex under WAL-mode
-        // promotion). Without this, `journal_mode = WAL` fails fast with
-        // "database is locked" instead of retrying.
-        connection
-            .busy_timeout(std::time::Duration::from_secs(5))
-            .map_err(|error| LogError::Sqlite(format!("event log busy-timeout error: {error}")))?;
-        connection
-            .pragma_update(None, "journal_mode", "WAL")
-            .map_err(|error| LogError::Sqlite(format!("event log WAL pragma error: {error}")))?;
-        connection
-            .pragma_update(None, "synchronous", "NORMAL")
-            .map_err(|error| LogError::Sqlite(format!("event log sync pragma error: {error}")))?;
+        configure_runtime_sqlite(&connection, busy_timeout)
+            .map_err(|error| LogError::Sqlite(format!("event log sqlite setup error: {error}")))?;
         connection
             .execute_batch(
                 "CREATE TABLE IF NOT EXISTS topic_heads (

--- a/crates/harn-vm/src/event_log/tests.rs
+++ b/crates/harn-vm/src/event_log/tests.rs
@@ -1,10 +1,11 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures::StreamExt;
 use rand::{rngs::StdRng, RngExt, SeedableRng};
-use rusqlite::params;
+use rusqlite::{params, Connection};
 use tokio::sync::broadcast;
 
 use super::util::{file_size, stream_from_broadcast};
@@ -284,6 +285,26 @@ async fn sqlite_backend_persists_and_checkpoints_after_compact() {
     assert!(compact.checkpointed);
     let wal = PathBuf::from(format!("{}-wal", path.display()));
     assert!(file_size(&wal) == 0 || !wal.exists());
+}
+
+#[test]
+fn sqlite_open_skips_wal_promotion_when_existing_wal_database_is_busy() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("events.sqlite");
+    drop(SqliteEventLog::open(path.clone(), 8).unwrap());
+
+    let writer = Connection::open(&path).unwrap();
+    writer.busy_timeout(Duration::from_millis(0)).unwrap();
+    writer
+        .execute_batch(
+            "BEGIN IMMEDIATE;
+             INSERT OR IGNORE INTO topic_heads(topic, last_id) VALUES ('held.open', 0);",
+        )
+        .unwrap();
+
+    let opened = SqliteEventLog::open_with_timeout(path, 8, Duration::from_millis(25)).unwrap();
+    drop(opened);
+    writer.execute_batch("ROLLBACK").unwrap();
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -77,6 +77,7 @@ pub mod runtime_context;
 pub(crate) mod runtime_guards;
 pub mod runtime_limits;
 pub mod runtime_paths;
+pub(crate) mod runtime_sqlite;
 pub mod schema;
 pub(crate) mod secret_patterns;
 pub mod secrets;

--- a/crates/harn-vm/src/llm/cache.rs
+++ b/crates/harn-vm/src/llm/cache.rs
@@ -4,13 +4,13 @@ use crate::value::VmDictExt;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, VecDeque};
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::runtime_limits::RuntimeLimits;
+use crate::runtime_sqlite::{configure_runtime_sqlite, DEFAULT_BUSY_TIMEOUT};
 use crate::stdlib::clock::now_wall_ms;
 use crate::stdlib::macros::{harn_builtin, register_builtin_defs, VmBuiltinDef};
 use crate::value::{VmError, VmValue};
@@ -555,19 +555,8 @@ fn sqlite_connection(path: &Path) -> Result<Connection, VmError> {
         })?;
     }
     let conn = Connection::open(path).map_err(sqlite_error)?;
-    // Set busy_timeout BEFORE the WAL pragma so SQLite waits out a transient
-    // SQLITE_BUSY while another process/connection is mid-write rather than
-    // failing the WAL-mode promotion fast. WAL then lets one writer and many
-    // readers proceed concurrently, which is what makes the cache safe when
-    // two sessions in the same project run read-heavy roles (evaluator,
-    // enrichment, QC) at once. Matches the proven event-log setup
-    // (crates/harn-vm/src/event_log/sqlite.rs).
-    conn.busy_timeout(Duration::from_secs(5))
-        .map_err(sqlite_error)?;
-    conn.pragma_update(None, "journal_mode", "WAL")
-        .map_err(sqlite_error)?;
-    conn.pragma_update(None, "synchronous", "NORMAL")
-        .map_err(sqlite_error)?;
+    configure_runtime_sqlite(&conn, DEFAULT_BUSY_TIMEOUT)
+        .map_err(|error| VmError::Runtime(format!("cache sqlite setup error: {error}")))?;
     conn.execute_batch(SQLITE_CREATE_TABLE)
         .map_err(sqlite_error)?;
     conn.execute_batch(SQLITE_CREATE_LRU_INDEX)

--- a/crates/harn-vm/src/runtime_sqlite.rs
+++ b/crates/harn-vm/src/runtime_sqlite.rs
@@ -1,0 +1,108 @@
+use std::fmt;
+use std::time::Duration;
+
+use rusqlite::{Connection, ErrorCode};
+
+pub(crate) const DEFAULT_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug)]
+pub(crate) enum RuntimeSqliteError {
+    BusyTimeout(rusqlite::Error),
+    JournalModeQuery(rusqlite::Error),
+    WalPragma(rusqlite::Error),
+    WalBusyNotWal {
+        mode: String,
+    },
+    WalBusyQuery {
+        wal_error: rusqlite::Error,
+        query_error: rusqlite::Error,
+    },
+    Synchronous(rusqlite::Error),
+}
+
+impl RuntimeSqliteError {
+    pub(crate) fn is_busy_or_locked(&self) -> bool {
+        match self {
+            Self::BusyTimeout(error)
+            | Self::JournalModeQuery(error)
+            | Self::WalPragma(error)
+            | Self::Synchronous(error) => is_sqlite_busy_or_locked(error),
+            Self::WalBusyNotWal { .. } => true,
+            Self::WalBusyQuery {
+                wal_error,
+                query_error,
+            } => is_sqlite_busy_or_locked(wal_error) || is_sqlite_busy_or_locked(query_error),
+        }
+    }
+}
+
+impl fmt::Display for RuntimeSqliteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BusyTimeout(error) => write!(f, "busy_timeout failed: {error}"),
+            Self::JournalModeQuery(error) => write!(f, "journal_mode query failed: {error}"),
+            Self::WalPragma(error) => write!(f, "WAL journal_mode pragma failed: {error}"),
+            Self::WalBusyNotWal { mode } => write!(
+                f,
+                "WAL journal_mode pragma was busy and journal_mode stayed {mode}"
+            ),
+            Self::WalBusyQuery {
+                wal_error,
+                query_error,
+            } => write!(
+                f,
+                "WAL journal_mode pragma failed: {wal_error}; journal_mode query also failed: {query_error}"
+            ),
+            Self::Synchronous(error) => write!(f, "synchronous pragma failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for RuntimeSqliteError {}
+
+pub(crate) fn configure_runtime_sqlite(
+    connection: &Connection,
+    busy_timeout: Duration,
+) -> Result<(), RuntimeSqliteError> {
+    connection
+        .busy_timeout(busy_timeout)
+        .map_err(RuntimeSqliteError::BusyTimeout)?;
+    ensure_wal_journal_mode(connection)?;
+    connection
+        .pragma_update(None, "synchronous", "NORMAL")
+        .map_err(RuntimeSqliteError::Synchronous)?;
+    Ok(())
+}
+
+fn ensure_wal_journal_mode(connection: &Connection) -> Result<(), RuntimeSqliteError> {
+    match current_journal_mode(connection) {
+        Ok(mode) if mode.eq_ignore_ascii_case("wal") => return Ok(()),
+        Ok(_) => {}
+        Err(error) => return Err(RuntimeSqliteError::JournalModeQuery(error)),
+    }
+
+    match connection.pragma_update(None, "journal_mode", "WAL") {
+        Ok(()) => Ok(()),
+        Err(error) if is_sqlite_busy_or_locked(&error) => match current_journal_mode(connection) {
+            Ok(mode) if mode.eq_ignore_ascii_case("wal") => Ok(()),
+            Ok(mode) => Err(RuntimeSqliteError::WalBusyNotWal { mode }),
+            Err(query_error) => Err(RuntimeSqliteError::WalBusyQuery {
+                wal_error: error,
+                query_error,
+            }),
+        },
+        Err(error) => Err(RuntimeSqliteError::WalPragma(error)),
+    }
+}
+
+fn current_journal_mode(connection: &Connection) -> Result<String, rusqlite::Error> {
+    connection.query_row("PRAGMA journal_mode", [], |row| row.get::<_, String>(0))
+}
+
+fn is_sqlite_busy_or_locked(error: &rusqlite::Error) -> bool {
+    matches!(
+        error,
+        rusqlite::Error::SqliteFailure(failure, _)
+            if matches!(failure.code, ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked)
+    )
+}


### PR DESCRIPTION
## Summary
- add one shared helper for Harn-owned runtime SQLite databases to configure busy_timeout, WAL journal mode, and synchronous=NORMAL
- make WAL setup idempotent when a database is already in WAL mode, avoiding noisy startup failures from concurrent opens
- reuse the helper in event log, LLM cache, and durable rate-limit storage while keeping the user-facing sqlite_open builtin explicit/configurable
- add a regression for opening an already-WAL event log while another connection holds a writer lock

## Dogfood finding
Running latest Burin headless context and diagnose commands in parallel against the same project produced: `event log WAL pragma error: database is locked`. The fix makes the startup path skip redundant WAL promotion for existing WAL databases and keeps bounded busy handling for real setup contention.

## Verification
- cargo fmt --check -p harn-vm
- cargo test -p harn-vm sqlite_open_skips_wal_promotion_when_existing_wal_database_is_busy
- cargo test -p harn-vm sqlite_backend_persists_and_checkpoints_after_compact
- cargo test -p harn-vm sqlite_cache_connection_uses_wal_journal_mode
- cargo test -p harn-vm rate_limit_db_uses_wal_journal_mode
- git diff --check
- git diff --cached --check
- pre-push hook: markdownlint, targeted Rust checks, generated highlight keywords
