### PR TITLE
Fix unclosed response tag parse guidance

### DIFF
--- a/changelog.d/3561.changed.md
+++ b/changelog.d/3561.changed.md
@@ -1,1 +1,4 @@
-- **Release binary size gate now allows the v0.8.139 x86_64 Linux binary (#3561).** The release workflow and local size-check script now share a 187 MiB ratchet, matching the 186.11 MiB stripped binary produced by the v0.8.139 release build.
+- **Release binary size gate now allows the v0.8.139 x86_64 Linux binary
+  (#3561).** The release workflow and local size-check script now share a
+  187 MiB ratchet, matching the 186.11 MiB stripped binary produced by the
+  v0.8.139 release build.

--- a/changelog.d/3563.fixed.md
+++ b/changelog.d/3563.fixed.md
@@ -1,0 +1,4 @@
+- **Text tool-call parser diagnostics now classify unclosed `<user_response>`
+  blocks correctly (#3563).** An accepted opening tag without its closing
+  `</user_response>` is reported as an unclosed block instead of the
+  contradictory unknown-tag fallback.

--- a/crates/harn-vm/src/llm/tools/parse/tagged.rs
+++ b/crates/harn-vm/src/llm/tools/parse/tagged.rs
@@ -385,7 +385,12 @@ pub(crate) fn parse_text_tool_calls_with_tools(
                 end += 1;
             }
             let fragment = &src[start..end];
-            if fragment.starts_with('<') && !fragment.contains('>') {
+            if let Some(tag) = known_top_level_open_tag(fragment) {
+                violations.push(format!(
+                    "Unclosed <{tag}> block. Close it with </{tag}> or remove it; only \
+                     <tool_call>, <assistant_prose>, <user_response>, and <done> are accepted.",
+                ));
+            } else if fragment.starts_with('<') && !fragment.contains('>') {
                 violations.push(format!(
                     "Unclosed tag starting at {:?}. Close it or remove it; only \
                      <tool_call>, <assistant_prose>, <user_response>, and <done> are accepted.",
@@ -432,6 +437,23 @@ pub(crate) fn parse_text_tool_calls_with_tools(
         violations,
         done_marker,
         canonical: canonical_parts.join("\n\n"),
+    }
+}
+
+fn known_top_level_open_tag(fragment: &str) -> Option<&'static str> {
+    let name = fragment
+        .trim()
+        .strip_prefix('<')?
+        .strip_suffix('>')?
+        .split_whitespace()
+        .next()
+        .unwrap_or("");
+    match name {
+        "tool_call" | "toolcall" => Some("tool_call"),
+        "assistant_prose" | "assistantprose" => Some("assistant_prose"),
+        "user_response" | "userresponse" => Some("user_response"),
+        "done" => Some("done"),
+        _ => None,
     }
 }
 

--- a/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
+++ b/crates/harn-vm/src/llm/tools/tests/validation_and_tagged.rs
@@ -690,6 +690,29 @@ fn tagged_parser_accepts_user_response_tag() {
 }
 
 #[test]
+fn tagged_parser_reports_unclosed_user_response_as_unclosed_not_unknown() {
+    let tools = sample_tool_registry();
+    let text = "<user_response>Visible answer without a close tag.";
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert!(
+        result
+            .violations
+            .iter()
+            .any(|violation| violation.contains("Unclosed <user_response> block")),
+        "unclosed user_response should get a precise close-tag diagnostic: {:?}",
+        result.violations
+    );
+    assert!(
+        !result
+            .violations
+            .iter()
+            .any(|violation| violation.contains("Unknown top-level tag")),
+        "unclosed accepted tags must not be misreported as unknown: {:?}",
+        result.violations
+    );
+}
+
+#[test]
 fn tagged_parser_ignores_inline_user_response_placeholder() {
     let tools = sample_tool_registry();
     let text =


### PR DESCRIPTION
## Summary
- report unclosed accepted response tags like `<user_response>` as unclosed blocks instead of unknown top-level tags
- add a tagged-parser regression for the live malformed final-answer shape

## Verification
- cargo test -p harn-vm tagged_parser_reports_unclosed_user_response_as_unclosed_not_unknown
- cargo test -p harn-vm tagged_parser
- pre-commit hooks
- pre-push hooks