### PR TITLE
Raise release binary size budget

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -88,8 +88,8 @@ env:
   CARGO_INCREMENTAL: "0"
   SCCACHE_GHA_ENABLED: "true"
   # Keep a narrow release-size ratchet while allowing the current stripped
-  # Linux x86_64 binary, which is 185.20 MiB at v0.8.120.
-  BINARY_SIZE_BUDGET_MB: "186"
+  # Linux x86_64 binary, which is 186.11 MiB at v0.8.139.
+  BINARY_SIZE_BUDGET_MB: "187"
 
 jobs:
   setup:

--- a/scripts/check_binary_size.sh
+++ b/scripts/check_binary_size.sh
@@ -10,7 +10,7 @@ build_release=1
 emit_bloat=1
 target="${HARN_RELEASE_TARGET:-}"
 harn_bin="${HARN_BIN:-}"
-budget_mb="${BINARY_SIZE_BUDGET_MB:-186}"
+budget_mb="${BINARY_SIZE_BUDGET_MB:-187}"
 report_dir="${BINARY_SIZE_REPORT_DIR:-}"
 
 usage() {
@@ -24,7 +24,7 @@ Options:
   --no-build           Check an already-built release binary
   --target TARGET      Cargo target triple to build/check
   --bin PATH           Override the harn binary path
-  --budget-mb MB       Maximum binary size in MiB (default: 186)
+  --budget-mb MB       Maximum binary size in MiB (default: 187)
   --report-dir DIR     Directory for binary-size and cargo-bloat reports
   --skip-bloat         Only write binary-size.txt; do not run cargo-bloat
   -h, --help           Show this help


### PR DESCRIPTION
## Summary
- raise the release binary size ratchet from 186 MiB to 187 MiB
- keep the workflow comment and local checker default aligned with the v0.8.139 Linux x64 release binary size

## Verification
- bash -n scripts/check_binary_size.sh
- git diff --check
- HARN_BIN=/Users/ksinder/.codex/tmp/harn-target-release-v0.8.139-rerun/debug/harn make check-generated-registry
- pre-commit hook
- pre-push hook