### PR TITLE
Optimize VM inline-cache dispatch

### DIFF
--- a/changelog.d/vm-inline-cache-frame-index.changed.md
+++ b/changelog.d/vm-inline-cache-frame-index.changed.md
@@ -1,0 +1,4 @@
+- **VM inline-cache dispatch now avoids per-op hash lookups.** Call frames cache
+  the VM-local inline-cache set for their chunk once at entry, so adaptive
+  binary, property, method, and direct-call cache reads/writes index directly
+  into VM-local feedback during hot dispatch.

--- a/crates/harn-vm/src/bench_internals.rs
+++ b/crates/harn-vm/src/bench_internals.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::chunk::Op;
@@ -74,6 +75,53 @@ impl InlineCacheSlotLookupFixture {
     }
 }
 
+struct VmInlineCacheReadFixture {
+    vm: Vm,
+    cache_set: usize,
+    cache_id: u64,
+    hash_control: HashMap<u64, Vec<crate::chunk::InlineCacheEntry>>,
+    slots: Vec<usize>,
+}
+
+impl VmInlineCacheReadFixture {
+    fn new(
+        chunk: &Chunk,
+        slots: Vec<usize>,
+        mut entry_for_slot: impl FnMut(usize) -> crate::chunk::InlineCacheEntry,
+    ) -> Self {
+        let slot_count = chunk.inline_cache_slot_count();
+        let cache_id = chunk.cache_id();
+        let mut vm = Vm::new();
+        let cache_set = vm.inline_cache_set_index_for_chunk(chunk);
+        let mut hash_entries = vec![crate::chunk::InlineCacheEntry::Empty; slot_count];
+        for &slot in &slots {
+            let entry = entry_for_slot(slot);
+            vm.set_inline_cache_entry_by_index(cache_set, slot_count, slot, entry.clone());
+            hash_entries[slot] = entry;
+        }
+
+        Self {
+            vm,
+            cache_set,
+            cache_id,
+            hash_control: HashMap::from([(cache_id, hash_entries)]),
+            slots,
+        }
+    }
+
+    fn op_count(&self) -> usize {
+        self.slots.len()
+    }
+
+    #[inline]
+    fn hash_entry(&self, slot: usize) -> Option<crate::chunk::InlineCacheEntry> {
+        self.hash_control
+            .get(&self.cache_id)
+            .and_then(|entries| entries.get(slot))
+            .cloned()
+    }
+}
+
 /// Bytecode-length presets for the adaptive-binary-cache read microbench.
 /// The fixture walks N adjacent `Op::Add` slots, exercising the same
 /// cache-read shape that `execute_adaptive_binary` issues on every
@@ -84,22 +132,18 @@ pub const ADAPTIVE_BINARY_CACHE_READ_COUNTS: [usize; 4] = [8, 32, 128, 512];
 
 /// Microbench fixture for the adaptive-binary inline-cache read path.
 ///
-/// `Chunk::inline_cache_entry` (the pre-optimization path) clones the
-/// wrapping `InlineCacheEntry` enum on every dispatch — a 24-32B memcpy
-/// that the variant-checking match in `try_specialized_binary`
-/// destructures and throws away. `Chunk::peek_adaptive_binary_cache`
-/// (the new path) returns just the `(AdaptiveBinaryOp,
-/// AdaptiveBinaryState)` pair by value (both `Copy`), so the read is a
-/// single scalar move instead of a clone.
+/// The control path performs the old per-dispatch hash lookup and clones the
+/// wrapping `InlineCacheEntry` enum — a 24-32B memcpy that the variant-checking
+/// match in `try_specialized_binary` destructures and throws away. The
+/// production path uses the frame-local cache-set index and returns just the
+/// `(AdaptiveBinaryOp, AdaptiveBinaryState)` pair by value (both `Copy`).
 ///
 /// The fixture pre-warms every slot to the Specialized state (the steady
 /// state of a hot loop) so the bench measures the read overhead with no
 /// per-iteration state transitions. The accumulator sums the cached
 /// `hits` counter so the optimizer cannot dead-code the loop.
 pub struct AdaptiveBinaryCacheReadFixture {
-    chunk: Chunk,
-    offsets: Vec<usize>,
-    slots: Vec<usize>,
+    cache: VmInlineCacheReadFixture,
 }
 
 impl AdaptiveBinaryCacheReadFixture {
@@ -116,41 +160,39 @@ impl AdaptiveBinaryCacheReadFixture {
             let slot = chunk
                 .inline_cache_slot(offset)
                 .expect("Op::Add registers an inline-cache slot at emit time");
-            // Pre-warm to Specialized{Int}, which is the steady state of a
-            // hot loop after `ADAPTIVE_QUICKEN_THRESHOLD` Int-Int Adds.
-            // That's the case that exercises the IC read on every dispatch.
-            chunk.set_inline_cache_entry(
-                slot,
-                InlineCacheEntry::AdaptiveBinary {
-                    op: AdaptiveBinaryOp::Add,
-                    state: AdaptiveBinaryState::Specialized {
-                        shape: BinaryShape::Int,
-                        hits: 1_000,
-                        misses: 0,
-                    },
-                },
-            );
             slots.push(slot);
         }
-        Self {
-            chunk,
-            offsets,
-            slots,
-        }
+        let cache = VmInlineCacheReadFixture::new(&chunk, slots, |_slot| {
+            // Pre-warm to Specialized{Int}, which is the steady state of a hot
+            // loop after `ADAPTIVE_QUICKEN_THRESHOLD` Int-Int Adds.
+            InlineCacheEntry::AdaptiveBinary {
+                op: AdaptiveBinaryOp::Add,
+                state: AdaptiveBinaryState::Specialized {
+                    shape: BinaryShape::Int,
+                    hits: 1_000,
+                    misses: 0,
+                },
+            }
+        });
+        Self { cache }
     }
 
     pub fn op_count(&self) -> usize {
-        self.offsets.len()
+        self.cache.op_count()
     }
 
-    /// Sweep all slots via the new Copy peek path. Returns the sum of
-    /// observed `hits` counters so the optimizer cannot dead-code the
-    /// loop.
+    /// Sweep all slots via the production frame-indexed peek path. Returns
+    /// the sum of observed `hits` counters so the optimizer cannot dead-code
+    /// the loop.
     pub fn invoke_peek(&self) -> u64 {
         use crate::chunk::AdaptiveBinaryState;
         let mut acc = 0u64;
-        for &slot in &self.slots {
-            if let Some((_op, state)) = self.chunk.peek_adaptive_binary_cache(slot) {
+        for &slot in &self.cache.slots {
+            if let Some((_op, state)) = self
+                .cache
+                .vm
+                .peek_adaptive_binary_cache_by_index(self.cache.cache_set, slot)
+            {
                 let hits = match state {
                     AdaptiveBinaryState::Specialized { hits, .. } => hits,
                     AdaptiveBinaryState::Warmup { hits, .. } => hits as u64,
@@ -161,15 +203,15 @@ impl AdaptiveBinaryCacheReadFixture {
         acc
     }
 
-    /// Control sweep using the pre-optimization `inline_cache_entry`
-    /// clone path. Same accumulator shape so the criterion bench can
+    /// Control sweep using the pre-optimization per-dispatch hash lookup plus
+    /// full `InlineCacheEntry` clone. Same accumulator shape so Criterion can
     /// A/B the two paths inside a single binary.
     pub fn invoke_clone_control(&self) -> u64 {
         use crate::chunk::{AdaptiveBinaryState, InlineCacheEntry};
         let mut acc = 0u64;
-        for &slot in &self.slots {
-            let entry = self.chunk.inline_cache_entry(slot);
-            if let InlineCacheEntry::AdaptiveBinary { state, .. } = entry {
+        for &slot in &self.cache.slots {
+            let entry = self.cache.hash_entry(slot);
+            if let Some(InlineCacheEntry::AdaptiveBinary { state, .. }) = entry {
                 let hits = match state {
                     AdaptiveBinaryState::Specialized { hits, .. } => hits,
                     AdaptiveBinaryState::Warmup { hits, .. } => hits as u64,
@@ -190,13 +232,11 @@ pub const METHOD_CACHE_READ_COUNTS: [usize; 4] = [8, 32, 128, 512];
 
 /// Microbench fixture for the method inline-cache read path.
 ///
-/// `Chunk::inline_cache_entry` (the pre-optimization path) clones the
-/// wrapping `InlineCacheEntry` enum on every dispatch — a 32-48B memcpy
-/// that the variant-checking `let-else` in `try_cached_method`
-/// destructures and throws away. `Chunk::peek_method_cache` (the new
-/// path) returns just the `(name_idx, argc, target)` triple by value
-/// (all three are `Copy` — `u16`, `usize`, `MethodCacheTarget`), so the
-/// read is a single scalar move out of the cache instead of a clone.
+/// The control path performs the old per-dispatch hash lookup and clones the
+/// wrapping `InlineCacheEntry` enum — a 32-48B memcpy that the variant-checking
+/// `let-else` in `try_cached_method` destructures and throws away. The
+/// production path uses the frame-local cache-set index and returns just the
+/// `(name_idx, argc, target)` triple by value (all three are `Copy`).
 ///
 /// The fixture pre-warms every slot to a `Method` entry (the steady
 /// state of a hot pipeline like `xs.contains(...).filter(...).count()`)
@@ -204,9 +244,7 @@ pub const METHOD_CACHE_READ_COUNTS: [usize; 4] = [8, 32, 128, 512];
 /// transitions. The accumulator sums the cached `argc` so the optimizer
 /// cannot dead-code the loop.
 pub struct MethodCacheReadFixture {
-    chunk: Chunk,
-    offsets: Vec<usize>,
-    slots: Vec<usize>,
+    cache: VmInlineCacheReadFixture,
 }
 
 impl MethodCacheReadFixture {
@@ -223,53 +261,52 @@ impl MethodCacheReadFixture {
             let slot = chunk
                 .inline_cache_slot(offset)
                 .expect("Op::MethodCall registers an inline-cache slot at emit time");
+            slots.push(slot);
+        }
+        let cache = VmInlineCacheReadFixture::new(&chunk, slots, |_slot| {
             // Pre-warm to a Method entry with `ListContains` — a 1-arg
             // method-call shape that flows through every method-call
             // dispatcher (`execute_method_call`, `execute_method_call_sync`,
             // `execute_method_call_spread`).
-            chunk.set_inline_cache_entry(
-                slot,
-                InlineCacheEntry::Method {
-                    name_idx: 0,
-                    argc: 1,
-                    target: MethodCacheTarget::ListContains,
-                },
-            );
-            slots.push(slot);
-        }
-        Self {
-            chunk,
-            offsets,
-            slots,
-        }
+            InlineCacheEntry::Method {
+                name_idx: 0,
+                argc: 1,
+                target: MethodCacheTarget::ListContains,
+            }
+        });
+        Self { cache }
     }
 
     pub fn op_count(&self) -> usize {
-        self.offsets.len()
+        self.cache.op_count()
     }
 
-    /// Sweep all slots via the new Copy peek path. Returns the sum of
-    /// observed `argc` values so the optimizer cannot dead-code the
-    /// loop.
+    /// Sweep all slots via the production frame-indexed peek path. Returns
+    /// the sum of observed `argc` values so the optimizer cannot dead-code
+    /// the loop.
     pub fn invoke_peek(&self) -> usize {
         let mut acc = 0usize;
-        for &slot in &self.slots {
-            if let Some((_name_idx, argc, _target)) = self.chunk.peek_method_cache(slot) {
+        for &slot in &self.cache.slots {
+            if let Some((_name_idx, argc, _target)) = self
+                .cache
+                .vm
+                .peek_method_cache_by_index(self.cache.cache_set, slot)
+            {
                 acc = acc.wrapping_add(argc);
             }
         }
         acc
     }
 
-    /// Control sweep using the pre-optimization `inline_cache_entry`
-    /// clone path. Same accumulator shape so the criterion bench can
+    /// Control sweep using the pre-optimization per-dispatch hash lookup plus
+    /// full `InlineCacheEntry` clone. Same accumulator shape so Criterion can
     /// A/B the two paths inside a single binary.
     pub fn invoke_clone_control(&self) -> usize {
         use crate::chunk::InlineCacheEntry;
         let mut acc = 0usize;
-        for &slot in &self.slots {
-            let entry = self.chunk.inline_cache_entry(slot);
-            if let InlineCacheEntry::Method { argc, .. } = entry {
+        for &slot in &self.cache.slots {
+            let entry = self.cache.hash_entry(slot);
+            if let Some(InlineCacheEntry::Method { argc, .. }) = entry {
                 acc = acc.wrapping_add(argc);
             }
         }
@@ -284,23 +321,18 @@ pub const PROPERTY_CACHE_READ_COUNTS: [usize; 4] = [8, 32, 128, 512];
 
 /// Microbench fixture for the property inline-cache read path.
 ///
-/// `Chunk::inline_cache_entry` (the pre-optimization path) clones the
-/// wrapping `InlineCacheEntry` enum on every dispatch — a 32-48B memcpy
-/// (the wrapping enum is padded to the largest variant, `DirectCall`)
-/// that the variant-checking `let-else` in `try_cached_property`
-/// destructures and throws away. `Chunk::peek_property_cache` (the new
-/// path) returns just the `Property` payload (`u16 + PropertyCacheTarget`),
-/// skipping the outer enum tag init and the padding-to-largest-variant
-/// memcpy. The accumulator sums the cached `name_idx` so the optimizer
-/// cannot dead-code the loop.
+/// The control path performs the old per-dispatch hash lookup and clones the
+/// wrapping `InlineCacheEntry` enum — a 32-48B memcpy (the wrapping enum is
+/// padded to the largest variant, `DirectCall`) that the variant-checking
+/// `let-else` in `try_cached_property` destructures and throws away. The
+/// production path uses the frame-local cache-set index and returns just the
+/// `Property` payload (`u16 + PropertyCacheTarget`).
 ///
 /// The fixture pre-warms every slot to a unit `PropertyCacheTarget`
 /// (`ListCount`) — the hottest steady state for any property-access
 /// pipeline (`.count` on collections, `.first` / `.last`, etc.).
 pub struct PropertyCacheReadFixture {
-    chunk: Chunk,
-    offsets: Vec<usize>,
-    slots: Vec<usize>,
+    cache: VmInlineCacheReadFixture,
 }
 
 impl PropertyCacheReadFixture {
@@ -317,48 +349,46 @@ impl PropertyCacheReadFixture {
             let slot = chunk
                 .inline_cache_slot(offset)
                 .expect("Op::GetProperty registers an inline-cache slot at emit time");
-            chunk.set_inline_cache_entry(
-                slot,
-                InlineCacheEntry::Property {
-                    name_idx: 7,
-                    target: PropertyCacheTarget::ListCount,
-                },
-            );
             slots.push(slot);
         }
-        Self {
-            chunk,
-            offsets,
-            slots,
-        }
+        let cache =
+            VmInlineCacheReadFixture::new(&chunk, slots, |_slot| InlineCacheEntry::Property {
+                name_idx: 7,
+                target: PropertyCacheTarget::ListCount,
+            });
+        Self { cache }
     }
 
     pub fn op_count(&self) -> usize {
-        self.offsets.len()
+        self.cache.op_count()
     }
 
-    /// Sweep all slots via the new peek path. Returns the sum of
-    /// observed `name_idx` values so the optimizer cannot dead-code
+    /// Sweep all slots via the production frame-indexed peek path. Returns
+    /// the sum of observed `name_idx` values so the optimizer cannot dead-code
     /// the loop.
     pub fn invoke_peek(&self) -> usize {
         let mut acc = 0usize;
-        for &slot in &self.slots {
-            if let Some((name_idx, _target)) = self.chunk.peek_property_cache(slot) {
+        for &slot in &self.cache.slots {
+            if let Some((name_idx, _target)) = self
+                .cache
+                .vm
+                .peek_property_cache_by_index(self.cache.cache_set, slot)
+            {
                 acc = acc.wrapping_add(name_idx as usize);
             }
         }
         acc
     }
 
-    /// Control sweep using the pre-optimization `inline_cache_entry`
-    /// clone path. Same accumulator shape so the criterion bench can
+    /// Control sweep using the pre-optimization per-dispatch hash lookup plus
+    /// full `InlineCacheEntry` clone. Same accumulator shape so Criterion can
     /// A/B the two paths inside a single binary.
     pub fn invoke_clone_control(&self) -> usize {
         use crate::chunk::InlineCacheEntry;
         let mut acc = 0usize;
-        for &slot in &self.slots {
-            let entry = self.chunk.inline_cache_entry(slot);
-            if let InlineCacheEntry::Property { name_idx, .. } = entry {
+        for &slot in &self.cache.slots {
+            let entry = self.cache.hash_entry(slot);
+            if let Some(InlineCacheEntry::Property { name_idx, .. }) = entry {
                 acc = acc.wrapping_add(name_idx as usize);
             }
         }
@@ -374,19 +404,17 @@ pub const DIRECT_CALL_STATE_READ_COUNTS: [usize; 4] = [8, 32, 128, 512];
 
 /// Microbench fixture for the direct-call inline-cache read path.
 ///
-/// `Chunk::inline_cache_entry` clones the wrapping
-/// `InlineCacheEntry::DirectCall { state: DirectCallState }` on every
-/// dispatch. `Chunk::peek_direct_call_state` returns just the inner
-/// `DirectCallState`, avoiding the outer enum copy and variant check in
+/// The control path performs the old per-dispatch hash lookup and clones the
+/// wrapping `InlineCacheEntry::DirectCall { state: DirectCallState }`. The
+/// production path uses the frame-local cache-set index and returns just the
+/// inner `DirectCallState`, avoiding the outer enum copy and variant check in
 /// `try_cached_direct_call`.
 ///
 /// Pre-warms every slot to `Specialized { argc: 1, hits: 1000, misses: 0,
 /// target: Arc<VmClosure> }`, the steady state of any hot
 /// `x.map(predicate)`-style direct-call call site.
 pub struct DirectCallStateReadFixture {
-    chunk: Chunk,
-    offsets: Vec<usize>,
-    slots: Vec<usize>,
+    cache: VmInlineCacheReadFixture,
 }
 
 impl DirectCallStateReadFixture {
@@ -404,39 +432,35 @@ impl DirectCallStateReadFixture {
             let slot = chunk
                 .inline_cache_slot(offset)
                 .expect("Op::Call registers an inline-cache slot at emit time");
-            chunk.set_inline_cache_entry(
-                slot,
-                InlineCacheEntry::DirectCall {
-                    state: DirectCallState::Specialized {
-                        argc: 1,
-                        target: DirectCallTarget::Closure(Arc::clone(&target_closure)),
-                        hits: 1_000,
-                        misses: 0,
-                    },
-                },
-            );
             slots.push(slot);
         }
-        Self {
-            chunk,
-            offsets,
-            slots,
-        }
+        let cache =
+            VmInlineCacheReadFixture::new(&chunk, slots, |_slot| InlineCacheEntry::DirectCall {
+                state: DirectCallState::Specialized {
+                    argc: 1,
+                    target: DirectCallTarget::Closure(Arc::clone(&target_closure)),
+                    hits: 1_000,
+                    misses: 0,
+                },
+            });
+        Self { cache }
     }
 
     pub fn op_count(&self) -> usize {
-        self.offsets.len()
+        self.cache.op_count()
     }
 
-    /// Sweep all slots via the new peek path. Returns the sum of
-    /// observed `argc` values so the optimizer cannot dead-code the
-    /// loop.
+    /// Sweep all slots via the production frame-indexed peek path. Returns
+    /// the sum of observed `argc` values so the optimizer cannot dead-code
+    /// the loop.
     pub fn invoke_peek(&self) -> usize {
         use crate::chunk::DirectCallState;
         let mut acc = 0usize;
-        for &slot in &self.slots {
-            if let Some(DirectCallState::Specialized { argc, .. }) =
-                self.chunk.peek_direct_call_state(slot)
+        for &slot in &self.cache.slots {
+            if let Some(DirectCallState::Specialized { argc, .. }) = self
+                .cache
+                .vm
+                .peek_direct_call_state_by_index(self.cache.cache_set, slot)
             {
                 acc = acc.wrapping_add(argc);
             }
@@ -444,16 +468,16 @@ impl DirectCallStateReadFixture {
         acc
     }
 
-    /// Control sweep using the full `inline_cache_entry` clone path. Same
-    /// accumulator shape.
+    /// Control sweep using the pre-optimization per-dispatch hash lookup plus
+    /// full `InlineCacheEntry` clone. Same accumulator shape.
     pub fn invoke_clone_control(&self) -> usize {
         use crate::chunk::{DirectCallState, InlineCacheEntry};
         let mut acc = 0usize;
-        for &slot in &self.slots {
-            let entry = self.chunk.inline_cache_entry(slot);
-            if let InlineCacheEntry::DirectCall {
+        for &slot in &self.cache.slots {
+            let entry = self.cache.hash_entry(slot);
+            if let Some(InlineCacheEntry::DirectCall {
                 state: DirectCallState::Specialized { argc, .. },
-            } = entry
+            }) = entry
             {
                 acc = acc.wrapping_add(argc);
             }

--- a/crates/harn-vm/src/chunk.rs
+++ b/crates/harn-vm/src/chunk.rs
@@ -1046,28 +1046,10 @@ impl Chunk {
         Some(materialized)
     }
 
-    #[cfg(feature = "vm-bench-internals")]
-    pub(crate) fn inline_cache_entry(&self, slot: usize) -> InlineCacheEntry {
-        self.inline_caches
-            .lock()
-            .get(slot)
-            .cloned()
-            .unwrap_or(InlineCacheEntry::Empty)
-    }
-
-    /// Adaptive-binary fast path read. Returns the cached
-    /// `(op, state)` pair by value (both `Copy`) when slot holds an
-    /// `AdaptiveBinary` entry, else `None`. Skips the
-    /// `InlineCacheEntry::clone` that `inline_cache_entry` performs:
-    /// since `AdaptiveBinaryState: Copy`, the read does a single
-    /// scalar move out of the cache instead of a 24-32B memcpy of the
-    /// wrapping enum (which the variant-checking match destructures
-    /// and throws away anyway). Fires on every Add/Sub/Mul/Div/Mod/Eq/
-    /// Neq/Less/Greater/LessEq/GreaterEq dispatch, so the per-op
-    /// savings compound across the millions of dispatches a typical
-    /// loop body issues.
+    /// Test helper for the chunk-local scratch inline cache. Production
+    /// dispatch reads VM-local cache sets through `Vm`.
     #[inline]
-    #[cfg(any(test, feature = "vm-bench-internals"))]
+    #[cfg(test)]
     pub(crate) fn peek_adaptive_binary_cache(
         &self,
         slot: usize,
@@ -1078,19 +1060,10 @@ impl Chunk {
         }
     }
 
-    /// Method-cache fast path read. Returns the cached `(name_idx, argc,
-    /// target)` triple by value (all three are `Copy`) when `slot` holds a
-    /// `Method` entry, else `None`. Skips the full `InlineCacheEntry::clone`
-    /// that `inline_cache_entry` performs on every `Op::MethodCall`,
-    /// `Op::MethodCallOpt`, and `Op::MethodCallSpread` dispatch: the
-    /// variant-checking `let-else` in `try_cached_method` destructures and
-    /// throws the wrapping enum away anyway, so reading the payload by `Copy`
-    /// avoids the 32-48B enum memcpy. Method-call dispatch is the second-
-    /// hottest IC-keyed opcode class after the adaptive binary ops, so the
-    /// per-dispatch savings compound across the millions of method calls a
-    /// typical pipeline (`xs.filter(...).map(...).count()`) issues.
+    /// Test helper for the chunk-local scratch inline cache. Production
+    /// dispatch reads VM-local cache sets through `Vm`.
     #[inline]
-    #[cfg(any(test, feature = "vm-bench-internals"))]
+    #[cfg(test)]
     pub(crate) fn peek_method_cache(&self, slot: usize) -> Option<(u16, usize, MethodCacheTarget)> {
         match self.inline_caches.lock().get(slot)? {
             &InlineCacheEntry::Method {
@@ -1102,17 +1075,10 @@ impl Chunk {
         }
     }
 
-    /// Property-cache fast path read. Returns the cached `(name_idx, target)`
-    /// pair by value when `slot` holds a `Property` entry, else `None`. The
-    /// outer `InlineCacheEntry` is the worst-case-sized variant (DirectCall
-    /// at ~48 bytes including padding); cloning it just to discard four other
-    /// variants in `try_cached_property`'s variant-check is wasted work. The
-    /// peek returns just the `Property` payload (`u16` + `PropertyCacheTarget`),
-    /// skipping the outer enum tag init and the padding-to-largest-variant
-    /// memcpy. Fires on every `Op::GetProperty` / `Op::GetPropertyOpt`
-    /// dispatch, which is the dominant opcode for any field-read-heavy code.
+    /// Test helper for the chunk-local scratch inline cache. Production
+    /// dispatch reads VM-local cache sets through `Vm`.
     #[inline]
-    #[cfg(any(test, feature = "vm-bench-internals"))]
+    #[cfg(test)]
     pub(crate) fn peek_property_cache(&self, slot: usize) -> Option<(u16, PropertyCacheTarget)> {
         match self.inline_caches.lock().get(slot)? {
             InlineCacheEntry::Property { name_idx, target } => Some((*name_idx, target.clone())),
@@ -1120,17 +1086,10 @@ impl Chunk {
         }
     }
 
-    /// Direct-call cache state read. Returns just the inner `DirectCallState`
-    /// by value when `slot` holds a `DirectCall` entry, else `None`. Used by
-    /// both `try_cached_direct_call(_)` (steady-state Specialized hit check)
-    /// and `next_direct_call_entry` (Warmup → Specialized state-machine
-    /// transition). Peeking the inner state directly skips the outer
-    /// `InlineCacheEntry` discriminant check and tag init that the dispatcher
-    /// otherwise pays on every `Op::Call` (closure callee) and the named-fn
-    /// fast path inside `Op::CallBuiltin`. Single peek per dispatch covers
-    /// both the read check and the write-back computation.
+    /// Test helper for the chunk-local scratch inline cache. Production
+    /// dispatch reads VM-local cache sets through `Vm`.
     #[inline]
-    #[cfg(any(test, feature = "vm-bench-internals"))]
+    #[cfg(test)]
     pub(crate) fn peek_direct_call_state(&self, slot: usize) -> Option<DirectCallState> {
         match self.inline_caches.lock().get(slot)? {
             InlineCacheEntry::DirectCall { state } => Some(state.clone()),
@@ -1138,7 +1097,7 @@ impl Chunk {
         }
     }
 
-    #[cfg(any(test, feature = "vm-bench-internals"))]
+    #[cfg(test)]
     pub(crate) fn set_inline_cache_entry(&self, slot: usize, entry: InlineCacheEntry) {
         if let Some(existing) = self.inline_caches.lock().get_mut(slot) {
             *existing = entry;

--- a/crates/harn-vm/src/vm/cache.rs
+++ b/crates/harn-vm/src/vm/cache.rs
@@ -1,53 +1,56 @@
 use crate::chunk::{
-    AdaptiveBinaryOp, AdaptiveBinaryState, ChunkRef, DirectCallState, InlineCacheEntry,
+    AdaptiveBinaryOp, AdaptiveBinaryState, Chunk, DirectCallState, InlineCacheEntry,
     MethodCacheTarget, PropertyCacheTarget,
 };
 
 use super::Vm;
 
 impl Vm {
-    fn inline_cache_entries_mut_by_key(
-        &mut self,
-        cache_id: u64,
-        slot_count: usize,
-    ) -> &mut Vec<InlineCacheEntry> {
-        let entries = self
-            .inline_caches
-            .entry(cache_id)
-            .or_insert_with(|| vec![InlineCacheEntry::Empty; slot_count]);
+    pub(crate) fn inline_cache_set_index_for_chunk(&mut self, chunk: &Chunk) -> usize {
+        self.inline_cache_set_index_for_key(chunk.cache_id(), chunk.inline_cache_slot_count())
+    }
+
+    fn inline_cache_set_index_for_key(&mut self, cache_id: u64, slot_count: usize) -> usize {
+        if let Some(&index) = self.inline_cache_set_by_chunk.get(&cache_id) {
+            self.ensure_inline_cache_set_len(index, slot_count);
+            return index;
+        }
+
+        let index = self.inline_cache_sets.len();
+        self.inline_cache_sets
+            .push(vec![InlineCacheEntry::Empty; slot_count]);
+        self.inline_cache_set_by_chunk.insert(cache_id, index);
+        index
+    }
+
+    fn ensure_inline_cache_set_len(&mut self, cache_set: usize, slot_count: usize) {
+        let Some(entries) = self.inline_cache_sets.get_mut(cache_set) else {
+            return;
+        };
         if entries.len() < slot_count {
             entries.resize(slot_count, InlineCacheEntry::Empty);
         }
-        entries
-    }
-
-    fn inline_cache_entries_mut(&mut self, chunk: &ChunkRef) -> &mut Vec<InlineCacheEntry> {
-        self.inline_cache_entries_mut_by_key(chunk.cache_id(), chunk.inline_cache_slot_count())
     }
 
     #[inline]
-    pub(crate) fn peek_adaptive_binary_cache_by_key(
-        &mut self,
-        cache_id: u64,
-        slot_count: usize,
+    pub(crate) fn peek_adaptive_binary_cache_by_index(
+        &self,
+        cache_set: usize,
         slot: usize,
     ) -> Option<(AdaptiveBinaryOp, AdaptiveBinaryState)> {
-        match self
-            .inline_cache_entries_mut_by_key(cache_id, slot_count)
-            .get(slot)?
-        {
+        match self.inline_cache_sets.get(cache_set)?.get(slot)? {
             &InlineCacheEntry::AdaptiveBinary { op, state } => Some((op, state)),
             _ => None,
         }
     }
 
     #[inline]
-    pub(crate) fn peek_method_cache(
-        &mut self,
-        chunk: &ChunkRef,
+    pub(crate) fn peek_method_cache_by_index(
+        &self,
+        cache_set: usize,
         slot: usize,
     ) -> Option<(u16, usize, MethodCacheTarget)> {
-        match self.inline_cache_entries_mut(chunk).get(slot)? {
+        match self.inline_cache_sets.get(cache_set)?.get(slot)? {
             &InlineCacheEntry::Method {
                 name_idx,
                 argc,
@@ -58,64 +61,110 @@ impl Vm {
     }
 
     #[inline]
-    pub(crate) fn peek_property_cache(
-        &mut self,
-        chunk: &ChunkRef,
+    pub(crate) fn peek_property_cache_by_index(
+        &self,
+        cache_set: usize,
         slot: usize,
     ) -> Option<(u16, PropertyCacheTarget)> {
-        match self.inline_cache_entries_mut(chunk).get(slot)? {
+        match self.inline_cache_sets.get(cache_set)?.get(slot)? {
             InlineCacheEntry::Property { name_idx, target } => Some((*name_idx, target.clone())),
             _ => None,
         }
     }
 
     #[inline]
-    pub(crate) fn peek_direct_call_state(
-        &mut self,
-        chunk: &ChunkRef,
+    pub(crate) fn peek_direct_call_state_by_index(
+        &self,
+        cache_set: usize,
         slot: usize,
     ) -> Option<DirectCallState> {
-        match self.inline_cache_entries_mut(chunk).get(slot)? {
+        match self.inline_cache_sets.get(cache_set)?.get(slot)? {
             InlineCacheEntry::DirectCall { state } => Some(state.clone()),
             _ => None,
         }
     }
 
-    pub(crate) fn set_inline_cache_entry(
+    #[inline]
+    pub(crate) fn set_inline_cache_entry_by_index(
         &mut self,
-        chunk: &ChunkRef,
-        slot: usize,
-        entry: InlineCacheEntry,
-    ) {
-        self.set_inline_cache_entry_by_key(
-            chunk.cache_id(),
-            chunk.inline_cache_slot_count(),
-            slot,
-            entry,
-        );
-    }
-
-    pub(crate) fn set_inline_cache_entry_by_key(
-        &mut self,
-        cache_id: u64,
+        cache_set: usize,
         slot_count: usize,
         slot: usize,
         entry: InlineCacheEntry,
     ) {
-        let entries = self.inline_cache_entries_mut_by_key(cache_id, slot_count);
+        self.ensure_inline_cache_set_len(cache_set, slot_count);
+        let Some(entries) = self.inline_cache_sets.get_mut(cache_set) else {
+            return;
+        };
         if let Some(existing) = entries.get_mut(slot) {
             *existing = entry;
         }
     }
+}
 
-    #[cfg(test)]
-    pub(crate) fn inline_cache_entries_for_chunk(
-        &self,
-        chunk: &crate::chunk::Chunk,
-    ) -> Vec<InlineCacheEntry> {
-        self.inline_caches
-            .get(&chunk.cache_id())
-            .cloned()
-            .unwrap_or_else(|| vec![InlineCacheEntry::Empty; chunk.inline_cache_slot_count()])
+#[cfg(test)]
+mod tests {
+    use crate::chunk::{
+        AdaptiveBinaryOp, AdaptiveBinaryState, BinaryShape, Chunk, InlineCacheEntry, Op,
+    };
+    use crate::Vm;
+
+    #[test]
+    fn cache_set_index_reuses_chunk_identity() {
+        let mut chunk = Chunk::new();
+        let op_offset = chunk.code.len();
+        chunk.emit(Op::Add, 1);
+        let slot = chunk
+            .inline_cache_slot(op_offset)
+            .expect("adaptive op registers inline-cache slot");
+        let slot_count = chunk.inline_cache_slot_count();
+
+        let mut vm = Vm::new();
+        let cache_set = vm.inline_cache_set_index_for_chunk(&chunk);
+        assert_eq!(cache_set, vm.inline_cache_set_index_for_chunk(&chunk));
+
+        let cloned_chunk = chunk.clone();
+        assert_eq!(
+            cache_set,
+            vm.inline_cache_set_index_for_chunk(&cloned_chunk),
+            "Chunk clones preserve cache identity and should share VM feedback"
+        );
+
+        let mut other_chunk = Chunk::new();
+        other_chunk.emit(Op::Add, 1);
+        assert_ne!(
+            cache_set,
+            vm.inline_cache_set_index_for_chunk(&other_chunk),
+            "distinct chunks need distinct VM-local cache sets"
+        );
+
+        vm.set_inline_cache_entry_by_index(
+            cache_set,
+            slot_count,
+            slot,
+            InlineCacheEntry::AdaptiveBinary {
+                op: AdaptiveBinaryOp::Add,
+                state: AdaptiveBinaryState::Specialized {
+                    shape: BinaryShape::Int,
+                    hits: 7,
+                    misses: 0,
+                },
+            },
+        );
+
+        let cached = vm
+            .peek_adaptive_binary_cache_by_index(cache_set, slot)
+            .expect("warmed cache entry");
+        assert!(matches!(
+            cached,
+            (
+                AdaptiveBinaryOp::Add,
+                AdaptiveBinaryState::Specialized {
+                    shape: BinaryShape::Int,
+                    hits: 7,
+                    misses: 0,
+                }
+            )
+        ));
     }
 }

--- a/crates/harn-vm/src/vm/debug.rs
+++ b/crates/harn-vm/src/vm/debug.rs
@@ -617,8 +617,11 @@ impl Vm {
         self.stopped = false;
 
         let local_slots = Self::fresh_local_slots(&chunk);
+        let chunk = Arc::new(chunk);
+        let inline_cache_set = self.inline_cache_set_index_for_chunk(&chunk);
         self.frames.push(CallFrame {
-            chunk: Arc::new(chunk),
+            chunk,
+            inline_cache_set,
             ip: 0,
             stack_base: saved_stack_len,
             saved_env,

--- a/crates/harn-vm/src/vm/execution.rs
+++ b/crates/harn-vm/src/vm/execution.rs
@@ -275,8 +275,10 @@ impl Vm {
         } else {
             None
         };
+        let inline_cache_set = self.inline_cache_set_index_for_chunk(&chunk);
         self.frames.push(CallFrame {
             chunk,
+            inline_cache_set,
             ip: 0,
             stack_base: self.stack.len(),
             saved_env: self.env.clone(),

--- a/crates/harn-vm/src/vm/ops/arithmetic.rs
+++ b/crates/harn-vm/src/vm/ops/arithmetic.rs
@@ -105,20 +105,21 @@ impl super::super::Vm {
 
     pub(super) fn execute_adaptive_binary(&mut self, op: AdaptiveBinaryOp) -> Result<(), VmError> {
         // Read the cache slot from the chunk side table, then access the
-        // VM-local cache by scalar chunk metadata. Avoiding a shared Chunk
-        // clone here keeps parallel workers from contending on the same
-        // compiled closure refcount in arithmetic-heavy pool tasks.
-        let (cache_id, slot_count, cache_slot) = {
+        // VM-local cache through the frame-local cache-set index.
+        let cache_site = {
             let frame = self.frames.last().unwrap();
-            let op_offset = frame.ip.saturating_sub(1);
-            let cache_id = frame.chunk.cache_id();
-            let slot_count = frame.chunk.inline_cache_slot_count();
-            let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            (cache_id, slot_count, cache_slot)
+            frame.inline_cache_site_for_previous_op()
         };
         let b = self.pop()?;
         let a = self.pop()?;
-        let result = self.adaptive_binary_compute(op, a, b, cache_id, slot_count, cache_slot)?;
+        let result = self.adaptive_binary_compute(
+            op,
+            a,
+            b,
+            cache_site.cache_set,
+            cache_site.slot_count,
+            cache_site.slot,
+        )?;
         self.stack.push(result);
         Ok(())
     }
@@ -134,12 +135,12 @@ impl super::super::Vm {
         op: AdaptiveBinaryOp,
         a: VmValue,
         b: VmValue,
-        cache_id: u64,
+        cache_set: usize,
         slot_count: usize,
         cache_slot: Option<usize>,
     ) -> Result<VmValue, VmError> {
         let cached_state = cache_slot
-            .and_then(|slot| self.peek_adaptive_binary_cache_by_key(cache_id, slot_count, slot))
+            .and_then(|slot| self.peek_adaptive_binary_cache_by_index(cache_set, slot))
             .filter(|(cached_op, _)| *cached_op == op)
             .map(|(_, state)| state);
 
@@ -147,8 +148,8 @@ impl super::super::Vm {
 
         if let Some((result, next_state)) = Self::try_specialized_binary(op, cached_state, &a, &b) {
             if let Some(slot) = cache_slot {
-                self.set_inline_cache_entry_by_key(
-                    cache_id,
+                self.set_inline_cache_entry_by_index(
+                    cache_set,
                     slot_count,
                     slot,
                     InlineCacheEntry::AdaptiveBinary {
@@ -162,8 +163,8 @@ impl super::super::Vm {
             let result = Self::generic_binary_result(self, op, a, b)?;
             if let (Some(slot), Some(shape)) = (cache_slot, shape) {
                 let next_state = Self::next_adaptive_binary_state(cached_state, shape);
-                self.set_inline_cache_entry_by_key(
-                    cache_id,
+                self.set_inline_cache_entry_by_index(
+                    cache_set,
                     slot_count,
                     slot,
                     InlineCacheEntry::AdaptiveBinary {

--- a/crates/harn-vm/src/vm/ops/call.rs
+++ b/crates/harn-vm/src/vm/ops/call.rs
@@ -849,15 +849,14 @@ impl super::super::Vm {
     /// leaves `ip` untouched so [`execute_call_async`] can read the operand
     /// exactly once.
     pub(super) fn execute_call_sync(&mut self) -> Option<Result<(), VmError>> {
-        let (chunk, argc, cache_slot) = {
+        let (cache_site, argc) = {
             let frame = self.frames.last().unwrap();
-            let op_offset = frame.ip.saturating_sub(1);
-            let chunk = Arc::clone(&frame.chunk);
             let argc = frame.chunk.code[frame.ip] as usize;
-            let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            (chunk, argc, cache_slot)
+            (frame.inline_cache_site_for_previous_op(), argc)
         };
-        let cached_state = cache_slot.and_then(|slot| self.peek_direct_call_state(&chunk, slot));
+        let cached_state = cache_site
+            .slot
+            .and_then(|slot| self.peek_direct_call_state_by_index(cache_site.cache_set, slot));
         let callee_idx = self.stack.len().checked_sub(argc + 1)?;
         let closure = match self.try_cached_direct_call(cached_state.as_ref(), argc, callee_idx) {
             Some(closure) => closure,
@@ -870,13 +869,18 @@ impl super::super::Vm {
             return None;
         }
 
-        if let Some(slot) = cache_slot {
+        if let Some(slot) = cache_site.slot {
             let next_entry = Self::next_direct_call_entry(
                 cached_state,
                 argc,
                 DirectCallTarget::Closure(Arc::clone(&closure)),
             );
-            self.set_inline_cache_entry(&chunk, slot, next_entry);
+            self.set_inline_cache_entry_by_index(
+                cache_site.cache_set,
+                cache_site.slot_count,
+                slot,
+                next_entry,
+            );
         }
 
         let frame = self.frames.last_mut().unwrap();
@@ -1072,16 +1076,17 @@ impl super::super::Vm {
     /// resolves synchronously in the hot case but still pays the
     /// future-state-machine tax.
     pub(super) fn execute_call_builtin_sync(&mut self) -> Option<Result<(), VmError>> {
-        let (chunk, name_idx, argc, cache_slot) = {
+        let (chunk, cache_site, name_idx, argc) = {
             let frame = self.frames.last().unwrap();
-            let op_offset = frame.ip.saturating_sub(1);
             let chunk = Arc::clone(&frame.chunk);
+            let cache_site = frame.inline_cache_site_for_previous_op();
             let name_idx = frame.chunk.read_u16(frame.ip + 8) as usize;
             let argc = frame.chunk.code[frame.ip + 10] as usize;
-            let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            (chunk, name_idx, argc, cache_slot)
+            (chunk, cache_site, name_idx, argc)
         };
-        let cached_state = cache_slot.and_then(|slot| self.peek_direct_call_state(&chunk, slot));
+        let cached_state = cache_site
+            .slot
+            .and_then(|slot| self.peek_direct_call_state_by_index(cache_site.cache_set, slot));
         let name = Self::const_str(&chunk.constants[name_idx]).ok()?;
 
         // Names handled by `try_call_special_name` are runtime constructs
@@ -1113,13 +1118,18 @@ impl super::super::Vm {
             return None;
         }
 
-        if let Some(slot) = cache_slot {
+        if let Some(slot) = cache_site.slot {
             let next_entry = Self::next_direct_call_entry(
                 cached_state,
                 argc,
                 DirectCallTarget::Closure(Arc::clone(&closure)),
             );
-            self.set_inline_cache_entry(&chunk, slot, next_entry);
+            self.set_inline_cache_entry_by_index(
+                cache_site.cache_set,
+                cache_site.slot_count,
+                slot,
+                next_entry,
+            );
         }
 
         let frame = self.frames.last_mut().unwrap();
@@ -1309,8 +1319,11 @@ impl super::super::Vm {
         let saved_iterator_depth = popped.saved_iterator_depth;
         self.iterators.truncate(saved_iterator_depth);
         self.stack.truncate(stack_base);
+        let chunk = Arc::clone(&closure.func.chunk);
+        let inline_cache_set = self.inline_cache_set_index_for_chunk(&chunk);
         self.frames.push(CallFrame {
-            chunk: Arc::clone(&closure.func.chunk),
+            chunk,
+            inline_cache_set,
             ip: 0,
             stack_base,
             saved_env: parent_env,
@@ -1480,18 +1493,19 @@ impl super::super::Vm {
     }
 
     pub(super) async fn execute_method_call(&mut self, optional: bool) -> Result<(), VmError> {
-        let (chunk, name_idx, argc, cache_slot) = {
+        let (chunk, cache_site, name_idx, argc) = {
             let frame = self.frames.last_mut().unwrap();
-            let op_offset = frame.ip.saturating_sub(1);
             let chunk = Arc::clone(&frame.chunk);
+            let cache_site = frame.inline_cache_site_for_previous_op();
             let name_idx = frame.chunk.read_u16(frame.ip);
             frame.ip += 2;
             let argc = frame.chunk.code[frame.ip] as usize;
             frame.ip += 1;
-            let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            (chunk, name_idx, argc, cache_slot)
+            (chunk, cache_site, name_idx, argc)
         };
-        let cached_method = cache_slot.and_then(|slot| self.peek_method_cache(&chunk, slot));
+        let cached_method = cache_site
+            .slot
+            .and_then(|slot| self.peek_method_cache_by_index(cache_site.cache_set, slot));
         let args_start = self.stack_arg_start(argc)?;
         let obj_idx = args_start
             .checked_sub(1)
@@ -1544,9 +1558,10 @@ impl super::super::Vm {
                 self.stack.truncate(obj_idx);
                 self.call_method_async(obj, method, &args).await?
             };
-            if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
-                self.set_inline_cache_entry(
-                    &chunk,
+            if let (Some(slot), Some(target)) = (cache_site.slot, cache_target) {
+                self.set_inline_cache_entry_by_index(
+                    cache_site.cache_set,
+                    cache_site.slot_count,
                     slot,
                     InlineCacheEntry::Method {
                         name_idx,
@@ -1566,16 +1581,17 @@ impl super::super::Vm {
         &mut self,
         optional: bool,
     ) -> Option<Result<(), VmError>> {
-        let (chunk, name_idx, argc, cache_slot) = {
+        let (chunk, cache_site, name_idx, argc) = {
             let frame = self.frames.last().unwrap();
-            let op_offset = frame.ip.saturating_sub(1);
             let chunk = Arc::clone(&frame.chunk);
+            let cache_site = frame.inline_cache_site_for_previous_op();
             let name_idx = frame.chunk.read_u16(frame.ip);
             let argc = frame.chunk.code[frame.ip + 2] as usize;
-            let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            (chunk, name_idx, argc, cache_slot)
+            (chunk, cache_site, name_idx, argc)
         };
-        let cached_method = cache_slot.and_then(|slot| self.peek_method_cache(&chunk, slot));
+        let cached_method = cache_site
+            .slot
+            .and_then(|slot| self.peek_method_cache_by_index(cache_site.cache_set, slot));
 
         let args_start = match self.stack.len().checked_sub(argc) {
             Some(args_start) => args_start,
@@ -1589,7 +1605,8 @@ impl super::super::Vm {
 
         if optional && matches!(obj, VmValue::Nil) {
             return Some(self.finish_method_call_sync(
-                &chunk,
+                cache_site.cache_set,
+                cache_site.slot_count,
                 argc,
                 Ok(VmValue::Nil),
                 name_idx,
@@ -1606,7 +1623,8 @@ impl super::super::Vm {
             &self.stack[args_start..],
         ) {
             return Some(self.finish_method_call_sync(
-                &chunk,
+                cache_site.cache_set,
+                cache_site.slot_count,
                 argc,
                 Ok(result),
                 name_idx,
@@ -1620,7 +1638,8 @@ impl super::super::Vm {
                 Ok(method) => method,
                 Err(err) => {
                     return Some(self.finish_method_call_sync(
-                        &chunk,
+                        cache_site.cache_set,
+                        cache_site.slot_count,
                         argc,
                         Err(err),
                         name_idx,
@@ -1635,9 +1654,15 @@ impl super::super::Vm {
                 method,
                 &self.stack[args_start..],
             ) {
-                return Some(
-                    self.finish_method_call_sync(&chunk, argc, result, name_idx, None, None),
-                );
+                return Some(self.finish_method_call_sync(
+                    cache_site.cache_set,
+                    cache_site.slot_count,
+                    argc,
+                    result,
+                    name_idx,
+                    None,
+                    None,
+                ));
             }
         }
 
@@ -1646,7 +1671,8 @@ impl super::super::Vm {
                 Ok(method) => method,
                 Err(err) => {
                     return Some(self.finish_method_call_sync(
-                        &chunk,
+                        cache_site.cache_set,
+                        cache_site.slot_count,
                         argc,
                         Err(err),
                         name_idx,
@@ -1667,12 +1693,21 @@ impl super::super::Vm {
             (result, cache_target)
         };
 
-        Some(self.finish_method_call_sync(&chunk, argc, result, name_idx, cache_slot, cache_target))
+        Some(self.finish_method_call_sync(
+            cache_site.cache_set,
+            cache_site.slot_count,
+            argc,
+            result,
+            name_idx,
+            cache_site.slot,
+            cache_target,
+        ))
     }
 
     fn finish_method_call_sync(
         &mut self,
-        chunk: &crate::chunk::ChunkRef,
+        cache_set: usize,
+        slot_count: usize,
         argc: usize,
         result: Result<VmValue, VmError>,
         name_idx: u16,
@@ -1691,8 +1726,9 @@ impl super::super::Vm {
 
         let result = result?;
         if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
-            self.set_inline_cache_entry(
-                chunk,
+            self.set_inline_cache_entry_by_index(
+                cache_set,
+                slot_count,
                 slot,
                 InlineCacheEntry::Method {
                     name_idx,
@@ -1706,16 +1742,17 @@ impl super::super::Vm {
     }
 
     pub(super) async fn execute_method_call_spread(&mut self) -> Result<(), VmError> {
-        let (chunk, name_idx, cache_slot) = {
+        let (chunk, cache_site, name_idx) = {
             let frame = self.frames.last_mut().unwrap();
-            let op_offset = frame.ip.saturating_sub(1);
             let chunk = Arc::clone(&frame.chunk);
+            let cache_site = frame.inline_cache_site_for_previous_op();
             let name_idx = frame.chunk.read_u16(frame.ip);
             frame.ip += 2;
-            let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            (chunk, name_idx, cache_slot)
+            (chunk, cache_site, name_idx)
         };
-        let cached_method = cache_slot.and_then(|slot| self.peek_method_cache(&chunk, slot));
+        let cached_method = cache_site
+            .slot
+            .and_then(|slot| self.peek_method_cache_by_index(cache_site.cache_set, slot));
         let args_val = self.pop()?;
         let obj = self.pop()?;
         let args = match args_val {
@@ -1754,9 +1791,10 @@ impl super::super::Vm {
             } else {
                 self.call_method_async(obj, method, &args).await?
             };
-            if let (Some(slot), Some(target)) = (cache_slot, cache_target) {
-                self.set_inline_cache_entry(
-                    &chunk,
+            if let (Some(slot), Some(target)) = (cache_site.slot, cache_target) {
+                self.set_inline_cache_entry_by_index(
+                    cache_site.cache_set,
+                    cache_site.slot_count,
                     slot,
                     InlineCacheEntry::Method {
                         name_idx,

--- a/crates/harn-vm/src/vm/ops/collections.rs
+++ b/crates/harn-vm/src/vm/ops/collections.rs
@@ -439,16 +439,17 @@ impl super::super::Vm {
     }
 
     pub(super) fn execute_get_property(&mut self, optional: bool) -> Result<(), VmError> {
-        let (chunk, name_idx, cache_slot) = {
+        let (chunk, cache_site, name_idx) = {
             let frame = self.frames.last_mut().unwrap();
-            let op_offset = frame.ip.saturating_sub(1);
             let chunk = Arc::clone(&frame.chunk);
+            let cache_site = frame.inline_cache_site_for_previous_op();
             let name_idx = frame.chunk.read_u16(frame.ip);
             frame.ip += 2;
-            let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            (chunk, name_idx, cache_slot)
+            (chunk, cache_site, name_idx)
         };
-        let cached_property = cache_slot.and_then(|slot| self.peek_property_cache(&chunk, slot));
+        let cached_property = cache_site
+            .slot
+            .and_then(|slot| self.peek_property_cache_by_index(cache_site.cache_set, slot));
 
         let obj = self.pop()?;
         if optional && matches!(obj, VmValue::Nil) {
@@ -466,9 +467,10 @@ impl super::super::Vm {
                 )
             };
 
-            if let (Some(slot), Some(target)) = (cache_slot, target) {
-                self.set_inline_cache_entry(
-                    &chunk,
+            if let (Some(slot), Some(target)) = (cache_site.slot, target) {
+                self.set_inline_cache_entry_by_index(
+                    cache_site.cache_set,
+                    cache_site.slot_count,
                     slot,
                     InlineCacheEntry::Property { name_idx, target },
                 );

--- a/crates/harn-vm/src/vm/ops/stack.rs
+++ b/crates/harn-vm/src/vm/ops/stack.rs
@@ -245,15 +245,12 @@ impl super::super::Vm {
     /// value rather than a placeholder — the take only happens for adds proven
     /// to succeed.
     pub(super) fn execute_concat_assign_local(&mut self) -> Result<(), VmError> {
-        let (slot_idx, cache_id, slot_count, cache_slot) = {
+        let (slot_idx, cache_site) = {
             let frame = self.frames.last_mut().unwrap();
-            let op_offset = frame.ip.saturating_sub(1);
+            let cache_site = frame.inline_cache_site_for_previous_op();
             let slot_idx = frame.chunk.read_u16(frame.ip) as usize;
             frame.ip += 2;
-            let cache_id = frame.chunk.cache_id();
-            let slot_count = frame.chunk.inline_cache_slot_count();
-            let cache_slot = frame.chunk.inline_cache_slot(op_offset);
-            (slot_idx, cache_id, slot_count, cache_slot)
+            (slot_idx, cache_site)
         };
         let rhs = self.pop()?;
         let frame = self.frames.last_mut().unwrap();
@@ -291,9 +288,9 @@ impl super::super::Vm {
             AdaptiveBinaryOp::Add,
             lhs,
             rhs,
-            cache_id,
-            slot_count,
-            cache_slot,
+            cache_site.cache_set,
+            cache_site.slot_count,
+            cache_site.slot,
         )?;
         let frame = self.frames.last_mut().unwrap();
         let slot = frame

--- a/crates/harn-vm/src/vm/scope.rs
+++ b/crates/harn-vm/src/vm/scope.rs
@@ -162,8 +162,11 @@ impl Vm {
             self.pending_function_bp = Some(closure.func.name.clone());
         }
 
+        let chunk = Arc::clone(&closure.func.chunk);
+        let inline_cache_set = self.inline_cache_set_index_for_chunk(&chunk);
         self.frames.push(CallFrame {
-            chunk: Arc::clone(&closure.func.chunk),
+            chunk,
+            inline_cache_set,
             ip: 0,
             stack_base: self.stack.len(),
             saved_env,

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -62,6 +62,10 @@ pub(crate) struct InterruptHandler {
 /// Call frame for function execution.
 pub(crate) struct CallFrame {
     pub(crate) chunk: ChunkRef,
+    /// VM-local inline-cache set for this frame's chunk. Computed once at
+    /// frame entry so hot opcode dispatch can index cache feedback directly
+    /// instead of hashing the chunk id on every cached opcode.
+    pub(crate) inline_cache_set: usize,
     pub(crate) ip: usize,
     pub(crate) stack_base: usize,
     pub(crate) saved_env: VmEnv,
@@ -97,6 +101,24 @@ pub(crate) struct CallFrame {
     pub(crate) local_scope_base: usize,
     /// Current compiler local scope depth, updated by PushScope/PopScope.
     pub(crate) local_scope_depth: usize,
+}
+
+pub(crate) struct InlineCacheSite {
+    pub(crate) cache_set: usize,
+    pub(crate) slot_count: usize,
+    pub(crate) slot: Option<usize>,
+}
+
+impl CallFrame {
+    #[inline]
+    pub(crate) fn inline_cache_site_for_previous_op(&self) -> InlineCacheSite {
+        let op_offset = self.ip.saturating_sub(1);
+        InlineCacheSite {
+            cache_set: self.inline_cache_set,
+            slot_count: self.chunk.inline_cache_slot_count(),
+            slot: self.chunk.inline_cache_slot(op_offset),
+        }
+    }
 }
 
 /// Exception handler for try/catch.
@@ -194,8 +216,11 @@ pub struct Vm {
     pub(crate) sync_runtime: Arc<crate::synchronization::VmSyncRuntime>,
     /// Shared process-local cells, maps, and mailboxes inherited by child VMs.
     pub(crate) shared_state_runtime: Arc<crate::shared_state::VmSharedStateRuntime>,
-    /// Per-isolate inline cache entries keyed by compiled chunk identity.
-    pub(crate) inline_caches: HashMap<u64, Vec<crate::chunk::InlineCacheEntry>>,
+    /// Per-isolate inline cache entries. `inline_cache_set_by_chunk` maps a
+    /// compiled chunk identity to an index in this vector at frame entry; the
+    /// dispatch loop uses the frame-local index for per-op reads/writes.
+    pub(crate) inline_cache_sets: Vec<Vec<crate::chunk::InlineCacheEntry>>,
+    pub(crate) inline_cache_set_by_chunk: HashMap<u64, usize>,
     /// VM-scoped pool registry inherited by child VMs and scoped into Tokio tasks.
     pub(crate) pool_registry: Arc<crate::stdlib::pool::PoolRegistry>,
     /// Shared task/channel wait graph for this VM execution tree.
@@ -365,7 +390,8 @@ impl VmBaseline {
             spawned_tasks: BTreeMap::new(),
             sync_runtime: Arc::new(crate::synchronization::VmSyncRuntime::new()),
             shared_state_runtime: Arc::new(crate::shared_state::VmSharedStateRuntime::new()),
-            inline_caches: HashMap::new(),
+            inline_cache_sets: Vec::new(),
+            inline_cache_set_by_chunk: HashMap::new(),
             pool_registry: crate::stdlib::pool::new_pool_registry(),
             wait_for_graph: Arc::new(crate::wait_for_graph::VmWaitForGraph::new()),
             held_sync_guards: Vec::new(),
@@ -594,7 +620,8 @@ impl Vm {
             spawned_tasks: BTreeMap::new(),
             sync_runtime: Arc::new(crate::synchronization::VmSyncRuntime::new()),
             shared_state_runtime: Arc::new(crate::shared_state::VmSharedStateRuntime::new()),
-            inline_caches: HashMap::new(),
+            inline_cache_sets: Vec::new(),
+            inline_cache_set_by_chunk: HashMap::new(),
             pool_registry: crate::stdlib::pool::new_pool_registry(),
             wait_for_graph: Arc::new(crate::wait_for_graph::VmWaitForGraph::new()),
             held_sync_guards: Vec::new(),
@@ -710,8 +737,12 @@ impl Vm {
         } else {
             None
         };
+        let chunk = Arc::new(chunk.clone());
+        let local_slots = Self::fresh_local_slots(&chunk);
+        let inline_cache_set = self.inline_cache_set_index_for_chunk(&chunk);
         self.frames.push(CallFrame {
-            chunk: Arc::new(chunk.clone()),
+            chunk,
+            inline_cache_set,
             ip: 0,
             stack_base: self.stack.len(),
             saved_env: self.env.clone(),
@@ -723,7 +754,7 @@ impl Vm {
             saved_source_dir: None,
             module_functions: None,
             module_state: None,
-            local_slots: Self::fresh_local_slots(chunk),
+            local_slots,
             local_scope_base: self.env.scope_depth().saturating_sub(1),
             local_scope_depth: 0,
         });
@@ -747,7 +778,8 @@ impl Vm {
             spawned_tasks: BTreeMap::new(),
             sync_runtime: self.sync_runtime.clone(),
             shared_state_runtime: self.shared_state_runtime.clone(),
-            inline_caches: HashMap::new(),
+            inline_cache_sets: Vec::new(),
+            inline_cache_set_by_chunk: HashMap::new(),
             pool_registry: self.pool_registry.clone(),
             wait_for_graph: self.wait_for_graph.clone(),
             held_sync_guards: Vec::new(),

--- a/crates/harn-vm/src/vm/tests_runtime.rs
+++ b/crates/harn-vm/src/vm/tests_runtime.rs
@@ -93,12 +93,11 @@ fn run_harn_with_inline_cache_entries(source: &str) -> (Vec<InlineCacheEntry>, S
                 register_vm_stdlib(&mut vm);
                 vm.set_harness(crate::Harness::real());
                 let result = vm.execute(&chunk).await.unwrap();
-                let mut inline_cache_entries = vm.inline_cache_entries_for_chunk(&chunk);
-                for (cache_id, entries) in &vm.inline_caches {
-                    if *cache_id != chunk.cache_id() {
-                        inline_cache_entries.extend(entries.clone());
-                    }
-                }
+                let inline_cache_entries = vm
+                    .inline_cache_sets
+                    .iter()
+                    .flat_map(|entries| entries.iter().cloned())
+                    .collect();
                 (inline_cache_entries, vm.output().to_string(), result)
             })
             .await

--- a/perf/vm/bench_adaptive_binary_cache_read.rs
+++ b/perf/vm/bench_adaptive_binary_cache_read.rs
@@ -8,12 +8,10 @@ use harn_vm::bench_internals::{AdaptiveBinaryCacheReadFixture, ADAPTIVE_BINARY_C
 /// Mul / Div / Mod / Eq / Neq / Less / Greater / LessEq / GreaterEq) —
 /// the hottest opcode class in the VM dispatch loop.
 ///
-/// `inline_cache_slot/copy_peek` exercises `peek_adaptive_binary_cache`,
-/// which returns the cached `(op, state)` pair by value (both `Copy`).
-/// `inline_cache_slot/clone_control` exercises the pre-optimization
-/// `inline_cache_entry` path that cloned the wrapping `InlineCacheEntry`
-/// enum on every dispatch — a 24-32B memcpy that the variant-checking
-/// match destructures and throws away.
+/// `adaptive_binary_cache_read/frame_index_peek` exercises the production
+/// frame-local cache-set lookup and `peek_adaptive_binary_cache_by_index`.
+/// `adaptive_binary_cache_read/hash_lookup_clone_control` exercises the old
+/// per-dispatch hash lookup plus full `InlineCacheEntry` clone.
 ///
 /// The N axis (8/32/128/512) approximates a small predicate, a loop
 /// body, and a deep stdlib fn body. Per-op savings compound across
@@ -24,7 +22,7 @@ fn bench_adaptive_binary_cache_read(c: &mut Criterion) {
         .map(AdaptiveBinaryCacheReadFixture::new)
         .collect::<Vec<_>>();
 
-    let mut optimized = c.benchmark_group("adaptive_binary_cache_read/copy_peek");
+    let mut optimized = c.benchmark_group("adaptive_binary_cache_read/frame_index_peek");
     for fixture in &fixtures {
         let benchmark = format!("ops_{:03}", fixture.op_count());
         optimized.bench_with_input(
@@ -37,7 +35,7 @@ fn bench_adaptive_binary_cache_read(c: &mut Criterion) {
     }
     optimized.finish();
 
-    let mut baseline = c.benchmark_group("adaptive_binary_cache_read/clone_control");
+    let mut baseline = c.benchmark_group("adaptive_binary_cache_read/hash_lookup_clone_control");
     for fixture in &fixtures {
         let benchmark = format!("ops_{:03}", fixture.op_count());
         baseline.bench_with_input(

--- a/perf/vm/bench_direct_call_state_read.rs
+++ b/perf/vm/bench_direct_call_state_read.rs
@@ -8,20 +8,17 @@ use harn_vm::bench_internals::{DirectCallStateReadFixture, DIRECT_CALL_STATE_REA
 /// path inside `Op::CallBuiltin` — i.e. every user-fn invocation in
 /// a Harn program after warmup.
 ///
-/// `direct_call_state_read/copy_peek` exercises `peek_direct_call_state`,
-/// returning just the inner `DirectCallState` (still clones because it
-/// holds the `Arc<VmClosure>` cached target, but skips the wrapping
-/// `InlineCacheEntry` discriminant init and padding-to-largest-variant
-/// memcpy). `direct_call_state_read/clone_control` exercises the
-/// full `inline_cache_entry` path that clones the complete
-/// `InlineCacheEntry` enum on every dispatch.
+/// `direct_call_state_read/frame_index_peek` exercises the production
+/// frame-local cache-set lookup and `peek_direct_call_state_by_index`.
+/// `direct_call_state_read/hash_lookup_clone_control` exercises the old
+/// per-dispatch hash lookup plus full `InlineCacheEntry` clone.
 fn bench_direct_call_state_read(c: &mut Criterion) {
     let fixtures = DIRECT_CALL_STATE_READ_COUNTS
         .into_iter()
         .map(DirectCallStateReadFixture::new)
         .collect::<Vec<_>>();
 
-    let mut optimized = c.benchmark_group("direct_call_state_read/copy_peek");
+    let mut optimized = c.benchmark_group("direct_call_state_read/frame_index_peek");
     for fixture in &fixtures {
         let benchmark = format!("ops_{:03}", fixture.op_count());
         optimized.bench_with_input(
@@ -34,7 +31,7 @@ fn bench_direct_call_state_read(c: &mut Criterion) {
     }
     optimized.finish();
 
-    let mut baseline = c.benchmark_group("direct_call_state_read/clone_control");
+    let mut baseline = c.benchmark_group("direct_call_state_read/hash_lookup_clone_control");
     for fixture in &fixtures {
         let benchmark = format!("ops_{:03}", fixture.op_count());
         baseline.bench_with_input(

--- a/perf/vm/bench_method_cache_read.rs
+++ b/perf/vm/bench_method_cache_read.rs
@@ -9,14 +9,10 @@ use harn_vm::bench_internals::{MethodCacheReadFixture, METHOD_CACHE_READ_COUNTS}
 /// chained-collection pipeline (`xs.filter(...).map(...).count()`,
 /// `s.contains(...)`, etc.), which most Harn user code exercises.
 ///
-/// `method_cache_read/copy_peek` exercises `peek_method_cache`, which
-/// returns the cached `(name_idx, argc, target)` triple by value — all
-/// three are `Copy` (`u16` / `usize` / `MethodCacheTarget` unit enum).
-/// `method_cache_read/clone_control` exercises the pre-optimization
-/// `inline_cache_entry` path that cloned the wrapping `InlineCacheEntry`
-/// enum on every dispatch — a 32-48B memcpy (largest variant size) that
-/// the variant-checking `let-else` in `try_cached_method` destructures
-/// and throws away.
+/// `method_cache_read/frame_index_peek` exercises the production frame-local
+/// cache-set lookup and `peek_method_cache_by_index`. `method_cache_read/
+/// hash_lookup_clone_control` exercises the old per-dispatch hash lookup plus
+/// full `InlineCacheEntry` clone.
 ///
 /// The N axis (8/32/128/512) approximates a small predicate, a loop
 /// body, and a deep stdlib pipeline. Per-op savings compound across
@@ -27,7 +23,7 @@ fn bench_method_cache_read(c: &mut Criterion) {
         .map(MethodCacheReadFixture::new)
         .collect::<Vec<_>>();
 
-    let mut optimized = c.benchmark_group("method_cache_read/copy_peek");
+    let mut optimized = c.benchmark_group("method_cache_read/frame_index_peek");
     for fixture in &fixtures {
         let benchmark = format!("ops_{:03}", fixture.op_count());
         optimized.bench_with_input(
@@ -40,7 +36,7 @@ fn bench_method_cache_read(c: &mut Criterion) {
     }
     optimized.finish();
 
-    let mut baseline = c.benchmark_group("method_cache_read/clone_control");
+    let mut baseline = c.benchmark_group("method_cache_read/hash_lookup_clone_control");
     for fixture in &fixtures {
         let benchmark = format!("ops_{:03}", fixture.op_count());
         baseline.bench_with_input(

--- a/perf/vm/bench_property_cache_read.rs
+++ b/perf/vm/bench_property_cache_read.rs
@@ -8,19 +8,17 @@ use harn_vm::bench_internals::{PropertyCacheReadFixture, PROPERTY_CACHE_READ_COU
 /// dominant opcode for any field-read-heavy code (`obj.field`,
 /// `xs.count`, `pair.0`, etc.).
 ///
-/// `property_cache_read/copy_peek` exercises `peek_property_cache`,
-/// returning just the `Property` payload (`u16 + PropertyCacheTarget`).
-/// `property_cache_read/clone_control` exercises the pre-optimization
-/// `inline_cache_entry` path that cloned the wrapping `InlineCacheEntry`
-/// enum — a 32-48B memcpy (padded to the largest variant, `DirectCall`)
-/// that `try_cached_property`'s `let-else` destructures and throws away.
+/// `property_cache_read/frame_index_peek` exercises the production
+/// frame-local cache-set lookup and `peek_property_cache_by_index`.
+/// `property_cache_read/hash_lookup_clone_control` exercises the old
+/// per-dispatch hash lookup plus full `InlineCacheEntry` clone.
 fn bench_property_cache_read(c: &mut Criterion) {
     let fixtures = PROPERTY_CACHE_READ_COUNTS
         .into_iter()
         .map(PropertyCacheReadFixture::new)
         .collect::<Vec<_>>();
 
-    let mut optimized = c.benchmark_group("property_cache_read/copy_peek");
+    let mut optimized = c.benchmark_group("property_cache_read/frame_index_peek");
     for fixture in &fixtures {
         let benchmark = format!("ops_{:03}", fixture.op_count());
         optimized.bench_with_input(
@@ -33,7 +31,7 @@ fn bench_property_cache_read(c: &mut Criterion) {
     }
     optimized.finish();
 
-    let mut baseline = c.benchmark_group("property_cache_read/clone_control");
+    let mut baseline = c.benchmark_group("property_cache_read/hash_lookup_clone_control");
     for fixture in &fixtures {
         let benchmark = format!("ops_{:03}", fixture.op_count());
         baseline.bench_with_input(


### PR DESCRIPTION
## Summary
- Add frame-local inline-cache set indices so hot VM dispatch reads and writes adaptive binary, property, method, and direct-call cache entries without per-op HashMap lookups.
- Move cache-read benchmarks onto the production VM-local cache path and keep an explicit hash-lookup/clone control group.
- Remove stale bench-only chunk cache accessors, tighten test-only cache helper docs, and add a changelog fragment.

## Verification
- `cargo fmt --check`
- `cargo check -p harn-vm`
- `cargo check -p harn-vm --features vm-bench-internals`
- `cargo test -p harn-vm vm::cache::tests::cache_set_index_reuses_chunk_identity -- --exact`
- `cargo test -p harn-vm inline_cache -- --nocapture`
- `cargo check --manifest-path perf/vm/Cargo.toml --benches`
- Cache-read Criterion smoke benches for adaptive binary, method, property, and direct-call paths with `--sample-size 10 --warm-up-time 1 --measurement-time 1`
- Pre-commit hook: markdown, rustfmt, prompt-prose lint, changed-package clippy
- Pre-push hook: markdown and targeted local checks

## Bench Notes
The frame-indexed cache-read groups consistently beat the hash-lookup/clone control groups in the smoke benches. Example adaptive binary results ranged from ~46 ns vs ~1.19 us at 8 ops to ~3.29 us vs ~27.9 us at 512 ops.