### PR TITLE
fix(tools): strip leaked heredoc wrapper from tool args before dispatch

### DIFF
--- a/changelog.d/heredoc-wrapper-leak.fixed.md
+++ b/changelog.d/heredoc-wrapper-leak.fixed.md
@@ -1,0 +1,8 @@
+Stop a leaked tool-call heredoc wrapper from corrupting written files. When a model delivers a
+`content: <<EOF\n...\nEOF` value through a channel that never runs the heredoc grammar — a native
+JSON string `"<<EOF\n...\nEOF"`, or chat-template `<parameter=content>`/DSML markup — the `<<TAG`
+opener and closing sentinel previously leaked verbatim into the file, so the first line became a
+literal `<<EOF` (e.g. Zig: `expected type expression, found '<<'`) and the build failed. The
+dispatch normalizer (`normalize_tool_args`) now strips a value that is *entirely* one well-formed
+heredoc, recursing into nested `ops` arrays. A value that merely contains `<<` (a shift operator, a
+real mid-file `<<EOF`) or a partially-wrapping heredoc is left byte-identical.

--- a/crates/harn-vm/src/llm/tools/messages.rs
+++ b/crates/harn-vm/src/llm/tools/messages.rs
@@ -172,7 +172,48 @@ pub(crate) fn normalize_tool_args(name: &str, args: &serde_json::Value) -> serde
         }
     }
 
+    // Strip a leaked tool-call heredoc wrapper from any string argument that is
+    // *entirely* a `<<TAG\n...\nTAG` heredoc. The model is taught the
+    // `content: <<EOF\n...\nEOF` envelope, then sometimes delivers the value
+    // through a channel that never ran the heredoc grammar — a native JSON
+    // string `"<<EOF\n...\nEOF"`, or chat-template/DSML markup — so the opener
+    // and closing sentinel leak verbatim into the written file (e.g. Zig:
+    // `expected type expression, found '<<'`). This is the single chokepoint
+    // every dispatched call passes through, so it covers native and text
+    // channels alike; `unwrap_fully_wrapping_heredoc` is strict enough to leave
+    // a value that merely contains `<<` (a shift operator, a real mid-file
+    // `<<EOF`) byte-identical.
+    for value in obj.values_mut() {
+        strip_wrapping_heredoc_in_place(value);
+    }
+
     let mut normalized = serde_json::Value::Object(obj);
     coerce_integer_like_tool_args(&mut normalized);
     normalized
+}
+
+/// Recursively unwrap a leaked, fully-wrapping `<<TAG\n...\nTAG` heredoc from
+/// every string leaf of a tool-argument value. Recurses into nested
+/// objects/arrays so a batched `ops: [{ new_body: "<<EOF\n...\nEOF" }]` (the
+/// shape weak models emit through the native/markup channels) is healed the same
+/// way a top-level `content` is. Non-string, non-container leaves are untouched.
+fn strip_wrapping_heredoc_in_place(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::String(text) => {
+            if let Some(unwrapped) = crate::llm::tools::unwrap_fully_wrapping_heredoc(text) {
+                *text = unwrapped;
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items.iter_mut() {
+                strip_wrapping_heredoc_in_place(item);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for nested in map.values_mut() {
+                strip_wrapping_heredoc_in_place(nested);
+            }
+        }
+        _ => {}
+    }
 }

--- a/crates/harn-vm/src/llm/tools/mod.rs
+++ b/crates/harn-vm/src/llm/tools/mod.rs
@@ -25,6 +25,7 @@ pub(crate) use parse::parse_fenced_json_tool_calls;
 pub(crate) use parse::parse_text_tool_argument_payload;
 pub(crate) use parse::parse_text_tool_calls_in_format;
 pub(crate) use parse::parse_text_tool_calls_with_tools;
+pub(crate) use parse::unwrap_fully_wrapping_heredoc;
 pub(crate) use parse::StreamingToolCallDetector;
 pub(crate) use parse::TextToolFormat;
 #[cfg(test)]

--- a/crates/harn-vm/src/llm/tools/parse/mod.rs
+++ b/crates/harn-vm/src/llm/tools/parse/mod.rs
@@ -20,6 +20,7 @@ pub(crate) use native_json::parse_native_json_tool_calls;
 pub(crate) use streaming::StreamingToolCallDetector;
 pub(crate) use syntax::ident_length;
 pub(crate) use syntax::unescape_heredoc_body;
+pub(crate) use syntax::unwrap_fully_wrapping_heredoc;
 pub(crate) use syntax::{scan_heredoc, HeredocError};
 pub(crate) use tagged::parse_text_tool_calls_with_tools;
 

--- a/crates/harn-vm/src/llm/tools/parse/syntax.rs
+++ b/crates/harn-vm/src/llm/tools/parse/syntax.rs
@@ -742,6 +742,52 @@ pub(super) fn skip_heredoc_body(src: &str, start: usize) -> Option<usize> {
     scan_heredoc(src, start).ok().map(|span| span.end)
 }
 
+/// Unwrap a string value that is *entirely* one well-formed `<<TAG\n...\nTAG`
+/// heredoc, returning its body. Returns `None` for any value that is not a
+/// single fully-wrapping heredoc (the common case), so callers can leave the
+/// value byte-identical.
+///
+/// This is the defense against a heredoc leaking into a tool argument through a
+/// channel that never ran the heredoc grammar: the model is taught the
+/// `content: <<EOF\n...\nEOF` tool-call envelope, then (a) emits the value as a
+/// native JSON string `"<<EOF\n...\nEOF"`, or (b) nests it inside chat-template
+/// `<parameter=content><<EOF\n...\nEOF</parameter>` / DSML markup. In both cases
+/// the `<<TAG` opener and closing sentinel are the model's tool-call delimiters,
+/// not file content — but because the value arrived as a literal string, no
+/// parser stripped them, so the written file's first line becomes a literal
+/// `<<EOF` and the build fails (e.g. Zig: `expected type expression, found
+/// '<<'`). Unwrapping here makes the delimiters drop out exactly as they would
+/// have on the canonical bare-call heredoc path.
+///
+/// The match is deliberately strict to avoid corrupting a legitimate value that
+/// merely *contains* a `<<` (a shift operator, a merge-conflict marker, a bash
+/// `<<EOF` mid-file): the value must, after trimming surrounding whitespace,
+/// begin with a `<<TAG` opener AND have the heredoc's closing sentinel consume
+/// the entire remaining value. A heredoc that closes early (more content after
+/// the sentinel) is left untouched, because that trailing content would be lost.
+pub(crate) fn unwrap_fully_wrapping_heredoc(value: &str) -> Option<String> {
+    let trimmed = value.trim_start();
+    let lead = value.len() - trimmed.len();
+    // Cheap reject: a fully-wrapping heredoc must START with the `<<` opener.
+    if !trimmed.starts_with("<<") {
+        return None;
+    }
+    let span = scan_heredoc(value, lead).ok()?;
+    // The closing sentinel must consume the whole value (only trailing
+    // whitespace may follow). Anything else means the `<<TAG` was real content
+    // with a coincidental sentinel-looking line, or a partial wrap we must not
+    // silently truncate.
+    if !value[span.end..].trim().is_empty() {
+        return None;
+    }
+    let raw = &value[span.content.clone()];
+    if span.escaped {
+        Some(unescape_heredoc_body(raw))
+    } else {
+        Some(raw.to_string())
+    }
+}
+
 /// Outcome of searching for a tag while stepping over heredoc bodies.
 pub(super) enum CloseScan {
     /// The tag begins at this byte offset, outside any heredoc body.

--- a/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
+++ b/crates/harn-vm/src/llm/tools/tests/heredoc_and_messages.rs
@@ -1533,3 +1533,272 @@ fn thinking_tags_inside_arguments_round_trip_verbatim() {
         result.prose
     );
 }
+
+#[test]
+fn repro_zig_shift_operators_in_heredoc_body() {
+    // Zig source uses `<<`, `<<=`, and `>>` as shift operators. None of these
+    // are heredoc openers — they appear mid-line or even at a line start inside
+    // the body — and the captured `content` must equal the body byte-for-byte
+    // with no `<<TAG` opener/closer leaking in.
+    let tools = sample_tool_registry();
+    let body = "const std = @import(\"std\");\n\
+pub fn pack(a: u32, b: u32) u32 {\n\
+    return (a << 2) | (b >> 1);\n\
+}\n\
+test \"shift\" {\n\
+    var x: u32 = 1;\n\
+    x <<= 4;\n\
+    try std.testing.expect(x == 16);\n\
+}";
+    let text = format!(
+        "edit({{\n    action: \"create\",\n    path: \"src/writer.zig\",\n    content: <<EOF\n{body}\nEOF\n}})"
+    );
+    let result = parse_bare_calls_in_body(&text, Some(&tools));
+    assert_eq!(
+        result.calls.len(),
+        1,
+        "should parse one call, errors: {:?}",
+        result.errors
+    );
+    let content = result.calls[0]["arguments"]["content"].as_str().unwrap();
+    assert_eq!(
+        content, body,
+        "heredoc body with shift operators must be captured byte-for-byte"
+    );
+    assert!(
+        !content.contains("<<EOF"),
+        "the heredoc opener must never leak into content: {content:?}"
+    );
+}
+
+#[test]
+fn repro_heredoc_body_line_starts_with_double_angle() {
+    // A body line that *starts* with `<<` (a leading shift, or merge-conflict
+    // marker style) must stay literal content; it must not be read as a new
+    // heredoc opener or leak the delimiter.
+    let tools = sample_tool_registry();
+    let body = "pub fn f(x: u32) u32 {\n\
+    return x\n\
+        << 2;\n\
+}";
+    let text = format!(
+        "edit({{ action: \"create\", path: \"src/writer.zig\", content: <<EOF\n{body}\nEOF }})"
+    );
+    let result = parse_bare_calls_in_body(&text, Some(&tools));
+    assert_eq!(
+        result.calls.len(),
+        1,
+        "should parse one call, errors: {:?}",
+        result.errors
+    );
+    let content = result.calls[0]["arguments"]["content"].as_str().unwrap();
+    assert_eq!(
+        content, body,
+        "leading `<<` line must be preserved verbatim"
+    );
+}
+
+#[test]
+fn repro_heredoc_body_containing_delimiter_like_line() {
+    // A body line equal to the tag with trailing content (`EOF` used as an
+    // identifier prefix on its own line) is covered by the word-boundary rule.
+    // But a body line that is *exactly* the tag would close early. The model
+    // chooses a tag unlikely to appear; verify a near-collision (`EOFX`) does
+    // not terminate.
+    let tools = sample_tool_registry();
+    let body = "line one\nEOFX is not the tag\nline three";
+    let text =
+        format!("edit({{ action: \"create\", path: \"a.zig\", content: <<EOF\n{body}\nEOF }})");
+    let result = parse_bare_calls_in_body(&text, Some(&tools));
+    assert_eq!(result.calls.len(), 1, "errors: {:?}", result.errors);
+    let content = result.calls[0]["arguments"]["content"].as_str().unwrap();
+    assert_eq!(content, body, "near-collision tag line must not terminate");
+}
+
+#[test]
+fn repro_heredoc_body_contains_another_heredoc_opener_line() {
+    // The body itself contains a line `content: <<INNER` (e.g. the model is
+    // writing a Harn/eval fixture file that documents the tool format). The
+    // OUTER scan must run to its own `EOF` closer and capture the inner
+    // `<<INNER` line as literal content.
+    let tools = sample_tool_registry();
+    let body = "Example tool call:\ncontent: <<INNER\nsome inner text\nINNER\nend of example";
+    let text =
+        format!("edit({{ action: \"create\", path: \"doc.md\", content: <<EOF\n{body}\nEOF }})");
+    let result = parse_bare_calls_in_body(&text, Some(&tools));
+    assert_eq!(result.calls.len(), 1, "errors: {:?}", result.errors);
+    let content = result.calls[0]["arguments"]["content"].as_str().unwrap();
+    assert_eq!(content, body, "inner heredoc opener line must stay literal");
+}
+
+#[test]
+fn repro_top_level_chunker_heredoc_with_shift() {
+    // Drive the FULL tagged top-level parser (not just the bare body parser):
+    // a `<tool_call>` wrapping an edit whose content is Zig with `<<` shifts.
+    // The top-level chunker's `skip_heredoc_body` must step over the body and
+    // not let `<<` leak or mis-chunk.
+    let tools = sample_tool_registry();
+    let body = "pub fn f(a: u32) u32 {\n    return a << 3;\n}";
+    let text = format!(
+        "<tool_call>\nedit({{ action: \"create\", path: \"src/writer.zig\", content: <<EOF\n{body}\nEOF }})\n</tool_call>"
+    );
+    let result = parse_text_tool_calls_with_tools(&text, Some(&tools));
+    assert_eq!(
+        result.calls.len(),
+        1,
+        "errors: {:?} violations: {:?}",
+        result.errors,
+        result.violations
+    );
+    let content = result.calls[0]["arguments"]["content"].as_str().unwrap();
+    assert_eq!(
+        content, body,
+        "top-level chunker must capture shift body verbatim"
+    );
+}
+
+#[test]
+fn normalize_strips_native_json_leaked_heredoc_content() {
+    // Observed live (fw-gpt-oss-120b zig-feat): the model emits a NATIVE JSON
+    // tool call whose `content` value is itself the heredoc envelope
+    // `"<<EOF\n...\nEOF"`. Because it arrived as a valid JSON string, no parser
+    // stripped the delimiters, so the written file's first line became a literal
+    // `<<EOF` and Zig failed with `expected type expression, found '<<'`.
+    // normalize_tool_args is the universal dispatch chokepoint and must heal it.
+    let body = "fn valueMatchesType(value: []const u8) bool {\n    return value.len << 1 > 0;\n}";
+    let args = json!({
+        "action": "replace_range",
+        "path": "src/schema.zig",
+        "range_start": 121,
+        "range_end": 129,
+        "content": format!("<<EOF\n{body}\nEOF"),
+    });
+    let normalized = normalize_tool_args("edit", &args);
+    let content = normalized["content"].as_str().unwrap();
+    assert_eq!(
+        content, body,
+        "the leaked heredoc opener/closer must be stripped, leaving the body"
+    );
+    assert!(
+        !content.contains("<<EOF") && !content.starts_with("<<"),
+        "no `<<EOF` delimiter may remain: {content:?}"
+    );
+}
+
+#[test]
+fn normalize_strips_native_json_leaked_heredoc_with_trailing_whitespace() {
+    let body = "const x = 1;";
+    let args = json!({ "content": format!("  <<EOF\n{body}\nEOF\n  ") });
+    let normalized = normalize_tool_args("edit", &args);
+    assert_eq!(normalized["content"].as_str().unwrap(), body);
+}
+
+#[test]
+fn normalize_strips_leaked_heredoc_in_nested_ops_new_body() {
+    // Batched `ops: [{ new_body: "<<EOF\n...\nEOF" }]` through the native channel
+    // must be healed at every leaf, not just top-level args.
+    let body = "x +%= 1;";
+    let args = json!({
+        "path": "a.zig",
+        "ops": [
+            { "op": "replace_body", "function_name": "f", "new_body": format!("<<EOF\n{body}\nEOF") }
+        ],
+    });
+    let normalized = normalize_tool_args("edit", &args);
+    let nb = normalized["ops"][0]["new_body"].as_str().unwrap();
+    assert_eq!(nb, body, "nested leaked heredoc must be stripped: {nb:?}");
+}
+
+#[test]
+fn normalize_preserves_content_that_merely_contains_double_angle() {
+    // A real Zig body using `<<` shift operators (not a wrapping heredoc) must
+    // pass through byte-identical — the strip is strictly opt-in on a value
+    // that is ENTIRELY one heredoc.
+    let body = "pub fn f(a: u32) u32 {\n    return a << 2;\n}";
+    let args = json!({ "action": "create", "path": "a.zig", "content": body });
+    let normalized = normalize_tool_args("edit", &args);
+    assert_eq!(
+        normalized["content"].as_str().unwrap(),
+        body,
+        "content with shift operators must be byte-identical"
+    );
+}
+
+#[test]
+fn normalize_preserves_partial_heredoc_wrap_with_trailing_content() {
+    // A heredoc that closes EARLY (content after the sentinel) is NOT a clean
+    // full wrap; unwrapping would silently drop the trailing bytes, so we leave
+    // the value untouched.
+    let value = "<<EOF\nbody line\nEOF\nORPHAN TRAILING CONTENT";
+    let args = json!({ "content": value });
+    let normalized = normalize_tool_args("edit", &args);
+    assert_eq!(
+        normalized["content"].as_str().unwrap(),
+        value,
+        "a partially-wrapping heredoc must be left byte-identical"
+    );
+}
+
+#[test]
+fn normalize_strips_function_markup_leaked_heredoc_via_full_parse() {
+    // End-to-end: chat-template function markup where the model nested a heredoc
+    // inside `<parameter=content>`. The markup parser keeps the param value
+    // verbatim (so `content` is `<<EOF\n...\nEOF`), and the dispatch chokepoint
+    // then strips the wrapper. Drive the real tagged parser + normalize.
+    let tools = sample_tool_registry();
+    let body = "fn f() void {\n    var x: u32 = 1;\n    x <<= 4;\n}";
+    let text = format!(
+        "<tool_call>\n<function=edit>\n<parameter=action>\ncreate\n</parameter>\n<parameter=path>\nsrc/writer.zig\n</parameter>\n<parameter=content>\n<<EOF\n{body}\nEOF\n</parameter>\n</function>\n</tool_call>"
+    );
+    let result = parse_text_tool_calls_with_tools(&text, Some(&tools));
+    assert_eq!(
+        result.calls.len(),
+        1,
+        "errors: {:?} violations: {:?}",
+        result.errors,
+        result.violations
+    );
+    let raw = result.calls[0]["arguments"]["content"].as_str().unwrap();
+    // The markup parser itself keeps the heredoc verbatim...
+    assert!(
+        raw.starts_with("<<EOF"),
+        "function-markup keeps the param value verbatim: {raw:?}"
+    );
+    // ...and the dispatch normalizer strips the leaked wrapper.
+    let normalized = normalize_tool_args("edit", &result.calls[0]["arguments"]);
+    assert_eq!(
+        normalized["content"].as_str().unwrap(),
+        body,
+        "normalize must strip the function-markup-nested heredoc wrapper"
+    );
+}
+
+#[test]
+fn normalize_preserves_markdown_fenced_content() {
+    // A markdown ```fence``` is legitimate file content (the model is NOT taught
+    // to wrap tool-call values in fences), so it must pass through untouched.
+    // This documents that the heredoc strip is heredoc-specific and does not
+    // generalize to other delimiter-bearing content classes.
+    let body = "# Title\n\n```rust\nfn main() {}\n```\nDone.";
+    let args = json!({ "action": "create", "path": "README.md", "content": body });
+    let normalized = normalize_tool_args("edit", &args);
+    assert_eq!(
+        normalized["content"].as_str().unwrap(),
+        body,
+        "markdown fenced content must be byte-identical"
+    );
+}
+
+#[test]
+fn normalize_preserves_legit_file_that_is_entirely_a_bash_heredoc() {
+    // Edge case: the file content the model is legitimately writing IS itself a
+    // shell heredoc that happens to close at end-of-content. This is the one
+    // shape the strict unwrap will collapse — but it collapses to exactly the
+    // body, which is the only sensible interpretation when the value is byte-
+    // for-byte a single `<<TAG\n...\nTAG`. Asserting the documented behavior so a
+    // future change is a conscious decision, not an accident.
+    let body = "echo hello\necho world";
+    let args = json!({ "content": format!("<<SH\n{body}\nSH") });
+    let normalized = normalize_tool_args("edit", &args);
+    assert_eq!(normalized["content"].as_str().unwrap(), body);
+}


### PR DESCRIPTION
## Problem

Cheap-model zig runs were failing not on capability but on a **tool-call parser leak**: the `<<TAG` heredoc opener (and its closing sentinel) was ending up verbatim inside the file the agent wrote, so the first line became a literal `<<EOF` and the Zig compiler reported `expected type expression, found '<<'`. The model then thrashed — re-cleaning and re-inserting its patch across the whole budget with **0 files successfully written** (zig-feat: 30/23/32 edit attempts; zig-test: file churns 620→804→616 lines).

## Root cause (structured forensics on fw-gpt-oss-120b zig trials)

The model is taught the `content: <<EOF\n...\nEOF` tool-call envelope. But it delivers that value through channels that **never run the heredoc grammar**, and the wrapper leaks:

1. **Native JSON tool calls** — `function.arguments.content` is the literal string `"<<EOF\n...\nEOF"`. Valid JSON, so it passes through untouched. (`eval-zig-feat-...e65bb06b` id 374: native arg `content` begins `<<EOF\ntest "schema validation...`.)
2. **Chat-template function markup** — `<parameter=content><<EOF\n...\nEOF</parameter>`. `function_markup_param_value` keeps string params verbatim. (`eval-zig-feat-...760bb88d` id 254: parsed `content` is `<<EOF\nfn valueMatchesType(...)\n...\nEOF`.)

The well-formed *bare-call* heredoc path (`scan_heredoc`) was already robust to `<<` operators inside bodies — verified with new regression tests. The leak is exclusively on these non-heredoc-aware channels.

## Fix

`normalize_tool_args` is the single dispatch chokepoint every tool call passes through (native + text). Add `unwrap_fully_wrapping_heredoc` (reusing the `scan_heredoc` grammar authority) and strip a string arg that is **entirely** one well-formed `<<TAG\n...\nTAG` heredoc, recursing into nested `ops` arrays. One fix heals all channels.

Strictly opt-in: a value that merely contains `<<` (a shift operator, a real mid-file `<<EOF`) or a partially-wrapping heredoc is left **byte-identical**. Markdown fences and other content classes are untouched.

## Other content classes

Checked: markdown ```` ``` ```` fences and shift/operator content are **not** stripped (regression tests assert byte-identity) — the model is only taught heredoc as the value envelope, so only heredoc is a leak vector.

## Tests / verification

- `cargo nextest`-equivalent `cargo test -p harn-vm --lib llm::tools` → **251 passed**; full heredoc file **76 passed**.
- Test-first: the 4 strip tests **fail on origin/main** (delimiters remain) and pass with the fix; the negative tests pass both ways.
- `cargo fmt --all --check` clean; `cargo clippy -p harn-vm --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)