### PR TITLE
fix(agent-loop): stop accusing a tool-active model of a narration loop

### DIFF
--- a/changelog.d/3593.fixed.md
+++ b/changelog.d/3593.fixed.md
@@ -1,0 +1,1 @@
+Agent loop: the depth>=4 no-progress nudge no longer accuses a tool-active model of being "stuck in a narration loop." When the model is issuing real tool calls but the loop's progress signal has not advanced, the nudge now steers it to re-read the failing output and target a different location instead of telling it to stop narrating.

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -2167,6 +2167,10 @@ fn __next_progress_count(made_progress, turns_since_progress) {
  * this turn — the content nudge takes precedence so a turn is never
  * double-injected; this streak nudge is the fallback for toolless churn.
  * Depth is `turns_since_progress`.
+ *
+ * @effects: []
+ * @errors: []
+ * @api_stability: experimental
  */
 pub fn __progress_nudge_text(depth, has_tools, tool_mode = "text", made_tool_calls = false) {
   let action = if has_tools {

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -2168,7 +2168,7 @@ fn __next_progress_count(made_progress, turns_since_progress) {
  * double-injected; this streak nudge is the fallback for toolless churn.
  * Depth is `turns_since_progress`.
  */
-fn __progress_nudge_text(depth, has_tools, tool_mode = "text") {
+pub fn __progress_nudge_text(depth, has_tools, tool_mode = "text", made_tool_calls = false) {
   let action = if has_tools {
     if tool_mode == "native" {
       "Call exactly one native tool through the provider tool channel now, or give your final answer and stop."
@@ -2179,6 +2179,18 @@ fn __progress_nudge_text(depth, has_tools, tool_mode = "text") {
     "Make concrete progress in your reply now, or state your final answer and stop."
   }
   if depth >= 4 {
+    // The "stuck in a narration loop / Do not restate the plan" framing is only
+    // truthful when the recent turns were PURE PROSE. When the model IS issuing
+    // real tool calls (edits/looks/searches/runs) but the loop's progress signal
+    // still has not advanced, accusing it of narrating is wrong and unhelpful —
+    // it is making changes that are not landing. Steer it to a DIFFERENT change
+    // instead of telling it to stop narrating.
+    if made_tool_calls {
+      return "You have made no progress for "
+        + to_string(depth)
+        + " turns — your tool calls are not advancing the task. Stop repeating the same kind of change: re-read the failing output, target a DIFFERENT location, and make one concrete change. "
+        + action
+    }
     return "You have made no progress for "
       + to_string(depth)
       + " turns — you are stuck in a narration loop. "
@@ -3844,15 +3856,21 @@ fn __agent_loop_run(message, session, initial_opts) {
           && len(turn_rejected) == 0 {
           let has_tools = len(opts?.tools?.tools ?? []) > 0
           let tool_mode = agent_tool_call_paradigm(turn_opts).kind
+          let made_tool_calls = tool_count > 0
           agent_session_inject_feedback(
             session.session_id,
             "no_progress_streak",
-            __progress_nudge_text(turns_since_progress, has_tools, tool_mode),
+            __progress_nudge_text(turns_since_progress, has_tools, tool_mode, made_tool_calls),
           )
           agent_emit_event(
             session.session_id,
             "no_progress_streak_nudge",
-            {iteration: iteration_index, turns_since_progress: turns_since_progress, has_tools: has_tools},
+            {
+              iteration: iteration_index,
+              turns_since_progress: turns_since_progress,
+              has_tools: has_tools,
+              made_tool_calls: made_tool_calls,
+            },
           )
         }
       }
@@ -4013,6 +4031,9 @@ fn __agent_loop_run(message, session, initial_opts) {
   return unwrap(run)
 }
 
+// Whether THIS turn actually issued tool calls. When it did, the
+// "narration loop" framing is false (the model is acting, not narrating)
+// so the nudge steers toward a DIFFERENT change instead.
 // Capture the PRIMARY provider/model once, before any post-turn escalation
 // can rebind `opts`. A failed escalated turn falls back to this for one
 // retry instead of unwinding the whole loop into a fake success.

--- a/crates/harn-vm/tests/builtin_registry_alignment.rs
+++ b/crates/harn-vm/tests/builtin_registry_alignment.rs
@@ -167,6 +167,7 @@ const RUNTIME_ONLY_EXCEPTIONS: &[&str] = &[
     "__pool_snapshot",
     "__pool_submit",
     "__pool_wait",
+    "__progress_nudge_text",
     "__range__",
     "__register_persona",
     "__register_step",

--- a/tests/agent/progress_nudge_test.harn
+++ b/tests/agent/progress_nudge_test.harn
@@ -1,0 +1,54 @@
+// Run: harn test tests/agent/progress_nudge_test.harn
+//
+// Unit tests for the no-progress streak nudge copy (`__progress_nudge_text` in
+// std/agent/loop). The depth>=4 "stuck in a narration loop / Do not restate the
+// plan" framing is only truthful when the recent turns were PURE PROSE. When the
+// model IS issuing real tool calls but the loop's progress signal still has not
+// advanced, accusing it of narrating is wrong — it is making changes that are not
+// landing. These pin both branches.
+import { __progress_nudge_text } from "std/agent/loop"
+
+/**
+ * depth>=4 with NO tool calls this turn: the legacy narration-loop framing is
+ * correct (the model is churning pure prose).
+ */
+pipeline test_depth4_toolless_keeps_narration_framing(_task) {
+  let msg = __progress_nudge_text(4, true, "text", false)
+  assert(
+    contains(msg, "narration loop") && contains(msg, "Do not restate the plan"),
+    "toolless depth>=4 must keep the narration-loop framing; got: ${msg}",
+  )
+}
+
+/**
+ * depth>=4 WHEN the model made real tool calls this turn: the narration-loop
+ * accusation must be GONE (it is acting, not narrating), and the nudge must steer
+ * toward a DIFFERENT change instead.
+ */
+pipeline test_depth4_with_tool_calls_drops_narration_framing(_task) {
+  let msg = __progress_nudge_text(4, true, "text", true)
+  assert(
+    !contains(msg, "narration loop"),
+    "depth>=4 WITH real tool calls must NOT accuse the model of a narration loop; got: ${msg}",
+  )
+  assert(
+    !contains(msg, "Do not restate the plan"),
+    "depth>=4 WITH real tool calls must NOT tell the model to stop restating the plan; got: ${msg}",
+  )
+  assert(
+    contains(msg, "not advancing the task") && contains(msg, "DIFFERENT location"),
+    "the tool-active nudge must steer toward a different change; got: ${msg}",
+  )
+}
+
+/**
+ * Below depth 4 the copy is unchanged regardless of the new flag (no narration
+ * accusation at depth 2/3 to begin with).
+ */
+pipeline test_lower_depths_unchanged(_task) {
+  let d3 = __progress_nudge_text(3, true, "text", true)
+  assert(contains(d3, "Still no progress after"), "depth 3 copy unchanged; got: ${d3}")
+  assert(!contains(d3, "narration loop"), "depth 3 never asserted a narration loop; got: ${d3}")
+  let d2 = __progress_nudge_text(2, true, "text", false)
+  assert(contains(d2, "No progress last turn"), "depth 2 copy unchanged; got: ${d2}")
+}


### PR DESCRIPTION
## The bug

The depth>=4 no-progress streak nudge (`__progress_nudge_text` in `std/agent/loop`) asserts the model is "**stuck in a narration loop**" and tells it "**Do not restate the plan**". That framing is only truthful when the recent turns were PURE PROSE.

When the model IS issuing real tool calls (edits/looks/searches/runs) but the loop's `turns_since_progress` signal still has not advanced, the accusation is false and unhelpful — the model is acting, not narrating; its changes are just not landing. (Observed live in a Burin zig-feat thrash run: the model issued real edit/look/verify calls every turn and was repeatedly told it was "stuck in a narration loop".)

## The fix
Thread whether THIS turn issued tool calls (`tool_count > 0`) into the nudge. When it did:
- drop the "narration loop" / "Do not restate the plan" framing, and
- steer the model to re-read the failing output and target a **DIFFERENT location** with one concrete change.

The toolless depth>=4 path keeps the original narration-loop copy unchanged.

## Mechanism test
`tests/agent/progress_nudge_test.harn`: pins the toolless path keeps the narration framing, the tool-active path drops it and steers to a different change, and the depth-2/3 copy is unchanged. `__progress_nudge_text` is exported `pub` (still `__`-prefixed / docs-excluded) as the test seam, mirroring the `std/agent/judge_internals` pattern.

> Note: the local shared cargo target cache is currently corrupted (`tree-sitter`/`libsqlite3-sys` stale bindgen), so the rebuilt-binary unit run could not complete locally; `harn check` on `loop.harn` is clean and CI builds the stdlib from source. The test logic is pure string assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)