### PR TITLE
Avoid redacting source token declarations

### DIFF
--- a/changelog.d/redaction-source-token.fixed.md
+++ b/changelog.d/redaction-source-token.fixed.md
@@ -1,0 +1,2 @@
+Avoid redacting source declarations such as `pub const Token = struct` as secret assignments while preserving
+generic token assignment redaction.

--- a/crates/harn-vm/src/redact/patterns.rs
+++ b/crates/harn-vm/src/redact/patterns.rs
@@ -357,6 +357,23 @@ mod tests {
     }
 
     #[test]
+    fn sensitive_assignment_preserves_source_declarations() {
+        run_clean();
+        let input = "pub const Token = struct { kind: u8 };\nconst Secret = enum { a, b };";
+        let out = scan_secret_patterns(input, crate::redact::REDACTED_PLACEHOLDER);
+        assert!(matches!(out, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn sensitive_assignment_redacts_placeholder_secret_words() {
+        run_clean();
+        let input = "Checkout incident needed the same query token=secret";
+        let out = scan_secret_patterns(input, crate::redact::REDACTED_PLACEHOLDER);
+        assert!(out.contains("<redacted:sensitive_assignment:"));
+        assert!(!out.contains("token=secret"));
+    }
+
+    #[test]
     fn replaces_jwt_tokens() {
         run_clean();
         let input = "token=eyJabcd.eyJefgh.signature_pad here";

--- a/crates/harn-vm/src/secret_patterns.rs
+++ b/crates/harn-vm/src/secret_patterns.rs
@@ -120,6 +120,6 @@ pub(crate) const DEFAULT_SECRET_PATTERN_SPECS: &[SecretPatternSpec] = &[
         detector: "sensitive-assignment",
         source: "detect-secrets-keyword-detector",
         title: "Sensitive key/value assignment",
-        regex: r#"(?i)\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|password|passwd|secret|token)\s*[:=]\s*["']?[A-Za-z0-9._\-+/=]{6,}["']?"#,
+        regex: r#"(?i)\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|password|passwd|secret|token)\s*[:=]\s*(?:"[A-Za-z0-9._\-+/=]{6,}"|'[A-Za-z0-9._\-+/=]{6,}'|[A-Za-z0-9._\-+/=]*[0-9._\-+/=][A-Za-z0-9._\-+/=]*|secret|hidden|hideme|password|passwd|token)"#,
     },
 ];

--- a/crates/harn-vm/src/stdlib/secret_scan.rs
+++ b/crates/harn-vm/src/stdlib/secret_scan.rs
@@ -369,6 +369,12 @@ config = { client_secret: "QWxhZGRpbjpPcGVuU2VzYW1lQWNjZXNzVG9rZW4=" }
     }
 
     #[test]
+    fn scan_content_preserves_source_declarations_with_secretish_identifiers() {
+        let findings = scan_content("pub const Token = struct { kind: u8 };\n");
+        assert!(findings.is_empty());
+    }
+
+    #[test]
     fn scan_content_redacts_private_key_blocks() {
         let findings = scan_content(
             "-----BEGIN OPENSSH PRIVATE KEY-----\nZXhhbXBsZQ==\n-----END OPENSSH PRIVATE KEY-----\n",


### PR DESCRIPTION
## Summary

- Tighten the shared `sensitive_assignment` secret pattern so unquoted bare values need a token-like digit or separator.
- Add regressions proving `pub const Token = struct` is preserved in redaction and `secret_scan`.
- Preserve existing generic assignment coverage for cases like `token=abc123` and `token = "secret123"`.

## Root Cause

The fallback sensitive-assignment regex treated any six-letter bare RHS after a secretish identifier as a secret. That masked ordinary source declarations such as Zig's `pub const Token = struct`, corrupting model-visible code context in Burin headless runs.

## Validation

- `cargo fmt --check -p harn-vm`
- `cargo test -p harn-vm sensitive_assignment`
- `cargo test -p harn-vm scan_content_preserves_source_declarations`
- `cargo test -p harn-vm scan_content_keeps_generic_assignment_without_specific_detector`
- `git diff --check`
- Harn pre-commit checks
- Harn pre-push checks