### PR TITLE
Treat product tool errors as resource failures

### DIFF
--- a/changelog.d/product-error-resource-fail-fast.fixed.md
+++ b/changelog.d/product-error-resource-fail-fast.fixed.md
@@ -1,0 +1,2 @@
+Treat product-level `Error:` tool results and policy-backed resource metadata as failures/keys for
+intra-turn same-resource fail-fast scheduling.

--- a/conformance/tests/agents/agent_loop_intra_turn_resource_fail_fast.expected
+++ b/conformance/tests/agents/agent_loop_intra_turn_resource_fail_fast.expected
@@ -9,6 +9,14 @@ true
 done
 true
 true
+true
+done
+true
+true
+true
+done
+true
+true
 done
 true
 true

--- a/conformance/tests/agents/agent_loop_intra_turn_resource_fail_fast.harn
+++ b/conformance/tests/agents/agent_loop_intra_turn_resource_fail_fast.harn
@@ -7,8 +7,14 @@
  */
 import { llm_text, with_llm_script } from "std/testing"
 
-fn edit_tools() {
+fn edit_tools(metadata_key = "annotations") {
   var tools = tool_registry()
+  let metadata = {kind: "edit", side_effect_level: "workspace_write", arg_schema: {path_params: ["path"]}}
+  let metadata_field = if metadata_key == "policy" {
+    {policy: metadata}
+  } else {
+    {annotations: metadata}
+  }
   tools = tool_define(
     tools,
     "edit",
@@ -18,32 +24,76 @@ fn edit_tools() {
         if args?.fail ?? false {
           throw "rejected " + to_string(args?.path ?? "") + " " + to_string(args?.marker ?? "")
         }
+        if args?.fail_return ?? false {
+          return "Error: rejected " + to_string(args?.path ?? "") + " " + to_string(args?.marker ?? "")
+        }
         return "applied " + to_string(args?.path ?? "") + " " + to_string(args?.marker ?? "")
       },
       parameters: {
         path: {type: "string", description: "Workspace-relative path"},
         marker: {type: "string", description: "Probe marker"},
         fail: {type: "boolean", description: "Whether this call rejects"},
+        fail_return: {type: "boolean", description: "Whether this call returns a product-level error"},
       },
       returns: {type: "string"},
-      annotations: {kind: "edit", side_effect_level: "workspace_write", arg_schema: {path_params: ["path"]}},
-    },
+    }
+      + metadata_field,
   )
   return tools
 }
 
 fn same_file_failure_batch() {
   return [
-    {id: "a1", name: "edit", arguments: {path: "src/a.zig", marker: "first", fail: true}},
-    {id: "a2", name: "edit", arguments: {path: "src/a.zig", marker: "second", fail: false}},
-    {id: "b1", name: "edit", arguments: {path: "src/b.zig", marker: "other", fail: false}},
+    {
+      id: "a1",
+      name: "edit",
+      arguments: {path: "src/a.zig", marker: "first", fail: true, fail_return: false},
+    },
+    {
+      id: "a2",
+      name: "edit",
+      arguments: {path: "src/a.zig", marker: "second", fail: false, fail_return: false},
+    },
+    {
+      id: "b1",
+      name: "edit",
+      arguments: {path: "src/b.zig", marker: "other", fail: false, fail_return: false},
+    },
+  ]
+}
+
+fn same_file_product_error_batch() {
+  return [
+    {
+      id: "a1",
+      name: "edit",
+      arguments: {path: "src/a.zig", marker: "first", fail: false, fail_return: true},
+    },
+    {
+      id: "a2",
+      name: "edit",
+      arguments: {path: "src/a.zig", marker: "second", fail: false, fail_return: false},
+    },
+    {
+      id: "b1",
+      name: "edit",
+      arguments: {path: "src/b.zig", marker: "other", fail: false, fail_return: false},
+    },
   ]
 }
 
 fn same_file_success_batch() {
   return [
-    {id: "a1", name: "edit", arguments: {path: "src/a.zig", marker: "first", fail: false}},
-    {id: "a2", name: "edit", arguments: {path: "src/a.zig", marker: "second", fail: false}},
+    {
+      id: "a1",
+      name: "edit",
+      arguments: {path: "src/a.zig", marker: "first", fail: false, fail_return: false},
+    },
+    {
+      id: "a2",
+      name: "edit",
+      arguments: {path: "src/a.zig", marker: "second", fail: false, fail_return: false},
+    },
   ]
 }
 
@@ -56,7 +106,7 @@ fn run_scripted(calls, opts = {}) {
         nil,
         {
           provider: "mock",
-          tools: edit_tools(),
+          tools: opts?.tools ?? edit_tools(),
           tool_format: "native",
           loop_until_done: true,
           max_iterations: 3,
@@ -64,7 +114,8 @@ fn run_scripted(calls, opts = {}) {
         }
           + opts,
       )
-      let transcript = json_stringify(llm_mock_calls()[1].messages)
+      let mock_calls = llm_mock_calls()
+      let transcript = json_stringify(mock_calls[len(mock_calls) - 1].messages)
       return {result: result, transcript: transcript}
     },
   )
@@ -77,6 +128,18 @@ pipeline main() {
   __io_println(contains(defaulted.transcript, "skipped dependent `edit` call"))
   __io_println(!contains(defaulted.transcript, "applied src/a.zig second"))
   __io_println(contains(defaulted.transcript, "applied src/b.zig other"))
+  // Burin exposes this metadata as `policy`; Harn must treat it as resource annotations.
+  let policy_metadata = run_scripted(same_file_failure_batch(), {tools: edit_tools("policy")})
+  __io_println(policy_metadata.result.status)
+  __io_println(contains(policy_metadata.transcript, "skipped dependent `edit` call"))
+  __io_println(!contains(policy_metadata.transcript, "applied src/a.zig second"))
+  __io_println(contains(policy_metadata.transcript, "applied src/b.zig other"))
+  // Product-level errors returned as text (`Error: ...`) also block same-resource siblings.
+  let product_error = run_scripted(same_file_product_error_batch())
+  __io_println(product_error.result.status)
+  __io_println(contains(product_error.transcript, "skipped dependent `edit` call"))
+  __io_println(!contains(product_error.transcript, "applied src/a.zig second"))
+  __io_println(contains(product_error.transcript, "applied src/b.zig other"))
   // A successful first edit does not block a later same-file edit.
   let successful = run_scripted(same_file_success_batch())
   __io_println(successful.result.status)

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -501,9 +501,16 @@ fn __tool_entry_annotations(entry) {
   if type_of(direct) == "dict" {
     return direct
   }
+  let policy = entry?.policy
+  if type_of(policy) == "dict" {
+    return policy
+  }
   let func = entry?.function
   if type_of(func) == "dict" && type_of(func?.annotations) == "dict" {
     return func.annotations
+  }
+  if type_of(func) == "dict" && type_of(func?.policy) == "dict" {
+    return func.policy
   }
   return {}
 }
@@ -766,6 +773,9 @@ fn __emit_tool_lifecycle_start(envelope) {
 }
 
 fn __tool_terminal_status(result) -> string {
+  if __tool_result_product_error(result) {
+    return "failed"
+  }
   if result?.ok || result?.success {
     return "completed"
   }
@@ -1811,6 +1821,9 @@ fn __dispatch_results_list(dispatch) {
 }
 
 fn __tool_result_ok(result) {
+  if __tool_result_product_error(result) {
+    return false
+  }
   if result?.ok != nil {
     return result.ok ? true : false
   }
@@ -1819,6 +1832,31 @@ fn __tool_result_ok(result) {
   }
   let status = result?.status ?? ""
   return status == "ok" || status == "success"
+}
+
+/**
+ * Some host tools report product-level rejections as a successful transport
+ * result whose rendered/observation text begins with `Error:`. Treating those
+ * as successful makes same-turn resource fail-fast and rejected-tool accounting
+ * blind to edit rejections. This predicate intentionally does not rewrite the
+ * result payload; it only classifies the result for scheduling/lifecycle.
+ */
+fn __tool_result_product_error(result) -> bool {
+  if type_of(result) != "dict" {
+    return false
+  }
+  for key in ["error", "observation", "rendered_result", "result", "output"] {
+    if result[key] != nil {
+      let text = trim(to_string(result[key]))
+      if starts_with(text, "Error:") {
+        return true
+      }
+      if starts_with(text, "[result of ") && contains(text, "\nError:") {
+        return true
+      }
+    }
+  }
+  return false
 }
 
 fn __tool_result_name(result) {


### PR DESCRIPTION
## Summary
- classify product-level `Error:` tool observations as failed tool results for lifecycle and intra-turn resource fail-fast scheduling
- add a conformance case where a mutating edit tool returns `Error: ...` with `ok: true`/`status: ok`, matching the Burin edit-rejection shape seen in zig-feat
- keep successful same-resource edit batches and explicit fail-fast opt-out behavior unchanged

## Root cause
Burin edit rejections can arrive as successful transport envelopes with `error: null`, `ok: true`, `status: ok`, and `result`/`observation` text beginning with `Error:`. The same-resource scheduler only treated transport/status failures as failures, so later sibling edits to the same file could still run after an earlier rejection in the same assistant turn.

## Verification
- `cargo build --bin harn`
- `./target/debug/harn fmt --check crates/harn-stdlib/src/stdlib/agent/loop.harn conformance/tests/agents/agent_loop_intra_turn_resource_fail_fast.harn`
- `./target/debug/harn check crates/harn-stdlib/src/stdlib/agent/loop.harn`
- `./target/debug/harn check conformance/tests/agents/agent_loop_intra_turn_resource_fail_fast.harn`
- `./target/debug/harn test conformance --filter agent_loop_intra_turn_resource_fail_fast`
- `git diff --check -- crates/harn-stdlib/src/stdlib/agent/loop.harn conformance/tests/agents/agent_loop_intra_turn_resource_fail_fast.harn conformance/tests/agents/agent_loop_intra_turn_resource_fail_fast.expected changelog.d/product-error-resource-fail-fast.fixed.md`