### PR TITLE
Normalize pseudo-tool wrapper intents

### DIFF
--- a/changelog.d/pseudo-tool-lowering.fixed.md
+++ b/changelog.d/pseudo-tool-lowering.fixed.md
@@ -1,0 +1,2 @@
+- Normalize marker and generic pseudo-tool wrappers with clear read/search/run intent before tool
+  dispatch, reducing recoverable value-model tool-call denials.

--- a/crates/harn-vm/src/llm/tools/compat.rs
+++ b/crates/harn-vm/src/llm/tools/compat.rs
@@ -82,7 +82,7 @@ pub(crate) fn normalize_tool_call_shape(
         return resolve_semantic_alias(recovered, inner_arguments);
     }
 
-    if is_marker_wrapper {
+    if is_marker_wrapper || is_generic_wrapper_name(&normalized_name) {
         if let Some(inferred_name) = infer_tool_name_from_arguments(&arguments) {
             return (inferred_name, arguments);
         }
@@ -234,7 +234,7 @@ fn remap_edit_action_args(verb: &str, arguments: serde_json::Value) -> serde_jso
 fn is_generic_wrapper_name(name: &str) -> bool {
     matches!(
         name,
-        "tool" | "tool.call" | "tool.exec" | "function" | "function.call" | "call"
+        "tool" | "tool.call" | "tool.exec" | "tool_call" | "function" | "function.call" | "call"
     )
 }
 
@@ -245,6 +245,19 @@ fn is_harmony_marker_wrapper_name(name: &str) -> bool {
 
 fn infer_tool_name_from_arguments(arguments: &serde_json::Value) -> Option<String> {
     let object = arguments.as_object()?;
+    let intent = object
+        .get("intent")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .map(str::to_ascii_lowercase);
+    match intent.as_deref() {
+        Some("read" | "open" | "look" | "view" | "list" | "ls") => {
+            return Some("look".to_string());
+        }
+        Some("search" | "grep" | "find") => return Some("search".to_string()),
+        _ => {}
+    }
+
     let has_command_shape = object
         .get("command")
         .or_else(|| object.get("commands"))
@@ -320,8 +333,28 @@ mod tests {
     }
 
     #[test]
-    fn preserves_unrecognized_harmony_marker_wrapper_shape() {
+    fn infers_look_from_harmony_marker_wrapper_read_intent() {
         let arguments = serde_json::json!({"intent": "read", "file": "src/lib.rs"});
+        let (name, normalized_arguments) =
+            normalize_tool_call_shape("<|constrain|>json", arguments.clone());
+
+        assert_eq!(name, "look");
+        assert_eq!(normalized_arguments, arguments);
+    }
+
+    #[test]
+    fn infers_search_from_tool_call_wrapper_search_intent() {
+        let arguments = serde_json::json!({"intent": "search", "path": "src", "query": "fn parse"});
+        let (name, normalized_arguments) =
+            normalize_tool_call_shape("tool_call", arguments.clone());
+
+        assert_eq!(name, "search");
+        assert_eq!(normalized_arguments, arguments);
+    }
+
+    #[test]
+    fn preserves_unrecognized_harmony_marker_wrapper_shape() {
+        let arguments = serde_json::json!({"intent": "summarize", "file": "src/lib.rs"});
         let (name, normalized_arguments) =
             normalize_tool_call_shape("<|constrain|>json", arguments.clone());
 

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -660,6 +660,44 @@ fn native_json_fallback_infers_run_from_harmony_marker_wrapper() {
 }
 
 #[test]
+fn native_json_fallback_infers_look_from_harmony_marker_wrapper_read_intent() {
+    let known: std::collections::BTreeSet<String> = ["look", "run", "search"]
+        .into_iter()
+        .map(String::from)
+        .collect();
+    let text =
+        r#"{"name":"<|constrain|>json","arguments":{"intent":"read","path":"src/main.zig"}}"#;
+    let (calls, errors) = parse_native_json_tool_calls(text, &known);
+    assert!(errors.is_empty(), "no errors expected: {errors:?}");
+    assert_eq!(
+        calls.len(),
+        1,
+        "marker wrapper read intent should parse: {calls:?}"
+    );
+    assert_eq!(calls[0]["name"], json!("look"));
+    assert_eq!(calls[0]["arguments"]["path"], json!("src/main.zig"));
+}
+
+#[test]
+fn native_json_fallback_infers_search_from_tool_call_wrapper_search_intent() {
+    let known: std::collections::BTreeSet<String> = ["look", "run", "search"]
+        .into_iter()
+        .map(String::from)
+        .collect();
+    let text =
+        r#"{"name":"tool_call","arguments":{"intent":"search","path":"src","query":"fn parse"}}"#;
+    let (calls, errors) = parse_native_json_tool_calls(text, &known);
+    assert!(errors.is_empty(), "no errors expected: {errors:?}");
+    assert_eq!(
+        calls.len(),
+        1,
+        "tool_call wrapper search intent should parse: {calls:?}"
+    );
+    assert_eq!(calls[0]["name"], json!("search"));
+    assert_eq!(calls[0]["arguments"]["query"], json!("fn parse"));
+}
+
+#[test]
 fn native_json_fallback_parses_flat_envelope_with_string_encoded_arguments() {
     // Regression: OpenAI's on-the-wire flat shape encodes `arguments` as a JSON
     // STRING (`{"name":"read","arguments":"{\"path\":\"a\"}"}`), which local


### PR DESCRIPTION
## Summary
- Treat `tool_call` as a generic wrapper name in tool-call compatibility normalization.
- Infer canonical `look` / `search` / `run` from marker or generic pseudo-tool wrappers when their argument object carries clear intent.
- Add native JSON fallback coverage for `<|constrain|>json` read intent and `tool_call` search intent.

## Verification
- `CARGO_TARGET_DIR=/tmp/harn-target-pseudo-tool cargo test -p harn-vm llm::tools::compat --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-pseudo-tool cargo test -p harn-vm native_json_fallback_infers --lib`
- `CARGO_TARGET_DIR=/tmp/harn-target-pseudo-tool cargo fmt --all --check`
- `git diff --check`
- pre-commit hook
- pre-push hook

## Note
Observed while mining Burin `zig-feat` transcripts: value models emitted recoverable pseudo-tools like `<|constrain|>json` with read intent and `tool_call` with search intent. This keeps the recovery in Harn's parser rather than Burin-specific loop code.