### PR TITLE
fix(catalog): declare vision on the local gemma-4 route (#3585)

### DIFF
--- a/changelog.d/3585.fixed.md
+++ b/changelog.d/3585.fixed.md
@@ -1,0 +1,1 @@
+Declare vision on the local Gemma 4 capability route so its emitted `capability_tags` and structured caps agree with the model's real multimodality and its hosted siblings (gemini/openrouter/together/nvidia). Previously the local OpenAI-compat `gemma-4*` rule dropped `vision`, giving hosts an inconsistent, route-dependent capability view.

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -2331,6 +2331,28 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
     }
 
     #[test]
+    fn local_gemma4_exposes_vision_like_hosted_siblings() {
+        // harn#3585: Gemma 4 is multimodal on every served surface. The local
+        // OpenAI-compat route must declare vision so the derived structured caps
+        // and the emitted `capability_tags` agree with the gemini/openrouter/
+        // together siblings — previously the local route dropped `vision`,
+        // contradicting the model's real multimodality and the structured caps.
+        reset();
+        for model in ["gemma-4-e4b-it", "gemma-4-e2b-it", "gemma-4-26b-a4b-it"] {
+            let caps = lookup("local", model);
+            assert!(
+                caps.vision_supported,
+                "local {model} should expose vision_supported"
+            );
+            let tags = crate::llm_config::capability_tags_from_capabilities(&caps);
+            assert!(
+                tags.iter().any(|t| t == "vision"),
+                "local {model} emitted capability_tags should include `vision`, got {tags:?}"
+            );
+        }
+    }
+
+    #[test]
     fn ollama_vision_models_have_no_reasoning_scaffold() {
         // Fix B: bakllava / llama3.2-vision / gemma3 are caption/vision models
         // with no reasoning capability; they must resolve to the "none" thinking

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -1476,6 +1476,12 @@ native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
+# Gemma 4 is genuinely multimodal (text+image) on every served surface, so the
+# local OpenAI-compat route exposes vision just like the gemini/openrouter/
+# together siblings (see 50-gemini-gemma.toml). Without this the emitted
+# `capability_tags` drop `vision` for the local route, contradicting the
+# structured caps and the model's real multimodality (harn#3585).
+vision_supported = true
 server_parser = "none"
 honors_chat_template_kwargs = false
 recommended_endpoint = "/v1/chat/completions"

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/20-local-ollama.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/20-local-ollama.toml
@@ -349,6 +349,12 @@ native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"
 thinking_modes = ["enabled"]
+# Gemma 4 is genuinely multimodal (text+image) on every served surface, so the
+# local OpenAI-compat route exposes vision just like the gemini/openrouter/
+# together siblings (see 50-gemini-gemma.toml). Without this the emitted
+# `capability_tags` drop `vision` for the local route, contradicting the
+# structured caps and the model's real multimodality (harn#3585).
+vision_supported = true
 server_parser = "none"
 honors_chat_template_kwargs = false
 recommended_endpoint = "/v1/chat/completions"

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -96,7 +96,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `llamacpp` | `*devstral-small-2*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `json` | no | yes | `text_only` | yes | no |
 | `local` | `*qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `local` | `*qwen3*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `local` | `gemma-4*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `local` | `gemma-4*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `minimax` | `minimax-m3*` | `any` | `adaptive` | yes | no | no | yes | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `minimax` | `minimax-m2.7*` | `any` | `enabled` | no | no | no | no | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `json` | yes | yes | `native_unreliable` | yes | yes |
 | `minimax` | `minimax-m2.5*` | `any` | `enabled` | no | no | no | no | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -6101,7 +6101,8 @@
       "stream_timeout": 300.0,
       "modalities": {
         "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -6144,6 +6145,7 @@
       "capability_tags": [
         "streaming",
         "tools",
+        "vision",
         "thinking",
         "structured_output"
       ],
@@ -6168,7 +6170,8 @@
       "stream_timeout": 600.0,
       "modalities": {
         "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -6211,6 +6214,7 @@
       "capability_tags": [
         "streaming",
         "tools",
+        "vision",
         "thinking",
         "structured_output"
       ],
@@ -6233,7 +6237,8 @@
       "stream_timeout": 600.0,
       "modalities": {
         "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -6276,6 +6281,7 @@
       "capability_tags": [
         "streaming",
         "tools",
+        "vision",
         "thinking",
         "structured_output"
       ],
@@ -6299,7 +6305,8 @@
       "stream_timeout": 300.0,
       "modalities": {
         "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -6342,6 +6349,7 @@
       "capability_tags": [
         "streaming",
         "tools",
+        "vision",
         "thinking",
         "structured_output"
       ],
@@ -6365,7 +6373,8 @@
       "stream_timeout": 300.0,
       "modalities": {
         "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -6408,6 +6417,7 @@
       "capability_tags": [
         "streaming",
         "tools",
+        "vision",
         "thinking",
         "structured_output"
       ],


### PR DESCRIPTION
## Problem (#3585)

`gemma-4-e4b-it` had three disagreeing capability representations. The root cause of the *emitted-tags* drift: the `local` OpenAI-compat capability rule for `gemma-4*` declared `native_tools` + `thinking_modes` but **omitted vision**, while every hosted sibling (`gemini`, `openrouter`, `together`, `nvidia`) declares `vision_supported = true`. So `capability_tags_from_capabilities(lookup("local", "gemma-4-e4b-it"))` dropped `vision`, contradicting the structured caps and the model's real multimodality. Hosts reading `capability_tags` got an under-specified, internally-inconsistent view that drifts between provider routes.

## Fix

- Add `vision_supported = true` to the `local` `gemma-4*` rule in `capability_sources/20-providers/20-local-ollama.toml`.
- Regenerate `capabilities.toml` (`harn providers build-capabilities`) and `docs/src/provider-matrix.md` (`harn providers matrix`) — provider-support artifacts unchanged.
- Add a regression test (`local_gemma4_exposes_vision_like_hosted_siblings`) asserting both `vision_supported` and the emitted `vision` tag for the e4b/e2b/26b local routes.

## Audit (#3585 ask 2)

Checked the other multimodal rules: the `gemini`/`openrouter`/`together`/`nvidia` `gemma-4*` rules and the Ollama vision models already declare vision. This drop was **local-gemma-specific**, not a general emitter bug — the emitter (`capability_tags_from_capabilities`) already adds `vision` whenever `vision || vision_supported`.

## Remaining (out of scope here)

Ask 3 (a standing fragment ↔ structured-caps ↔ emitted-tags consistency gate) is broader infra; the hand-authored display `capabilities` field on the catalog fragment is independent of the derived/emitted tags. Tracked on the issue.

## Verification

- `cargo test -p harn-vm --lib gemma4` → 4 passed (incl. new test).
- `make check-provider-capabilities check-provider-matrix check-provider-support` → all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)