### PR TITLE
Fix four convergence-audit bugs in the Harn runtime

### DIFF
--- a/changelog.d/3581.fixed.md
+++ b/changelog.d/3581.fixed.md
@@ -1,0 +1,6 @@
+Fixed four agent-loop convergence bugs found by audit: `strip_thinking_tags` no longer corrupts
+tool-call arguments that contain `<think>`/`</think>` inside strings or heredoc bodies; completion
+and step verdict classification now reads the leading word (so `done.` and `done — all pass` are
+recognized) and drops the reflexive `yes`/`true` done-tokens; a single-message compaction archive is
+no longer discarded as a false-terminal `context_overflow`; and provider-catalog fragment
+leading-key bleed (which mislabelled `openai/gpt-oss-120b`) is fixed with a build-time validator.

--- a/conformance/tests/agents/agent_runtime_features.expected
+++ b/conformance/tests/agents/agent_runtime_features.expected
@@ -2,6 +2,8 @@ list_directory
 true
 true
 2
+2
+true
 true
 true
 true

--- a/conformance/tests/agents/agent_runtime_features.harn
+++ b/conformance/tests/agents/agent_runtime_features.harn
@@ -53,8 +53,13 @@ pipeline test(task) {
     {role: "user", content: "Then update the diagnostics."},
   ]
   let llm_compacted = transcript_auto_compact(base_messages, {provider: "mock", keep_last: 1, token_threshold: 1})
-  __io_println(len(llm_compacted))
-  __io_println(llm_compacted[0].content.contains("auto-compacted"))
+  // transcript_auto_compact now returns { messages, archived, summary }; the
+  // archived count and summary come straight from the engine instead of being
+  // inferred from a length delta.
+  __io_println(len(llm_compacted.messages))
+  __io_println(llm_compacted.archived)
+  __io_println(llm_compacted.messages[0].content.contains("auto-compacted"))
+  __io_println(llm_compacted.summary.contains("auto-compacted"))
   let custom_compacted = transcript_auto_compact(
     base_messages,
     {
@@ -64,7 +69,7 @@ pipeline test(task) {
       compact_callback: { archived -> {summary: "custom compact " + to_string(len(archived))} },
     },
   )
-  __io_println(custom_compacted[0].content.contains("custom compact 2"))
+  __io_println(custom_compacted.messages[0].content.contains("custom compact 2"))
   let policy_compacted = transcript_auto_compact(
     base_messages,
     {
@@ -76,7 +81,8 @@ pipeline test(task) {
     },
   )
   __io_println(
-    policy_compacted[0].content.contains("policy compact preserve_test_failures failing test names"),
+    policy_compacted.messages[0].content
+      .contains("policy compact preserve_test_failures failing test names"),
   )
   let loop_compacted = agent_loop(
     "Inspect the workspace",

--- a/crates/harn-cli/src/commands/providers/build.rs
+++ b/crates/harn-cli/src/commands/providers/build.rs
@@ -106,8 +106,23 @@ fn generated_provider_config(source_dir: &Path) -> Result<GeneratedProviderConfi
     for path in &fragments {
         let fragment = fs::read_to_string(path)
             .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+        // Reject bare `key = value` lines that appear before the first table
+        // header in a model fragment. Fragments are concatenated as raw text, so
+        // any such leading key binds at runtime to the PREVIOUS fragment's last
+        // model table instead of this fragment's first model — silently
+        // mislabeling a model's tier/open_weight/strengths across the fragment
+        // boundary. Keep every model key inside an explicit `[models.X]` table so
+        // concatenation can never reattach it. Scoped to `60-models/`: other
+        // fragment dirs (defaults, routing, aliases) legitimately set root-level
+        // `ProvidersConfig` fields like `default_provider`.
+        let label = fragment_label(source_dir, path);
+        if is_model_fragment(&label) {
+            if let Some(error) = leading_bare_key_error(&label, &fragment) {
+                return Err(error);
+            }
+        }
         body.push_str("\n# --- source: ");
-        body.push_str(&fragment_label(source_dir, path));
+        body.push_str(&label);
         body.push_str(" ---\n");
         body.push_str(fragment.trim_end());
         body.push('\n');
@@ -200,4 +215,94 @@ fn fragment_label(source_dir: &Path, path: &Path) -> String {
         .unwrap_or(path)
         .to_string_lossy()
         .replace('\\', "/")
+}
+
+/// True when a fragment label names a `60-models/` model fragment, where bare
+/// keys are model metadata that must live inside a `[models.X]` table. Other
+/// source dirs (`00-base`, `20-routing`, `40-defaults`, ...) legitimately set
+/// root-level `ProvidersConfig` fields like `default_provider`, so the
+/// leading-bare-key guard does not apply to them.
+fn is_model_fragment(label: &str) -> bool {
+    label.starts_with("60-models/") || label.contains("/60-models/")
+}
+
+/// Return an error message when `fragment` has any bare `key = value` line
+/// before its first `[table]` header. Such a key has no table to belong to
+/// inside the fragment, so after the fragments are concatenated as raw text it
+/// silently attaches to the PREVIOUS fragment's last table — the leading-key
+/// bleed that mislabels a model across the fragment boundary. Comments and
+/// blank lines before the first table are fine; only assignment lines are
+/// rejected. Returns `None` when the fragment is clean.
+fn leading_bare_key_error(label: &str, fragment: &str) -> Option<String> {
+    for (line_number, raw) in fragment.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if line.starts_with('[') {
+            // Reached the first table header without seeing a bare key: clean.
+            return None;
+        }
+        // A non-comment, non-blank, non-header line before the first table.
+        // Only `key = value` assignments are the bleed hazard.
+        if line.contains('=') {
+            let key = line.split('=').next().unwrap_or(line).trim();
+            return Some(format!(
+                "provider catalog fragment {label} has a leading bare key `{key}` on line {} \
+                 before its first [table] header. Move it inside the model's `[models.X]` table: \
+                 a bare key before the first table binds to the PREVIOUS fragment's last model \
+                 after concatenation, silently mislabeling that model.",
+                line_number + 1
+            ));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::leading_bare_key_error;
+
+    #[test]
+    fn rejects_leading_bare_key_before_first_table() {
+        let fragment = "\
+# a comment is fine
+tier = \"mid\"
+open_weight = true
+[models.\"x\"]
+name = \"X\"
+";
+        let error =
+            leading_bare_key_error("60-models/test.toml", fragment).expect("leading key rejected");
+        assert!(error.contains("leading bare key `tier`"), "got: {error}");
+        assert!(error.contains("line 2"), "should report the line: {error}");
+    }
+
+    #[test]
+    fn accepts_fragment_with_only_comments_before_first_table() {
+        let fragment = "\
+# header comment
+# another note
+
+[models.\"x\"]
+name = \"X\"
+tier = \"mid\"
+open_weight = true
+";
+        assert!(leading_bare_key_error("60-models/test.toml", fragment).is_none());
+    }
+
+    #[test]
+    fn accepts_keys_inside_tables() {
+        // Bare keys AFTER a table header belong to that table and are allowed.
+        let fragment = "\
+[models.\"x\"]
+name = \"X\"
+tier = \"mid\"
+[models.\"y\"]
+name = \"Y\"
+tier = \"frontier\"
+";
+        assert!(leading_bare_key_error("60-models/test.toml", fragment).is_none());
+    }
 }

--- a/crates/harn-lsp/src/constants.rs
+++ b/crates/harn-lsp/src/constants.rs
@@ -451,7 +451,7 @@ pub(crate) const BUILTINS: &[(&str, &str)] = &[
     ),
     (
         "transcript_auto_compact",
-        "transcript_auto_compact(messages, options?) -> list",
+        "transcript_auto_compact(messages, options?) -> dict",
     ),
     ("host_capabilities", "host_capabilities() -> dict"),
     ("host_has", "host_has(capability, op?) -> bool"),
@@ -1020,7 +1020,7 @@ pub(crate) fn builtin_doc(name: &str) -> Option<String> {
         "transcript" => "**transcript(metadata?)** → dict — Create a new transcript",
         "transcript_compact" => "**transcript_compact(transcript, options?)** → dict — Compact a transcript with the runtime compaction engine",
         "transcript_summarize" => "**transcript_summarize(transcript, options?)** → dict — Summarize and compact a transcript with an LLM",
-        "transcript_auto_compact" => "**transcript_auto_compact(messages, options?)** → list — Apply the agent-loop compaction pipeline to a message list",
+        "transcript_auto_compact" => "**transcript_auto_compact(messages, options?)** → dict — Apply the agent-loop compaction pipeline to a message list, returning { messages, archived, summary }",
         "schema_check" => "**schema_check(data, schema)** → Result — Validate data against an extended Harn schema and return `Result.Ok(data)` without applying defaults",
         "schema_parse" => "**schema_parse(data, schema)** → Result — Validate data against an extended Harn schema and return `Result.Ok(data)` with defaults applied",
         "schema_report" => "**schema_report(data, schema, apply_defaults?)** → dict — Validate data and return `{ok, message, errors, issues, value?}` without throwing",

--- a/crates/harn-stdlib/src/stdlib/agent/autocompact.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/autocompact.harn
@@ -196,21 +196,6 @@ fn __compact_options(opts, engine_strategy, keep_last) {
   return compact_opts
 }
 
-fn __auto_compact_summary(before, after) {
-  if len(after) == 0 || len(before) == len(after) {
-    return ""
-  }
-  let head = after[0]
-  if type_of(head) != "dict" {
-    return ""
-  }
-  let {role = "", content = ""} = head ?? {}
-  if role != "user" || type_of(content) != "string" {
-    return ""
-  }
-  return content
-}
-
 fn __compaction_enabled(opts) {
   let auto_cfg = opts?.auto_compact
   let policy_cfg = opts?.compaction
@@ -413,13 +398,16 @@ pub fn agent_autocompact_if_needed(session, opts) {
   if pre_control?.control == "block" {
     return nil
   }
-  let compacted = transcript_auto_compact(messages, compact_opts)
-  let summary = __auto_compact_summary(messages, compacted)
-  let archived = if summary != "" {
-    len(messages) - len(compacted) + 1
-  } else {
-    0
-  }
+  let compact_result = transcript_auto_compact(messages, compact_opts)
+  let compacted = compact_result.messages
+  // Trust the engine's archived count, not a length delta: when exactly one
+  // message is archived and one summary is inserted, len(before) == len(after),
+  // so inferring "did compaction happen?" from the lengths discards a real
+  // compaction. `archived == 0` means the engine did nothing. The engine also
+  // returns the summary text it inserted (its index depends on keep_first), so
+  // we no longer reverse-engineer it from messages[0].
+  let archived = compact_result.archived
+  let summary = compact_result.summary
   if archived > 0 {
     __host_agent_session_replace_messages(session.session_id, compacted, summary)
     let metadata = {
@@ -514,13 +502,14 @@ pub fn agent_emergency_compact(session, opts, attempt) {
     estimated_tokens_before: estimate_tokens(messages),
   }
   __host_fire_session_hook("pre_compact", pre_payload)
-  let compacted = transcript_auto_compact(messages, compact_opts)
-  let summary = __auto_compact_summary(messages, compacted)
-  let archived = if summary != "" {
-    len(messages) - len(compacted) + 1
-  } else {
-    0
-  }
+  let compact_result = transcript_auto_compact(messages, compact_opts)
+  let compacted = compact_result.messages
+  // Use the engine's true archived count. A length-delta heuristic reads an
+  // archive-exactly-one emergency compaction as archived == 0, which the agent
+  // loop treats as terminal/irreducible context_overflow and gives up on a
+  // RECOVERABLE overflow. The engine also returns the inserted summary text.
+  let archived = compact_result.archived
+  let summary = compact_result.summary
   if archived > 0 {
     __host_agent_session_replace_messages(session.session_id, compacted, summary)
     let metadata = {

--- a/crates/harn-stdlib/src/stdlib/agent/judge.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/judge.harn
@@ -121,7 +121,11 @@ fn __judge_invoke_structured(harness: Harness, judge_cfg, opts, payload) {
   }
   let result = checkpoint.data
   let {reasoning = "", next_step = ""} = result ?? {}
-  let done_verdicts = ["done", "pass", "passed", "safe", "true", "yes", "yield", "yield_to_user", "complete", "completed"]
+  // The done-judge prompt only ever asks for `done` or `continue`. A reflexive
+  // `"yes"` from a cheap model usually means "yes, keep going" (continue), and
+  // a bare `"true"` is just as ambiguous — classifying either as DONE
+  // terminates incomplete work. Both are dropped from the allow-list.
+  let done_verdicts = ["done", "pass", "passed", "safe", "yield", "yield_to_user", "complete", "completed"]
   let feedback_default = judge_cfg?.feedback_fallback ?? ""
   let outcome = __judge_classify_verdict(
     result?.verdict ?? "continue",

--- a/crates/harn-stdlib/src/stdlib/agent/judge_internals.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/judge_internals.harn
@@ -67,6 +67,47 @@ pub fn __judge_verdict_token(raw_verdict) {
 }
 
 /**
+ * Punctuation that cheap models hang off the leading verdict word
+ * (`"done."`, `"done!"`, `"pass:"`, `"(done)"`, quotes/asterisks from
+ * markdown emphasis). Stripped from both ends of the leading token before
+ * the allow-list compare so a decorated `done` still classifies as DONE.
+ */
+const __JUDGE_TOKEN_PUNCT = ".,;:!?\"'`*_-)("
+
+/**
+ * Reduce a normalized verdict to its leading whitespace-delimited word with
+ * surrounding punctuation stripped. Cheap models decorate enum values
+ * (`"done."`, `"yes, complete"`, `"done — all tests pass"`); the verdict's
+ * *intent* is its first word, so classification keys on that word instead of
+ * requiring whole-string equality. `"not done yet"` reduces to `"not"`
+ * (still a veto), while `"done."` reduces to `"done"` (a pass).
+ *
+ * @effects: []
+ * @errors: []
+ * @api_stability: internal
+ * @example: __judge_leading_word("done.")
+ */
+pub fn __judge_leading_word(normalized) {
+  var first = ""
+  for piece in normalized.split(" ") {
+    if first == "" && trim(piece) != "" {
+      first = trim(piece)
+    }
+  }
+  // Strip leading punctuation.
+  var start = 0
+  while start < len(first) && __JUDGE_TOKEN_PUNCT.contains(first.char_at(start)) {
+    start = start + 1
+  }
+  // Strip trailing punctuation.
+  var stop = len(first)
+  while stop > start && __JUDGE_TOKEN_PUNCT.contains(first.char_at(stop - 1)) {
+    stop = stop - 1
+  }
+  return first[start:stop]
+}
+
+/**
  * Classify a raw verdict string against an allow-list of pass tokens and
  * compose the `{vetoed, feedback?}` outcome. `feedback_candidates` is
  * tried in order: the first non-nil, non-empty entry wins. Falls back
@@ -74,9 +115,10 @@ pub fn __judge_verdict_token(raw_verdict) {
  *
  * Used by `agent_step_judge` (pass tokens like "pass"/"yes"/"approve") and
  * by `agent_verify_or_continue` (pass tokens like "done"/"complete").
- * The raw verdict is normalized through `__judge_verdict_token` first, so
- * a verdict that captured trailing JSON junk still classifies correctly
- * and the stored/emitted `verdict` field carries the clean token.
+ * The raw verdict is normalized through `__judge_verdict_token` first, then
+ * reduced to its leading word so a decorated enum value (`"done."`,
+ * `"done — all tests pass"`) still classifies. The stored/emitted `verdict`
+ * field carries the clean leading word.
  *
  * @effects: []
  * @errors: []
@@ -84,7 +126,7 @@ pub fn __judge_verdict_token(raw_verdict) {
  * @example: __judge_classify_verdict("pass", ["pass", "yes"], [critique], default)
  */
 pub fn __judge_classify_verdict(raw_verdict, pass_tokens, feedback_candidates, feedback_default) {
-  let normalized = __judge_verdict_token(raw_verdict)
+  let normalized = __judge_leading_word(__judge_verdict_token(raw_verdict))
   if contains(pass_tokens, normalized) {
     return {vetoed: false, verdict: normalized}
   }

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/10-openai-gemini-mistral.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/10-openai-gemini-mistral.toml
@@ -251,3 +251,8 @@ api_dialect = "openai_chat"
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.15, output_per_mtok = 0.60, cache_read_per_mtok = 0.015 }
 architecture = { parameter_count_b = 119.0, active_parameter_count_b = 6.5, moe = true, license = "Apache-2.0", source_url = "https://docs.mistral.ai/models/model-cards/mistral-small-4-0-26-03", last_verified = "2026-06-05" }
+# Self-described metadata (matches the mistral-small-4-2603 equivalence group);
+# previously relied on cross-fragment leading-key bleed.
+tier = "mid"
+open_weight = true
+strengths = ["cheap", "coding", "speed", "tool_use", "long_context"]

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/20-open-weight-openrouter.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/20-open-weight-openrouter.toml
@@ -1,9 +1,6 @@
 # Open-weight executor candidates (<$2/Mtok with function calling). Use
 # these via OpenRouter or Fireworks for fast secondary-model dispatch.
 # Pricing snapshot 2026-05 from OpenRouter / Artificial Analysis.
-tier = "mid"
-open_weight = true
-strengths = ["cheap", "coding", "speed"]
 [models."qwen/qwen3-coder"]
 name = "Qwen3 Coder 480B A35B"
 provider = "openrouter"
@@ -75,3 +72,14 @@ api_dialect = "openai_chat"
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.15, output_per_mtok = 0.60 }
 architecture = { parameter_count_b = 117.0, active_parameter_count_b = 5.1, moe = true, license = "Apache-2.0", source_url = "https://developers.openai.com/api/docs/models/gpt-oss-120b", last_verified = "2026-06-05" }
+# Explicit metadata so this row is self-described. It was previously the last
+# model in this fragment with no inline tier/open_weight/strengths, so the next
+# fragment's (now-removed) leading bare keys bled in and mislabeled it as
+# `open_weight = false` with a spurious `vision` strength. GPT-OSS 120B is
+# Apache-2.0 (open weight) and text-only; it is Burin's cheap coding executor.
+# `tier`/`open_weight`/`strengths` match the rest of the openai-gpt-oss-120b
+# equivalence group (the validator requires one tier per logical model — the
+# conservative shared baseline is `frontier`).
+tier = "frontier"
+open_weight = true
+strengths = ["cheap", "coding", "tool_use", "reasoning"]

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/25-openrouter-frontier-agents.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/25-openrouter-frontier-agents.toml
@@ -1,10 +1,6 @@
 # Current OpenRouter-hosted coding/agent models that are not direct provider
 # defaults. Pricing snapshots are from OpenRouter's live `/api/v1/models`.
 
-tier = "frontier"
-open_weight = false
-strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning", "vision"]
-complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "deepseek", "kimi"]
 [models."qwen/qwen3.7-plus"]
 name = "Qwen3.7 Plus"
 provider = "openrouter"
@@ -44,3 +40,8 @@ provider = "openrouter"
 context_window = 256000
 capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
 pricing = { input_per_mtok = 0.20, output_per_mtok = 1.15, cache_read_per_mtok = 0.04 }
+# Self-described metadata (matches the step-3.7-flash equivalence group);
+# previously relied on cross-fragment leading-key bleed.
+tier = "frontier"
+open_weight = false
+strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning"]

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/26-together-frontier-agents.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/26-together-frontier-agents.toml
@@ -2,10 +2,6 @@
 # `GET /v1/models`. Keep rows here when Harn supports the provider but the
 # model is absent from direct-provider catalogs.
 
-tier = "frontier"
-open_weight = false
-strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning"]
-complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "deepseek", "kimi"]
 [models."Qwen/Qwen3.7-Max"]
 name = "Qwen3.7 Max (Together)"
 provider = "together"
@@ -56,3 +52,8 @@ provider = "together"
 context_window = 196608
 capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
 pricing = { input_per_mtok = 0.30, output_per_mtok = 1.20, cache_read_per_mtok = 0.06 }
+# Self-described metadata (matches the minimax-m2.7 equivalence group);
+# previously relied on cross-fragment leading-key bleed.
+tier = "frontier"
+open_weight = true
+strengths = ["speed", "coding", "agentic", "tool_use", "reasoning", "long_context"]

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/30-cerebras.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/30-cerebras.toml
@@ -9,9 +9,6 @@
 # the raw model name). Users routing via `model: "cerebras/<name>"` get
 # the slash-prefixed selector stripped by `normalize_model_id` while
 # `infer_provider` routes them to this provider.
-tier = "mid"
-open_weight = true
-strengths = ["cheap", "tool_use"]
 [models."gpt-oss-120b"]
 name = "GPT-OSS 120B (Cerebras)"
 provider = "cerebras"
@@ -45,4 +42,9 @@ pricing = { input_per_mtok = 0.85, output_per_mtok = 1.20 }
 availability = "dedicated"
 deprecated = true
 deprecation_note = "Cerebras no longer returns this model from public discovery; use a provisioned dedicated endpoint alias if your organization still serves these weights."
+# Self-described metadata; previously relied on cross-fragment leading-key
+# bleed. Deprecated legacy route.
+tier = "mid"
+open_weight = true
+strengths = ["tool_use"]
 

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/40-minimax.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/40-minimax.toml
@@ -19,9 +19,6 @@
 # Tool calls + thinking-mode are supported (release notes call out
 # "agentic harness" support); structured output is delimited (no native
 # JSON schema mode), and prompt caching is hit-priced at 20% of input.
-tier = "mid"
-open_weight = true
-strengths = ["speed", "tool_use"]
 [models."MiniMax-M3"]
 name = "MiniMax M3"
 provider = "minimax"
@@ -126,3 +123,7 @@ provider = "openrouter"
 context_window = 204800
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.33, output_per_mtok = 1.20 }
+# Self-described metadata; previously relied on cross-fragment leading-key bleed.
+tier = "frontier"
+open_weight = true
+strengths = ["coding", "agentic", "tool_use", "reasoning"]

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/50-zai.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/50-zai.toml
@@ -1,9 +1,6 @@
 # Z.AI GLM-5 family. GLM-5.2 is the current 1M-context open-weight flagship;
 # GLM-5.1 / GLM-5 are kept for pinned callers. Direct Z.AI tariff via the
 # OpenAI-compatible /v1 endpoint. OpenRouter mirrors live below.
-tier = "mid"
-open_weight = true
-strengths = ["coding", "agentic", "cheap"]
 [models."glm-5"]
 name = "GLM 5"
 provider = "zai"
@@ -70,3 +67,7 @@ provider = "openrouter"
 context_window = 202752
 capabilities = ["tools", "streaming", "vision"]
 pricing = { input_per_mtok = 1.20, output_per_mtok = 4.00 }
+# Self-described metadata; previously relied on cross-fragment leading-key bleed.
+tier = "frontier"
+open_weight = true
+strengths = ["vision", "coding", "agentic"]

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/60-deepseek-openrouter-qwen.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/60-deepseek-openrouter-qwen.toml
@@ -3,9 +3,6 @@
 # cap. `deepseek-chat`/`deepseek-reasoner` are retained as deprecated
 # aliases on V4-Flash (non-thinking) and V4-Flash thinking-mode
 # respectively; per provider notes they retire 2026-07-24.
-tier = "mid"
-open_weight = true
-strengths = ["vision", "speed"]
 [models."deepseek-v4-flash"]
 name = "DeepSeek V4 Flash"
 provider = "deepseek"
@@ -76,3 +73,7 @@ name = "Qwen3.5 9B"
 provider = "openrouter"
 context_window = 131072
 capabilities = ["tools", "streaming"]
+# Self-described metadata; previously relied on cross-fragment leading-key bleed.
+tier = "small"
+open_weight = true
+strengths = ["cheap", "speed"]

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/70-local-ollama.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/70-local-ollama.toml
@@ -1,9 +1,6 @@
 # Ollama / local models — no `pricing` (free); context_window reflects
 # model card ceiling. `runtime_context_window` caps what Harn will
 # actually feed the runtime (host memory budget).
-tier = "small"
-open_weight = true
-strengths = ["cheap", "speed"]
 [models."llama3.2"]
 name = "Llama 3.2"
 provider = "ollama"
@@ -67,4 +64,8 @@ context_window = 262144
 runtime_context_window = 32768
 stream_timeout = 600.0
 capabilities = ["tools", "streaming"]
+# Self-described metadata; previously relied on cross-fragment leading-key bleed.
+tier = "mid"
+open_weight = true
+strengths = ["coding", "agentic"]
 

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/80-local-runtimes.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/80-local-runtimes.toml
@@ -1,7 +1,4 @@
 # llama.cpp — Unsloth Dynamic 2.0 GGUF served by llama-server.
-tier = "mid"
-open_weight = true
-strengths = ["coding", "agentic"]
 [models."qwen3.6-35b-a3b-ud-q4-k-xl"]
 name = "Qwen3.6 35B (Unsloth Q4_K_XL, llama.cpp)"
 provider = "llamacpp"

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -1941,14 +1941,16 @@ api_dialect = "openai_chat"
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.15, output_per_mtok = 0.60, cache_read_per_mtok = 0.015 }
 architecture = { parameter_count_b = 119.0, active_parameter_count_b = 6.5, moe = true, license = "Apache-2.0", source_url = "https://docs.mistral.ai/models/model-cards/mistral-small-4-0-26-03", last_verified = "2026-06-05" }
+# Self-described metadata (matches the mistral-small-4-2603 equivalence group);
+# previously relied on cross-fragment leading-key bleed.
+tier = "mid"
+open_weight = true
+strengths = ["cheap", "coding", "speed", "tool_use", "long_context"]
 
 # --- source: 60-models/20-open-weight-openrouter.toml ---
 # Open-weight executor candidates (<$2/Mtok with function calling). Use
 # these via OpenRouter or Fireworks for fast secondary-model dispatch.
 # Pricing snapshot 2026-05 from OpenRouter / Artificial Analysis.
-tier = "mid"
-open_weight = true
-strengths = ["cheap", "coding", "speed"]
 [models."qwen/qwen3-coder"]
 name = "Qwen3 Coder 480B A35B"
 provider = "openrouter"
@@ -2020,15 +2022,22 @@ api_dialect = "openai_chat"
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.15, output_per_mtok = 0.60 }
 architecture = { parameter_count_b = 117.0, active_parameter_count_b = 5.1, moe = true, license = "Apache-2.0", source_url = "https://developers.openai.com/api/docs/models/gpt-oss-120b", last_verified = "2026-06-05" }
+# Explicit metadata so this row is self-described. It was previously the last
+# model in this fragment with no inline tier/open_weight/strengths, so the next
+# fragment's (now-removed) leading bare keys bled in and mislabeled it as
+# `open_weight = false` with a spurious `vision` strength. GPT-OSS 120B is
+# Apache-2.0 (open weight) and text-only; it is Burin's cheap coding executor.
+# `tier`/`open_weight`/`strengths` match the rest of the openai-gpt-oss-120b
+# equivalence group (the validator requires one tier per logical model — the
+# conservative shared baseline is `frontier`).
+tier = "frontier"
+open_weight = true
+strengths = ["cheap", "coding", "tool_use", "reasoning"]
 
 # --- source: 60-models/25-openrouter-frontier-agents.toml ---
 # Current OpenRouter-hosted coding/agent models that are not direct provider
 # defaults. Pricing snapshots are from OpenRouter's live `/api/v1/models`.
 
-tier = "frontier"
-open_weight = false
-strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning", "vision"]
-complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "deepseek", "kimi"]
 [models."qwen/qwen3.7-plus"]
 name = "Qwen3.7 Plus"
 provider = "openrouter"
@@ -2068,16 +2077,17 @@ provider = "openrouter"
 context_window = 256000
 capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
 pricing = { input_per_mtok = 0.20, output_per_mtok = 1.15, cache_read_per_mtok = 0.04 }
+# Self-described metadata (matches the step-3.7-flash equivalence group);
+# previously relied on cross-fragment leading-key bleed.
+tier = "frontier"
+open_weight = false
+strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning"]
 
 # --- source: 60-models/26-together-frontier-agents.toml ---
 # Current Together serverless frontier/agent routes observed through
 # `GET /v1/models`. Keep rows here when Harn supports the provider but the
 # model is absent from direct-provider catalogs.
 
-tier = "frontier"
-open_weight = false
-strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning"]
-complementary_with = ["anthropic-claude", "openai-gpt", "google-gemini", "deepseek", "kimi"]
 [models."Qwen/Qwen3.7-Max"]
 name = "Qwen3.7 Max (Together)"
 provider = "together"
@@ -2128,6 +2138,11 @@ provider = "together"
 context_window = 196608
 capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
 pricing = { input_per_mtok = 0.30, output_per_mtok = 1.20, cache_read_per_mtok = 0.06 }
+# Self-described metadata (matches the minimax-m2.7 equivalence group);
+# previously relied on cross-fragment leading-key bleed.
+tier = "frontier"
+open_weight = true
+strengths = ["speed", "coding", "agentic", "tool_use", "reasoning", "long_context"]
 
 # --- source: 60-models/30-cerebras.toml ---
 # Cerebras-hosted open-weight models. Serverless rows mirror
@@ -2141,9 +2156,6 @@ pricing = { input_per_mtok = 0.30, output_per_mtok = 1.20, cache_read_per_mtok =
 # the raw model name). Users routing via `model: "cerebras/<name>"` get
 # the slash-prefixed selector stripped by `normalize_model_id` while
 # `infer_provider` routes them to this provider.
-tier = "mid"
-open_weight = true
-strengths = ["cheap", "tool_use"]
 [models."gpt-oss-120b"]
 name = "GPT-OSS 120B (Cerebras)"
 provider = "cerebras"
@@ -2177,6 +2189,11 @@ pricing = { input_per_mtok = 0.85, output_per_mtok = 1.20 }
 availability = "dedicated"
 deprecated = true
 deprecation_note = "Cerebras no longer returns this model from public discovery; use a provisioned dedicated endpoint alias if your organization still serves these weights."
+# Self-described metadata; previously relied on cross-fragment leading-key
+# bleed. Deprecated legacy route.
+tier = "mid"
+open_weight = true
+strengths = ["tool_use"]
 
 # --- source: 60-models/40-minimax.toml ---
 # MiniMax family ─ pricing pages:
@@ -2200,9 +2217,6 @@ deprecation_note = "Cerebras no longer returns this model from public discovery;
 # Tool calls + thinking-mode are supported (release notes call out
 # "agentic harness" support); structured output is delimited (no native
 # JSON schema mode), and prompt caching is hit-priced at 20% of input.
-tier = "mid"
-open_weight = true
-strengths = ["speed", "tool_use"]
 [models."MiniMax-M3"]
 name = "MiniMax M3"
 provider = "minimax"
@@ -2307,14 +2321,15 @@ provider = "openrouter"
 context_window = 204800
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.33, output_per_mtok = 1.20 }
+# Self-described metadata; previously relied on cross-fragment leading-key bleed.
+tier = "frontier"
+open_weight = true
+strengths = ["coding", "agentic", "tool_use", "reasoning"]
 
 # --- source: 60-models/50-zai.toml ---
 # Z.AI GLM-5 family. GLM-5.2 is the current 1M-context open-weight flagship;
 # GLM-5.1 / GLM-5 are kept for pinned callers. Direct Z.AI tariff via the
 # OpenAI-compatible /v1 endpoint. OpenRouter mirrors live below.
-tier = "mid"
-open_weight = true
-strengths = ["coding", "agentic", "cheap"]
 [models."glm-5"]
 name = "GLM 5"
 provider = "zai"
@@ -2381,6 +2396,10 @@ provider = "openrouter"
 context_window = 202752
 capabilities = ["tools", "streaming", "vision"]
 pricing = { input_per_mtok = 1.20, output_per_mtok = 4.00 }
+# Self-described metadata; previously relied on cross-fragment leading-key bleed.
+tier = "frontier"
+open_weight = true
+strengths = ["vision", "coding", "agentic"]
 
 # --- source: 60-models/60-deepseek-openrouter-qwen.toml ---
 # DeepSeek V4 family ─ pricing pages: api-docs.deepseek.com/quick_start/pricing.
@@ -2388,9 +2407,6 @@ pricing = { input_per_mtok = 1.20, output_per_mtok = 4.00 }
 # cap. `deepseek-chat`/`deepseek-reasoner` are retained as deprecated
 # aliases on V4-Flash (non-thinking) and V4-Flash thinking-mode
 # respectively; per provider notes they retire 2026-07-24.
-tier = "mid"
-open_weight = true
-strengths = ["vision", "speed"]
 [models."deepseek-v4-flash"]
 name = "DeepSeek V4 Flash"
 provider = "deepseek"
@@ -2461,14 +2477,15 @@ name = "Qwen3.5 9B"
 provider = "openrouter"
 context_window = 131072
 capabilities = ["tools", "streaming"]
+# Self-described metadata; previously relied on cross-fragment leading-key bleed.
+tier = "small"
+open_weight = true
+strengths = ["cheap", "speed"]
 
 # --- source: 60-models/70-local-ollama.toml ---
 # Ollama / local models — no `pricing` (free); context_window reflects
 # model card ceiling. `runtime_context_window` caps what Harn will
 # actually feed the runtime (host memory budget).
-tier = "small"
-open_weight = true
-strengths = ["cheap", "speed"]
 [models."llama3.2"]
 name = "Llama 3.2"
 provider = "ollama"
@@ -2532,12 +2549,13 @@ context_window = 262144
 runtime_context_window = 32768
 stream_timeout = 600.0
 capabilities = ["tools", "streaming"]
-
-# --- source: 60-models/80-local-runtimes.toml ---
-# llama.cpp — Unsloth Dynamic 2.0 GGUF served by llama-server.
+# Self-described metadata; previously relied on cross-fragment leading-key bleed.
 tier = "mid"
 open_weight = true
 strengths = ["coding", "agentic"]
+
+# --- source: 60-models/80-local-runtimes.toml ---
+# llama.cpp — Unsloth Dynamic 2.0 GGUF served by llama-server.
 [models."qwen3.6-35b-a3b-ud-q4-k-xl"]
 name = "Qwen3.6 35B (Unsloth Q4_K_XL, llama.cpp)"
 provider = "llamacpp"

--- a/crates/harn-vm/src/llm/tools/parse/syntax.rs
+++ b/crates/harn-vm/src/llm/tools/parse/syntax.rs
@@ -163,18 +163,72 @@ pub(super) fn strip_thinking_tags(text: &str) -> std::borrow::Cow<'_, str> {
     if !text.contains("<think>") && !text.contains("</think>") {
         return std::borrow::Cow::Borrowed(text);
     }
-    let mut result = text.to_string();
-    while let Some(start) = result.find("<think>") {
-        if let Some(end) = result[start..].find("</think>") {
-            result.replace_range(start..start + end + "</think>".len(), "");
-        } else {
-            result.replace_range(start..start + "<think>".len(), "");
+    // Strip thinking blocks from the surrounding prose only. A `<think>` /
+    // `</think>` literal *inside* a quoted string argument or a `<<TAG ... TAG`
+    // heredoc body is file content (editing an HTML/Markdown/test/prompt file
+    // that mentions those tokens), not a leaked thinking channel — stripping it
+    // would silently corrupt the tool-call argument before it is parsed. Copy
+    // string spans and heredoc bodies through verbatim, applying the same
+    // content-vs-structure rule `strip_tool_call_wrappers` and `find_close_tag`
+    // use, and only excise `<think>...</think>` blocks that begin outside those
+    // spans.
+    let bytes = text.as_bytes();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    // When inside a thinking block, we drop everything (including string/heredoc
+    // bytes) up to the matching `</think>`: a tool call that lives inside the
+    // model's thinking channel is not a real call, so its content is discarded
+    // just as before. Outside a thinking block, strings/heredocs are preserved
+    // verbatim so a literal `<think>` in an argument is never mistaken for a
+    // channel marker.
+    let mut in_think = false;
+    while i < text.len() {
+        if in_think {
+            if text[i..].starts_with("</think>") {
+                i += "</think>".len();
+                in_think = false;
+            } else {
+                i += text[i..].chars().next().map_or(1, char::len_utf8);
+            }
+            continue;
         }
+        if matches!(bytes[i], b'"' | b'\'' | b'`') {
+            if let Some(after) = skip_string_span(text, i) {
+                out.push_str(&text[i..after]);
+                i = after;
+                continue;
+            }
+        }
+        if bytes[i] == b'<' && bytes.get(i + 1) == Some(&b'<') {
+            if let Some(after) = skip_heredoc_body(text, i) {
+                out.push_str(&text[i..after]);
+                i = after;
+                continue;
+            }
+        }
+        if text[i..].starts_with("<think>") {
+            // Only treat this as a real thinking block (and drop its body) when
+            // a matching `</think>` actually follows; an unterminated `<think>`
+            // strips just the marker and keeps the trailing content, matching
+            // the prior behavior so a real tool call after a stray open isn't
+            // swallowed.
+            i += "<think>".len();
+            if text[i..].contains("</think>") {
+                in_think = true;
+            }
+            continue;
+        }
+        if text[i..].starts_with("</think>") {
+            // A stray close marker with no matching open: drop the marker,
+            // matching the old behavior that removed dangling `</think>`.
+            i += "</think>".len();
+            continue;
+        }
+        let ch_len = text[i..].chars().next().map_or(1, char::len_utf8);
+        out.push_str(&text[i..i + ch_len]);
+        i += ch_len;
     }
-    while result.contains("</think>") {
-        result = result.replace("</think>", "");
-    }
-    std::borrow::Cow::Owned(result)
+    std::borrow::Cow::Owned(out)
 }
 
 /// Strip `<tool_call>`/`</tool_call>` (and the compact `<toolcall>` spelling)

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -1477,3 +1477,59 @@ fn heredoc_escaped_body_unterminated_errors() {
         "unterminated escaped heredoc must surface a parse error"
     );
 }
+
+#[test]
+fn thinking_tags_inside_arguments_round_trip_verbatim() {
+    // A tool call that legitimately edits a file mentioning `<think>` /
+    // `</think>` — inside a heredoc body and inside a quoted string argument —
+    // must keep those bytes verbatim. The thinking-tag strip is content-aware:
+    // it only removes a real `<think>...</think>` block in the surrounding
+    // prose, never bytes inside a string or heredoc argument.
+    let tools = sample_tool_registry();
+    let text = concat!(
+        "<think>I should write a file documenting the think tags.</think>\n",
+        "edit({\n",
+        "    action: \"create\",\n",
+        "    path: \"doc.md\",\n",
+        "    title: \"use <think> and </think> markers\",\n",
+        "    content: <<EOF\n",
+        "Models emit <think>reasoning</think> on the thinking channel.\n",
+        "Keep the </think> close tag intact in docs.\n",
+        "EOF\n",
+        "})",
+    );
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert_eq!(
+        result.calls.len(),
+        1,
+        "should parse one call, errors: {:?}",
+        result.errors
+    );
+    let args = &result.calls[0]["arguments"];
+
+    // The quoted string argument keeps both tags verbatim.
+    let title = args["title"].as_str().expect("title is a string");
+    assert_eq!(
+        title, "use <think> and </think> markers",
+        "string argument must preserve <think>/</think> bytes verbatim: {title}"
+    );
+
+    // The heredoc body keeps both tags verbatim.
+    let content = args["content"].as_str().expect("content is a string");
+    assert!(
+        content.contains("<think>reasoning</think>"),
+        "heredoc body must preserve inline <think>...</think>: {content}"
+    );
+    assert!(
+        content.contains("Keep the </think> close tag intact"),
+        "heredoc body must preserve a standalone </think>: {content}"
+    );
+
+    // The surrounding-prose thinking block was still stripped: its inner text
+    // must not survive into any parsed value or the visible prose.
+    assert!(
+        !result.prose.contains("I should write a file documenting"),
+        "surrounding-prose <think> block must be stripped from prose: {:?}",
+        result.prose
+    );
+}

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -3741,7 +3741,9 @@ mod tests {
         let group_tiers: std::collections::BTreeSet<_> = config
             .models
             .values()
-            .filter(|m| m.equivalence_group.as_deref() == Some("openai-gpt-oss-120b") && !m.deprecated)
+            .filter(|m| {
+                m.equivalence_group.as_deref() == Some("openai-gpt-oss-120b") && !m.deprecated
+            })
             .map(|m| m.tier.clone())
             .collect();
         assert_eq!(

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -3707,6 +3707,51 @@ mod tests {
     }
 
     #[test]
+    fn embedded_openrouter_gpt_oss_120b_has_no_fragment_bleed() {
+        // Regression for the provider-catalog leading-key bleed: the openrouter
+        // `openai/gpt-oss-120b` row was the last model in its fragment with no
+        // inline tier/open_weight/strengths, so the next fragment's leading bare
+        // keys reattached to it after raw-text concatenation — mislabeling it as
+        // `open_weight = false` with a spurious `vision` strength. It must now be
+        // self-described: open weight, no vision, and a tier consistent with the
+        // rest of its equivalence group.
+        let config = default_config();
+        let model = config
+            .models
+            .get("openai/gpt-oss-120b")
+            .expect("openrouter gpt-oss-120b row");
+        assert_eq!(model.provider, "openrouter");
+        assert_eq!(
+            model.open_weight,
+            Some(true),
+            "gpt-oss-120b is Apache-2.0 open weight, not the bled-in open_weight=false"
+        );
+        assert!(
+            !model.strengths.iter().any(|s| s == "vision"),
+            "gpt-oss-120b is text-only; the bled-in `vision` strength must be gone: {:?}",
+            model.strengths
+        );
+        assert!(
+            !model.strengths.is_empty(),
+            "gpt-oss-120b must carry its own strengths, not None"
+        );
+
+        // tier is a property of the logical model: every active row in the
+        // openai-gpt-oss-120b equivalence group must agree.
+        let group_tiers: std::collections::BTreeSet<_> = config
+            .models
+            .values()
+            .filter(|m| m.equivalence_group.as_deref() == Some("openai-gpt-oss-120b") && !m.deprecated)
+            .map(|m| m.tier.clone())
+            .collect();
+        assert_eq!(
+            group_tiers.len(),
+            1,
+            "openai-gpt-oss-120b group must share one tier, got {group_tiers:?}"
+        );
+    }
+
+    #[test]
     fn embedded_catalog_every_model_targets_a_registered_provider() {
         let config = default_config();
         let known: std::collections::BTreeSet<&str> =

--- a/crates/harn-vm/src/stdlib/workflow/compact.rs
+++ b/crates/harn-vm/src/stdlib/workflow/compact.rs
@@ -79,9 +79,27 @@ fn non_negative_usize(value: &VmValue, builtin: &str, key: &str) -> Result<usize
     }
 }
 
-/// Apply the workflow/agent transcript auto-compaction primitive to a message list.
+/// Apply the workflow/agent transcript auto-compaction primitive to a message
+/// list, returning `{ messages, archived, summary }`.
+///
+/// `archived` is the engine's true archived-message count (the number of older
+/// messages folded into the single inserted summary), surfaced directly from
+/// the compaction lifecycle. Callers MUST use this field rather than inferring
+/// compaction from `len(before) == len(after)`: when the engine archives
+/// exactly one message and inserts one summary the lengths are equal, so a
+/// length-delta heuristic reads a real compaction as a no-op and discards the
+/// engine's shrunk transcript (and, on the emergency-overflow path, reports a
+/// recoverable overflow as terminal). `archived == 0` means no compaction
+/// happened (already under threshold, a PreCompact hook blocked, or the engine
+/// found nothing to do); in that case `messages` is the input list unchanged,
+/// `archived` is 0, and `summary` is "".
+///
+/// `summary` is the exact summary text the engine inserted, so callers do not
+/// have to reverse-engineer it from a fixed index in `messages` — the summary's
+/// insertion index depends on `keep_first`, so reading `messages[0]` is wrong
+/// whenever the first turns are preserved.
 #[harn_builtin(
-    sig = "transcript_auto_compact(messages: list, options?: dict|nil) -> list",
+    sig = "transcript_auto_compact(messages: list, options?: dict|nil) -> dict",
     kind = "async",
     category = "workflow.host"
 )]
@@ -191,7 +209,10 @@ pub(super) async fn transcript_auto_compact_builtin(
     };
     let lifecycle =
         crate::orchestration::CompactLifecycle::new(crate::orchestration::CompactMode::Workflow);
-    crate::orchestration::run_compaction_lifecycle_with_ctx(
+    // `Ok(None)` means no compaction happened (under threshold / hook blocked /
+    // nothing to do); the messages vec is left untouched, so archived is 0.
+    // Otherwise the engine reports its real archived-message count.
+    let outcome = crate::orchestration::run_compaction_lifecycle_with_ctx(
         Some(&ctx),
         &mut messages,
         &mut config,
@@ -199,12 +220,26 @@ pub(super) async fn transcript_auto_compact_builtin(
         lifecycle,
     )
     .await?;
-    Ok(VmValue::List(std::sync::Arc::new(
+    let (archived, summary) = outcome
+        .map(|o| (o.archived_messages, o.summary))
+        .unwrap_or((0, String::new()));
+    let compacted_messages = VmValue::List(std::sync::Arc::new(
         messages
             .iter()
             .map(crate::stdlib::json_to_vm_value)
             .collect(),
-    )))
+    ));
+    let mut result = crate::value::DictMap::new();
+    result.insert(crate::value::intern_key("messages"), compacted_messages);
+    result.insert(
+        crate::value::intern_key("archived"),
+        VmValue::Int(archived as i64),
+    );
+    result.insert(
+        crate::value::intern_key("summary"),
+        VmValue::String(arcstr::ArcStr::from(summary)),
+    );
+    Ok(VmValue::dict(result))
 }
 
 #[cfg(test)]

--- a/docs/llm/harn-quickref.md
+++ b/docs/llm/harn-quickref.md
@@ -1752,11 +1752,16 @@ Compaction entrypoints accept a typed host/user instruction lane through
 ```harn
 import {compact_preserving_test_failures} from "std/agent/autocompact"
 
-let compacted = transcript_auto_compact(messages, {
+// Returns { messages, archived, summary }. Use `archived` (the engine's true
+// archived-message count) to tell whether compaction happened -- never infer
+// it from a length delta, since archiving one message and inserting one
+// summary leaves the length unchanged.
+let result = transcript_auto_compact(messages, {
   keep_last: 1,
   token_threshold: 1,
   policy: compact_preserving_test_failures({author: "host"})
 })
+let compacted = result.messages
 ```
 
 Omitting `extend_default_instructions` or setting it to `true` appends the

--- a/docs/src/builtins.md
+++ b/docs/src/builtins.md
@@ -1896,7 +1896,7 @@ llm_mock_clear()
 | `transcript.clear_reminders(transcript, selector)` | transcript: dict, selector: dict | dict | Return `{transcript, removed_count}` after removing pending reminders selected by `id`, `tag`, or `dedupe_key`; multiple selectors are combined with AND semantics. |
 | `transcript_summarize(transcript, options?)` | transcript: dict, options: dict | transcript | Summarize and compact a transcript via `llm_call` |
 | `transcript_compact(transcript, options?)` | transcript: dict, options: dict | transcript | Compact a transcript with the runtime compaction engine, preserving durable artifacts and compaction events. Pending reminders are TTL-processed and deduped before compaction; only `preserve_on_compact: true` reminders survive verbatim. `strategy: "custom"` requires `custom_compactor`, a closure called with `(messages, reminders)` that returns the replacement transcript state |
-| `transcript_auto_compact(messages, options?)` | messages: list, options: dict | list | Apply the agent-loop compaction pipeline to a message list using `llm`, `truncate`, or `custom` strategy |
+| `transcript_auto_compact(messages, options?)` | messages: list, options: dict | dict | Apply the agent-loop compaction pipeline to a message list using `llm`, `truncate`, or `custom` strategy; returns `{ messages, archived, summary }` |
 
 ### Provider configuration
 
@@ -2807,7 +2807,7 @@ Bare `llm_call(...)` does not fire reminder providers.
 | `estimate_tokens(messages)` | messages: list | int | Estimate token count for a message list (chars / 4 heuristic) |
 | `microcompact(text, max_chars?)` | text, max_chars (default 20000) | string | Snip oversized text, keeping head and tail with a marker |
 | `select_artifacts_adaptive(artifacts, policy)` | artifacts: list, policy: dict | list | Deduplicate, microcompact oversized artifacts, then select with token budget |
-| `transcript_auto_compact(messages, options?)` | messages: list, options: dict | list | Run the same transcript auto-compaction pipeline used by `agent_loop` |
+| `transcript_auto_compact(messages, options?)` | messages: list, options: dict | dict | Run the same transcript auto-compaction pipeline used by `agent_loop`; returns `{ messages, archived, summary }` |
 
 `std/context` also provides the host-neutral
 `harn.context_artifact.v1` envelope for durable repository context. Hosts use
@@ -3043,7 +3043,7 @@ and offline analysis.
 | `transcript_resume(transcript)` | transcript | transcript | Mark transcript active again and append an internal lifecycle event |
 | `transcript_compact(transcript, options?)` | transcript, options | transcript | Compact a transcript with the runtime compaction engine, including reminder TTL/dedupe/preserve handling and `strategy: "custom"` plus `custom_compactor(messages, reminders)` |
 | `transcript_summarize(transcript, options?)` | transcript, options | transcript | Compact via LLM-generated summary |
-| `transcript_auto_compact(messages, options?)` | messages, options | list | Apply the agent-loop compaction pipeline to a message list |
+| `transcript_auto_compact(messages, options?)` | messages, options | dict | Apply the agent-loop compaction pipeline to a message list; returns `{ messages, archived, summary }` |
 | `transcript_render_visible(transcript)` | transcript | string | Render only public/human-visible messages |
 | `transcript_render_full(transcript)` | transcript | string | Render the full execution history |
 

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -3759,7 +3759,6 @@
       "tier": "mid",
       "open_weight": true,
       "strengths": [
-        "speed",
         "tool_use"
       ]
     },
@@ -10774,12 +10773,13 @@
       ],
       "family": "minimax",
       "lineage": "minimax",
-      "tier": "mid",
+      "tier": "frontier",
       "open_weight": true,
       "strengths": [
         "coding",
         "agentic",
-        "cheap"
+        "tool_use",
+        "reasoning"
       ]
     },
     {
@@ -11228,7 +11228,9 @@
       "strengths": [
         "cheap",
         "coding",
-        "speed"
+        "speed",
+        "tool_use",
+        "long_context"
       ]
     },
     {
@@ -11476,22 +11478,13 @@
       ],
       "family": "openai-gpt",
       "lineage": "openai-legacy",
-      "complementary_with": [
-        "anthropic-claude",
-        "openai-gpt",
-        "google-gemini",
-        "deepseek",
-        "kimi"
-      ],
       "tier": "frontier",
-      "open_weight": false,
+      "open_weight": true,
       "strengths": [
-        "agentic",
+        "cheap",
         "coding",
-        "long_context",
         "tool_use",
-        "reasoning",
-        "vision"
+        "reasoning"
       ]
     },
     {
@@ -11794,13 +11787,6 @@
       ],
       "family": "openrouter",
       "lineage": "openrouter",
-      "complementary_with": [
-        "anthropic-claude",
-        "openai-gpt",
-        "google-gemini",
-        "deepseek",
-        "kimi"
-      ],
       "tier": "frontier",
       "open_weight": false,
       "strengths": [
@@ -12088,11 +12074,12 @@
       ],
       "family": "glm",
       "lineage": "glm",
-      "tier": "mid",
+      "tier": "frontier",
       "open_weight": true,
       "strengths": [
         "vision",
-        "speed"
+        "coding",
+        "agentic"
       ]
     },
     {
@@ -12741,11 +12728,15 @@
       ],
       "family": "minimax",
       "lineage": "minimax",
-      "tier": "mid",
+      "tier": "frontier",
       "open_weight": true,
       "strengths": [
-        "cheap",
-        "tool_use"
+        "speed",
+        "coding",
+        "agentic",
+        "tool_use",
+        "reasoning",
+        "long_context"
       ]
     },
     {

--- a/tests/agent/autocompact_archived_test.harn
+++ b/tests/agent/autocompact_archived_test.harn
@@ -1,0 +1,89 @@
+// Run: harn test tests/agent/autocompact_archived_test.harn
+//
+// Regression tests for the single-message-compaction archive accounting in
+// `std/agent/autocompact`. The compaction engine drains `archived_count`
+// messages and inserts exactly one summary, so a compaction that archives
+// exactly one message leaves `len(before) == len(after)`. The old `.harn`
+// layer inferred "did compaction happen?" from that length delta, so an
+// archive-exactly-one compaction read as `archived == 0`: the engine's
+// shrunk transcript was discarded, and on the emergency-overflow path a
+// RECOVERABLE context_overflow was misreported as terminal (the loop
+// `break`s on `archived <= 0`).
+//
+// `transcript_auto_compact` now returns `{ messages, archived, summary }`
+// with the engine's true archived count and the inserted summary text, so the
+// length-delta inference is gone.
+pipeline test_archive_exactly_one_reports_archived(task) {
+  // keep_first 1 + keep_last 1 over 3 messages drains exactly the single
+  // middle message and inserts one summary -> len(before) == len(after) == 3,
+  // the precise case the length-delta heuristic got wrong.
+  let messages = [
+    {role: "user", content: "u0 ".repeat(10)},
+    {role: "user", content: "u1 ".repeat(10)},
+    {role: "user", content: "u2 ".repeat(10)},
+  ]
+  let result = transcript_auto_compact(
+    messages,
+    {compact_strategy: "truncate", keep_first: 1, keep_last: 1, token_threshold: 1},
+  )
+  // Exactly one message was archived...
+  assert_eq(result.archived, 1)
+  // ...and yet the transcript length is unchanged (1 drained, 1 summary in).
+  assert_eq(len(result.messages), len(messages))
+  // A real summary was produced and surfaced.
+  assert_eq(result.summary != "", true)
+  assert_eq(result.summary.contains("auto-compacted 1 older messages"), true)
+}
+
+pipeline test_archived_count_is_not_inferred_from_length(task) {
+  // The bug was specifically `archived = if len(before) == len(after) { 0 }`.
+  // Prove archived is reported even though the lengths match.
+  let messages = [
+    {role: "user", content: "u0 ".repeat(10)},
+    {role: "user", content: "u1 ".repeat(10)},
+    {role: "user", content: "u2 ".repeat(10)},
+  ]
+  let result = transcript_auto_compact(
+    messages,
+    {compact_strategy: "truncate", keep_first: 1, keep_last: 1, token_threshold: 1},
+  )
+  let length_unchanged = len(result.messages) == len(messages)
+  // Length is unchanged but archived > 0 -> a length-delta inference would be
+  // wrong here, which is the whole point of this fix.
+  assert_eq(length_unchanged, true)
+  assert_eq(result.archived > 0, true)
+}
+
+pipeline test_summary_index_follows_keep_first(task) {
+  // The engine inserts the summary at index `keep_first`, not index 0. The
+  // consumer must read the summary from the engine, not from messages[0].
+  let messages = [
+    {role: "user", content: "preserved-head ".repeat(8)},
+    {role: "user", content: "u1 ".repeat(10)},
+    {role: "user", content: "u2 ".repeat(10)},
+    {role: "user", content: "u3 ".repeat(10)},
+  ]
+  let result = transcript_auto_compact(
+    messages,
+    {compact_strategy: "truncate", keep_first: 1, keep_last: 1, token_threshold: 1},
+  )
+  // The first message is the preserved head, NOT the summary.
+  assert_eq(result.messages[0].content.contains("preserved-head"), true)
+  // The summary lives at the keep_first boundary (index 1) and matches the
+  // engine-returned summary text.
+  assert_eq(result.messages[1].content, result.summary)
+  assert_eq(result.summary.contains("auto-compacted"), true)
+}
+
+pipeline test_no_compaction_reports_zero_archived(task) {
+  // Under threshold: nothing to do. archived is 0, messages unchanged, and the
+  // summary is empty -- the genuine terminal/irreducible signal.
+  let messages = [{role: "user", content: "small"}, {role: "assistant", content: "ok"}]
+  let result = transcript_auto_compact(
+    messages,
+    {compact_strategy: "truncate", keep_last: 1, token_threshold: 1000000},
+  )
+  assert_eq(result.archived, 0)
+  assert_eq(len(result.messages), len(messages))
+  assert_eq(result.summary, "")
+}

--- a/tests/agent/judge_verdict_test.harn
+++ b/tests/agent/judge_verdict_test.harn
@@ -8,7 +8,11 @@
 // `continue",  "reasoning":`. The classifier must strip the junk so the
 // stored/emitted verdict is the clean token AND classification keys on the
 // real verdict (a mangled pass token must not read as a veto).
-import { __judge_classify_verdict, __judge_verdict_token } from "std/agent/judge_internals"
+import {
+  __judge_classify_verdict,
+  __judge_leading_word,
+  __judge_verdict_token,
+} from "std/agent/judge_internals"
 
 const DONE_TOKENS = ["done", "complete"]
 
@@ -43,16 +47,56 @@ pipeline test_mangled_pass_token_still_classifies_as_pass(task) {
   assert_eq(outcome.verdict, "done")
 }
 
-pipeline test_prose_verdict_without_json_junk_is_unchanged(task) {
-  // Multi-word prose verdicts carry signal; only JSON structural characters
-  // mark upstream mangling, so plain prose passes through verbatim.
+pipeline test_prose_verdict_keys_on_leading_word(task) {
+  // `__judge_verdict_token` still returns the whole prose verdict (only JSON
+  // structural chars mark upstream mangling). Classification, however, keys on
+  // the leading word: `"not done yet"` -> `"not"` -> still a veto, and the
+  // stored verdict carries the clean leading word.
   assert_eq(__judge_verdict_token("not done yet"), "not done yet")
   let outcome = __judge_classify_verdict("not done yet", DONE_TOKENS, [], "fallback")
   assert_eq(outcome.vetoed, true)
-  assert_eq(outcome.verdict, "not done yet")
+  assert_eq(outcome.verdict, "not")
+}
+
+pipeline test_leading_word_strips_decoration(task) {
+  // Cheap models decorate enum values. The leading word reduction strips
+  // trailing/leading punctuation and keeps only the first whitespace token.
+  assert_eq(__judge_leading_word("done."), "done")
+  assert_eq(__judge_leading_word("done!"), "done")
+  assert_eq(__judge_leading_word("done — all tests pass"), "done")
+  assert_eq(__judge_leading_word("(done)"), "done")
+  assert_eq(__judge_leading_word("**done**"), "done")
+  assert_eq(__judge_leading_word("not"), "not")
+}
+
+pipeline test_decorated_done_classifies_as_pass(task) {
+  // `"done."` (trailing period) must pass, not spuriously veto a correct
+  // completion.
+  let dot = __judge_classify_verdict("done.", DONE_TOKENS, [], "fallback")
+  assert_eq(dot.vetoed, false)
+  assert_eq(dot.verdict, "done")
+  let dash = __judge_classify_verdict("done — all tests pass", DONE_TOKENS, [], "fallback")
+  assert_eq(dash.vetoed, false)
+  assert_eq(dash.verdict, "done")
+}
+
+pipeline test_yes_complete_classifies_as_pass(task) {
+  // `"yes, complete"` -> JSON-junk cut at the comma -> `"yes"`. With "yes" in
+  // the allow-list it passes; the leading-word reduction keeps the token clean.
+  let outcome = __judge_classify_verdict("yes, complete", ["yes", "done"], [], "fallback")
+  assert_eq(outcome.vetoed, false)
+  assert_eq(outcome.verdict, "yes")
+}
+
+pipeline test_leading_not_still_vetoes(task) {
+  // A leading negation must always veto regardless of trailing decoration.
+  let outcome = __judge_classify_verdict("not done yet.", DONE_TOKENS, [], "fallback")
+  assert_eq(outcome.vetoed, true)
+  assert_eq(outcome.verdict, "not")
 }
 
 pipeline test_empty_and_nil_verdicts(task) {
   assert_eq(__judge_verdict_token(nil), "")
   assert_eq(__judge_verdict_token("\",,"), "")
+  assert_eq(__judge_leading_word(""), "")
 }


### PR DESCRIPTION
Implements fixes for four confirmed bugs found by a convergence audit. Each fix has its own commit and regression test(s). These are core-runtime changes, so this PR is intentionally **not** set to auto-merge — please review.

## Fix 1 — `strip_thinking_tags` silently corrupts tool-call arguments (HIGH, live edit path)
`strip_thinking_tags` ran plain `String::replace`/`find` of `<think>`/`</think>` over the whole response before parsing, with no string/heredoc awareness. A tool call whose argument legitimately contained those literals (editing an HTML/MD/test/prompt file mentioning `<think>`) silently lost bytes and wrote wrong content.

Rewrote the strip to walk the text with the same `skip_string_span` / `skip_heredoc_body` helpers the parser already uses (mirroring `strip_tool_call_wrappers`): only a real `<think>...</think>` block in the surrounding prose is excised; bytes inside quoted string args and heredoc bodies pass through verbatim. Unterminated `<think>` still strips only the marker.

Test: `thinking_tags_inside_arguments_round_trip_verbatim` (harn-vm) — `<think>`/`</think>` inside both a quoted string arg and a heredoc body round-trip verbatim while a surrounding thinking block is still stripped.

## Fix 2 — verdict classification is brittle exact-token match (MEDIUM)
`__judge_classify_verdict` did full-string equality against the pass-token allow-list, so `"done."`, `"done — all tests pass"`, `"(done)"` spuriously VETOED a correct completion (worst on cheap models that decorate enum values).

Added `__judge_leading_word`, which reduces a normalized verdict to its first whitespace-delimited token with surrounding punctuation stripped, and classifies on that: `"not done yet"` → `"not"` (still a veto); `"done."` → `"done"` (a pass). Also dropped `"true"` and `"yes"` from the done-judge allow-list (the done-judge prompt only asks `done`/`continue`; a reflexive `"yes"` meaning "keep going" used to terminate incomplete work). `step_judge`'s `pass_verdicts` keep `"yes"` since that judge genuinely asks pass/revise.

Tests: extended `tests/agent/judge_verdict_test.harn` (decorated-done passes, leading-not still vetoes, leading-word stripping, etc.).

## Fix 3 — single-message compaction archive silently discarded → false-terminal context_overflow (MEDIUM)
The `.harn` layer inferred "did compaction happen?" from `len(before) == len(after)`. The engine drains `archived_count` messages and inserts one summary, so when `archived_count == 1` the lengths are equal → inferred `archived = 0`: the shrunk transcript was discarded, and the emergency-overflow path read `archived <= 0` as terminal/irreducible overflow and gave up on a recoverable one.

`transcript_auto_compact` now returns `{ messages, archived, summary }` with the engine's true `archived_messages` count and the exact inserted summary text (whose index depends on `keep_first`, so reading `messages[0]` was also wrong). Both call sites and the doc/registry references are updated; the now-dead `__auto_compact_summary` helper is removed.

Tests: `tests/agent/autocompact_archived_test.harn` (archive-exactly-one reports `archived == 1` with len unchanged and a real summary; keep_first summary index; no-op reports `archived == 0`). Conformance fixture + golden updated.

## Fix 4 — provider-catalog leading-key bleed across fragment boundaries (HIGH)
Catalog source fragments are concatenated as raw text, so any bare key before a fragment's first `[models.X]` table binds at runtime to the *previous* fragment's last model. The openrouter `openai/gpt-oss-120b` row (Burin's cheap coding executor) absorbed the next fragment's leading keys → mislabeled `open_weight = false` with a spurious `vision` strength; eight other models across the nine boundaries were mislabeled the same way.

Removed the redundant leading bare-key block from each model fragment, gave the nine former bleed-victim last-models explicit self-described metadata consistent with their equivalence groups, added a build-time validator (`leading_bare_key_error`, scoped to `60-models/`) that rejects leading bare keys, and regenerated `providers.toml` + `spec/provider-catalog/*.json`.

Tests: 3 validator unit tests + an embedded-catalog regression asserting `openai/gpt-oss-120b` is open-weight, vision-free, and tier-consistent with its group.

## Verification
- `cargo build` (whole workspace) clean.
- `cargo test -p harn-vm` (4000 tests) and `cargo test -p harn-cli` (908 tests) green.
- `.harn` agent suite (`harn test tests/agent/`, 43 tests) green; conformance `agent_runtime_features` green.
- Provider catalog gates green: `check-provider-config`, `check-provider-catalog`, `check-provider-catalog-drift`, `check-provider-capabilities`, `check-provider-matrix`, `check-provider-support`, `check-docs-model-refs`, `check-docs-snippets`.

## Follow-up note
The nine fragment-boundary bleed-victims now have explicit metadata I set to match their equivalence-group siblings / model semantics. These values are worth a quick reviewer sanity-check since the previous (bled-in) values were wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)