### PR TITLE
DRY: consolidate eval-inspector path resolution and event_log cursor aliases

### DIFF
--- a/crates/harn-cli/src/commands/mcp/serve/tools.rs
+++ b/crates/harn-cli/src/commands/mcp/serve/tools.rs
@@ -914,12 +914,9 @@ async fn inspect_eval_run(request: EvalInspectRunRequest) -> Result<JsonValue, S
             .as_ref()
             .and_then(|path| path.parent().map(Path::to_path_buf))
     });
-    let summary_path = request.summary_json.or_else(|| {
-        output_dir
-            .as_ref()
-            .map(|dir| dir.join("summary.json"))
-            .filter(|path| path.exists())
-    });
+    let summary_path = request
+        .summary_json
+        .or_else(|| existing_child(output_dir.as_deref(), "summary.json"));
     let summary = summary_path
         .as_ref()
         .and_then(|path| load_json_file(path).ok());
@@ -927,37 +924,19 @@ async fn inspect_eval_run(request: EvalInspectRunRequest) -> Result<JsonValue, S
     let events_dir = request
         .events_dir
         .or_else(|| path_from_summary(&summary, "event_log_dir"))
-        .or_else(|| {
-            output_dir
-                .as_ref()
-                .map(|dir| dir.join("events"))
-                .filter(|path| path.exists())
-        });
-    let events_db = request.events_db.or_else(|| {
-        output_dir
-            .as_ref()
-            .map(|dir| dir.join("events.sqlite"))
-            .filter(|path| path.exists())
-    });
-    let per_run_jsonl = request.per_run_jsonl.or_else(|| {
-        output_dir
-            .as_ref()
-            .map(|dir| dir.join("per_run.jsonl"))
-            .filter(|path| path.exists())
-    });
+        .or_else(|| existing_child(output_dir.as_deref(), "events"));
+    let events_db = request
+        .events_db
+        .or_else(|| existing_child(output_dir.as_deref(), "events.sqlite"));
+    let per_run_jsonl = request
+        .per_run_jsonl
+        .or_else(|| existing_child(output_dir.as_deref(), "per_run.jsonl"));
     let run_record = request
         .run_record
         .or_else(|| path_from_summary(&summary, "run_record_path"));
-    let llm_transcript_dir = path_from_summary(&summary, "llm_transcript_dir").or_else(|| {
-        output_dir
-            .as_ref()
-            .map(|dir| dir.join("llm"))
-            .filter(|path| path.exists())
-    });
-    let final_diff = output_dir
-        .as_ref()
-        .map(|dir| dir.join("artifacts/final.diff"))
-        .filter(|path| path.exists());
+    let llm_transcript_dir = path_from_summary(&summary, "llm_transcript_dir")
+        .or_else(|| existing_child(output_dir.as_deref(), "llm"));
+    let final_diff = existing_child(output_dir.as_deref(), "artifacts/final.diff");
 
     let artifact_inventory = vec![
         artifact_report("output_dir", output_dir.as_deref())?,
@@ -1017,6 +996,15 @@ fn load_json_file(path: &Path) -> Result<JsonValue, String> {
     let content =
         fs::read_to_string(path).map_err(|error| format!("read {}: {error}", path.display()))?;
     serde_json::from_str(&content).map_err(|error| format!("parse {}: {error}", path.display()))
+}
+
+/// `output_dir/<name>` when it exists on disk, else `None` — the conventional
+/// eval-bundle artifact layout fallback used when a path isn't given explicitly
+/// or named in the summary.
+fn existing_child(output_dir: Option<&Path>, name: &str) -> Option<PathBuf> {
+    output_dir
+        .map(|dir| dir.join(name))
+        .filter(|path| path.exists())
 }
 
 fn path_from_summary(summary: &Option<JsonValue>, key: &str) -> Option<PathBuf> {

--- a/crates/harn-vm/src/stdlib/event_log.rs
+++ b/crates/harn-vm/src/stdlib/event_log.rs
@@ -236,13 +236,7 @@ fn parse_read_options(args: &[VmValue]) -> Result<ReadOptions, VmError> {
     match args.first() {
         Some(VmValue::Dict(options)) => {
             let topic = parse_topic(options.get("topic"), "event_log.read")?;
-            let from_cursor = parse_cursor(
-                options
-                    .get("from_cursor")
-                    .or_else(|| options.get("cursor"))
-                    .or_else(|| options.get("from")),
-                "event_log.read",
-            )?;
+            let from_cursor = parse_dict_cursor(options, "event_log.read")?;
             let limit = parse_limit(options.get("limit"), "event_log.read")?;
             let kind_prefix =
                 optional_string(options.get("kind_prefix"), "event_log.read", "kind_prefix")?;
@@ -266,13 +260,7 @@ fn parse_subscribe_options(args: &[VmValue]) -> Result<SubscribeOptions, VmError
     match args.first() {
         Some(VmValue::Dict(options)) => {
             let topic = parse_topic(options.get("topic"), "event_log.subscribe")?;
-            let from_cursor = parse_cursor(
-                options
-                    .get("from_cursor")
-                    .or_else(|| options.get("cursor"))
-                    .or_else(|| options.get("from")),
-                "event_log.subscribe",
-            )?;
+            let from_cursor = parse_dict_cursor(options, "event_log.subscribe")?;
             let kind_prefix = optional_string(
                 options.get("kind_prefix"),
                 "event_log.subscribe",
@@ -310,6 +298,21 @@ fn parse_cursor(value: Option<&VmValue>, builtin: &str) -> Result<Option<u64>, V
             other.type_name()
         ))),
     }
+}
+
+/// Read the cursor from an options dict, accepting `from_cursor`, `cursor`, and
+/// `from` as aliases. Shared by the `read` and `subscribe` dict forms.
+fn parse_dict_cursor(
+    options: &crate::value::DictMap,
+    builtin: &str,
+) -> Result<Option<u64>, VmError> {
+    parse_cursor(
+        options
+            .get("from_cursor")
+            .or_else(|| options.get("cursor"))
+            .or_else(|| options.get("from")),
+        builtin,
+    )
 }
 
 fn parse_limit(value: Option<&VmValue>, builtin: &str) -> Result<usize, VmError> {


### PR DESCRIPTION
Behavior-preserving DRY cleanup in the eval-inspector / event-log area (no functional change; no user-facing change → `no-changelog-needed`).

## What
- **`inspect_eval_run`** repeated `output_dir.as_ref().map(|dir| dir.join(X)).filter(|p| p.exists())` **six times** to discover the conventional eval-bundle artifact layout. Extracted a single `existing_child(output_dir, name)` helper.
- **`event_log.read`** and **`event_log.subscribe`** each inlined the same three-alias cursor lookup (`from_cursor` → `cursor` → `from`). Extracted `parse_dict_cursor`, so the alias set is defined in one place and the two dict forms can't drift.

Net −48/+36 lines, and the two dict-form parsers now share their cursor semantics.

## Why these and not more
While surveying I found ~21 modules defining their own `required_string` and ~15 defining `optional_string`. I deliberately **did not** unify them: they diverge in coercion (strict `String` vs `display`, empty-allowed vs not), **error variant** (`TypeError` vs `Runtime` vs `Thrown` — which changes Harn `try`/`catch` behavior), and message text (pinned by conformance tests). A shared helper there would be behavior-altering churn, not valuable DRY. Only the genuinely identical, local duplication is consolidated here.

## Verification
The extracted helpers are literal moves of the existing expressions. Confirmed by the existing `eval_inspect_run_reports_artifacts_and_event_chain` serve test and the `event_log` read/subscribe conformance suite (5 passed). Pre-commit clippy/fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)