### PR TITLE
ci: stop the sccache daemon before post-job orphan cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,18 @@ jobs:
           make check-provider-catalog-drift
           make check-docs-workflow-quickstart
           make check-vm-rss-soak
+      # sccache-action starts a long-lived `sccache --start-server` daemon that
+      # outlives every job step. GitHub's post-job "Cleaning up orphan
+      # processes" phase then terminates it, and on the ubuntu lanes that
+      # termination has intermittently surfaced as a non-zero JOB exit (exit 2)
+      # AFTER every gate already passed — a pure post-job flake (bit #3588,
+      # #3593). Shutting the server down gracefully here leaves no orphan for
+      # the cleanup phase to kill. `if: always()` so it runs even when a gate
+      # failed; `|| true` so teardown can never itself fail the job.
+      - name: Stop sccache server
+        if: always()
+        shell: bash
+        run: '"${SCCACHE_PATH:-sccache}" --stop-server || true'
 
   audit-scripts:
     name: Audit scripts
@@ -260,6 +272,12 @@ jobs:
             export CHANGELOG_GUARD_BASE="$base"
           fi
           cargo run --quiet --bin harn -- run scripts/check_changelog_no_retroactive_edits.harn
+      # Gracefully stop the sccache daemon so the post-job orphan-cleanup phase
+      # has nothing to terminate (see the Stop-sccache note in rust-builds).
+      - name: Stop sccache server
+        if: always()
+        shell: bash
+        run: '"${SCCACHE_PATH:-sccache}" --stop-server || true'
 
   windows-plan:
     name: Windows CI routing
@@ -494,6 +512,12 @@ jobs:
         # `-D warnings` (from the job env) promotes every warning to a hard
         # failure so it fails the PR instead of the release.
         run: cargo clippy --workspace --all-targets -- -D warnings
+      # Gracefully stop the sccache daemon so the post-job orphan-cleanup phase
+      # has nothing to terminate (see the Stop-sccache note in rust-builds).
+      - name: Stop sccache server
+        if: always()
+        shell: bash
+        run: '"${SCCACHE_PATH:-sccache}" --stop-server || true'
 
   portal:
     name: Portal frontend
@@ -602,6 +626,12 @@ jobs:
       - run: make test-e2e
         env:
           NEXTEST_PROFILE: e2e
+      # Gracefully stop the sccache daemon so the post-job orphan-cleanup phase
+      # has nothing to terminate (see the Stop-sccache note in rust-builds).
+      - name: Stop sccache server
+        if: always()
+        shell: bash
+        run: '"${SCCACHE_PATH:-sccache}" --stop-server || true'
 
   ci-status:
     name: CI status


### PR DESCRIPTION
## Problem

The "Harn conformance + audit" job (and other sccache lanes) intermittently fails with **exit code 2 during GitHub's post-job "Cleaning up orphan processes" phase**, *after every conformance/audit gate has already passed green*. This bit #3588 and #3593: on #3593 the failing run's conformance step was green and two sibling runs on the same branch succeeded — the only difference was the post-job orphan-cleanup terminating the `sccache --start-server` daemon and surfacing a non-zero job exit.

`mozilla-actions/sccache-action` starts a long-lived background `sccache` server that outlives every step. GitHub's orphan cleanup kills it at job end, and on the ubuntu lanes that kill has intermittently propagated to the job result.

## Fix

Add an `if: always()` **"Stop sccache server"** teardown step to every sccache-using lane (rust-builds matrix → audit/test/lint, audit-scripts, macos clippy, e2e). A graceful `sccache --stop-server` shuts the daemon down cleanly so the orphan-cleanup phase has nothing left to terminate.

- `if: always()` — runs even when a gate failed, so teardown always happens.
- `|| true` — teardown can never itself fail the job.
- Placed after all gates — cannot affect any conformance/audit verdict.
- No new actions, permissions, or `${{ }}` `run:` expansion (injection-safe; actionlint clean).

The release-binaries workflow already sidesteps this class on macOS via `use_sccache: "false"`; this keeps the cache benefit on the PR/merge-queue lanes while removing the orphan that triggers the flake.

## Verification

- `actionlint .github/workflows/ci.yml` passes clean.
- YAML parses; all 14 jobs intact.
- The change is purely additive teardown; the conformance gate (`make conformance` + the audit `check-*` suite) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)