### PR TITLE
Add `harn test --coverage` line coverage with LCOV output

### DIFF
--- a/changelog.d/test-coverage.added.md
+++ b/changelog.d/test-coverage.added.md
@@ -1,0 +1,6 @@
+- `harn test --coverage` reports per-file line coverage for the Harn source a
+  user test suite executes, and `--coverage-out <path>` writes an LCOV tracefile
+  consumable by Codecov, `genhtml`, and the VS Code Coverage Gutters extension.
+  Coverage reuses the per-instruction source-line table the VM already carries,
+  so it needs no separate instrumentation pass; recording is opt-in and adds a
+  single predictable branch to the dispatch loop when no session is active.

--- a/crates/harn-cli/src/cli/test.rs
+++ b/crates/harn-cli/src/cli/test.rs
@@ -65,6 +65,14 @@ pub(crate) struct TestArgs {
     /// Re-run user tests when watched files change.
     #[arg(long)]
     pub watch: bool,
+    /// Collect line coverage for executed Harn source and print a per-file
+    /// summary after the run. Supported for user test suites.
+    #[arg(long, action = ArgAction::SetTrue)]
+    pub coverage: bool,
+    /// Write an LCOV tracefile to this path (implies --coverage). Consumable by
+    /// Codecov, `genhtml`, and the VS Code Coverage Gutters extension.
+    #[arg(long = "coverage-out", value_name = "PATH")]
+    pub coverage_out: Option<String>,
     /// Show per-test timing and detailed failures.
     #[arg(short = 'v', long = "verbose", action = ArgAction::SetTrue)]
     pub verbose: bool,

--- a/crates/harn-cli/src/commands/test.rs
+++ b/crates/harn-cli/src/commands/test.rs
@@ -26,6 +26,25 @@ pub(crate) async fn run_command(args: TestArgs) {
         );
     }
 
+    if args.coverage || args.coverage_out.is_some() {
+        if args.watch {
+            command_error(
+                "`harn test --coverage` cannot combine with --watch; the watch loop never terminates so no report would be written",
+            );
+        }
+        if args.determinism || args.evals {
+            command_error("`harn test --coverage` cannot combine with --determinism or --evals");
+        }
+        if matches!(
+            args.target.as_deref(),
+            Some("conformance") | Some("protocols") | Some("agents-conformance")
+        ) {
+            command_error(
+                "`harn test --coverage` is supported for user test suites, not conformance / protocols / agents-conformance",
+            );
+        }
+    }
+
     let shard_requested = args.shard_index.is_some() || args.shard_total.is_some();
     if args.target.as_deref() == Some("agents-conformance") {
         run_agents_conformance_command(args, shard_requested).await;
@@ -213,6 +232,9 @@ async fn run_user_test_target(path: &str, args: &TestArgs, cli_skill_dirs: &[Pat
     if args.watch {
         run_watch_tests(path, run_args).await;
     } else {
+        let coverage = (args.coverage || args.coverage_out.is_some()).then(|| CoverageOptions {
+            out: args.coverage_out.clone(),
+        });
         run_user_tests(
             path,
             run_args,
@@ -220,9 +242,18 @@ async fn run_user_test_target(path: &str, args: &TestArgs, cli_skill_dirs: &[Pat
                 junit_path: args.junit.as_deref(),
                 json_out_path: args.json_out.as_deref(),
             },
+            coverage,
         )
         .await;
     }
+}
+
+/// Coverage knobs for a user-test run. Present only when `--coverage` (or
+/// `--coverage-out`) was requested.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct CoverageOptions {
+    /// Optional LCOV output path.
+    pub out: Option<String>,
 }
 
 fn default_test_dir_or_exit() -> String {
@@ -2058,6 +2089,7 @@ pub(crate) async fn run_user_tests(
     path_str: &str,
     args: UserTestRunArgs<'_>,
     report_config: UserTestReportConfig<'_>,
+    coverage: Option<CoverageOptions>,
 ) {
     let path = PathBuf::from(path_str);
     if !path.exists() {
@@ -2072,6 +2104,15 @@ pub(crate) async fn run_user_tests(
             preflight_report_path(p);
         }
     }
+    if let Some(opts) = &coverage {
+        if let Some(out) = &opts.out {
+            preflight_report_path(out);
+        }
+        // Arm coverage before any test worker spins up a VM so every isolate
+        // the run constructs records into the shared report.
+        harn_vm::coverage::begin_session();
+    }
+
     let summary = run_user_tests_once(&path, args).await;
 
     if !report_config.is_empty() {
@@ -2085,8 +2126,37 @@ pub(crate) async fn run_user_tests(
         }
     }
 
+    // Emit coverage before the failure exit so a failing suite still reports
+    // what it exercised.
+    if let Some(opts) = &coverage {
+        let report = harn_vm::coverage::end_session();
+        emit_coverage_report(&report, opts.out.as_deref());
+    }
+
     if summary.failed > 0 {
         process::exit(1);
+    }
+}
+
+/// Print the per-file coverage summary and, when an LCOV path was requested,
+/// write the tracefile. A write failure fails the run loudly.
+fn emit_coverage_report(report: &harn_vm::coverage::Coverage, out: Option<&str>) {
+    if report.is_empty() {
+        eprintln!("\n[coverage] no executed source files were found on disk to report");
+        return;
+    }
+    let (covered, total) = report.totals();
+    println!(
+        "\nLine coverage: {covered}/{total} ({:.1}%)\n{}",
+        report.percent(),
+        report.render_text(),
+    );
+    if let Some(path) = out {
+        if let Err(error) = fs::write(path, report.render_lcov()) {
+            eprintln!("failed to write coverage report to {path}: {error}");
+            process::exit(1);
+        }
+        println!("LCOV tracefile written to {path}");
     }
 }
 

--- a/crates/harn-cli/tests/coverage_cli.rs
+++ b/crates/harn-cli/tests/coverage_cli.rs
@@ -1,0 +1,95 @@
+//! E2E coverage for `harn test --coverage`.
+//!
+//! Spawns the real binary so the clap surface, the coverage session wiring,
+//! and the LCOV writer are exercised end to end. The line-accounting math
+//! itself is unit-tested in `harn_vm::coverage`.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn binary_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_harn"))
+}
+
+#[test]
+fn test_help_advertises_coverage_flags() {
+    let output = Command::new(binary_path())
+        .args(["test", "--help"])
+        .output()
+        .expect("spawn harn test --help");
+    assert!(output.status.success(), "exit={:?}", output.status.code());
+    let help = String::from_utf8_lossy(&output.stdout);
+    for token in ["--coverage", "--coverage-out"] {
+        assert!(
+            help.contains(token),
+            "expected `{token}` in `harn test --help`, got:\n{help}"
+        );
+    }
+}
+
+#[test]
+fn coverage_summary_and_lcov_distinguish_hit_and_unhit_lines() {
+    let temp = TempDir::new().unwrap();
+    let script = temp.path().join("cov_fixture.harn");
+    // `covered` runs via the test; `never_called` is compiled but never
+    // executed, so its body line must report as an unhit `DA:<line>,0`.
+    let source = "\
+fn covered(x) {
+  return x + 1
+}
+
+fn never_called(x) {
+  return x - 1
+}
+
+pipeline test_covers_one(task) {
+  assert_eq(covered(2), 3)
+}
+";
+    fs::write(&script, source).unwrap();
+    let lcov = temp.path().join("lcov.info");
+
+    let output = Command::new(binary_path())
+        .args([
+            "test",
+            script.to_str().unwrap(),
+            "--coverage",
+            "--coverage-out",
+            lcov.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn harn test --coverage");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "harn test --coverage should pass; exit={:?}\nstdout:\n{stdout}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        stdout.contains("Line coverage:"),
+        "expected a coverage summary on stdout, got:\n{stdout}"
+    );
+
+    let tracefile = fs::read_to_string(&lcov).expect("LCOV tracefile written");
+    assert!(
+        tracefile.contains("cov_fixture.harn"),
+        "LCOV should reference the fixture file:\n{tracefile}"
+    );
+    assert!(
+        tracefile.contains(",1"),
+        "LCOV should record at least one executed line:\n{tracefile}"
+    );
+    assert!(
+        tracefile.contains(",0"),
+        "LCOV should record the uncovered `never_called` body line:\n{tracefile}"
+    );
+    assert!(
+        tracefile.contains("end_of_record"),
+        "LCOV record should be terminated:\n{tracefile}"
+    );
+}

--- a/crates/harn-vm/src/coverage.rs
+++ b/crates/harn-vm/src/coverage.rs
@@ -1,0 +1,405 @@
+//! Line coverage for executed Harn programs.
+//!
+//! Harn already stores a source line for every emitted instruction
+//! (`Chunk::lines`), so line coverage needs no separate debug-info pass: the
+//! denominator is the set of distinct non-zero lines a chunk (and its nested
+//! function bodies) emit, and the numerator is the subset whose instructions
+//! actually ran.
+//!
+//! ## How it is wired
+//!
+//! Coverage is opt-in and process-global so it captures every VM isolate a run
+//! spins up (imports, parallel branches, spawned agents) without threading a
+//! flag through every constructor:
+//!
+//! * [`begin_session`] flips [`is_enabled`] on and clears the merged report.
+//! * Each [`crate::vm::Vm`] checks [`is_enabled`] at construction; when on it
+//!   carries its own [`Coverage`] accumulator and records a hit per executed
+//!   instruction in the dispatch loop.
+//! * On drop a VM folds its accumulator into the global report.
+//! * [`end_session`] flips coverage off and returns the merged [`Coverage`].
+//!
+//! ## File attribution
+//!
+//! A chunk compiled from an imported module carries its own `source_file`; the
+//! entry file's top-level chunk and its same-file function bodies carry `None`.
+//! We attribute a `None` chunk to the VM's primary file (the script under
+//! execution), and otherwise to the chunk's `source_file`. Nested function
+//! chunks inherit their parent's effective file when they carry no
+//! `source_file` of their own, so a module's uncalled helpers are still counted
+//! against the module — not misattributed to the entry script.
+//!
+//! Render filters to files that exist on disk, which drops the synthetic paths
+//! the embedded stdlib and in-memory `eval` chunks report.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use crate::chunk::Chunk;
+
+static COVERAGE_ON: AtomicBool = AtomicBool::new(false);
+static GLOBAL_REPORT: OnceLock<Mutex<Coverage>> = OnceLock::new();
+
+fn global() -> &'static Mutex<Coverage> {
+    GLOBAL_REPORT.get_or_init(|| Mutex::new(Coverage::new()))
+}
+
+/// True while a coverage session is active. Read once per VM construction and
+/// once per executed instruction, so it is a relaxed atomic load — effectively
+/// free and branch-predicted "off" when no session is running.
+#[inline]
+pub fn is_enabled() -> bool {
+    COVERAGE_ON.load(Ordering::Relaxed)
+}
+
+/// Start a coverage session: clear the merged report and enable recording on
+/// every VM constructed until [`end_session`].
+pub fn begin_session() {
+    {
+        let mut report = global().lock().unwrap();
+        *report = Coverage::new();
+    }
+    COVERAGE_ON.store(true, Ordering::SeqCst);
+}
+
+/// End the coverage session and return the merged report.
+pub fn end_session() -> Coverage {
+    COVERAGE_ON.store(false, Ordering::SeqCst);
+    let mut report = global().lock().unwrap();
+    std::mem::take(&mut *report)
+}
+
+/// Build a per-VM accumulator when a session is active, seeding the primary
+/// file used to attribute same-file (`source_file: None`) chunks. Returns
+/// `None` when coverage is off, so the dispatch-loop hook is a single
+/// `Option::is_some` branch on the hot path.
+pub(crate) fn for_primary(primary_file: Option<&str>) -> Option<Coverage> {
+    if !is_enabled() {
+        return None;
+    }
+    let mut cov = Coverage::new();
+    if let Some(file) = primary_file {
+        cov.set_primary_file(file);
+    }
+    Some(cov)
+}
+
+/// Fold one VM's accumulator into the global report. Called from `Vm::drop`.
+pub(crate) fn merge_into_global(data: Coverage) {
+    if data.files.is_empty() {
+        return;
+    }
+    let mut report = global().lock().unwrap();
+    report.merge(data);
+}
+
+/// Hit/total line sets for a single source file.
+#[derive(Debug, Clone, Default)]
+struct FileLines {
+    /// Every instrumentable (non-zero) line emitted for this file.
+    total: BTreeSet<u32>,
+    /// The subset that executed.
+    hit: BTreeSet<u32>,
+}
+
+/// Accumulated line coverage. Used both as a per-VM accumulator and, after
+/// merging, as the whole-run report.
+#[derive(Debug, Clone, Default)]
+pub struct Coverage {
+    /// The script under execution; receives lines from chunks that carry no
+    /// `source_file` of their own.
+    primary_file: Option<Arc<str>>,
+    files: BTreeMap<Arc<str>, FileLines>,
+    /// Chunk ids whose denominator tree has already been walked (per VM).
+    seen: HashSet<u64>,
+    /// Resolved effective file per chunk id, so a hit needs no re-walk.
+    file_of: HashMap<u64, Arc<str>>,
+}
+
+impl Coverage {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record the VM's primary file (the script passed to `execute`). Only the
+    /// first call wins so a nested sub-execution can't clobber it.
+    pub(crate) fn set_primary_file(&mut self, file: &str) {
+        if self.primary_file.is_none() {
+            self.primary_file = Some(Arc::from(file));
+        }
+    }
+
+    /// Record execution of the instruction at `ip` in `chunk`.
+    pub(crate) fn record(&mut self, chunk: &Chunk, ip: usize) {
+        let id = chunk.cache_id();
+        let file = match self.file_of.get(&id) {
+            Some(file) => file.clone(),
+            None => {
+                let effective = self.effective_file(chunk.source_file.as_deref());
+                self.register_tree(chunk, &effective);
+                self.file_of.get(&id).cloned().unwrap_or(effective)
+            }
+        };
+        if let Some(&line) = chunk.lines.get(ip) {
+            if line != 0 {
+                self.files.entry(file).or_default().hit.insert(line);
+            }
+        }
+    }
+
+    /// Resolve the file a `None`-`source_file` chunk belongs to.
+    fn effective_file(&self, source_file: Option<&str>) -> Arc<str> {
+        match source_file {
+            Some(path) => Arc::from(path),
+            None => self
+                .primary_file
+                .clone()
+                .unwrap_or_else(|| Arc::from("<unknown>")),
+        }
+    }
+
+    /// Walk `chunk` and its nested function bodies once, adding every
+    /// instrumentable line to the denominator. Idempotent per chunk id.
+    fn register_tree(&mut self, chunk: &Chunk, effective: &Arc<str>) {
+        let id = chunk.cache_id();
+        if !self.seen.insert(id) {
+            return;
+        }
+        self.file_of.insert(id, effective.clone());
+        {
+            let entry = self.files.entry(effective.clone()).or_default();
+            for &line in &chunk.lines {
+                if line != 0 {
+                    entry.total.insert(line);
+                }
+            }
+        }
+        for func in &chunk.functions {
+            let child = match func.chunk.source_file.as_deref() {
+                Some(path) => Arc::from(path),
+                None => effective.clone(),
+            };
+            self.register_tree(func.chunk.as_ref(), &child);
+        }
+    }
+
+    fn merge(&mut self, other: Coverage) {
+        for (file, lines) in other.files {
+            let entry = self.files.entry(file).or_default();
+            entry.total.extend(lines.total);
+            entry.hit.extend(lines.hit);
+        }
+    }
+
+    /// Files that exist on disk, in deterministic order. Drops the synthetic
+    /// paths embedded-stdlib and in-memory `eval` chunks report.
+    fn real_files(&self) -> Vec<(&str, &FileLines)> {
+        self.files
+            .iter()
+            .filter(|(file, _)| Path::new(file.as_ref()).exists())
+            .map(|(file, lines)| (file.as_ref(), lines))
+            .collect()
+    }
+
+    /// `(covered, total)` line counts across all on-disk files.
+    pub fn totals(&self) -> (usize, usize) {
+        self.real_files()
+            .into_iter()
+            .fold((0, 0), |(cov, total), (_, lines)| {
+                (cov + lines.hit.len(), total + lines.total.len())
+            })
+    }
+
+    /// Whole-run line coverage percentage (0.0 when there is nothing to cover).
+    pub fn percent(&self) -> f64 {
+        let (covered, total) = self.totals();
+        if total == 0 {
+            0.0
+        } else {
+            covered as f64 / total as f64 * 100.0
+        }
+    }
+
+    /// True when no on-disk file has any instrumentable line.
+    pub fn is_empty(&self) -> bool {
+        self.real_files().is_empty()
+    }
+
+    /// A human-readable per-file table plus a total line.
+    pub fn render_text(&self) -> String {
+        let files = self.real_files();
+        if files.is_empty() {
+            return "No coverage data (no executed source files found on disk).".to_string();
+        }
+        let name_width = files
+            .iter()
+            .map(|(file, _)| display_path(file).chars().count())
+            .max()
+            .unwrap_or(4)
+            .clamp(4, 60);
+        let mut out = String::new();
+        out.push_str(&format!(
+            "{:<name_width$}  {:>6}  {:>7}  {:>6}\n",
+            "File", "Lines", "Covered", "%"
+        ));
+        for (file, lines) in &files {
+            let total = lines.total.len();
+            let covered = lines.hit.len();
+            out.push_str(&format!(
+                "{:<name_width$}  {:>6}  {:>7}  {:>5.1}\n",
+                truncate(&display_path(file), name_width),
+                total,
+                covered,
+                pct(covered, total),
+            ));
+        }
+        let (covered, total) = self.totals();
+        out.push_str(&format!(
+            "{:<name_width$}  {:>6}  {:>7}  {:>5.1}\n",
+            "TOTAL",
+            total,
+            covered,
+            pct(covered, total),
+        ));
+        out
+    }
+
+    /// LCOV `tracefile` output for Codecov / VS Code Coverage Gutters / genhtml.
+    pub fn render_lcov(&self) -> String {
+        let mut out = String::new();
+        for (file, lines) in self.real_files() {
+            out.push_str("TN:\n");
+            out.push_str(&format!("SF:{file}\n"));
+            for &line in &lines.total {
+                let count = u8::from(lines.hit.contains(&line));
+                out.push_str(&format!("DA:{line},{count}\n"));
+            }
+            out.push_str(&format!("LF:{}\n", lines.total.len()));
+            out.push_str(&format!("LH:{}\n", lines.hit.len()));
+            out.push_str("end_of_record\n");
+        }
+        out
+    }
+}
+
+fn pct(covered: usize, total: usize) -> f64 {
+    if total == 0 {
+        0.0
+    } else {
+        covered as f64 / total as f64 * 100.0
+    }
+}
+
+/// Show a path relative to the current dir when possible, for compact tables.
+fn display_path(file: &str) -> String {
+    if let Ok(cwd) = std::env::current_dir() {
+        if let Ok(rel) = Path::new(file).strip_prefix(&cwd) {
+            return rel.to_string_lossy().into_owned();
+        }
+    }
+    file.to_string()
+}
+
+fn truncate(text: &str, width: usize) -> String {
+    let count = text.chars().count();
+    if count <= width {
+        return text.to_string();
+    }
+    // Keep the tail (the file name) since the leading dirs are the common
+    // prefix that carries the least signal.
+    let keep = width.saturating_sub(1);
+    let tail: String = text.chars().skip(count - keep).collect();
+    format!("…{tail}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chunk::{Chunk, Op};
+
+    fn chunk_with_lines(lines: &[u32]) -> Chunk {
+        let mut chunk = Chunk::new();
+        for &line in lines {
+            chunk.emit(Op::Nil, line);
+        }
+        chunk
+    }
+
+    #[test]
+    fn denominator_counts_distinct_nonzero_lines() {
+        let chunk = chunk_with_lines(&[1, 1, 2, 0, 3]);
+        let mut cov = Coverage::new();
+        cov.set_primary_file("/does/not/matter.harn");
+        // Register the denominator without executing anything.
+        cov.register_tree(&chunk, &Arc::from("/does/not/matter.harn"));
+        let lines = cov.files.values().next().unwrap();
+        // Lines 1, 2, 3 are instrumentable; the duplicate 1 and the 0 collapse.
+        assert_eq!(
+            lines.total.iter().copied().collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+        assert!(lines.hit.is_empty());
+    }
+
+    #[test]
+    fn hits_are_a_subset_of_the_denominator() {
+        let chunk = chunk_with_lines(&[10, 11, 12]);
+        let mut cov = Coverage::new();
+        cov.set_primary_file("/x.harn");
+        // Execute the instructions at index 0 and 2 (lines 10 and 12).
+        cov.record(&chunk, 0);
+        cov.record(&chunk, 2);
+        let lines = cov.files.values().next().unwrap();
+        assert_eq!(lines.total.len(), 3);
+        assert_eq!(lines.hit.iter().copied().collect::<Vec<_>>(), vec![10, 12]);
+    }
+
+    #[test]
+    fn line_zero_is_not_instrumentable() {
+        let chunk = chunk_with_lines(&[0, 5]);
+        let mut cov = Coverage::new();
+        cov.set_primary_file("/x.harn");
+        cov.record(&chunk, 0); // line 0 — synthetic, ignored
+        cov.record(&chunk, 1); // line 5 — counted
+        let lines = cov.files.values().next().unwrap();
+        assert_eq!(lines.total.iter().copied().collect::<Vec<_>>(), vec![5]);
+        assert_eq!(lines.hit.iter().copied().collect::<Vec<_>>(), vec![5]);
+    }
+
+    #[test]
+    fn merge_unions_totals_and_hits() {
+        let mut a = Coverage::new();
+        a.files.entry(Arc::from("/f.harn")).or_default().total = BTreeSet::from([1, 2, 3]);
+        a.files.entry(Arc::from("/f.harn")).or_default().hit = BTreeSet::from([1]);
+        let mut b = Coverage::new();
+        b.files.entry(Arc::from("/f.harn")).or_default().total = BTreeSet::from([3, 4]);
+        b.files.entry(Arc::from("/f.harn")).or_default().hit = BTreeSet::from([4]);
+        a.merge(b);
+        let lines = &a.files[&Arc::<str>::from("/f.harn")];
+        assert_eq!(
+            lines.total.iter().copied().collect::<Vec<_>>(),
+            vec![1, 2, 3, 4]
+        );
+        assert_eq!(lines.hit.iter().copied().collect::<Vec<_>>(), vec![1, 4]);
+    }
+
+    #[test]
+    fn lcov_shapes_da_lines() {
+        // Use a real on-disk path so the render filter keeps it.
+        let path = std::env::current_exe().unwrap();
+        let path_str = path.to_string_lossy().into_owned();
+        let mut cov = Coverage::new();
+        let arc: Arc<str> = Arc::from(path_str.as_str());
+        cov.files.entry(arc.clone()).or_default().total = BTreeSet::from([1, 2]);
+        cov.files.entry(arc).or_default().hit = BTreeSet::from([1]);
+        let lcov = cov.render_lcov();
+        assert!(lcov.contains(&format!("SF:{path_str}")));
+        assert!(lcov.contains("DA:1,1"));
+        assert!(lcov.contains("DA:2,0"));
+        assert!(lcov.contains("LF:2"));
+        assert!(lcov.contains("LH:1"));
+        assert!(lcov.contains("end_of_record"));
+    }
+}

--- a/crates/harn-vm/src/lib.rs
+++ b/crates/harn-vm/src/lib.rs
@@ -26,6 +26,7 @@ pub mod composition;
 pub mod config;
 pub mod connectors;
 pub mod corrections;
+pub mod coverage;
 pub(crate) mod durable_rate_limit;
 pub(crate) mod duration_parse;
 pub mod egress;

--- a/crates/harn-vm/src/vm/execution.rs
+++ b/crates/harn-vm/src/vm/execution.rs
@@ -392,6 +392,14 @@ impl Vm {
             }
 
             let op_byte = frame.chunk.code[frame.ip];
+            // Line-coverage hit. `self.coverage` is `None` unless a coverage
+            // session is active, so this is a single predictable branch on the
+            // hot path (and a disjoint-field borrow from `frame`, which holds
+            // `self.frames`). `frame.ip` is still the index of the instruction
+            // we just read, before the increment below.
+            if let Some(coverage) = self.coverage.as_mut() {
+                coverage.record(&frame.chunk, frame.ip);
+            }
             frame.ip += 1;
 
             // Sync/async split dispatch: skip the `execute_op` async fn

--- a/crates/harn-vm/src/vm/state.rs
+++ b/crates/harn-vm/src/vm/state.rs
@@ -289,6 +289,9 @@ pub struct Vm {
     pub(crate) source_file: Option<String>,
     /// Source text for error reporting.
     pub(crate) source_text: Option<String>,
+    /// Line-coverage accumulator. `Some` only while a coverage session is
+    /// active (see [`crate::coverage`]); folded into the global report on drop.
+    pub(crate) coverage: Option<crate::coverage::Coverage>,
     /// Optional bridge for delegating unknown builtins in bridge mode.
     pub(crate) bridge: Option<Arc<crate::bridge::HostBridge>>,
     /// Builtins denied by sandbox mode (`--deny` / `--allow` flags).
@@ -415,6 +418,7 @@ impl VmBaseline {
             source_cache: Arc::new(source_cache),
             source_file: self.source_file.clone(),
             source_text: self.source_text.clone(),
+            coverage: crate::coverage::for_primary(self.source_file.as_deref()),
             bridge: None,
             denied_builtins: Arc::clone(&self.denied_builtins),
             cancel_token: None,
@@ -645,6 +649,7 @@ impl Vm {
             source_cache: Arc::new(BTreeMap::new()),
             source_file: None,
             source_text: None,
+            coverage: crate::coverage::for_primary(None),
             bridge: None,
             denied_builtins: Arc::new(HashSet::new()),
             cancel_token: None,
@@ -714,6 +719,9 @@ impl Vm {
     pub fn set_source_info(&mut self, file: &str, text: &str) {
         self.source_file = Some(file.to_string());
         self.source_text = Some(text.to_string());
+        if let Some(cov) = self.coverage.as_mut() {
+            cov.set_primary_file(file);
+        }
         Arc::make_mut(&mut self.source_cache)
             .insert(std::path::PathBuf::from(file), text.to_string());
     }
@@ -803,6 +811,7 @@ impl Vm {
             source_cache: Arc::clone(&self.source_cache),
             source_file: self.source_file.clone(),
             source_text: self.source_text.clone(),
+            coverage: crate::coverage::for_primary(self.source_file.as_deref()),
             bridge: self.bridge.clone(),
             denied_builtins: Arc::clone(&self.denied_builtins),
             cancel_token: self.cancel_token.clone(),
@@ -1067,6 +1076,9 @@ impl Vm {
 
 impl Drop for Vm {
     fn drop(&mut self) {
+        if let Some(coverage) = self.coverage.take() {
+            crate::coverage::merge_into_global(coverage);
+        }
         self.cancel_spawned_tasks();
     }
 }

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -393,6 +393,8 @@ harn test conformance --verbose        # show per-test timing
 harn test conformance --timing         # show timing summary without verbose failures
 harn test tests/ --record              # record LLM fixtures
 harn test tests/ --replay              # replay LLM fixtures
+harn test tests/ --coverage            # print per-file line coverage
+harn test tests/ --coverage-out lcov.info  # also write an LCOV tracefile
 harn test agents-conformance --target http://localhost:8080 --api-key "$KEY"
 ```
 
@@ -414,6 +416,8 @@ harn test agents-conformance --target http://localhost:8080 --api-key "$KEY"
 | `--timeout <ms>` | Per-test timeout in milliseconds (default: 30000) |
 | `--record` | Record LLM responses to `.harn-fixtures/` |
 | `--replay` | Replay recorded LLM responses |
+| `--coverage` | Print per-file line coverage for executed Harn source (user test suites only) |
+| `--coverage-out <path>` | Write an LCOV tracefile (implies `--coverage`); consumable by Codecov, `genhtml`, and Coverage Gutters |
 
 When no path is given, `harn test` auto-discovers a `tests/` directory
 in the current folder. Conformance targets must resolve to a file or directory

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -510,6 +510,47 @@ Use `require` for runtime invariants in normal pipelines. The linter warns if
 you use `assert*` outside test pipelines, and it suggests `assert*` instead of
 `require` inside test pipelines.
 
+## Line coverage
+
+`harn test --coverage` reports per-file line coverage for the Harn source your
+user test suite executes:
+
+```bash
+# Print a per-file coverage summary after the run
+harn test tests/ --coverage
+
+# Also write an LCOV tracefile (implies --coverage)
+harn test tests/ --coverage --coverage-out coverage/lcov.info
+```
+
+The summary lists each executed source file with its instrumentable line count,
+the number of lines covered, and the percentage, followed by a `TOTAL` row:
+
+```text
+Line coverage: 41/47 (87.2%)
+File              Lines  Covered       %
+tests/math.harn      18       18   100.0
+src/util.harn        29       23    79.3
+TOTAL                47       41    87.2
+```
+
+The `--coverage-out` tracefile is standard
+[LCOV](https://github.com/linux-test-project/lcov), so it drops straight into
+Codecov, `genhtml`, and the VS Code Coverage Gutters extension.
+
+Notes:
+
+- Coverage reuses the per-instruction source-line table the VM already carries,
+  so it adds no separate instrumentation pass. Recording is opt-in; runs without
+  `--coverage` pay nothing.
+- The denominator is the set of distinct source lines that emit bytecode,
+  including the bodies of functions that are loaded but never called (which
+  therefore show as uncovered).
+- Reporting is filtered to source files that exist on disk, so the embedded
+  standard library and in-memory `eval` chunks are excluded.
+- `--coverage` is for user test suites; it cannot be combined with `--watch`,
+  `--determinism`, `--evals`, or the conformance / protocols targets.
+
 ## Cross-platform test coverage
 
 Most workspace tests run on both Unix and Windows. A small set of test


### PR DESCRIPTION
## What

Adds line coverage to the test runner: `harn test --coverage` prints a per-file
coverage summary, and `--coverage-out <path>` writes an LCOV tracefile.

This was the one remaining *major*, verified-open completeness gap in the
toolchain. Every SOTA toolchain ships coverage (Go `-cover`, Rust `llvm-cov`,
Python `coverage.py`); Harn didn't. It's low-complexity here specifically
because the VM already carries a per-instruction source-line table
(`Chunk::lines`), so coverage needs **no separate instrumentation pass** — just
a hit-recorder and an LCOV writer.

## How

- **`harn_vm::coverage`** (new module): a per-VM accumulator with
  parent-inherited file attribution, a process-global opt-in session, and
  `render_text` / `render_lcov`. The denominator is the set of distinct
  non-zero lines a chunk and its nested function bodies emit (so loaded-but-
  uncalled functions show as uncovered); the numerator is the subset that ran.
  Render filters to files that exist on disk, which drops the embedded stdlib
  and in-memory `eval` chunks.
- **VM wiring**: a `coverage` field armed from the global session flag in every
  `Vm` constructor, primary-file capture in `set_source_info`, a merge on drop,
  and a single per-instruction hit hook in `drive_dispatch_loop`. The hook is
  one predictable branch (`Option::is_some`) when no session is active, so runs
  without `--coverage` pay nothing.
- **CLI**: `--coverage` / `--coverage-out` on `harn test`, validated against
  incompatible modes (`--watch`, `--determinism`, `--evals`, conformance
  targets). The report is emitted even when the suite fails.

Example:

```text
Line coverage: 41/47 (87.2%)
File              Lines  Covered       %
tests/math.harn      18       18   100.0
src/util.harn        29       23    79.3
TOTAL                47       41    87.2
```

The `--coverage-out` tracefile is standard LCOV, so it drops straight into
Codecov, `genhtml`, and the VS Code Coverage Gutters extension.

## Tests / checks

- 5 unit tests in `harn_vm::coverage` for the denominator/hit/merge/LCOV math.
- An e2e test (`coverage_cli.rs`) asserting the help surface, the summary
  output, and that the LCOV distinguishes hit (`,1`) vs uncovered (`,0`) lines.
- `cargo clippy -p harn-vm -p harn-cli -- -D warnings` clean; `rustfmt` clean;
  docs in `testing.md` + `cli-reference.md`; changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ki2SdBC4tYKubS13Wnoium)_