### PR TITLE
Closes audit F5: fs write/delete symlink TOCTOU

### DIFF
--- a/changelog.d/audit-f5.security.md
+++ b/changelog.d/audit-f5.security.md
@@ -1,0 +1,12 @@
+- Closed a filesystem write/delete symlink-swap TOCTOU in the deterministic
+  `tools/{write_file, delete_file}` builtins (audit finding F5). The
+  workspace-scope check canonicalizes a copy of the path, but the subsequent
+  `write`/`remove_*` ran on the raw path and followed a symlink at the final
+  component at op time, so an in-workspace attacker could swap a check-passed
+  path for a symlink pointing outside the allowed roots and escape the
+  workspace. `write_file` now opens the final component with `O_NOFOLLOW` on
+  Unix (with an `lstat`-reject fallback elsewhere) so a symlink-final path is
+  rejected at open time rather than followed; `delete_file` re-validates an
+  escaping final-component symlink under the active policy and refuses to
+  remove through it. Normal in-root writes, overwrites, and deletes of real
+  files are unaffected.

--- a/crates/harn-hostlib/src/tools/file_io.rs
+++ b/crates/harn-hostlib/src/tools/file_io.rs
@@ -4,8 +4,8 @@
 //! Shapes are locked by `schemas/tools/{read_file,write_file,delete_file,list_directory}.{request,response}.json`.
 
 use std::fs as stdfs;
-use std::io::{Read, Seek};
-use std::path::PathBuf;
+use std::io::{Read, Seek, Write};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use base64::Engine;
@@ -180,10 +180,7 @@ pub(super) fn write_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
         }
     }
 
-    stdfs::write(&path, &bytes).map_err(|err| HostlibError::Backend {
-        builtin: WRITE_FILE_BUILTIN,
-        message: format!("write `{path_str}`: {err}"),
-    })?;
+    write_no_follow(WRITE_FILE_BUILTIN, &path, &path_str, &bytes)?;
 
     Ok(build_dict([
         ("path", str_value(&path_str)),
@@ -229,6 +226,19 @@ pub(super) fn delete_file(args: &[VmValue]) -> Result<VmValue, HostlibError> {
             });
         }
     };
+
+    // Defend against a symlink-swap TOCTOU: `enforce_path_scope` above
+    // canonicalized the path through any symlinks and validated where it
+    // *resolved*, but the actual `remove_*` runs on the raw path. If the
+    // final component is a symlink whose target now escapes the workspace
+    // roots, removing through it (notably `remove_dir_all`, which descends
+    // into a symlinked directory's real target) could delete out-of-root
+    // files. Re-validate the link target under the policy and reject an
+    // escaping symlink rather than following it. Removing an in-scope
+    // symlink, or a real file/dir, stays allowed.
+    if metadata.file_type().is_symlink() {
+        reject_escaping_symlink(DELETE_FILE_BUILTIN, &path, &path_str, FsAccess::Delete)?;
+    }
 
     // Capture the pre-image into any open snapshots before mutating disk
     // so a `session/restore_tool_call` can roll the delete back.
@@ -355,6 +365,122 @@ pub(super) fn list_directory(args: &[VmValue]) -> Result<VmValue, HostlibError> 
 
 fn file_size(metadata: &stdfs::Metadata) -> u64 {
     metadata.len()
+}
+
+/// Write `bytes` to `path` without ever following a symlink at the final
+/// path component.
+///
+/// `enforce_path_scope` validated where `path` *resolves* by canonicalizing
+/// a copy of it, but the subsequent disk write runs on the raw path and, by
+/// default, follows a symlink at write time. An attacker with in-workspace
+/// write access could swap the check-passed final component for a symlink
+/// pointing outside the allowed roots between the scope check and the write
+/// (a TOCTOU race), escaping the workspace.
+///
+/// On Unix we open with `O_NOFOLLOW`, which makes the kernel refuse to open
+/// the final component if it is a symlink — closing the race atomically, so
+/// the write targets the same inode the check observed (or fails). On other
+/// platforms we fall back to an `lstat` (no-follow) check on the final
+/// component before writing; this still rejects a symlink-final path,
+/// shrinking the race window to the gap between the `lstat` and the open
+/// (the OS sandbox layer remains the backstop there). Both paths keep
+/// behavior identical for the normal case: creating a new file and
+/// overwriting an existing real file inside the roots still succeed.
+fn write_no_follow(
+    builtin: &'static str,
+    path: &Path,
+    path_str: &str,
+    bytes: &[u8],
+) -> Result<(), HostlibError> {
+    let mut options = stdfs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        // libc::O_NOFOLLOW. Use the raw constant value so harn-hostlib does
+        // not need to take a direct `libc` dependency; the value is part of
+        // the stable Unix ABI across Linux and the BSDs/macOS.
+        #[cfg(target_os = "linux")]
+        const O_NOFOLLOW: i32 = 0x20000;
+        #[cfg(not(target_os = "linux"))]
+        const O_NOFOLLOW: i32 = 0x0100;
+        options.custom_flags(O_NOFOLLOW);
+    }
+
+    #[cfg(not(unix))]
+    {
+        // Cross-platform fallback: reject a symlink at the final component
+        // up front. lstat never follows the link, so this catches the swap
+        // without resolving it.
+        if let Ok(meta) = stdfs::symlink_metadata(path) {
+            if meta.file_type().is_symlink() {
+                return Err(HostlibError::SandboxViolation {
+                    builtin,
+                    path: path.display().to_string(),
+                    message: format!(
+                        "refusing to write `{path_str}`: final path component is a symlink \
+                         (potential workspace-escape via symlink swap)"
+                    ),
+                });
+            }
+        }
+    }
+
+    let mut file = options.open(path).map_err(|err| {
+        // On Unix an `O_NOFOLLOW` rejection of a symlink surfaces as ELOOP
+        // ("Too many levels of symbolic links"); report it as a sandbox
+        // violation rather than a generic backend error.
+        #[cfg(unix)]
+        if err.raw_os_error() == Some(40) {
+            return HostlibError::SandboxViolation {
+                builtin,
+                path: path.display().to_string(),
+                message: format!(
+                    "refusing to write `{path_str}`: final path component is a symlink \
+                     (potential workspace-escape via symlink swap)"
+                ),
+            };
+        }
+        HostlibError::Backend {
+            builtin,
+            message: format!("write `{path_str}`: {err}"),
+        }
+    })?;
+
+    file.write_all(bytes).map_err(|err| HostlibError::Backend {
+        builtin,
+        message: format!("write `{path_str}`: {err}"),
+    })
+}
+
+/// Reject deleting through a final-component symlink whose target escapes the
+/// active workspace roots.
+///
+/// `enforce_path_scope` canonicalized the path through the symlink and may
+/// have accepted it because the *target* was in-root at check time. Re-run
+/// the scope check on the link's resolved target so a swap to an
+/// out-of-root target is caught; if it now resolves outside the roots, the
+/// delete is refused. An in-scope symlink (or a real file/dir) is left for
+/// the caller to remove normally — `remove_file` unlinks a symlink itself
+/// without following it, so only the escaping case needs blocking.
+fn reject_escaping_symlink(
+    builtin: &'static str,
+    path: &Path,
+    path_str: &str,
+    access: FsAccess,
+) -> Result<(), HostlibError> {
+    // `enforce_path_scope` is a no-op when no restricted policy is active, so
+    // re-running it here re-derives the same verdict against the symlink's
+    // resolved target. If the target escapes the roots it now rejects.
+    enforce_path_scope(builtin, path, access).map_err(|_| HostlibError::SandboxViolation {
+        builtin,
+        path: path.display().to_string(),
+        message: format!(
+            "refusing to delete `{path_str}`: final path component is a symlink whose \
+             target escapes the workspace roots (potential symlink swap)"
+        ),
+    })
 }
 
 fn read_bytes(

--- a/crates/harn-hostlib/tests/fs_path_scope.rs
+++ b/crates/harn-hostlib/tests/fs_path_scope.rs
@@ -486,3 +486,141 @@ fn dict_field<'a>(value: &'a VmValue, key: &str) -> &'a VmValue {
         other => panic!("not a dict: {other:?}"),
     }
 }
+
+/// Regression for audit finding F5 (filesystem write/delete symlink-swap
+/// TOCTOU).
+///
+/// The scope check canonicalizes a *copy* of the path; the actual
+/// `write`/`remove_*` then ran on the raw path and followed a symlink at
+/// the final component at op time. An attacker with in-workspace write
+/// could plant a symlink at a check-passed path that points *outside* the
+/// roots, escaping the workspace on the subsequent write or delete.
+///
+/// A full race is impractical to drive deterministically, so this exercises
+/// the static guard two ways:
+///
+/// 1. An in-root symlink pointing *outside* — caught by the canonical
+///    scope check *and* the no-follow guard; the outside target must stay
+///    untouched.
+/// 2. An in-root symlink pointing to *another in-root* file — this passes
+///    the canonical scope check (its target is in-scope), so it isolates
+///    the new no-follow guard: the write must be refused / must not follow
+///    the link, leaving the link's in-root target unchanged. This is the
+///    case a swap-after-check would land on, made deterministic.
+///
+/// A normal in-root real-file write + overwrite + delete must still
+/// succeed (no regression).
+#[cfg(unix)]
+#[test]
+fn write_delete_reject_symlink_swap_escape() {
+    use std::os::unix::fs::symlink;
+
+    let root = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+
+    // A real, secret file living outside the workspace roots.
+    let secret = outside.path().join("secret.txt");
+    fs::write(&secret, "original-secret\n").unwrap();
+
+    // A symlink *inside* the root whose target escapes to the outside file.
+    let evil_link = root.path().join("evil_link.txt");
+    symlink(&secret, &evil_link).unwrap();
+
+    let reg = registry();
+    let _guard = PolicyGuard::worktree(&[root.path()]);
+
+    // (1) Writing through the in-root → outside symlink must NOT clobber the
+    // outside file.
+    let write_res = call(
+        &reg,
+        "hostlib_tools_write_file",
+        &[
+            ("path", vm_string(&path_string(&evil_link))),
+            ("content", vm_string("attacker-payload\n")),
+        ],
+    );
+    assert!(
+        write_res.is_err(),
+        "write through an escaping symlink must be rejected, got {write_res:?}"
+    );
+    assert_eq!(
+        fs::read_to_string(&secret).unwrap(),
+        "original-secret\n",
+        "the outside target must not be modified through the symlink"
+    );
+
+    // Deleting through the in-root → outside symlink must NOT remove the
+    // outside file.
+    let delete_res = call(
+        &reg,
+        "hostlib_tools_delete_file",
+        &[("path", vm_string(&path_string(&evil_link)))],
+    );
+    assert!(
+        delete_res.is_err(),
+        "delete through an escaping symlink must be rejected, got {delete_res:?}"
+    );
+    assert!(
+        secret.exists(),
+        "the outside target must not be deleted through the symlink"
+    );
+
+    // (2) Isolate the no-follow guard: a symlink whose target is *in-root*
+    // passes the canonical scope check, so only the new guard can stop the
+    // write from following it.
+    let in_root_target = root.path().join("victim.txt");
+    fs::write(&in_root_target, "victim-original\n").unwrap();
+    let benign_link = root.path().join("benign_link.txt");
+    symlink(&in_root_target, &benign_link).unwrap();
+    let write_through_in_root = call(
+        &reg,
+        "hostlib_tools_write_file",
+        &[
+            ("path", vm_string(&path_string(&benign_link))),
+            ("content", vm_string("payload-via-symlink\n")),
+        ],
+    );
+    assert!(
+        write_through_in_root.is_err(),
+        "the no-follow guard must refuse to write through a symlink-final path, got \
+         {write_through_in_root:?}"
+    );
+    assert_eq!(
+        fs::read_to_string(&in_root_target).unwrap(),
+        "victim-original\n",
+        "the symlink's target must not be modified by writing through the link"
+    );
+
+    // No regression: a normal in-root real file still writes, overwrites,
+    // and deletes cleanly.
+    let real = root.path().join("real.txt");
+    call(
+        &reg,
+        "hostlib_tools_write_file",
+        &[
+            ("path", vm_string(&path_string(&real))),
+            ("content", vm_string("v1\n")),
+        ],
+    )
+    .expect("in-root real-file create succeeds");
+    assert_eq!(fs::read_to_string(&real).unwrap(), "v1\n");
+
+    call(
+        &reg,
+        "hostlib_tools_write_file",
+        &[
+            ("path", vm_string(&path_string(&real))),
+            ("content", vm_string("v2\n")),
+        ],
+    )
+    .expect("in-root real-file overwrite succeeds");
+    assert_eq!(fs::read_to_string(&real).unwrap(), "v2\n");
+
+    call(
+        &reg,
+        "hostlib_tools_delete_file",
+        &[("path", vm_string(&path_string(&real)))],
+    )
+    .expect("in-root real-file delete succeeds");
+    assert!(!real.exists());
+}


### PR DESCRIPTION
## Audit finding F5 — filesystem write/delete symlink-swap TOCTOU

The deterministic `tools/{write_file, delete_file}` builtins in
`crates/harn-hostlib/src/tools/file_io.rs` ran their workspace-scope check
(`enforce_path_scope` → `check_fs_path_scope` → `normalize_for_policy`, which
canonicalizes a **copy** of the path), but the subsequent `std::fs::write` and
`remove_file`/`remove_dir`/`remove_dir_all` operated on the **raw** path and
followed a symlink at the final component **at op time**.

An attacker with in-workspace write access could swap a check-passed path for a
symlink pointing **outside** the allowed roots between the scope check and the
op (a classic TOCTOU race), escaping the workspace on write or delete.

## Fix

- **`write_file`**: replaced `std::fs::write` with `write_no_follow`, which
  opens the final component with **`O_NOFOLLOW`** on Unix
  (`OpenOptions::custom_flags`). The kernel refuses to open a symlink-final
  path, closing the race atomically so the write targets the same inode the
  check observed (or fails with a sandbox violation). On non-Unix it falls back
  to an `lstat` (`symlink_metadata`, no-follow) reject before opening. The raw
  `O_NOFOLLOW` value is inlined per-target so hostlib takes **no new `libc`
  dependency**.
- **`delete_file`**: when the final component is a symlink (already `lstat`'d),
  `reject_escaping_symlink` re-validates the resolved target under the active
  policy and refuses to remove through an escaping link (notably blocks
  `remove_dir_all` descending into a symlinked directory's real target).

Normal in-root creates, overwrites, and deletes of **real** files are
unaffected.

## Test

`write_delete_reject_symlink_swap_escape` in
`crates/harn-hostlib/tests/fs_path_scope.rs` (drives the public tool entry
points under a restricted `Worktree` policy):

1. Plants an in-root symlink → outside file; asserts write **and** delete are
   rejected and the outside target is untouched.
2. Plants an in-root symlink → another **in-root** file (passes the canonical
   scope check, so it **isolates the new no-follow guard** — this is the case a
   swap-after-check lands on, made deterministic); asserts the write is rejected
   and the link's target is unchanged.
3. Asserts a normal in-root real-file write + overwrite + delete still succeeds.

Verified the test **fails** without the guard (write-through succeeds, returns
`bytes_written: 20`) and **passes** with it.

## Verification

- `cargo test -p harn-hostlib` — 366+ pass, 0 fail (incl. all 7 `fs_path_scope`)
- `cargo build` (full workspace) — clean
- `cargo fmt --all --check` — clean
- `cargo clippy -p harn-hostlib --all-targets -- -D warnings` — clean

Adds `changelog.d/audit-f5.security.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)