### PR TITLE
fix(llm): reasoning-aware output floor for the structured-repair side-call

### DIFF
--- a/changelog.d/repair-floor-reasoning-aware.fixed.md
+++ b/changelog.d/repair-floor-reasoning-aware.fixed.md
@@ -1,0 +1,9 @@
+- `std/llm/safe`: the structured-output **repair** side-call now floors its
+  output budget reasoning-awarely (`repair_min_max_tokens`), the twin fix to the
+  #3598 judge floor. A flat 600-token repair budget was billed against the same
+  `max_tokens` as a reasoning route's hidden analysis channel, truncating the
+  repaired JSON verdict to empty (a silent dead-repair) on reasoning models such
+  as gpt-oss. Non-reasoning routes are unchanged (600 baseline); reasoning routes
+  are raised to `reasoning_budget + verdict headroom`. Applied in
+  `safe_structured_call`'s judge defaults and the `with_repair` caller-seam
+  handler, reusing the same floor as the judge path so the two never drift.

--- a/conformance/tests/stdlib/safe_repair_call_reasoning_floor.expected
+++ b/conformance/tests/stdlib/safe_repair_call_reasoning_floor.expected
@@ -1,0 +1,10 @@
+non_reasoning=600
+non_reasoning_is_600=true
+non_reasoning_at_or_above_judge_floor=true
+reasoning_exceeds_old_600=true
+reasoning_exceeds_1024_reasoning_budget=true
+reasoning_value=1792
+reasoning_matches_judge_floor=true
+high_scales_above_reasoning=true
+high_within_ceiling=true
+disabled_is_600=true

--- a/conformance/tests/stdlib/safe_repair_call_reasoning_floor.harn
+++ b/conformance/tests/stdlib/safe_repair_call_reasoning_floor.harn
@@ -1,0 +1,48 @@
+// Mechanism-fitness: std/llm/safe::repair_min_max_tokens reserves a
+// reasoning-aware output budget for the structured REPAIR side-call so a
+// repaired judge/router JSON verdict is never starved by the model's hidden
+// reasoning channel.
+//
+// Regression target (twin of #3598): the structured-output repair pass re-emits
+// the verdict JSON on the SAME route after a schema-validation failure, sharing
+// the route's reasoning channel budget. A flat 600-token repair floor is fully
+// consumable by a reasoning model's analysis spend (gpt-oss/Harmony resolves to
+// >=1024 reasoning tokens under Harn's auto policy), leaving zero budget for the
+// repaired verdict -> empty/length-truncated response that silently abstains
+// (dead-repair). The repair floor must scale with the route's resolved reasoning
+// budget, never below the historical 600 baseline on a non-reasoning route.
+import { repair_min_max_tokens, structured_min_max_tokens } from "std/llm/safe"
+
+pipeline test(task) {
+  // Non-reasoning route (mock model): historical 600 repair baseline, unchanged.
+  let non_reasoning = repair_min_max_tokens({provider: "mock", model: "mock-model"})
+  __io_println("non_reasoning=" + to_string(non_reasoning))
+  __io_println("non_reasoning_is_600=" + to_string(non_reasoning == 600))
+  // The non-reasoning repair baseline must NOT regress below the structured
+  // judge floor (512) — it stays at the higher historical 600.
+  __io_println("non_reasoning_at_or_above_judge_floor=" + to_string(non_reasoning >= 512))
+  // Reasoning route under Harn's auto policy (gpt-oss-120b -> effort low =
+  // 1024 reasoning tokens). The repair floor must clear BOTH the prior 600
+  // starvation budget AND the resolved reasoning budget, with verdict headroom.
+  let reasoning = repair_min_max_tokens({provider: "fireworks", model: "accounts/fireworks/models/gpt-oss-120b"})
+  __io_println("reasoning_exceeds_old_600=" + to_string(reasoning > 600))
+  __io_println("reasoning_exceeds_1024_reasoning_budget=" + to_string(reasoning > 1024))
+  __io_println("reasoning_value=" + to_string(reasoning))
+  // The repair floor tracks the judge floor on a reasoning route (shared route,
+  // shared reasoning channel) — they must NOT drift.
+  let judge = structured_min_max_tokens({provider: "fireworks", model: "accounts/fireworks/models/gpt-oss-120b"})
+  __io_println("reasoning_matches_judge_floor=" + to_string(reasoning == judge))
+  // High explicit reasoning effort scales the repair floor further yet stays
+  // clamped to the structured ceiling.
+  let high = repair_min_max_tokens(
+    {provider: "fireworks", model: "accounts/fireworks/models/gpt-oss-120b", reasoning_effort: "high"},
+  )
+  __io_println("high_scales_above_reasoning=" + to_string(high > reasoning))
+  __io_println("high_within_ceiling=" + to_string(high <= 32768))
+  // Explicit reasoning-off on a reasoning-capable route collapses to the flat
+  // 600 baseline (no needless inflation when the caller disabled reasoning).
+  let disabled = repair_min_max_tokens(
+    {provider: "fireworks", model: "accounts/fireworks/models/gpt-oss-120b", reasoning_effort: "off"},
+  )
+  __io_println("disabled_is_600=" + to_string(disabled == 600))
+}

--- a/crates/harn-stdlib/src/stdlib/llm/handlers.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/handlers.harn
@@ -16,7 +16,7 @@
 import { agent_emit_event } from "std/agent/state"
 import { cache_get, cache_put } from "std/cache"
 import { llm_call_options } from "std/llm/options"
-import { with_case_insensitive_keys } from "std/llm/safe"
+import { repair_min_max_tokens, with_case_insensitive_keys } from "std/llm/safe"
 
 /**
  * default_llm_caller returns a closure with the canonical (call) -> result
@@ -975,7 +975,23 @@ fn __repair_apply_strategy(call, envelope, strategy, max_tokens, temperature) {
   let original_prompt = to_string(call?.prompt ?? "")
   var repaired_opts = __opts_dict(call?.opts)
   if max_tokens != nil {
-    repaired_opts = repaired_opts + {max_tokens: to_int(max_tokens)}
+    // The repair pass re-issues a structured verdict on the SAME route, so it
+    // shares the reasoning channel's budget. A flat repair `max_tokens` (the
+    // 600 default) is the twin of the pre-#3598 judge starvation: on a
+    // reasoning route the hidden analysis channel drains the shared budget and
+    // truncates the repaired JSON to empty. Floor the repair budget reasoning-
+    // awarely for THIS route (computed from the call's own opts) so it is only
+    // ever raised, never lowered — a non-reasoning route keeps the requested
+    // budget, a reasoning route clears the truncation floor. Reuses the shared
+    // `repair_min_max_tokens` so this never drifts from the judge floor.
+    let requested = to_int(max_tokens) ?? 0
+    let floor = repair_min_max_tokens(repaired_opts)
+    let effective = if requested > floor {
+      requested
+    } else {
+      floor
+    }
+    repaired_opts = repaired_opts + {max_tokens: effective}
   }
   if temperature != nil {
     repaired_opts = repaired_opts + {temperature: temperature}
@@ -993,15 +1009,18 @@ fn __repair_apply_strategy(call, envelope, strategy, max_tokens, temperature) {
  *
  * One-shot repair pass on `schema_validation` failures. When `next(call)`
  * returns `{ok: false, status: "schema_validation", error}`, the wrapper
- * appends a corrective nudge to `call.prompt`, lowers `max_tokens` and
- * `temperature` for the repair pass, and asks `next` once more. The
+ * appends a corrective nudge to `call.prompt`, sets `max_tokens` (reasoning-aware
+ * floored) and `temperature` for the repair pass, and asks `next` once more. The
  * second envelope is returned with `repair_attempted: true`.
  *
  * Options:
  *   - strategy: string | closure(prompt, system, opts, envelope) -> string
  *               Custom corrective nudge. Falls back to a deterministic
  *               schema-failure message that lists the validator's hint.
- *   - max_tokens: int (default 600) — applied to the repair-pass opts
+ *   - max_tokens: int (default 600) — applied to the repair-pass opts, then
+ *                 floored reasoning-awarely via `repair_min_max_tokens` for the
+ *                 call's route (raised, never lowered) so a reasoning route's
+ *                 repaired JSON verdict is not starved by its reasoning channel
  *   - temperature: float (default 0.0)
  *   - enabled: bool (default true) — when false, behaves as a no-op pass
  *

--- a/crates/harn-stdlib/src/stdlib/llm/safe.harn
+++ b/crates/harn-stdlib/src/stdlib/llm/safe.harn
@@ -286,7 +286,9 @@ pub fn schema_retry_nudge_for(schema, hint) {
  *   temperature      -> 0.0
  *   schema_retries   -> 2
  *   repair.enabled   -> true
- *   repair.max_tokens-> 600
+ *   repair.max_tokens-> floored reasoning-awarely: `max(600, structured floor)`
+ *                       (600 baseline on a non-reasoning route; reasoning budget
+ *                       + verdict headroom on a reasoning route)
  *   repair.temperature -> 0.0
  *   schema_retry_nudge -> derived via `schema_retry_nudge_for`
  *   max_tokens       -> floored to `STRUCTURED_MIN_MAX_TOKENS` (512)
@@ -322,6 +324,17 @@ pub fn safe_structured_call(prompt, schema, options) {
  * (e.g. a 1200-token rubric judge) is left untouched.
  */
 let STRUCTURED_MIN_MAX_TOKENS = 512
+
+/**
+ * Minimum output-token budget for the structured REPAIR side-call on a
+ * NON-reasoning route. The repair pass re-emits the verdict JSON after a
+ * schema-validation failure; historically it ran with a flat 600-token budget.
+ * Kept as the non-reasoning baseline (never lowered) so a reasoning route is
+ * the only thing the reasoning-aware floor raises — preserving exact behavior
+ * for non-reasoning callers while fixing the reasoning-route starvation twin of
+ * the #3598 judge bug.
+ */
+let REPAIR_MIN_MAX_TOKENS = 600
 
 /**
  * Headroom (output tokens) reserved for the visible JSON verdict ON TOP of a
@@ -431,6 +444,29 @@ pub fn structured_min_max_tokens(options) {
   return floor
 }
 
+/**
+ * Reasoning-aware minimum output-token budget for the structured REPAIR
+ * side-call. The repair pass re-emits the verdict JSON on the SAME route after a
+ * schema-validation failure, so it shares the reasoning channel's `max_tokens`
+ * budget exactly like the main call. A flat 600-token repair floor is the twin
+ * of the pre-#3598 judge starvation: on a reasoning route the hidden analysis
+ * channel drains the shared budget and truncates the repaired JSON to empty -> a
+ * silent dead-repair. This returns `max(REPAIR_MIN_MAX_TOKENS, structured floor)`
+ * so a non-reasoning route keeps the historical 600 baseline (unchanged) while a
+ * reasoning route is raised to reasoning_budget + verdict headroom. It reuses
+ * `structured_min_max_tokens` so the repair floor never drifts from the judge
+ * floor. Only ever RAISES; an explicit larger repair budget is left untouched.
+ * @effects: []
+ * @errors: []
+ */
+pub fn repair_min_max_tokens(options) {
+  let floor = structured_min_max_tokens(options)
+  if floor > REPAIR_MIN_MAX_TOKENS {
+    return floor
+  }
+  return REPAIR_MIN_MAX_TOKENS
+}
+
 fn __apply_judge_defaults(schema, options) {
   var resolved = options
   let requested_max_tokens = to_int(resolved?.max_tokens ?? 0) ?? 0
@@ -456,8 +492,16 @@ fn __apply_judge_defaults(schema, options) {
   if repair?.enabled == nil {
     repair = repair + {enabled: true}
   }
-  if repair?.max_tokens == nil {
-    repair = repair + {max_tokens: 600}
+  // Floor the repair budget reasoning-awarely (see `repair_min_max_tokens`):
+  // a non-reasoning route keeps the historical 600 baseline, a reasoning route
+  // gets reasoning_budget + verdict headroom so the repaired JSON verdict is not
+  // starved by the route's hidden reasoning channel (twin of the #3598 judge
+  // bug). Resolved against the same options as the main floor so the two never
+  // drift. Only ever RAISES.
+  let repair_floor = repair_min_max_tokens(resolved)
+  let requested_repair_max_tokens = to_int(repair?.max_tokens ?? 0) ?? 0
+  if requested_repair_max_tokens < repair_floor {
+    repair = repair + {max_tokens: repair_floor}
   }
   if repair?.temperature == nil {
     repair = repair + {temperature: 0.0}


### PR DESCRIPTION
## Problem

The structured-output **repair** side-call in `std/llm/safe` used a flat, reasoning-blind `max_tokens: 600`. This is the twin of the pre-#3598 judge starvation: the repair pass re-emits the verdict JSON on the **same route** after a schema-validation failure, so it shares the route's reasoning channel budget. On a reasoning model (gpt-oss `low` resolves to `>= 1024` reasoning tokens under Harn's auto policy) the hidden analysis channel drains the 600-token budget, truncating the repaired JSON to empty -> a **silent dead-repair**. #3598 fixed exactly this class for the main structured floor; this side-call was missed.

### Exact starved call sites
- `crates/harn-stdlib/src/stdlib/llm/safe.harn` `__apply_judge_defaults`: `repair.max_tokens` defaulted to a flat `600`. The `repair` dict flows into the Rust `llm_call_structured_result` (`structured_envelope.rs` -> `merge_repair_options`), whose `overrides` are applied **last** over the base opts, overwriting the floored main `max_tokens` with `600`.
- `crates/harn-stdlib/src/stdlib/llm/handlers.harn` `with_repair` / `__repair_apply_strategy`: the caller-seam repair pass set `max_tokens` from its `600` default onto `call.opts` — same starvation.

## Fix (generalizable, behavior-preserving for non-reasoning routes)

New `repair_min_max_tokens(options)` pub helper returns `max(REPAIR_MIN_MAX_TOKENS=600, structured_min_max_tokens(options))`, **reusing the #3598 judge floor** so the repair budget never drifts from the judge path. A non-reasoning route keeps the historical `600` baseline (unchanged); a reasoning route is raised to `reasoning_budget + verdict headroom`. Applied in both `__apply_judge_defaults` and `__repair_apply_strategy` (raised, never lowered).

### Before/after resolved repair budget
| route | before | after |
|---|---|---|
| non-reasoning (mock) | 600 | **600** (unchanged) |
| gpt-oss `low` reasoning | 600 (starved) | **1792** (= the #3598 judge floor exactly) |
| gpt-oss `high` reasoning | 600 (starved) | scales further, clamped to 32768 ceiling |
| reasoning-off | 600 | 600 |

## Verification (deterministic, no cloud)
- New mechanism test `safe_repair_call_reasoning_floor` mirrors #3598's: non-reasoning floor = 600, gpt-oss low = 1792 (> old 600, > 1024 reasoning budget) and **matches the judge floor exactly** (no drift), high scales within ceiling, reasoning-off collapses to 600.
- `harn test conformance --filter safe` -> 14/14 PASS (incl. #3598's `safe_structured_call_reasoning_floor`).
- `harn test conformance --filter stdlib/` -> 307/307 PASS.
- `harn test conformance --filter repair` -> 16/16 PASS (incl. `llm_handlers_with_repair`).
- `cargo test -p harn-vm --lib llm` -> 1237/1237 PASS; repair Rust path 13/13.
- `cargo fmt --all -- --check` + `harn fmt --check` clean; HARN-STD-101 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)