### PR TITLE
fix(tools): decode surrogate-pair \u escapes and keep unknown-escape backslashes

### DIFF
--- a/crates/harn-vm/src/llm/tools/tests/mod.rs
+++ b/crates/harn-vm/src/llm/tools/tests/mod.rs
@@ -23,6 +23,7 @@ mod function_markup;
 mod heredoc_and_messages;
 mod native_tools;
 mod reserved_token;
+mod string_escape_fidelity;
 mod validation_and_tagged;
 
 pub(super) fn vm_dict(pairs: &[(&str, VmValue)]) -> VmValue {

--- a/crates/harn-vm/src/llm/tools/tests/string_escape_fidelity.rs
+++ b/crates/harn-vm/src/llm/tools/tests/string_escape_fidelity.rs
@@ -1,0 +1,123 @@
+//! Cross-channel fidelity regressions for the TypeScript tool-argument
+//! parser: a tool value must decode to the SAME bytes whether the model
+//! delivered it via a double/single-quoted string, a template literal, or a
+//! heredoc. Two silent-corruption bugs are pinned here (both failed on
+//! origin/main before the fix in `ts_value_parser.rs`):
+//!
+//!   1. A non-BMP scalar written as a UTF-16 surrogate pair (`😀`,
+//!      the form `JSON.stringify` and most provider APIs emit) errored with
+//!      `invalid \u escape` and the ENTIRE tool call was dropped.
+//!   2. An unknown escape (`\d`, `\w`, `\b` regex; `\begin` LaTeX) inside a
+//!      double/single-quoted string silently dropped the backslash (`"\d+"`
+//!      -> `d+`), while the template-literal and heredoc channels preserved it.
+
+use super::{json, parse_bare_calls_in_body, sample_tool_registry};
+
+/// A non-BMP scalar delivered as a `😀` surrogate pair (😀, U+1F600)
+/// must decode to that scalar, not drop the call. Source bytes literally
+/// contain `😀` (non-raw Rust literal so `\\u` => backslash-u).
+#[test]
+fn surrogate_pair_escape_decodes_and_keeps_call() {
+    let tools = sample_tool_registry();
+    let src = "run({ command: \"hi \\uD83D\\uDE00 there\" })";
+    let result = parse_bare_calls_in_body(src, Some(&tools));
+    assert!(
+        result.errors.is_empty(),
+        "surrogate pair should not error: {:?}",
+        result.errors
+    );
+    assert_eq!(result.calls.len(), 1, "call must not be dropped");
+    assert_eq!(
+        result.calls[0]["arguments"]["command"],
+        json!("hi \u{1F600} there")
+    );
+}
+
+/// The `\u{1F600}` brace form already decodes a full astral scalar — keep it
+/// working (guards against a regression in the shared `parse_unicode_escape`).
+#[test]
+fn brace_form_nonbmp_escape_decodes() {
+    let tools = sample_tool_registry();
+    let src = r#"run({ command: "hi \u{1F600} there" })"#;
+    let result = parse_bare_calls_in_body(src, Some(&tools));
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert_eq!(
+        result.calls[0]["arguments"]["command"],
+        json!("hi \u{1F600} there")
+    );
+}
+
+/// A lone high surrogate with no following low surrogate is genuinely invalid
+/// and must still be rejected (no silent half-character, no panic).
+#[test]
+fn lone_high_surrogate_still_rejected() {
+    let tools = sample_tool_registry();
+    let src = "run({ command: \"x \\uD83D y\" })";
+    let result = parse_bare_calls_in_body(src, Some(&tools));
+    assert!(
+        !result.errors.is_empty() || result.calls.is_empty(),
+        "a lone surrogate must not silently produce a value: {:?}",
+        result.calls
+    );
+}
+
+/// Regex `\d+\w*` written through a double-quoted string must keep its
+/// backslashes — same bytes the heredoc and template channels produce.
+#[test]
+fn unknown_escape_in_quoted_string_keeps_backslash() {
+    let tools = sample_tool_registry();
+    let result = parse_bare_calls_in_body(
+        r#"edit({ action: "create", path: "re.py", content: "p = '\d+\w*'" })"#,
+        Some(&tools),
+    );
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert_eq!(
+        result.calls[0]["arguments"]["content"],
+        json!("p = '\\d+\\w*'")
+    );
+}
+
+/// Cross-channel byte-identity: the SAME regex content delivered via a
+/// double-quoted string, a template literal, and a heredoc must decode to one
+/// identical value. (Before the fix the quoted channel diverged: `d+w*`.)
+#[test]
+fn regex_content_identical_across_channels() {
+    let tools = sample_tool_registry();
+    let expected = json!("p = '\\d+\\w*'");
+
+    let quoted = parse_bare_calls_in_body(
+        r#"edit({ action: "create", path: "re.py", content: "p = '\d+\w*'" })"#,
+        Some(&tools),
+    );
+    let template = parse_bare_calls_in_body(
+        "edit({ action: \"create\", path: \"re.py\", content: `p = '\\d+\\w*'` })",
+        Some(&tools),
+    );
+    let heredoc = parse_bare_calls_in_body(
+        "edit({ action: \"create\", path: \"re.py\", content: <<EOF\np = '\\d+\\w*'\nEOF\n })",
+        Some(&tools),
+    );
+
+    assert_eq!(quoted.calls[0]["arguments"]["content"], expected, "quoted");
+    assert_eq!(
+        template.calls[0]["arguments"]["content"], expected,
+        "template"
+    );
+    assert_eq!(
+        heredoc.calls[0]["arguments"]["content"], expected,
+        "heredoc"
+    );
+}
+
+/// Known escapes inside a quoted string still decode (no over-correction):
+/// `\n` `\t` stay control chars, `\\` stays one backslash, `\"` stays a quote.
+#[test]
+fn known_escapes_in_quoted_string_unchanged() {
+    let tools = sample_tool_registry();
+    let result = parse_bare_calls_in_body(r#"run({ command: "a\nb\tc\\d\"e" })"#, Some(&tools));
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+    assert_eq!(
+        result.calls[0]["arguments"]["command"],
+        json!("a\nb\tc\\d\"e")
+    );
+}

--- a/crates/harn-vm/src/llm/tools/ts_value_parser.rs
+++ b/crates/harn-vm/src/llm/tools/ts_value_parser.rs
@@ -320,7 +320,13 @@ impl<'a> TsValueParser<'a> {
                         out.push(char::from_u32(code)?);
                         pos += 2;
                     }
-                    other => out.push(other as char),
+                    // Unknown escape: keep the backslash AND the char. See the
+                    // `parse_string_literal` arm for the rationale — preserving
+                    // `\d`/`\w`/`\b` (regex), `\begin` (LaTeX), `\section`, etc.
+                    other => {
+                        out.push('\\');
+                        out.push(other as char);
+                    }
                 }
             } else if b == quote {
                 // Candidate close: is the continuation a valid object boundary?
@@ -436,7 +442,20 @@ impl<'a> TsValueParser<'a> {
                                 return Err("invalid \\x code point".to_string());
                             }
                         }
-                        other => out.push(other as char),
+                        // Unknown escape (`\d`, `\w`, `\b`, `\s` regex; `\begin`
+                        // LaTeX; `\section`; a Windows path's `\U`): keep BOTH the
+                        // backslash and the char. JS would collapse `\d` to `d`,
+                        // but tool arguments are content, not evaluated JS — the
+                        // model means the literal `\d`, and the template-literal,
+                        // heredoc, and native-JSON channels all preserve it. The
+                        // bare double/single-quoted channel silently dropping the
+                        // backslash was a cross-channel inconsistency that
+                        // corrupted every regex/LaTeX/format-string the model
+                        // delivered through quotes (`"\d+"` -> `d+`).
+                        other => {
+                            out.push('\\');
+                            self.push_scalar(&mut out, other);
+                        }
                     }
                 }
                 Some(b) => {
@@ -634,6 +653,16 @@ impl<'a> TsValueParser<'a> {
 
 /// Parse a `\uXXXX` or `\u{XXXXXX}` escape starting at bytes[0]. Returns the
 /// decoded character AND the number of bytes consumed after the `\u`.
+///
+/// The plain 4-hex `\uXXXX` form decodes a single UTF-16 code unit, so a
+/// non-BMP scalar (emoji, CJK extension B+, math alphanumerics) arrives as a
+/// **surrogate pair** `😀` — exactly what `JSON.stringify` and most
+/// provider APIs emit. A lone surrogate is not a valid `char`, so without
+/// pairing them `char::from_u32` returns `None`, the caller reports
+/// `invalid \u escape`, and the ENTIRE tool call is dropped (the model's
+/// `edit`/`write` silently never lands). Detect a high surrogate and fold the
+/// following `\uXXXX` low surrogate into the astral scalar, consuming its `\u`
+/// prefix too. The `\u{...}` brace form already carries the full scalar.
 fn parse_unicode_escape(bytes: &[u8]) -> Option<(char, usize)> {
     if bytes.first() == Some(&b'{') {
         // \u{XXXXXX}
@@ -644,7 +673,26 @@ fn parse_unicode_escape(bytes: &[u8]) -> Option<(char, usize)> {
     } else if bytes.len() >= 4 {
         let hex = std::str::from_utf8(&bytes[..4]).ok()?;
         let code = u32::from_str_radix(hex, 16).ok()?;
-        Some((char::from_u32(code)?, 4))
+        if let Some(ch) = char::from_u32(code) {
+            return Some((ch, 4));
+        }
+        // `code` is a surrogate (0xD800..=0xDFFF), invalid as a lone scalar.
+        // If it is a high surrogate followed by `\uXXXX` low surrogate, combine
+        // them into the astral code point. The trailing `\u` (2 bytes) plus its
+        // 4 hex digits are consumed in addition to the first form's 4.
+        if (0xD800..=0xDBFF).contains(&code)
+            && bytes.get(4) == Some(&b'\\')
+            && bytes.get(5) == Some(&b'u')
+            && bytes.len() >= 10
+        {
+            let low_hex = std::str::from_utf8(&bytes[6..10]).ok()?;
+            let low = u32::from_str_radix(low_hex, 16).ok()?;
+            if (0xDC00..=0xDFFF).contains(&low) {
+                let scalar = 0x1_0000 + ((code - 0xD800) << 10) + (low - 0xDC00);
+                return Some((char::from_u32(scalar)?, 10));
+            }
+        }
+        None
     } else {
         None
     }


### PR DESCRIPTION
## Two silent tool-arg corruption bugs in the TypeScript value parser

Same class as the heredoc-wrapper leak (#3587): a model delivers content through the `name({ key: "value" })` text channel and the parser silently mangles or drops it. Both confirmed with cross-channel round-trip tests that FAIL on origin/main and pass with this fix.

### Bug A — surrogate pairs drop the entire tool call (HIGH)

`parse_unicode_escape` decoded the plain 4-hex `\uXXXX` form with a single `char::from_u32`, which returns `None` for a lone UTF-16 surrogate (`0xD800..=0xDFFF`). But a non-BMP scalar — any emoji, CJK-extension-B char, or math-alphanumeric — is exactly what `JSON.stringify` and most provider APIs emit, as a **surrogate pair** `😀`. So `run({ command: "hi 😀" })` errored `invalid \u escape` and the **whole tool call was dropped** (`calls=[]`) — the model authored no edit and thrashed.

**Fix:** when the 4-hex form yields a high surrogate, fold the following `\uXXXX` low surrogate into the astral scalar. A lone high surrogate is still rejected.

### Bug B — unknown escapes silently drop the backslash in quoted strings (HIGH)

`parse_string_literal` and `recover_overclosed_object_string` had `other => out.push(other as char)` for unknown escapes, **dropping the `\`**. So a Python regex `"p = '\d+\w*'"` decoded to `p = 'd+w*'` — corrupting every regex (`\d \w \s \b`), LaTeX (`\begin`), and printf format string delivered through a double/single-quoted string. The template-literal and heredoc channels already preserve `\d`, so the same content corrupted or survived purely by which quote style the model happened to pick:

| channel | `\d+\w*` decodes to |
|---|---|
| heredoc (taught envelope) | `\d+\w*` ✓ |
| template literal | `\d+\w*` ✓ |
| **double/single-quoted (before)** | **`d+w*`** ✗ |

**Fix:** keep both the backslash and the char for unknown escapes, matching the template-literal, heredoc, and native-JSON channels. Known escapes (`\n \t \\ \" \' \u \x` + line continuation) are unchanged.

## Tests / verification

- New `string_escape_fidelity.rs`: 6 cross-channel fidelity regressions. **Test-first** — `surrogate_pair_*`, `unknown_escape_*`, and `regex_content_identical_across_channels` FAIL on origin/main; `lone_high_surrogate_still_rejected`, `brace_form_nonbmp_escape_decodes`, and `known_escapes_in_quoted_string_unchanged` pass both ways (guards against over-correction).
- `cargo test -p harn-vm --lib llm::tools` → **259 passed**.
- `cargo fmt --all --check` clean; `cargo clippy -p harn-vm --lib` clean.

Pure correctness bugs (silent content corruption / dropped call), so default-on like #3587 — no flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)