### PR TITLE
fix(tools): degrade malformed \x/\u escapes to literal instead of dropping the call

### DIFF
--- a/changelog.d/3592.fixed.md
+++ b/changelog.d/3592.fixed.md
@@ -1,0 +1,9 @@
+Stop a malformed `\x`/`\u` escape from dropping a whole tool call in the `name({ key: "value" })`
+text channel. A double/single-quoted string value containing Perl/PCRE `\x{1F600}`, a Windows path
+`C:\users\me`, a trailing `\x`, a short `\uAB`, or `\uABCG` previously errored with `invalid \x/\u
+escape` and the entire `edit`/`run` call was discarded — the model authored nothing and thrashed
+(the same class as the surrogate-pair drop, generalized to every other malformed-known-escape
+shape). The parser now degrades any escape that is not a complete `\xHH` / `\uHHHH` / `\u{...}` to
+its literal `\x`/`\u` bytes, byte-identical to the heredoc and template-literal channels, so the
+call still dispatches with the model's content. A complete-but-invalid escape (an unpaired
+surrogate) is still rejected, and well-formed `\xHH`/`\u{...}` escapes still decode.

--- a/crates/harn-vm/src/llm/tools/tests/string_escape_fidelity.rs
+++ b/crates/harn-vm/src/llm/tools/tests/string_escape_fidelity.rs
@@ -121,3 +121,91 @@ fn known_escapes_in_quoted_string_unchanged() {
         json!("a\nb\tc\\d\"e")
     );
 }
+
+/// Parse the `command` value of `run({ command: <literal> })`, returning the
+/// decoded string or an `Err` describing why the call was dropped.
+fn run_command(src: &str) -> Result<String, String> {
+    let tools = sample_tool_registry();
+    let result = parse_bare_calls_in_body(src, Some(&tools));
+    if !result.errors.is_empty() {
+        return Err(format!("{:?}", result.errors));
+    }
+    let call = result.calls.first().ok_or("call was dropped")?;
+    call["arguments"]["command"]
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| "command not a string".to_string())
+}
+
+/// A MALFORMED `\u`/`\x` escape (Perl `\x{...}`, a Windows path `\users`, a
+/// short `\uAB`, `\uABCG`, a trailing `\x`) must NOT drop the whole tool call.
+/// Before this fix `parse_string_literal` returned `Err` on any of these and
+/// the model's edit/run silently never landed — the exact #3589 surrogate
+/// signature, generalized to every other malformed-known-escape shape. The
+/// degraded behavior keeps the `\u`/`\x` literal, byte-identical to the heredoc
+/// and template-literal channels.
+#[test]
+fn malformed_known_escapes_keep_literal_not_dropped() {
+    // (source value literal, expected decoded command)
+    let cases = [
+        (r#""m/\x{1F600}/""#, r"m/\x{1F600}/"), // Perl/PCRE hex-brace regex
+        (r#""C:\xtra\data""#, r"C:\xtra\data"), // \x + non-hex, then \d unknown
+        (r#""ends with \x""#, r"ends with \x"), // trailing \x
+        (r#""bad \uAB stop""#, r"bad \uAB stop"), // short \u (2 hex)
+        (r#""bad \uABCG end""#, r"bad \uABCG end"), // \u + non-hex 4th digit
+        (r#""path C:\users\me""#, r"path C:\users\me"), // \u + non-hex (Windows)
+    ];
+    for (src_value, expected) in cases {
+        let src = format!("run({{ command: {src_value} }})");
+        let got =
+            run_command(&src).unwrap_or_else(|err| panic!("call dropped for {src_value}: {err}"));
+        assert_eq!(got, expected, "for source {src_value}");
+    }
+}
+
+/// Cross-channel byte-identity for a malformed escape: Perl `\x{1F600}` must
+/// decode to the SAME bytes via quoted string, template literal, and heredoc.
+/// Before the fix the quoted channel dropped the call while the other two
+/// preserved the content.
+#[test]
+fn malformed_escape_identical_across_channels() {
+    let tools = sample_tool_registry();
+    let expected = json!(r"m/\x{1F600}/");
+
+    let quoted = parse_bare_calls_in_body(r#"run({ command: "m/\x{1F600}/" })"#, Some(&tools));
+    let template = parse_bare_calls_in_body("run({ command: `m/\\x{1F600}/` })", Some(&tools));
+    let heredoc = parse_bare_calls_in_body(
+        "run({ command: <<EOF\nm/\\x{1F600}/\nEOF\n })",
+        Some(&tools),
+    );
+
+    assert_eq!(quoted.calls[0]["arguments"]["command"], expected, "quoted");
+    assert_eq!(
+        template.calls[0]["arguments"]["command"], expected,
+        "template"
+    );
+    assert_eq!(
+        heredoc.calls[0]["arguments"]["command"], expected,
+        "heredoc"
+    );
+}
+
+/// WELL-FORMED `\xHH` and `\uHHHH` escapes still decode (no over-correction):
+/// the degraded literal path must only engage when the escape is incomplete.
+#[test]
+fn well_formed_hex_and_unicode_escapes_still_decode() {
+    assert_eq!(
+        run_command(r#"run({ command: "\x41\x42" })"#).unwrap(),
+        "AB"
+    );
+    // A literal multibyte scalar in source survives (push_scalar, unaffected).
+    assert_eq!(
+        run_command(r#"run({ command: "snow ☃ done" })"#).unwrap(),
+        "snow \u{2603} done"
+    );
+    // `\u{...}` brace form still decodes a non-BMP scalar.
+    assert_eq!(
+        run_command(r#"run({ command: "emoji \u{1F600} done" })"#).unwrap(),
+        "emoji \u{1F600} done"
+    );
+}

--- a/crates/harn-vm/src/llm/tools/ts_value_parser.rs
+++ b/crates/harn-vm/src/llm/tools/ts_value_parser.rs
@@ -309,17 +309,26 @@ impl<'a> TsValueParser<'a> {
                     b'"' => out.push('"'),
                     b'`' => out.push('`'),
                     b'\n' => { /* line continuation — drop */ }
-                    b'u' => {
-                        let (ch, consumed) = parse_unicode_escape(&self.bytes[pos..])?;
-                        out.push(ch);
-                        pos += consumed;
-                    }
-                    b'x' => {
-                        let hex = std::str::from_utf8(self.bytes.get(pos..pos + 2)?).ok()?;
-                        let code = u32::from_str_radix(hex, 16).ok()?;
-                        out.push(char::from_u32(code)?);
-                        pos += 2;
-                    }
+                    b'u' => match parse_unicode_escape(&self.bytes[pos..]) {
+                        UnicodeEscape::Char(ch, consumed) => {
+                            out.push(ch);
+                            pos += consumed;
+                        }
+                        // An unpaired surrogate aborts recovery (return None) so
+                        // the caller reports the original error rather than
+                        // emitting a half-character.
+                        UnicodeEscape::InvalidScalar => return None,
+                        // Not a complete escape: keep `\u` literal, same as the
+                        // strict pass — never drop content.
+                        UnicodeEscape::NotEscape => out.push_str("\\u"),
+                    },
+                    b'x' => match parse_hex_escape(&self.bytes[pos..]) {
+                        Some((ch, consumed)) => {
+                            out.push(ch);
+                            pos += consumed;
+                        }
+                        None => out.push_str("\\x"),
+                    },
                     // Unknown escape: keep the backslash AND the char. See the
                     // `parse_string_literal` arm for the rationale — preserving
                     // `\d`/`\w`/`\b` (regex), `\begin` (LaTeX), `\section`, etc.
@@ -420,28 +429,32 @@ impl<'a> TsValueParser<'a> {
                         b'"' => out.push('"'),
                         b'`' => out.push('`'),
                         b'\n' => { /* line continuation — drop */ }
-                        b'u' => {
+                        b'u' => match parse_unicode_escape(&self.bytes[self.pos..]) {
                             // \uXXXX or \u{XXXXX}
-                            let (ch, consumed) = parse_unicode_escape(&self.bytes[self.pos..])
-                                .ok_or("invalid \\u escape in string literal")?;
-                            out.push(ch);
-                            self.pos += consumed;
-                        }
-                        b'x' => {
-                            if self.pos + 2 > self.bytes.len() {
-                                return Err("invalid \\x escape in string literal".to_string());
-                            }
-                            let hex = std::str::from_utf8(&self.bytes[self.pos..self.pos + 2])
-                                .map_err(|_| "invalid \\x escape".to_string())?;
-                            let code = u32::from_str_radix(hex, 16)
-                                .map_err(|_| "invalid \\x escape".to_string())?;
-                            if let Some(ch) = char::from_u32(code) {
+                            UnicodeEscape::Char(ch, consumed) => {
                                 out.push(ch);
-                                self.pos += 2;
-                            } else {
-                                return Err("invalid \\x code point".to_string());
+                                self.pos += consumed;
                             }
-                        }
+                            UnicodeEscape::InvalidScalar => {
+                                return Err("invalid \\u escape in string literal".to_string());
+                            }
+                            // Not a complete escape (`\users`, `\uAB`, `\uABCG`):
+                            // keep `\u` literal like any unknown escape rather than
+                            // dropping the whole call. Matches the heredoc and
+                            // template-literal channels byte-for-byte.
+                            UnicodeEscape::NotEscape => out.push_str("\\u"),
+                        },
+                        b'x' => match parse_hex_escape(&self.bytes[self.pos..]) {
+                            Some((ch, consumed)) => {
+                                out.push(ch);
+                                self.pos += consumed;
+                            }
+                            // Not a complete `\xHH` escape (Perl `\x{1F600}`, a
+                            // trailing `\x`, `\x` + non-hex): keep `\x` literal so
+                            // the call still dispatches with the model's content,
+                            // identical to the heredoc/template channels.
+                            None => out.push_str("\\x"),
+                        },
                         // Unknown escape (`\d`, `\w`, `\b`, `\s` regex; `\begin`
                         // LaTeX; `\section`; a Windows path's `\U`): keep BOTH the
                         // backslash and the char. JS would collapse `\d` to `d`,
@@ -651,30 +664,57 @@ impl<'a> TsValueParser<'a> {
     }
 }
 
-/// Parse a `\uXXXX` or `\u{XXXXXX}` escape starting at bytes[0]. Returns the
-/// decoded character AND the number of bytes consumed after the `\u`.
+/// Outcome of reading a `\u` escape, given the bytes that follow the `\u`.
+///
+/// The three cases drive the caller's never-drop-the-call contract: a complete,
+/// valid escape decodes; a complete-but-invalid one (unpaired surrogate, out of
+/// range) is rejected so we never emit a half-character; and anything that is
+/// not even a complete `\u` escape is kept as the literal text `\u…` rather than
+/// dropping the entire tool call.
+enum UnicodeEscape {
+    /// Decoded scalar plus the number of bytes consumed after `\u`.
+    Char(char, usize),
+    /// Syntactically a complete `\uHHHH` / `\u{HHHH}` escape, but the code point
+    /// is not a valid scalar (an unpaired surrogate, or out of range). The model
+    /// clearly intended a unicode escape, so reject rather than silently emit a
+    /// half-character — this keeps the lone-surrogate guard.
+    InvalidScalar,
+    /// Not a syntactically complete `\u` escape (`\u` not followed by four hex
+    /// digits or a `{HHHH}` group — e.g. a Windows path `\users`, a short
+    /// `\uAB`, or `\uABCG`). Treat `\u` as literal content; never drop the call.
+    NotEscape,
+}
+
+/// Classify a `\u` escape from the bytes following the `\u` prefix.
 ///
 /// The plain 4-hex `\uXXXX` form decodes a single UTF-16 code unit, so a
 /// non-BMP scalar (emoji, CJK extension B+, math alphanumerics) arrives as a
 /// **surrogate pair** `😀` — exactly what `JSON.stringify` and most
-/// provider APIs emit. A lone surrogate is not a valid `char`, so without
-/// pairing them `char::from_u32` returns `None`, the caller reports
-/// `invalid \u escape`, and the ENTIRE tool call is dropped (the model's
-/// `edit`/`write` silently never lands). Detect a high surrogate and fold the
-/// following `\uXXXX` low surrogate into the astral scalar, consuming its `\u`
-/// prefix too. The `\u{...}` brace form already carries the full scalar.
-fn parse_unicode_escape(bytes: &[u8]) -> Option<(char, usize)> {
+/// provider APIs emit. Detect a high surrogate and fold the following `\uXXXX`
+/// low surrogate into the astral scalar, consuming its `\u` prefix too. The
+/// `\u{...}` brace form already carries the full scalar.
+fn parse_unicode_escape(bytes: &[u8]) -> UnicodeEscape {
     if bytes.first() == Some(&b'{') {
-        // \u{XXXXXX}
-        let close = bytes.iter().position(|&b| b == b'}')?;
-        let hex = std::str::from_utf8(&bytes[1..close]).ok()?;
-        let code = u32::from_str_radix(hex, 16).ok()?;
-        Some((char::from_u32(code)?, close + 1))
-    } else if bytes.len() >= 4 {
-        let hex = std::str::from_utf8(&bytes[..4]).ok()?;
-        let code = u32::from_str_radix(hex, 16).ok()?;
+        // \u{XXXXXX}. Missing close brace or non-hex contents is not a complete
+        // escape — keep the `\u` literal rather than dropping the whole call.
+        let Some(close) = bytes.iter().position(|&b| b == b'}') else {
+            return UnicodeEscape::NotEscape;
+        };
+        let Some(code) = std::str::from_utf8(&bytes[1..close])
+            .ok()
+            .and_then(|hex| u32::from_str_radix(hex, 16).ok())
+        else {
+            return UnicodeEscape::NotEscape;
+        };
+        match char::from_u32(code) {
+            Some(ch) => UnicodeEscape::Char(ch, close + 1),
+            None => UnicodeEscape::InvalidScalar,
+        }
+    } else if bytes.len() >= 4 && bytes[..4].iter().all(u8::is_ascii_hexdigit) {
+        let code = u32::from_str_radix(std::str::from_utf8(&bytes[..4]).expect("ascii"), 16)
+            .expect("four hex digits");
         if let Some(ch) = char::from_u32(code) {
-            return Some((ch, 4));
+            return UnicodeEscape::Char(ch, 4);
         }
         // `code` is a surrogate (0xD800..=0xDFFF), invalid as a lone scalar.
         // If it is a high surrogate followed by `\uXXXX` low surrogate, combine
@@ -684,16 +724,37 @@ fn parse_unicode_escape(bytes: &[u8]) -> Option<(char, usize)> {
             && bytes.get(4) == Some(&b'\\')
             && bytes.get(5) == Some(&b'u')
             && bytes.len() >= 10
+            && bytes[6..10].iter().all(u8::is_ascii_hexdigit)
         {
-            let low_hex = std::str::from_utf8(&bytes[6..10]).ok()?;
-            let low = u32::from_str_radix(low_hex, 16).ok()?;
+            let low = u32::from_str_radix(std::str::from_utf8(&bytes[6..10]).expect("ascii"), 16)
+                .expect("four hex digits");
             if (0xDC00..=0xDFFF).contains(&low) {
                 let scalar = 0x1_0000 + ((code - 0xD800) << 10) + (low - 0xDC00);
-                return Some((char::from_u32(scalar)?, 10));
+                if let Some(ch) = char::from_u32(scalar) {
+                    return UnicodeEscape::Char(ch, 10);
+                }
             }
         }
-        None
+        // Complete `\uHHHH` syntax, but an unpaired / unmatched surrogate.
+        UnicodeEscape::InvalidScalar
     } else {
-        None
+        // `\u` not followed by four hex digits or `{...}`: literal `\u`.
+        UnicodeEscape::NotEscape
     }
+}
+
+/// Decode a `\xHH` escape (exactly two hex digits) from the bytes following the
+/// `\x` prefix. Returns the scalar and bytes consumed (always 2) when both
+/// following bytes are hex; otherwise `None` so the caller keeps `\x` literal
+/// instead of dropping the whole call. Every `0x00..=0xFF` value is a valid
+/// scalar, so there is no invalid-code-point case here. This keeps content like
+/// Perl `\x{1F600}`, a trailing `\x`, or `\x` + non-hex byte-identical to the
+/// heredoc and template-literal channels.
+fn parse_hex_escape(bytes: &[u8]) -> Option<(char, usize)> {
+    let pair = bytes.get(..2)?;
+    if !pair.iter().all(u8::is_ascii_hexdigit) {
+        return None;
+    }
+    let code = u32::from_str_radix(std::str::from_utf8(pair).expect("ascii"), 16).expect("two hex");
+    char::from_u32(code).map(|ch| (ch, 2))
 }


### PR DESCRIPTION
## Problem

Same silent tool-arg corruption class as #3587 (heredoc-wrapper leak) and #3589 (surrogate-pair drop / unknown-escape backslash drop), found by the same cross-channel **round-trip byte-identity** method: a model delivers content through the `name({ key: "value" })` text channel and the parser drops the **entire tool call** instead of dispatching the model's content.

A double/single-quoted string value whose content contained a **malformed** `\x` or `\u` escape errored out of `parse_string_literal` and the whole call was discarded (`calls=[]`) — the model authored no edit/run and thrashed. Confirmed with round-trips that FAIL on origin/main:

| content | quoted (before) | template | heredoc |
|---|---|---|---|
| `m/\x{1F600}/` (Perl/PCRE regex) | **call DROPPED** | `m/\x{1F600}/` ✓ | `m/\x{1F600}/` ✓ |
| `C:\users\me` (Windows path) | **call DROPPED** | `C:\users\me` ✓ | `C:\users\me` ✓ |
| `ends with \x` (trailing `\x`) | **call DROPPED** | preserved ✓ | preserved ✓ |
| `bad \uAB` / `\uABCG` (short / non-hex `\u`) | **call DROPPED** | preserved ✓ | preserved ✓ |

This is the exact #3589 signature — identical content dropped purely by which quote style the model picked. #3589 fixed the surrogate-pair case; this generalizes the fix to every other malformed-known-escape shape.

## Fix

`\x`/`\u` are decoded as known escapes, but only when they form a **complete** escape. `parse_unicode_escape` now classifies the result three ways (`Char` / `InvalidScalar` / `NotEscape`) and a new `parse_hex_escape` requires exactly two hex digits. When the escape is not syntactically complete, the parser keeps the `\x`/`\u` literal — byte-identical to the heredoc and template-literal channels — so the call still dispatches. Applied at both decode sites (`parse_string_literal` + `recover_overclosed_object_string`). Matches the #3589 "tool arguments are content, not evaluated JS" philosophy.

A complete-but-invalid escape (an unpaired surrogate, e.g. lone `\uD83D`) is still **rejected** so we never emit a half-character (the `lone_high_surrogate_*` guard from #3589 still passes). Well-formed `\xHH` / `\uHHHH` / `\u{...}` escapes still decode.

## Tests / verification

- New `malformed_known_escapes_keep_literal_not_dropped`, `malformed_escape_identical_across_channels`, and `well_formed_hex_and_unicode_escapes_still_decode` in `string_escape_fidelity.rs`. **Test-first**: the malformed cases FAIL on origin/main (call dropped) and pass with the fix; the over-correction guards pass both ways.
- `cargo test -p harn-vm --lib llm::tools` → **262 passed**.
- `cargo fmt --all --check` clean; `cargo clippy -p harn-vm --lib` clean.

Pure correctness bug (silent dropped call), so default-on like #3587/#3589 — no flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)