### PR TITLE
fix(security): strip secret env from run child + 0600 OAuth token file

### DIFF
--- a/changelog.d/run-env-secret-denylist.security.md
+++ b/changelog.d/run-env-secret-denylist.security.md
@@ -1,0 +1,11 @@
+- `run`/`command_run` no longer leak secret-bearing environment variables to
+  spawned child processes (and thus to the model, which reads child stdout as
+  the tool result). Under the default `inherit_clean`/`patch` env modes the
+  child environment now strips provider `*_API_KEY`s, `*_TOKEN`/`*_SECRET`/
+  `*_KEY` variables, and explicit names like `GITHUB_TOKEN`,
+  `HARN_CLOUD_API_KEY`, `BURIN_ADMIN_TOKEN`, and `AWS_SECRET_ACCESS_KEY`. Benign
+  build/toolchain vars (`PATH`, `HOME`, `LANG`, `CARGO_*`, …) are preserved, and
+  an explicit caller-supplied `env` is left untouched.
+- The file-backed OAuth/MCP token store now writes its sealed token file with
+  `0o600` permissions on Unix so a wide umask can't leave it group/world
+  readable.

--- a/crates/harn-hostlib/src/process/handle.rs
+++ b/crates/harn-hostlib/src/process/handle.rs
@@ -57,6 +57,67 @@ pub enum EnvMode {
     Patch,
 }
 
+/// Explicit secret-bearing environment variable names that the agent's
+/// `run`/`command_run` tool must never leak into a child process (and thus
+/// into the model context, since the child's stdout is returned to the
+/// model as the tool result). These are matched case-insensitively in
+/// addition to the suffix patterns in [`is_sensitive_env_name`].
+const EXPLICIT_SENSITIVE_ENV_NAMES: &[&str] = &[
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "HARN_CLOUD_API_KEY",
+    "BURIN_ADMIN_TOKEN",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+];
+
+/// Provider-namespace prefixes whose entire family of variables is treated
+/// as secret-bearing (e.g. `ANTHROPIC_API_KEY`, `OPENAI_ORG_ID`). Matched
+/// case-insensitively against the start of the variable name.
+const SENSITIVE_ENV_PREFIXES: &[&str] = &[
+    "ANTHROPIC_",
+    "OPENAI_",
+    "OPENROUTER_",
+    "FIREWORKS_",
+    "TOGETHER_",
+    "XAI_",
+    "GROQ_",
+];
+
+/// Returns `true` when an environment variable name looks like it carries a
+/// secret (provider API key, access token, OAuth client secret, etc.) and so
+/// must be stripped from a child process spawned by the agent's `run` tool.
+///
+/// The check is deliberately conservative about credentials but permissive
+/// about ordinary build/toolchain variables: `PATH`, `HOME`, `LANG`,
+/// `CARGO_HOME`, language toolchain vars, etc. are *not* sensitive and stay
+/// in the child environment so builds and tests still work.
+///
+/// Matching is case-insensitive and covers:
+/// - suffix patterns `_API_KEY`, `_TOKEN`, `_SECRET`, `_KEY`;
+/// - the provider prefixes in [`SENSITIVE_ENV_PREFIXES`];
+/// - the explicit names in [`EXPLICIT_SENSITIVE_ENV_NAMES`].
+pub fn is_sensitive_env_name(name: &str) -> bool {
+    let upper = name.to_ascii_uppercase();
+    if EXPLICIT_SENSITIVE_ENV_NAMES.contains(&upper.as_str()) {
+        return true;
+    }
+    if SENSITIVE_ENV_PREFIXES
+        .iter()
+        .any(|prefix| upper.starts_with(prefix))
+    {
+        return true;
+    }
+    // Suffix patterns catch the long tail of provider/service credentials
+    // (`*_API_KEY`, `*_TOKEN`, `*_SECRET`, `*_KEY`) without enumerating every
+    // vendor. `_KEY` is last and broadest; it still excludes benign names
+    // like `PATH`/`HOME`/`LANG` that don't end in these suffixes.
+    upper.ends_with("_API_KEY")
+        || upper.ends_with("_TOKEN")
+        || upper.ends_with("_SECRET")
+        || upper.ends_with("_KEY")
+}
+
 /// Parameters describing a single spawn. The spawner is responsible for any
 /// sandbox setup (Linux seccomp/landlock, macOS sandbox-exec, etc.) and for
 /// configuring the child's process group when requested.
@@ -211,4 +272,53 @@ pub fn current_spawner() -> Arc<dyn ProcessSpawner> {
 /// Spawn a process via the currently installed spawner.
 pub fn spawn_process(spec: SpawnSpec) -> Result<Box<dyn ProcessHandle>, ProcessError> {
     current_spawner().spawn(spec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_sensitive_env_name;
+
+    #[test]
+    fn denies_secret_bearing_names() {
+        // Suffix patterns.
+        assert!(is_sensitive_env_name("ANTHROPIC_API_KEY"));
+        assert!(is_sensitive_env_name("OPENAI_API_KEY"));
+        assert!(is_sensitive_env_name("SOME_VENDOR_TOKEN"));
+        assert!(is_sensitive_env_name("MY_CLIENT_SECRET"));
+        assert!(is_sensitive_env_name("RANDOM_KEY"));
+        // Explicit names.
+        assert!(is_sensitive_env_name("GITHUB_TOKEN"));
+        assert!(is_sensitive_env_name("GH_TOKEN"));
+        assert!(is_sensitive_env_name("HARN_CLOUD_API_KEY"));
+        assert!(is_sensitive_env_name("BURIN_ADMIN_TOKEN"));
+        assert!(is_sensitive_env_name("AWS_SECRET_ACCESS_KEY"));
+        assert!(is_sensitive_env_name("AWS_SESSION_TOKEN"));
+        // Provider prefixes (even without a key/token suffix).
+        assert!(is_sensitive_env_name("OPENROUTER_BASE_URL"));
+        assert!(is_sensitive_env_name("FIREWORKS_ACCOUNT"));
+        assert!(is_sensitive_env_name("TOGETHER_ORG"));
+        assert!(is_sensitive_env_name("XAI_REGION"));
+        assert!(is_sensitive_env_name("GROQ_PROJECT"));
+    }
+
+    #[test]
+    fn allows_benign_build_and_toolchain_names() {
+        assert!(!is_sensitive_env_name("PATH"));
+        assert!(!is_sensitive_env_name("HOME"));
+        assert!(!is_sensitive_env_name("CARGO_HOME"));
+        assert!(!is_sensitive_env_name("LANG"));
+        assert!(!is_sensitive_env_name("LC_ALL"));
+        assert!(!is_sensitive_env_name("TERM"));
+        assert!(!is_sensitive_env_name("USER"));
+        assert!(!is_sensitive_env_name("RUSTUP_HOME"));
+        assert!(!is_sensitive_env_name("CARGO_TARGET_DIR"));
+        assert!(!is_sensitive_env_name("SHELL"));
+    }
+
+    #[test]
+    fn matches_case_insensitively() {
+        assert!(is_sensitive_env_name("anthropic_api_key"));
+        assert!(is_sensitive_env_name("github_token"));
+        assert!(!is_sensitive_env_name("path"));
+    }
 }

--- a/crates/harn-hostlib/src/process/real.rs
+++ b/crates/harn-hostlib/src/process/real.rs
@@ -41,8 +41,26 @@ impl ProcessSpawner for RealSpawner {
             command.current_dir(cwd);
         }
 
-        if matches!(spec.env_mode, EnvMode::Replace) {
-            command.env_clear();
+        match spec.env_mode {
+            // `Replace` starts from an empty environment, so nothing to strip.
+            EnvMode::Replace => {
+                command.env_clear();
+            }
+            // `InheritClean`/`Patch` inherit the full parent environment. Strip
+            // secret-bearing variables (provider `*_API_KEY`s, `GITHUB_TOKEN`,
+            // `HARN_CLOUD_API_KEY`, etc.) so build/test commands — and the model
+            // that reads their stdout as the tool result — never see them.
+            // Caller-supplied `env` below is applied afterward and is an
+            // explicit opt-in, so it is intentionally not filtered here.
+            EnvMode::InheritClean | EnvMode::Patch => {
+                for (key, _) in std::env::vars_os() {
+                    if let Some(name) = key.to_str() {
+                        if super::handle::is_sensitive_env_name(name) {
+                            command.env_remove(&key);
+                        }
+                    }
+                }
+            }
         }
         for (key, value) in &spec.env {
             command.env(key, value);

--- a/crates/harn-hostlib/tests/process_tools_e2e.rs
+++ b/crates/harn-hostlib/tests/process_tools_e2e.rs
@@ -89,6 +89,63 @@ fn real_run_command_echoes_stdout_and_reports_exit_zero() {
 }
 
 #[test]
+fn real_run_command_strips_secret_env_from_child() {
+    // Regression for the provider-key exfiltration finding: under the default
+    // `InheritClean` env mode (no caller-supplied `env`), the agent `run` tool
+    // spawns a child that inherits the parent environment, and that child's
+    // stdout is returned to the model. Secret-bearing vars must be stripped so
+    // `run({command: "env"})` can't surface provider keys / tokens.
+    //
+    // SAFETY: setting/removing process-wide env vars is not thread-safe in
+    // general, but these names are unique to this test and removed before it
+    // returns, so no sibling test in this binary observes them.
+    unsafe {
+        std::env::set_var("ANTHROPIC_API_KEY", "sk-test-anthropic");
+        std::env::set_var("GITHUB_TOKEN", "ghp_test_github");
+        std::env::set_var("HARN_E2E_BENIGN_VAR", "keep-me");
+    }
+
+    let mut req = dict();
+    req.insert("argv".into(), vlist_str(&["env"]));
+    let resp = require_dict(call("hostlib_tools_run_command", req).unwrap());
+
+    unsafe {
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("GITHUB_TOKEN");
+        std::env::remove_var("HARN_E2E_BENIGN_VAR");
+    }
+
+    assert_eq!(require_int(&resp, "exit_code"), 0);
+    let child_env = require_str(&resp, "stdout");
+    assert!(
+        !child_env.contains("sk-test-anthropic"),
+        "ANTHROPIC_API_KEY leaked into child env:\n{child_env}"
+    );
+    assert!(
+        !child_env.contains("ghp_test_github"),
+        "GITHUB_TOKEN leaked into child env:\n{child_env}"
+    );
+    // Secret var NAMES (not just values) must also be gone, and a benign var +
+    // PATH must survive so real builds/tests still work.
+    assert!(
+        !child_env.contains("ANTHROPIC_API_KEY"),
+        "ANTHROPIC_API_KEY name still present in child env:\n{child_env}"
+    );
+    assert!(
+        !child_env.contains("GITHUB_TOKEN"),
+        "GITHUB_TOKEN name still present in child env:\n{child_env}"
+    );
+    assert!(
+        child_env.contains("HARN_E2E_BENIGN_VAR"),
+        "benign env var was incorrectly stripped:\n{child_env}"
+    );
+    assert!(
+        child_env.lines().any(|line| line.starts_with("PATH=")),
+        "PATH must remain available to child:\n{child_env}"
+    );
+}
+
+#[test]
 fn real_run_command_kills_child_when_timeout_elapses() {
     // Smoke: the real `wait_with_timeout` should fire SIGKILL when the
     // child blocks past the deadline. Use a very short sleep so the test

--- a/crates/harn-vm/src/stdlib/oauth_storage.rs
+++ b/crates/harn-vm/src/stdlib/oauth_storage.rs
@@ -553,6 +553,21 @@ fn write_file_entries(
                 tmp_path.display()
             ))
         })?;
+        // The envelope is AES-GCM sealed, but the on-disk file should still be
+        // owner-only so a wide umask (0644) can't leave it group/world-readable.
+        // Set the mode on the temp file before the rename so the final path is
+        // never observable at looser permissions.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(fs::Permissions::from_mode(0o600))
+                .map_err(|error| {
+                    VmError::Runtime(format!(
+                        "oauth storage: failed to set permissions on `{}`: {error}",
+                        tmp_path.display()
+                    ))
+                })?;
+        }
     }
     fs::rename(&tmp_path, path).map_err(|error| {
         VmError::Runtime(format!(
@@ -837,6 +852,28 @@ mod tests {
         let after = backend_get(&handle, "k").await.unwrap();
         assert!(matches!(after, VmValue::Nil));
         assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn file_backend_writes_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("tokens.bin");
+        let handle = match file_handle(path.to_str().unwrap(), b"correct-horse-battery-staple") {
+            VmValue::Dict(dict) => dict.as_ref().clone(),
+            other => panic!("expected dict handle, got {other:?}"),
+        };
+        backend_set(&handle, "k", &token_dict("super-secret"), None)
+            .await
+            .unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "expected token file mode 0o600, got {:o}",
+            mode & 0o777
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Security audit fixes (harn agent runtime)

Addresses two findings from the Burin Code + Harn agent-runtime security audit.

### F1 — HIGH (headline): `run` tool leaks provider API keys to the model

The `run`/`command_run` tool spawned child processes that **inherited the full parent environment unfiltered** (provider `*_API_KEY`s, `GITHUB_TOKEN`, `HARN_CLOUD_API_KEY`, `BURIN_ADMIN_TOKEN`, …), and the child's stdout is returned to the model as the tool result with no redaction (only the *persisted transcript* was scrubbed, via a separate clone). So `run({command:"env"})` / `printenv` / a build script echoing its env surfaced every secret into the LLM context — a direct **provider-key exfiltration-to-the-model** path.

**Root:** `crates/harn-hostlib/src/process/run_command.rs` resolves a missing `env` to `EnvMode::InheritClean`; `crates/harn-hostlib/src/process/real.rs` only called `env_clear()` for `EnvMode::Replace`, so `InheritClean`/`Patch` inherited everything despite the "Clean" name.

**Fix (defense at source):** under `InheritClean`/`Patch`, the spawner now strips secret-bearing variables from the child environment via a single testable helper `is_sensitive_env_name` (in `process/handle.rs`). Denylist:
- suffixes (case-insensitive): `_API_KEY`, `_TOKEN`, `_SECRET`, `_KEY`
- provider prefixes: `ANTHROPIC_`, `OPENAI_`, `OPENROUTER_`, `FIREWORKS_`, `TOGETHER_`, `XAI_`, `GROQ_`
- explicit names: `GITHUB_TOKEN`, `GH_TOKEN`, `HARN_CLOUD_API_KEY`, `BURIN_ADMIN_TOKEN`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`

`Replace` already clears; an explicit caller-supplied `env` is left untouched (the caller opted in); benign build/toolchain vars (`PATH`, `HOME`, `LANG`, `CARGO_*`, …) are preserved so builds/tests still work.

### F3 — LOW: file-backed MCP/OAuth token store not 0600

`crates/harn-vm/src/stdlib/oauth_storage.rs` (`write_file_entries`) wrote the token file via `File::create`+`rename` with no `set_permissions`, inheriting umask (often 0644). Contents are AES-GCM sealed, but the file should still be owner-only. Now `#[cfg(unix)]` chmod `0o600` on the temp file before the rename.

### Tests
- `is_sensitive_env_name` unit tests: denies the secret patterns/prefixes/names, allows `PATH`/`HOME`/`CARGO_HOME`/`LANG`/etc., case-insensitive.
- e2e: spawns `env` under default `inherit_clean` with fake `ANTHROPIC_API_KEY`/`GITHUB_TOKEN` in the parent env; asserts both names+values are **absent** from the child while a benign var and `PATH` survive.
- oauth_storage: asserts the written token file is mode `0o600` on Unix.

Verified: `cargo test -p harn-hostlib`, `cargo test -p harn-vm` (oauth_storage), `cargo build`, `cargo fmt --all --check`, `cargo clippy -p harn-hostlib -p harn-vm` all clean. Changelog fragment added under `changelog.d/`.

> Scope note: F3-CORS and F5-symlink-TOCTOU from the audit are intentionally **not** in this PR (separate follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)