### PR TITLE
fix(catalog): advertise vision for local vLLM gemma-4 route (#3585)

### DIFF
--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -1475,6 +1475,13 @@ model_match = "gemma-4*"
 native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"
+# Gemma 4 is genuinely multimodal regardless of where it is served, so the local
+# vLLM/SGLang route must advertise vision just like every hosted gemma-4 sibling
+# (gemini/openrouter/together/sambanova/nvidia) and the Ollama-native quant.
+# Omitting it dropped `vision` from the emitted capability_tags + image input
+# modality for local gemma-4 models, contradicting the structured caps (harn#3585).
+vision = true
+vision_supported = true
 thinking_modes = ["enabled"]
 server_parser = "none"
 honors_chat_template_kwargs = false

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/20-local-ollama.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/20-local-ollama.toml
@@ -348,6 +348,13 @@ model_match = "gemma-4*"
 native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"
+# Gemma 4 is genuinely multimodal regardless of where it is served, so the local
+# vLLM/SGLang route must advertise vision just like every hosted gemma-4 sibling
+# (gemini/openrouter/together/sambanova/nvidia) and the Ollama-native quant.
+# Omitting it dropped `vision` from the emitted capability_tags + image input
+# modality for local gemma-4 models, contradicting the structured caps (harn#3585).
+vision = true
+vision_supported = true
 thinking_modes = ["enabled"]
 server_parser = "none"
 honors_chat_template_kwargs = false

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -3423,6 +3423,26 @@ mod tests {
     }
 
     #[test]
+    fn test_local_vllm_gemma4_advertises_vision() {
+        // harn#3585: the local vLLM/SGLang `gemma-4*` route must advertise vision
+        // (Gemma 4 is multimodal) so the emitted capability_tags + image input
+        // modality match every hosted gemma-4 sibling instead of silently dropping
+        // it for the local provider.
+        reset_overrides();
+
+        let caps = crate::llm::capabilities::lookup("local", "gemma-4-e4b-it");
+        assert!(caps.vision || caps.vision_supported);
+
+        let gemma4_e4b =
+            model_catalog_entry("gemma-4-e4b-it").expect("gemma-4-e4b-it catalog entry");
+        assert!(
+            gemma4_e4b.capabilities.iter().any(|cap| cap == "vision"),
+            "local gemma-4-e4b-it should carry the vision capability tag, got {:?}",
+            gemma4_e4b.capabilities
+        );
+    }
+
+    #[test]
     fn test_external_config_overlays_default_catalog() {
         let mut config = default_config();
         let mut overlay = ProvidersConfig {

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -96,7 +96,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `llamacpp` | `*devstral-small-2*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `none` | `json` | no | yes | `text_only` | yes | no |
 | `local` | `*qwen3.6*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `local` | `*qwen3*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
-| `local` | `gemma-4*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
+| `local` | `gemma-4*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `minimax` | `minimax-m3*` | `any` | `adaptive` | yes | no | no | yes | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `minimax` | `minimax-m2.7*` | `any` | `enabled` | no | no | no | no | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `json` | yes | yes | `native_unreliable` | yes | yes |
 | `minimax` | `minimax-m2.5*` | `any` | `enabled` | no | no | no | no | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -6101,7 +6101,8 @@
       "stream_timeout": 300.0,
       "modalities": {
         "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -6144,6 +6145,7 @@
       "capability_tags": [
         "streaming",
         "tools",
+        "vision",
         "thinking",
         "structured_output"
       ],
@@ -6168,7 +6170,8 @@
       "stream_timeout": 600.0,
       "modalities": {
         "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -6211,6 +6214,7 @@
       "capability_tags": [
         "streaming",
         "tools",
+        "vision",
         "thinking",
         "structured_output"
       ],
@@ -6233,7 +6237,8 @@
       "stream_timeout": 600.0,
       "modalities": {
         "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -6276,6 +6281,7 @@
       "capability_tags": [
         "streaming",
         "tools",
+        "vision",
         "thinking",
         "structured_output"
       ],
@@ -6299,7 +6305,8 @@
       "stream_timeout": 300.0,
       "modalities": {
         "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -6342,6 +6349,7 @@
       "capability_tags": [
         "streaming",
         "tools",
+        "vision",
         "thinking",
         "structured_output"
       ],
@@ -6365,7 +6373,8 @@
       "stream_timeout": 300.0,
       "modalities": {
         "input": [
-          "text"
+          "text",
+          "image"
         ],
         "output": [
           "text"
@@ -6408,6 +6417,7 @@
       "capability_tags": [
         "streaming",
         "tools",
+        "vision",
         "thinking",
         "structured_output"
       ],


### PR DESCRIPTION
## Problem

`#3585`: local vLLM/SGLang gemma-4 models dropped `vision` from their emitted `capability_tags` and the `image` input modality, while every hosted gemma-4 sibling (gemini/openrouter/together/sambanova/nvidia) and the Ollama-native quant advertise it. Gemma 4 is genuinely multimodal regardless of where it is served, so this was an internally-inconsistent, under-specified catalog view that drifts between Harn versions (it surfaced as a vendored-vs-runtime skew in burin-code).

Root cause: the `[[provider.local]] model_match = "gemma-4*"` rule in `capability_sources/20-providers/20-local-ollama.toml` omitted `vision` / `vision_supported`. The `capability_tags` emitter (`capability_tags_from_capabilities`) and `modalities_from_caps` already emit `vision`/`image` when the structured caps say so — the structured caps were simply wrong for the local route.

## Fix

- Add `vision = true` / `vision_supported = true` to the local gemma-4 capability rule so the source fragment, structured caps, emitted `capability_tags`, and modalities all agree.
- Regenerate the embedded capabilities snapshot, provider catalog (JSON + bindings), and provider matrix.
- Add `test_local_vllm_gemma4_advertises_vision` asserting the local `gemma-4-e4b-it` catalog entry carries the `vision` tag.

## Scope

Exactly the 5 local gemma-4 models (e4b-it, 26b-a4b-it, 31b-it, 12b-it, …) gain `image` input modality + `vision` tag; no other model is touched. The `thinking` representation was already internally consistent on v0.8.142 (`modes: ["enabled"]` across local + hosted), so it is intentionally left unchanged — the only real disagreement was the missing vision.

Closes #3585

🤖 Generated with [Claude Code](https://claude.com/claude-code)