### PR TITLE
fix(crystallize): flag explicitly non-deterministic actions; dedup helpers

### DIFF
--- a/changelog.d/3555.fixed.md
+++ b/changelog.d/3555.fixed.md
@@ -1,0 +1,4 @@
+- Workflow crystallization now rejects traces whose actions are explicitly
+  marked non-deterministic (e.g. rejected tool calls, human-approval steps)
+  even when they are not flagged `fuzzy`, closing a hole where such actions
+  carrying a side effect could be mined into a "deterministic" workflow.

--- a/crates/harn-cli/src/commands/eval_tool_calls.rs
+++ b/crates/harn-cli/src/commands/eval_tool_calls.rs
@@ -885,14 +885,9 @@ fn latency_stats(values: impl IntoIterator<Item = u64>) -> LatencyStats {
     }
     values.sort_unstable();
     LatencyStats {
-        p50_ms: percentile(&values, 0.50),
-        p99_ms: percentile(&values, 0.99),
+        p50_ms: super::nearest_rank_percentile(&values, 0.50).unwrap_or(0),
+        p99_ms: super::nearest_rank_percentile(&values, 0.99).unwrap_or(0),
     }
-}
-
-fn percentile(sorted: &[u64], percentile: f64) -> u64 {
-    let rank = ((sorted.len() as f64 * percentile).ceil() as usize).saturating_sub(1);
-    sorted[rank.min(sorted.len() - 1)]
 }
 
 fn write_outputs(

--- a/crates/harn-cli/src/commands/mod.rs
+++ b/crates/harn-cli/src/commands/mod.rs
@@ -87,6 +87,19 @@ use std::path::{Path, PathBuf};
 
 use ignore::WalkBuilder;
 
+/// Nearest-rank percentile over a pre-sorted slice. `quantile` is clamped to
+/// `[0, 1]`; returns `None` for an empty slice. Shared by the latency
+/// summaries in the eval and orchestrator stats commands.
+pub(crate) fn nearest_rank_percentile(sorted: &[u64], quantile: f64) -> Option<u64> {
+    if sorted.is_empty() {
+        return None;
+    }
+    let rank = ((sorted.len() as f64 * quantile.clamp(0.0, 1.0)).ceil() as usize)
+        .saturating_sub(1)
+        .min(sorted.len() - 1);
+    sorted.get(rank).copied()
+}
+
 const GENERATED_SOURCE_WALK_DIRS: &[&str] = &[
     ".burin",
     ".build",
@@ -252,5 +265,22 @@ pub(crate) fn collect_harn_files(dir: &Path, out: &mut Vec<PathBuf>) {
                 out.push(path);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::nearest_rank_percentile;
+
+    #[test]
+    fn percentile_handles_empty_and_bounds() {
+        assert_eq!(nearest_rank_percentile(&[], 0.5), None);
+        let data = [10u64, 20, 30, 40, 50];
+        assert_eq!(nearest_rank_percentile(&data, 0.0), Some(10));
+        assert_eq!(nearest_rank_percentile(&data, 0.5), Some(30));
+        assert_eq!(nearest_rank_percentile(&data, 1.0), Some(50));
+        // Out-of-range quantiles clamp instead of panicking.
+        assert_eq!(nearest_rank_percentile(&data, 2.0), Some(50));
+        assert_eq!(nearest_rank_percentile(&[7u64], 0.99), Some(7));
     }
 }

--- a/crates/harn-cli/src/commands/orchestrator/stats.rs
+++ b/crates/harn-cli/src/commands/orchestrator/stats.rs
@@ -597,8 +597,14 @@ fn build_trigger_stats(trigger_id: String, mut acc: TriggerAccumulator) -> Trigg
                 dispatch_failures: handler_acc.dispatch_failures,
                 dlq_count: handler_acc.dlq_count,
                 dlq_rate: ratio(handler_acc.dlq_count, handler_acc.attempts),
-                median_duration_ms: percentile(&handler_acc.durations_ms, 0.50),
-                p99_duration_ms: percentile(&handler_acc.durations_ms, 0.99),
+                median_duration_ms: crate::commands::nearest_rank_percentile(
+                    &handler_acc.durations_ms,
+                    0.50,
+                ),
+                p99_duration_ms: crate::commands::nearest_rank_percentile(
+                    &handler_acc.durations_ms,
+                    0.99,
+                ),
             }
         })
         .collect();
@@ -616,8 +622,14 @@ fn build_trigger_stats(trigger_id: String, mut acc: TriggerAccumulator) -> Trigg
         predicate_misses: acc.predicate_misses,
         predicate_miss_rate: ratio(acc.predicate_misses, acc.predicate_evaluations),
         handler_attempts: acc.handler_attempts,
-        median_handler_duration_ms: percentile(&acc.handler_durations_ms, 0.50),
-        p99_handler_duration_ms: percentile(&acc.handler_durations_ms, 0.99),
+        median_handler_duration_ms: crate::commands::nearest_rank_percentile(
+            &acc.handler_durations_ms,
+            0.50,
+        ),
+        p99_handler_duration_ms: crate::commands::nearest_rank_percentile(
+            &acc.handler_durations_ms,
+            0.99,
+        ),
         llm_call_count: acc.llm_call_count,
         input_tokens: acc.input_tokens,
         output_tokens: acc.output_tokens,
@@ -697,16 +709,6 @@ fn attempt_duration_ms(
     let completed = OffsetDateTime::parse(&attempt.completed_at, &Rfc3339).ok()?;
     let delta = completed - started;
     u64::try_from(delta.whole_milliseconds()).ok()
-}
-
-fn percentile(sorted: &[u64], percentile: f64) -> Option<u64> {
-    if sorted.is_empty() {
-        return None;
-    }
-    let rank = ((sorted.len() as f64 * percentile).ceil() as usize)
-        .saturating_sub(1)
-        .min(sorted.len() - 1);
-    sorted.get(rank).copied()
 }
 
 fn ratio(numerator: u64, denominator: u64) -> f64 {

--- a/crates/harn-cli/src/commands/run/mod.rs
+++ b/crates/harn-cli/src/commands/run/mod.rs
@@ -330,7 +330,7 @@ pub(crate) fn compile_or_load_chunk_with_timing(
     // single-line warning when explicitly requested via the audit hook;
     // otherwise stay quiet to avoid bloating happy-path output.
     if let Err(err) = harn_vm::bytecode_cache::store(&lookup.key, &chunk) {
-        if std::env::var_os("HARN_BYTECODE_CACHE_DEBUG").is_some() {
+        if std::env::var_os(crate::dispatch::CACHE_DEBUG_ENV).is_some() {
             eprintln!("[harn] bytecode cache write skipped: {err}");
         }
     }

--- a/crates/harn-lint/src/linter.rs
+++ b/crates/harn-lint/src/linter.rs
@@ -1536,20 +1536,7 @@ impl<'a> Linter<'a> {
             }
         }
 
-        if self.scopes.len() > 1 {
-            let outer = &self.scopes[..self.scopes.len() - 1];
-            if outer.iter().any(|s| s.contains(name)) {
-                self.diagnostics.push(LintDiagnostic {
-                    code: Code::LintShadowVariable,
-                    rule: "shadow-variable".into(),
-                    message: format!("variable `{name}` shadows a variable in an outer scope"),
-                    span,
-                    severity: LintSeverity::Warning,
-                    suggestion: Some(format!("consider renaming to avoid shadowing `{name}`")),
-                    fix: None,
-                });
-            }
-        }
+        self.warn_if_shadows_outer_scope(name, span);
 
         if let Some(scope) = self.scopes.last_mut() {
             scope.insert(name.to_string());
@@ -1570,20 +1557,7 @@ impl<'a> Linter<'a> {
             return;
         }
 
-        if self.scopes.len() > 1 {
-            let outer = &self.scopes[..self.scopes.len() - 1];
-            if outer.iter().any(|s| s.contains(name)) {
-                self.diagnostics.push(LintDiagnostic {
-                    code: Code::LintShadowVariable,
-                    rule: "shadow-variable".into(),
-                    message: format!("variable `{name}` shadows a variable in an outer scope"),
-                    span,
-                    severity: LintSeverity::Warning,
-                    suggestion: Some(format!("consider renaming to avoid shadowing `{name}`")),
-                    fix: None,
-                });
-            }
-        }
+        self.warn_if_shadows_outer_scope(name, span);
 
         if let Some(scope) = self.scopes.last_mut() {
             scope.insert(name.to_string());
@@ -1593,6 +1567,27 @@ impl<'a> Linter<'a> {
             name: name.to_string(),
             span,
         });
+    }
+
+    /// Emit a `shadow-variable` warning when `name` is already bound in any
+    /// enclosing (non-current) scope. Shared by variable and parameter
+    /// declaration so the two stay in lockstep.
+    fn warn_if_shadows_outer_scope(&mut self, name: &str, span: Span) {
+        if self.scopes.len() <= 1 {
+            return;
+        }
+        let outer = &self.scopes[..self.scopes.len() - 1];
+        if outer.iter().any(|s| s.contains(name)) {
+            self.diagnostics.push(LintDiagnostic {
+                code: Code::LintShadowVariable,
+                rule: "shadow-variable".into(),
+                message: format!("variable `{name}` shadows a variable in an outer scope"),
+                span,
+                severity: LintSeverity::Warning,
+                suggestion: Some(format!("consider renaming to avoid shadowing `{name}`")),
+                fix: None,
+            });
+        }
     }
 
     pub(crate) fn lint_program(&mut self, nodes: &[SNode]) {

--- a/crates/harn-vm/src/egress/mod.rs
+++ b/crates/harn-vm/src/egress/mod.rs
@@ -1145,13 +1145,7 @@ impl EgressRule {
         match &self.matcher {
             EgressMatcher::Host(host) => target.host == *host,
             EgressMatcher::Suffix(suffix) => {
-                target.host.len() > suffix.len()
-                    && target.host.ends_with(suffix)
-                    && target
-                        .host
-                        .as_bytes()
-                        .get(target.host.len() - suffix.len() - 1)
-                        == Some(&b'.')
+                crate::harness_net::host_has_dns_suffix(&target.host, suffix)
             }
             EgressMatcher::Ip(ip) => target.ip == Some(*ip),
             EgressMatcher::Cidr(net) => target.ip.is_some_and(|ip| net.contains(&ip)),

--- a/crates/harn-vm/src/harness_net.rs
+++ b/crates/harn-vm/src/harness_net.rs
@@ -256,19 +256,21 @@ impl NetPolicyRule {
         }
         match &self.matcher {
             NetMatcher::Host(host) => target.host == *host,
-            NetMatcher::Suffix(suffix) => {
-                target.host.len() > suffix.len()
-                    && target.host.ends_with(suffix)
-                    && target
-                        .host
-                        .as_bytes()
-                        .get(target.host.len() - suffix.len() - 1)
-                        == Some(&b'.')
-            }
+            NetMatcher::Suffix(suffix) => host_has_dns_suffix(&target.host, suffix),
             NetMatcher::Ip(ip) => target.ip == Some(*ip),
             NetMatcher::Cidr(net) => target.ip.is_some_and(|ip| net.contains(&ip)),
         }
     }
+}
+
+/// True when `host` is a strict dot-delimited subdomain of `suffix`
+/// (e.g. `api.example.com` matches suffix `example.com`, but `notexample.com`
+/// and a bare `example.com` do not). Shared by the harness and egress
+/// suffix matchers so the boundary rule stays identical.
+pub(crate) fn host_has_dns_suffix(host: &str, suffix: &str) -> bool {
+    host.len() > suffix.len()
+        && host.ends_with(suffix)
+        && host.as_bytes().get(host.len() - suffix.len() - 1) == Some(&b'.')
 }
 
 impl NetPolicy {

--- a/crates/harn-vm/src/orchestration/crystallize/normalize.rs
+++ b/crates/harn-vm/src/orchestration/crystallize/normalize.rs
@@ -133,7 +133,7 @@ fn action_has_nondeterministic_side_effect(action: &CrystallizationAction) -> bo
     {
         return true;
     }
-    if action.deterministic == Some(false) && action.fuzzy.unwrap_or(false) {
+    if action.deterministic == Some(false) || action.fuzzy.unwrap_or(false) {
         return true;
     }
     action.side_effects.iter().any(|effect| {
@@ -620,5 +620,49 @@ fn artifact_type_for_side_effect(effect: &CrystallizationSideEffect) -> String {
         lower_kind
     } else {
         "unknown".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn action_with_side_effect(
+        deterministic: Option<bool>,
+        fuzzy: Option<bool>,
+    ) -> CrystallizationAction {
+        CrystallizationAction {
+            id: "a1".to_string(),
+            kind: "tool_call".to_string(),
+            side_effects: vec![CrystallizationSideEffect {
+                kind: "fs_write".to_string(),
+                target: "/tmp/out".to_string(),
+                ..CrystallizationSideEffect::default()
+            }],
+            deterministic,
+            fuzzy,
+            ..CrystallizationAction::default()
+        }
+    }
+
+    #[test]
+    fn explicitly_nondeterministic_action_is_flagged_even_when_not_fuzzy() {
+        // Rejected tool calls and human-approval steps are emitted with
+        // `deterministic: Some(false), fuzzy: Some(false)`; carrying a side
+        // effect they must still be treated as nondeterministic.
+        let action = action_with_side_effect(Some(false), Some(false));
+        assert!(action_has_nondeterministic_side_effect(&action));
+    }
+
+    #[test]
+    fn fuzzy_action_is_flagged_even_when_determinism_unset() {
+        let action = action_with_side_effect(None, Some(true));
+        assert!(action_has_nondeterministic_side_effect(&action));
+    }
+
+    #[test]
+    fn deterministic_non_fuzzy_action_is_not_flagged() {
+        let action = action_with_side_effect(Some(true), Some(false));
+        assert!(!action_has_nondeterministic_side_effect(&action));
     }
 }


### PR DESCRIPTION
Five small, unambiguous correctness/DRY fixes found while auditing the runtime. Each is independently reviewable.

## 1. Bug — crystallization nondeterminism gate too lax (`harn-vm`)
`action_has_nondeterministic_side_effect` required an action to be **both** `deterministic == Some(false)` **and** `fuzzy` before flagging it. But production code emits genuinely non-deterministic actions with `deterministic: Some(false), fuzzy: Some(false)` — rejected tool calls ([`api.rs:630`](https://github.com/burin-labs/harn/blob/main/crates/harn-vm/src/orchestration/crystallize/api.rs)) and human-approval steps ([`api.rs:652`](https://github.com/burin-labs/harn/blob/main/crates/harn-vm/src/orchestration/crystallize/api.rs)). Such an action carrying a side effect slipped past `trace_is_mineable` and could be mined into a "deterministic" workflow. Changed `&&` → `||` and added regression tests. (The existing test fixtures always set the two flags together, which is why this was never caught.)

## 2. DRY — duplicated DNS dot-suffix matcher (`harn-vm`)
The identical strict-subdomain boundary check (`host.len() > suffix.len() && ends_with && byte-before-suffix == '.'`) was copy-pasted into both the harness-net (`harness_net.rs`) and egress (`egress/mod.rs`) suffix matchers. Extracted `host_has_dns_suffix` and shared it.

## 3. DRY — duplicated shadow-variable diagnostic (`harn-lint`)
The outer-scope `shadow-variable` warning block was duplicated verbatim in `declare_variable` and `declare_parameter`. Extracted `warn_if_shadows_outer_scope`.

## 4. DRY — duplicated nearest-rank percentile (`harn-cli`)
The same `u64` nearest-rank percentile helper existed in both `eval_tool_calls` and `orchestrator::stats`. Extracted a single `commands::nearest_rank_percentile` (now also clamps the quantile to `[0,1]`; unit-tested).

## 5. DRY — hard-coded env-var string (`harn-cli`)
`run` hard-coded `"HARN_BYTECODE_CACHE_DEBUG"` instead of reusing the existing `dispatch::CACHE_DEBUG_ENV` constant.

## Verification
- `cargo check -p harn-vm -p harn-lint -p harn-cli` — clean.
- New tests pass: crystallize nondeterminism (3), `nearest_rank_percentile` bounds, existing lint shadow + egress/net suffix + bench percentile tests.
- Pre-commit hooks (fmt/clippy/test) passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)