### PR TITLE
fix(llm): recover complete text-tool arg payloads on empty terminal args

### DIFF
--- a/changelog.d/toolcall-arg-recovery.fixed.md
+++ b/changelog.d/toolcall-arg-recovery.fixed.md
@@ -1,0 +1,1 @@
+- **OpenAI-compatible streamed tool calls now preserve non-empty argument payloads.** Clean `tool_calls` finishes that stream Harn text-format or otherwise malformed multiline arguments no longer silently dispatch `{}`; complete text-format payloads are recovered and unrecoverable payloads carry an explicit parse error while length-truncation behavior is unchanged.

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -700,6 +700,39 @@ fn streaming_tool_call_id(provider_id: &str, fallback_index: usize) -> String {
     }
 }
 
+fn preview_chars(s: &str, max_chars: usize) -> String {
+    s.chars().take(max_chars).collect()
+}
+
+fn parse_openai_streamed_tool_arguments(
+    tool_name: &str,
+    arguments: &str,
+    stop_reason: Option<&str>,
+) -> serde_json::Value {
+    if arguments.trim().is_empty() {
+        return serde_json::json!({});
+    }
+    match serde_json::from_str::<serde_json::Value>(arguments) {
+        Ok(value) => value,
+        Err(json_error) => {
+            if crate::llm::agent_session_host::is_length_truncation(stop_reason) {
+                return serde_json::json!({});
+            }
+            crate::llm::tools::parse_text_tool_argument_payload(arguments, tool_name)
+                .unwrap_or_else(|text_error| {
+                    serde_json::json!({
+                        "__parse_error": format!(
+                            "Could not parse streamed tool arguments as JSON or Harn text-tool arguments: JSON error: {}; Harn text-tool error: {}. Raw input: {}",
+                            json_error,
+                            text_error,
+                            preview_chars(arguments, 200)
+                        )
+                    })
+                })
+        }
+    }
+}
+
 /// Pure SSE-line consumer used by the response wrapper and by tests
 /// that drive canned byte streams without standing up a full
 /// `reqwest::Response`. The Anthropic / OpenAI branches and the
@@ -1199,8 +1232,11 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
     }
 
     for (_, stream) in oai_tool_map {
-        let args = serde_json::from_str::<serde_json::Value>(&stream.args)
-            .unwrap_or(serde_json::Value::Object(Default::default()));
+        let args = parse_openai_streamed_tool_arguments(
+            &stream.name,
+            &stream.args,
+            stop_reason.as_deref(),
+        );
         // Dispatch under the id already used for streaming progress so
         // the executed lifecycle continues on the same wire id.
         let (name, args) = crate::llm::tools::normalize_tool_call_shape(&stream.name, args);
@@ -2223,6 +2259,140 @@ mod streaming_tool_call_tests {
             result.tool_calls[0]["arguments"],
             serde_json::json!({}),
             "truncated unparseable args fall back to the empty object"
+        );
+
+        clear_session_sinks(&session_id);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn openai_stream_text_format_arguments_recover_after_raw_partial() {
+        // Some OpenAI-compatible routes are prompted for Harn's text tool
+        // grammar but still surface the action through native tool_calls.
+        // During streaming this is not strict JSON, so clients see a
+        // raw_input_partial; on a clean tool_calls finish we can still recover
+        // the complete Harn object literal instead of dispatching `{}`.
+        let raw_args = r#"edit({ action: "replace_range", path: "src/main.rs", range_start: 1, range_end: 3, content: <<EOF
+fn main() {
+    println!("hello");
+}
+EOF
+})"#;
+        let frame = |value: serde_json::Value| format!("data: {value}\n");
+        let body = format!(
+            "{}{}data: [DONE]\n",
+            frame(serde_json::json!({
+                "choices": [{
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [{
+                            "index": 0,
+                            "id": "call_edit_text",
+                            "function": {"name": "edit", "arguments": raw_args}
+                        }]
+                    }
+                }]
+            })),
+            frame(serde_json::json!({
+                "choices": [{
+                    "index": 0,
+                    "finish_reason": "tool_calls",
+                    "delta": {}
+                }],
+                "usage": {"prompt_tokens": 4, "completion_tokens": 200}
+            })),
+        );
+        let session_id = fresh_session_id("oai-text-args-recover");
+        let (result, events) = drive(body.as_bytes(), &session_id, false).await;
+
+        let raw_partials: Vec<String> = events
+            .iter()
+            .filter_map(|event| match event {
+                AgentEvent::ToolCallUpdate {
+                    status: ToolCallStatus::Pending,
+                    raw_input_partial: Some(raw),
+                    ..
+                } => Some(raw.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            raw_partials
+                .iter()
+                .any(|raw| raw.contains("edit({") && raw.contains("fn main()")),
+            "expected multiline raw_input_partial before recovery; got {events:#?}"
+        );
+        assert_eq!(result.stop_reason.as_deref(), Some("tool_calls"));
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0]["name"], "edit");
+        assert_eq!(
+            result.tool_calls[0]["arguments"]["path"],
+            serde_json::json!("src/main.rs")
+        );
+        assert!(
+            result.tool_calls[0]["arguments"]["content"]
+                .as_str()
+                .is_some_and(|content| content.contains("println!(\"hello\")")),
+            "content should be recovered from the Harn text-tool payload: {:?}",
+            result.tool_calls[0]["arguments"]
+        );
+        assert_ne!(result.tool_calls[0]["arguments"], serde_json::json!({}));
+
+        clear_session_sinks(&session_id);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn openai_stream_non_length_unparseable_arguments_do_not_become_empty_object() {
+        // If the provider finishes cleanly but the native arguments channel is
+        // malformed and non-empty, preserve an explicit parse error. The `{}` fallback
+        // is reserved for length truncation (covered above) and true empty args.
+        let raw_args = "edit({\n  path: \"src/main.rs\",\n  content: <<EOF\nfn main() {\n";
+        let frame = |value: serde_json::Value| format!("data: {value}\n");
+        let body = format!(
+            "{}{}data: [DONE]\n",
+            frame(serde_json::json!({
+                "choices": [{
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [{
+                            "index": 0,
+                            "id": "call_edit_bad_text",
+                            "function": {"name": "edit", "arguments": raw_args}
+                        }]
+                    }
+                }]
+            })),
+            frame(serde_json::json!({
+                "choices": [{
+                    "index": 0,
+                    "finish_reason": "tool_calls",
+                    "delta": {}
+                }],
+                "usage": {"prompt_tokens": 4, "completion_tokens": 200}
+            })),
+        );
+        let session_id = fresh_session_id("oai-text-args-parse-error");
+        let (result, events) = drive(body.as_bytes(), &session_id, false).await;
+
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                AgentEvent::ToolCallUpdate {
+                    status: ToolCallStatus::Pending,
+                    raw_input_partial: Some(raw),
+                    ..
+                } if raw.contains("fn main()")
+            )),
+            "expected non-empty multiline raw_input_partial; got {events:#?}"
+        );
+        assert_eq!(result.stop_reason.as_deref(), Some("tool_calls"));
+        assert_eq!(result.tool_calls.len(), 1);
+        let arguments = &result.tool_calls[0]["arguments"];
+        assert_ne!(*arguments, serde_json::json!({}));
+        assert!(
+            arguments["__parse_error"]
+                .as_str()
+                .is_some_and(|message| message.contains("Could not parse streamed tool arguments")),
+            "unparseable clean-finish arguments must carry a parse error, got {arguments:?}"
         );
 
         clear_session_sinks(&session_id);

--- a/crates/harn-vm/src/llm/tools/mod.rs
+++ b/crates/harn-vm/src/llm/tools/mod.rs
@@ -22,6 +22,7 @@ pub(crate) use native::{
 };
 pub(crate) use parse::ident_length;
 pub(crate) use parse::parse_fenced_json_tool_calls;
+pub(crate) use parse::parse_text_tool_argument_payload;
 pub(crate) use parse::parse_text_tool_calls_in_format;
 pub(crate) use parse::parse_text_tool_calls_with_tools;
 pub(crate) use parse::StreamingToolCallDetector;

--- a/crates/harn-vm/src/llm/tools/parse/mod.rs
+++ b/crates/harn-vm/src/llm/tools/parse/mod.rs
@@ -93,14 +93,10 @@ pub(crate) fn parse_text_tool_argument_payload(
     }
 
     match syntax::parse_object_literal_from(trimmed, name) {
-        Ok((arguments, consumed)) if trimmed[consumed..].trim().is_empty() => {
-            return Ok(arguments);
-        }
-        Ok((_arguments, consumed)) => {
-            return Err(format!(
-                "trailing bytes after object literal argument at byte {consumed}"
-            ));
-        }
+        Ok((arguments, consumed)) if trimmed[consumed..].trim().is_empty() => Ok(arguments),
+        Ok((_arguments, consumed)) => Err(format!(
+            "trailing bytes after object literal argument at byte {consumed}"
+        )),
         Err(object_error) => {
             if let Some(name_len) = syntax::ident_length(trimmed.as_bytes()) {
                 if trimmed.as_bytes().get(name_len) == Some(&b'(') {

--- a/crates/harn-vm/src/llm/tools/parse/mod.rs
+++ b/crates/harn-vm/src/llm/tools/parse/mod.rs
@@ -74,6 +74,57 @@ pub(crate) fn parse_text_tool_calls_in_format(
     }
 }
 
+/// Parse the argument payload from a provider-native tool call that appears to
+/// contain Harn's text-tool syntax rather than strict JSON.
+///
+/// Some OpenAI-compatible providers receive a text-tool prompt but still
+/// surface the model's action through `tool_calls[].function.arguments`. In
+/// that case the argument string may be `{ path: "a.rs", content: <<EOF ... }`
+/// or even `edit({ ... })`. Recover those complete text-format payloads
+/// without requiring a registered tool schema; callers still own normalizing
+/// the final `(name, arguments)` pair.
+pub(crate) fn parse_text_tool_argument_payload(
+    text: &str,
+    name: &str,
+) -> Result<serde_json::Value, String> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Ok(serde_json::json!({}));
+    }
+
+    match syntax::parse_object_literal_from(trimmed, name) {
+        Ok((arguments, consumed)) if trimmed[consumed..].trim().is_empty() => {
+            return Ok(arguments);
+        }
+        Ok((_arguments, consumed)) => {
+            return Err(format!(
+                "trailing bytes after object literal argument at byte {consumed}"
+            ));
+        }
+        Err(object_error) => {
+            if let Some(name_len) = syntax::ident_length(trimmed.as_bytes()) {
+                if trimmed.as_bytes().get(name_len) == Some(&b'(') {
+                    let call_name = trimmed[..name_len].to_string();
+                    match syntax::parse_ts_call_from(trimmed, call_name) {
+                        Ok((arguments, consumed)) if trimmed[consumed..].trim().is_empty() => {
+                            return Ok(arguments);
+                        }
+                        Ok((_arguments, consumed)) => {
+                            return Err(format!(
+                                "trailing bytes after tool-call expression at byte {consumed}"
+                            ));
+                        }
+                        Err(call_error) => {
+                            return Err(format!("{object_error}; {call_error}"));
+                        }
+                    }
+                }
+            }
+            Err(object_error)
+        }
+    }
+}
+
 /// Result of parsing a prose-interleaved TS tool-call stream.
 ///
 /// The scanner walks the model's text once and splits it into three
@@ -109,4 +160,59 @@ pub(crate) struct TextToolParseResult {
     /// Used as the assistant's history entry so future turns see the
     /// well-formed shape instead of the raw provider bytes.
     pub canonical: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_text_tool_argument_payload;
+
+    #[test]
+    fn text_tool_argument_payload_parses_object_literal_heredoc() {
+        let parsed = parse_text_tool_argument_payload(
+            r#"{ action: "create", path: "src/main.rs", content: <<EOF
+fn main() {
+    println!("hello");
+}
+EOF
+}"#,
+            "edit",
+        )
+        .expect("object literal payload parses");
+
+        assert_eq!(parsed["action"], serde_json::json!("create"));
+        assert_eq!(parsed["path"], serde_json::json!("src/main.rs"));
+        assert!(
+            parsed["content"]
+                .as_str()
+                .is_some_and(|content| content.contains("println!(\"hello\")")),
+            "content should come from the heredoc body: {parsed:?}"
+        );
+    }
+
+    #[test]
+    fn text_tool_argument_payload_parses_wrapped_call() {
+        let parsed = parse_text_tool_argument_payload(
+            r#"edit({ action: "replace_range", path: "src/lib.rs", range_start: 1, range_end: 2 })"#,
+            "edit",
+        )
+        .expect("wrapped call payload parses");
+
+        assert_eq!(parsed["action"], serde_json::json!("replace_range"));
+        assert_eq!(parsed["path"], serde_json::json!("src/lib.rs"));
+        assert_eq!(parsed["range_start"], serde_json::json!(1));
+    }
+
+    #[test]
+    fn text_tool_argument_payload_rejects_trailing_bytes() {
+        let error = parse_text_tool_argument_payload(
+            r#"{ action: "create", path: "src/main.rs" } trailing"#,
+            "edit",
+        )
+        .expect_err("trailing bytes should fail");
+
+        assert!(
+            error.contains("trailing bytes"),
+            "unexpected error: {error}"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

gpt-oss / Harmony text routes sometimes finalize an edit tool call with empty `{}` arguments even though the full argument payload streamed in the partial. The agent loop sees `empty_arguments_dropped` and burns iterations re-issuing the call.

## Fix

When a text-channel tool call finalizes with empty `{}` args, recover the complete argument payload from the accumulated streaming partial if it parses. Genuinely length-truncated calls still preserve `{}`; unrecoverable non-length args emit `__parse_error` so the failure is surfaced rather than silently dropped.

## Tests

New unit tests in `crates/harn-vm/src/llm/tools/parse/mod.rs` cover the object-literal-with-heredoc payload, the wrapped `name({...})` call form, and trailing-byte rejection. `cargo check -p harn-vm` and the parse unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)