### PR TITLE
Fix eval-inspector and coverage inspection-output fidelity

### DIFF
--- a/changelog.d/coverage-out-empty-report.fixed.md
+++ b/changelog.d/coverage-out-empty-report.fixed.md
@@ -1,0 +1,4 @@
+`harn test --coverage-out <path>` now always writes the LCOV tracefile, even
+when no on-disk source executed. An explicitly requested artifact is no longer
+silently skipped on an empty report (which would break a CI step that consumes
+the file); the empty report renders to a valid zero-record LCOV.

--- a/changelog.d/eval-inspector-sample-fidelity.fixed.md
+++ b/changelog.d/eval-inspector-sample-fidelity.fixed.md
@@ -1,0 +1,6 @@
+The `harn.eval.inspect_run` dossier now reports sample-scoped event stats
+accurately. `first_sampled_id`/`last_sampled_id` and the provenance
+`chain_breaks_in_sample`/`sample_chain_ok` cover only the sampled prefix window
+instead of leaking full-scan values when a JSONL topic has more records than
+`limit`, and `agent_event_topics` is deduplicated when a topic surfaces from
+both the JSONL dir and the sqlite log.

--- a/crates/harn-cli/src/commands/mcp/serve/tools.rs
+++ b/crates/harn-cli/src/commands/mcp/serve/tools.rs
@@ -1210,8 +1210,11 @@ struct EventTopicStats {
     roles: BTreeMap<String, u64>,
     first_id: Option<u64>,
     last_id: Option<u64>,
+    first_sampled_id: Option<u64>,
+    last_sampled_id: Option<u64>,
     previous_record_hash: Option<String>,
     provenance_breaks: u64,
+    sample_provenance_breaks: u64,
     provenance_records: u64,
     samples: Vec<JsonValue>,
 }
@@ -1219,16 +1222,24 @@ struct EventTopicStats {
 impl EventTopicStats {
     fn observe(&mut self, value: &JsonValue, sample_limit: usize, include_payloads: bool) {
         self.records_scanned += 1;
-        if self.sampled_event_count < sample_limit as u64 {
+        let id = value.get("id").and_then(JsonValue::as_u64);
+        self.first_id = self.first_id.or(id);
+        self.last_id = id.or(self.last_id);
+
+        // The sample is the first `sample_limit` records, so the sample-scoped
+        // fields describe exactly that prefix window — distinct from the
+        // full-scan `first_id`/`last_id` whenever a backend scans past the
+        // limit (the JSONL reader walks every line; sqlite is already bounded).
+        let is_sampled = self.sampled_event_count < sample_limit as u64;
+        if is_sampled {
             self.sampled_event_count += 1;
+            self.first_sampled_id = self.first_sampled_id.or(id);
+            self.last_sampled_id = id.or(self.last_sampled_id);
             if include_payloads && self.samples.len() < 5 {
                 self.samples.push(value.clone());
             }
         }
 
-        let id = value.get("id").and_then(JsonValue::as_u64);
-        self.first_id = self.first_id.or(id);
-        self.last_id = id.or(self.last_id);
         let event = value.get("event").unwrap_or(value);
         if let Some(kind) = event.get("kind").and_then(JsonValue::as_str) {
             *self.kinds.entry(kind.to_string()).or_default() += 1;
@@ -1259,6 +1270,9 @@ impl EventTopicStats {
             if let Some(previous) = self.previous_record_hash.as_deref() {
                 if prev_hash != Some(previous) {
                     self.provenance_breaks += 1;
+                    if is_sampled {
+                        self.sample_provenance_breaks += 1;
+                    }
                 }
             }
             self.previous_record_hash = Some(record_hash.to_string());
@@ -1284,8 +1298,8 @@ fn event_records_report(
         "latest_id": latest_id,
         "first_event_id": stats.first_id,
         "last_event_id": stats.last_id,
-        "first_sampled_id": stats.first_id,
-        "last_sampled_id": stats.last_id,
+        "first_sampled_id": stats.first_sampled_id,
+        "last_sampled_id": stats.last_sampled_id,
         "kinds": stats.kinds,
         "payload_event_types": stats.payload_types,
         "roles": stats.roles,
@@ -1293,8 +1307,8 @@ fn event_records_report(
             "records_with_hash": stats.provenance_records,
             "chain_breaks": stats.provenance_breaks,
             "chain_ok": stats.provenance_breaks == 0,
-            "chain_breaks_in_sample": stats.provenance_breaks,
-            "sample_chain_ok": stats.provenance_breaks == 0,
+            "chain_breaks_in_sample": stats.sample_provenance_breaks,
+            "sample_chain_ok": stats.sample_provenance_breaks == 0,
         },
         "samples": stats.samples,
     })
@@ -1382,13 +1396,18 @@ fn event_chain_summary(topic_names: &[String], event_topics: &[JsonValue]) -> Js
             }
         }
     }
+    // A topic can surface from both the JSONL dir and the sqlite db, so dedup
+    // (and sort, for deterministic output) before reporting.
+    let mut agent_event_topics: Vec<String> = topic_names
+        .iter()
+        .filter(|name| name.starts_with("observability.agent_events."))
+        .cloned()
+        .collect();
+    agent_event_topics.sort();
+    agent_event_topics.dedup();
     json!({
         "has_agent_transcript": topic_names.iter().any(|name| name == "agent.transcript.llm"),
-        "agent_event_topics": topic_names
-            .iter()
-            .filter(|name| name.starts_with("observability.agent_events."))
-            .cloned()
-            .collect::<Vec<_>>(),
+        "agent_event_topics": agent_event_topics,
         "payload_event_types": aggregate_payload_types,
         "tool_call_events": aggregate_payload_types.get("tool_call").copied().unwrap_or(0),
         "tool_call_update_events": aggregate_payload_types

--- a/crates/harn-cli/src/commands/mcp/serve_tests.rs
+++ b/crates/harn-cli/src/commands/mcp/serve_tests.rs
@@ -1223,6 +1223,14 @@ async fn eval_inspect_run_reports_artifacts_and_event_chain() {
     assert_eq!(agent_events["record_count"], 2);
     assert_eq!(agent_events["sampled_event_count"], 1);
     assert_eq!(agent_events["counts_complete"], true);
+    // Full-scan ids span both records; the sample-scoped ids cover only the
+    // first record (limit=1), so `last_sampled_id` must not leak the tail.
+    assert_eq!(agent_events["first_event_id"], 1);
+    assert_eq!(agent_events["last_event_id"], 2);
+    assert_eq!(agent_events["first_sampled_id"], 1);
+    assert_eq!(agent_events["last_sampled_id"], 1);
+    assert_eq!(agent_events["provenance"]["chain_breaks_in_sample"], 0);
+    assert_eq!(agent_events["provenance"]["sample_chain_ok"], true);
     assert!(dossier["gaps"]
         .as_array()
         .unwrap()

--- a/crates/harn-cli/src/commands/test.rs
+++ b/crates/harn-cli/src/commands/test.rs
@@ -2143,14 +2143,18 @@ pub(crate) async fn run_user_tests(
 fn emit_coverage_report(report: &harn_vm::coverage::Coverage, out: Option<&str>) {
     if report.is_empty() {
         eprintln!("\n[coverage] no executed source files were found on disk to report");
-        return;
+    } else {
+        let (covered, total) = report.totals();
+        println!(
+            "\nLine coverage: {covered}/{total} ({:.1}%)\n{}",
+            report.percent(),
+            report.render_text(),
+        );
     }
-    let (covered, total) = report.totals();
-    println!(
-        "\nLine coverage: {covered}/{total} ({:.1}%)\n{}",
-        report.percent(),
-        report.render_text(),
-    );
+    // Honour an explicit --coverage-out even for an empty report: a CI step that
+    // consumes the tracefile should find it rather than fail on a missing
+    // artifact. An empty `Coverage` renders to a valid empty LCOV (zero
+    // records).
     if let Some(path) = out {
         if let Err(error) = fs::write(path, report.render_lcov()) {
             eprintln!("failed to write coverage report to {path}: {error}");

--- a/crates/harn-vm/src/coverage.rs
+++ b/crates/harn-vm/src/coverage.rs
@@ -386,6 +386,16 @@ mod tests {
     }
 
     #[test]
+    fn empty_report_renders_a_valid_empty_lcov() {
+        // An empty report has no on-disk records, so the tracefile is empty —
+        // still a valid LCOV file, which `--coverage-out` writes rather than
+        // skipping (a missing artifact would break a CI consumer).
+        let cov = Coverage::new();
+        assert!(cov.is_empty());
+        assert_eq!(cov.render_lcov(), "");
+    }
+
+    #[test]
     fn lcov_shapes_da_lines() {
         // Use a real on-disk path so the render filter keeps it.
         let path = std::env::current_exe().unwrap();


### PR DESCRIPTION
Two correctness bugs in the recently-merged eval/test **inspection-output** surface (areas of #3568 and #3567). Both files are uncontended by the in-flight tool-format / streaming / resource-hardening work.

## `harn.eval.inspect_run` sample-scoped stats (#3568)
`event_records_report` wired its *sample-scoped* fields to the *full-scan* stats:
- `first_sampled_id`/`last_sampled_id` were byte-identical to `first_event_id`/`last_event_id`
- provenance `chain_breaks_in_sample`/`sample_chain_ok` were byte-identical to the full-scan `chain_breaks`/`chain_ok`

On the SQLite path the scan is bounded to `limit`, so they coincided. But the **JSONL** path walks *every* line while only the first `limit` records are "sampled" — so for a topic larger than `limit`, the sample-scoped fields silently reported the *whole file's* bounds. In a chain-of-custody dossier whose entire purpose is accurate provenance, that mislabeling is wrong.

Fix: track `first_sampled_id`/`last_sampled_id` and sample-scoped provenance breaks within the sample prefix window (the break comparison reuses the shared prev-hash walk — correct because the sample is a prefix). Also **dedup** `agent_event_topics`, which could list a topic twice when it surfaced from both the JSONL dir and the sqlite log.

## `harn test --coverage-out` empty report (#3567)
When no on-disk source executed, `emit_coverage_report` returned early and never wrote the LCOV file **even when `--coverage-out <path>` was explicitly requested** — leaving a CI step that consumes the tracefile with a missing artifact. Fix: always write the tracefile when `--coverage-out` is given; an empty `Coverage` renders to a valid zero-record LCOV.

## Tests
- Extended the existing eval-inspector fixture (`limit=1` over a 2-record topic) to assert `last_sampled_id == 1` while `last_event_id == 2`, plus the sample-scoped provenance fields. These assertions fail on the pre-fix code.
- Added a `harn_vm::coverage` unit test for the empty-LCOV contract.
- `cargo test -p harn-vm --lib coverage::`, the eval-inspector serve test, and `coverage_cli` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)