### PR TITLE
[codex] Pin safe tool formats for GLM and Moonshot aliases

### DIFF
--- a/changelog.d/3569.fixed.md
+++ b/changelog.d/3569.fixed.md
@@ -1,0 +1,1 @@
+Pinned unsafe GLM and Moonshot alias tool-format defaults to safe formats.

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -1859,6 +1859,34 @@ mod tests {
     }
 
     #[test]
+    fn every_catalogued_alias_tool_format_pin_is_safe_for_route() {
+        // Alias pins are consumed directly by downstream catalogs and CLI
+        // routing. They must not encode a known-broken channel that the
+        // central runtime guard would have to correct later.
+        reset();
+        let catalog = crate::llm_config::parse_config_toml(BUILTIN_PROVIDERS_TOML)
+            .expect("providers.toml must parse at build time");
+        let mut unsafe_pins = Vec::new();
+        for (alias, def) in &catalog.aliases {
+            let Some(tool_format) = def.tool_format.as_deref() else {
+                continue;
+            };
+            let decision = validate_tool_format(&def.provider, &def.id, tool_format);
+            if let Some(correction) = decision.correction.as_deref() {
+                unsafe_pins.push(format!(
+                    "{alias} -> {}:{} pins {tool_format}, would be corrected to {} ({correction})",
+                    def.provider, def.id, decision.effective
+                ));
+            }
+        }
+        assert!(
+            unsafe_pins.is_empty(),
+            "aliases pin unsafe tool_format values:\n- {}",
+            unsafe_pins.join("\n- ")
+        );
+    }
+
+    #[test]
     fn tool_capability_audit_reports_suggested_defaults() {
         reset();
         let capabilities: CapabilitiesFile = toml::from_str(

--- a/crates/harn-vm/src/llm/catalog_sources/30-aliases/aliases.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/30-aliases/aliases.toml
@@ -140,12 +140,12 @@ tool_format = "native"
 [aliases."moonshot-kimi-k2.7-code"]
 id = "moonshot/kimi-k2.7-code"
 provider = "moonshot"
-tool_format = "native"
+tool_format = "json"
 
 [aliases."moonshot-kimi-k2.7-code-highspeed"]
 id = "moonshot/kimi-k2.7-code-highspeed"
 provider = "moonshot"
-tool_format = "native"
+tool_format = "json"
 
 # DeepInfra — open-weight OpenAI-compatible host.
 [aliases."deepinfra-deepseek"]
@@ -156,7 +156,7 @@ tool_format = "native"
 [aliases."deepinfra-glm-5.2"]
 id = "deepinfra/zai-org/GLM-5.2"
 provider = "deepinfra"
-tool_format = "native"
+tool_format = "json"
 
 [aliases."deepinfra-kimi-k2.7-code"]
 id = "deepinfra/moonshotai/Kimi-K2.7-Code"
@@ -428,7 +428,7 @@ tool_format = "native"
 [aliases."openrouter-glm-5.2"]
 id = "z-ai/glm-5.2"
 provider = "openrouter"
-tool_format = "native"
+tool_format = "text"
 
 # DeepSeek V4 direct API aliases.
 [aliases.deepseek]

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -945,12 +945,12 @@ tool_format = "native"
 [aliases."moonshot-kimi-k2.7-code"]
 id = "moonshot/kimi-k2.7-code"
 provider = "moonshot"
-tool_format = "native"
+tool_format = "json"
 
 [aliases."moonshot-kimi-k2.7-code-highspeed"]
 id = "moonshot/kimi-k2.7-code-highspeed"
 provider = "moonshot"
-tool_format = "native"
+tool_format = "json"
 
 # DeepInfra — open-weight OpenAI-compatible host.
 [aliases."deepinfra-deepseek"]
@@ -961,7 +961,7 @@ tool_format = "native"
 [aliases."deepinfra-glm-5.2"]
 id = "deepinfra/zai-org/GLM-5.2"
 provider = "deepinfra"
-tool_format = "native"
+tool_format = "json"
 
 [aliases."deepinfra-kimi-k2.7-code"]
 id = "deepinfra/moonshotai/Kimi-K2.7-Code"
@@ -1233,7 +1233,7 @@ tool_format = "native"
 [aliases."openrouter-glm-5.2"]
 id = "z-ai/glm-5.2"
 provider = "openrouter"
-tool_format = "native"
+tool_format = "text"
 
 # DeepSeek V4 direct API aliases.
 [aliases.deepseek]

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -13663,7 +13663,7 @@
       "name": "deepinfra-glm-5.2",
       "model_id": "deepinfra/zai-org/GLM-5.2",
       "provider": "deepinfra",
-      "tool_format": "native"
+      "tool_format": "json"
     },
     {
       "name": "deepinfra-kimi-k2.7-code",
@@ -13955,13 +13955,13 @@
       "name": "moonshot-kimi-k2.7-code",
       "model_id": "moonshot/kimi-k2.7-code",
       "provider": "moonshot",
-      "tool_format": "native"
+      "tool_format": "json"
     },
     {
       "name": "moonshot-kimi-k2.7-code-highspeed",
       "model_id": "moonshot/kimi-k2.7-code-highspeed",
       "provider": "moonshot",
-      "tool_format": "native"
+      "tool_format": "json"
     },
     {
       "name": "nvidia-deepseek-v4-pro",
@@ -14056,7 +14056,7 @@
       "name": "openrouter-glm-5.2",
       "model_id": "z-ai/glm-5.2",
       "provider": "openrouter",
-      "tool_format": "native"
+      "tool_format": "text"
     },
     {
       "name": "openrouter-kat-coder-pro-v2",


### PR DESCRIPTION
## Summary

- Pin Moonshot Kimi K2.7 aliases to the JSON tool format.
- Pin DeepInfra GLM 5.2 to JSON and OpenRouter GLM 5.2 to text tools.
- Add a provider catalog test that rejects alias tool_format pins that runtime safety logic would correct.

## Validation

- `cargo test -p harn-vm catalogued_alias -- --nocapture`
- `make check-provider-catalog`
- Pre-commit hook: changed-package `harn-vm` clippy
- Pre-push hook: targeted local checks
