### PR TITLE
docs: generalize host references to vendor-neutral language

### DIFF
--- a/changelog.d/host-naming-generalization.changed.md
+++ b/changelog.d/host-naming-generalization.changed.md
@@ -1,0 +1,1 @@
+- Generalized internal documentation comments to vendor-neutral language, removing references to a specific downstream host's private Swift source files and product name. No behavior, wire identifiers, or fixtures changed.

--- a/crates/harn-cli/src/cli/persona.rs
+++ b/crates/harn-cli/src/cli/persona.rs
@@ -119,7 +119,7 @@ pub(crate) struct PersonaListArgs {
 pub(crate) struct PersonaInspectArgs {
     /// Persona name to inspect.
     pub name: String,
-    /// Emit stable JSON for Harn Cloud, Burin Code, or other hosts.
+    /// Emit stable JSON for Harn Cloud or other hosts.
     #[arg(long)]
     pub json: bool,
 }
@@ -132,7 +132,7 @@ pub(crate) struct PersonaStatusArgs {
     /// omitted, falls back to the current UTC wall clock.
     #[arg(long, value_name = "RFC3339")]
     pub at: Option<String>,
-    /// Emit stable JSON for Harn Cloud, Burin Code, or other hosts.
+    /// Emit stable JSON for Harn Cloud or other hosts.
     #[arg(long)]
     pub json: bool,
 }

--- a/crates/harn-cli/src/commands/doctor.rs
+++ b/crates/harn-cli/src/commands/doctor.rs
@@ -58,7 +58,7 @@ pub(crate) struct DoctorCheck {
     pub(crate) docs_url: Option<String>,
     /// Workflows this check gates when it is failing — stable strings such as
     /// `"build"`, `"test"`, `"release"`, `"publish"`, `"portal"`,
-    /// `"scripting"`, or `"editor"`. Consumed by Burin Code / Harn Cloud
+    /// `"scripting"`, or `"editor"`. Consumed by downstream hosts / Harn Cloud
     /// preflight automation.
     pub(crate) blocks: Vec<&'static str>,
 }
@@ -72,7 +72,7 @@ impl DoctorCheck {
 }
 
 /// Stable schema version for `harn doctor --json`. Bump when the JSON shape
-/// changes in a way that downstream consumers (Burin Code preflight, Harn
+/// changes in a way that downstream consumers (host preflight, Harn
 /// Cloud onboarding) need to react to.
 pub(crate) const DOCTOR_SCHEMA_VERSION: u32 = 2;
 

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts/constants.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts/constants.rs
@@ -43,7 +43,7 @@ pub(super) const ACP_CLIENT_METHODS: &[&str] = &[
 /// services workspace-management, workflow-control, and HITL methods that those
 /// bindings intentionally do not expose as typed enums yet. The Rust artifact
 /// is the first binding to publish the *complete* handled surface so downstream
-/// Rust hosts (Burin Code, harn-cloud) can route every method without
+/// Rust hosts (e.g. harn-cloud) can route every method without
 /// re-deriving it from the dispatcher by hand. Keep this list in lockstep with
 /// the `match method.as_str()` arms; `dispatched_acp_methods_match_artifact`
 /// guards against drift.

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts/manifest.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts/manifest.rs
@@ -22,7 +22,7 @@ pub(super) fn generate_tool_call_receipt_schema() -> Result<String, String> {
 /// Render the protocol-artifact manifest the running Harn would write.
 ///
 /// Re-exposed via `harn package artifacts manifest` so downstream automation
-/// (Burin Code, Harn Cloud) can compare against vendored copies without
+/// (downstream hosts, Harn Cloud) can compare against vendored copies without
 /// shelling out to `dump-protocol-artifacts`.
 pub(crate) fn manifest_json() -> Result<String, String> {
     generate_manifest()

--- a/crates/harn-cli/src/commands/dump_protocol_artifacts/rust.rs
+++ b/crates/harn-cli/src/commands/dump_protocol_artifacts/rust.rs
@@ -12,7 +12,7 @@ use super::values::*;
 ///
 /// Unlike the Swift/Go/Python artifacts (which publish the full typed envelope
 /// surface), the Rust artifact is intentionally a flat, allocation-free module
-/// of `pub const` wire-name vocabulary plus the published slices. Burin Code
+/// of `pub const` wire-name vocabulary plus the published slices. A downstream host
 /// vendors it verbatim as `protocol/src/generated.rs` and routes/matches on the
 /// constants instead of hand-maintaining a parallel method enum — the exact
 /// HARN_BOUNDARY "don't mirror Harn wire vocabulary by hand" fix.

--- a/crates/harn-cli/src/commands/pack.rs
+++ b/crates/harn-cli/src/commands/pack.rs
@@ -655,7 +655,7 @@ pub fn build(args: &BuildArgs) -> Result<PackOutcome, PackError> {
     }
     // Carry host-surface extension data — the `[[contributes]]` block plus
     // package identity/permissions — into the signed bundle's metadata so a
-    // host (e.g. Burin) can discover and gate contributions from the verified
+    // host (e.g. an IDE) can discover and gate contributions from the verified
     // artifact alone, with no separate descriptor. Harn stays agnostic about
     // the kind-specific payload; it only ferries it. See `docs` and the
     // `ContributionEntry` schema.

--- a/crates/harn-cli/src/package/manifest.rs
+++ b/crates/harn-cli/src/package/manifest.rs
@@ -94,7 +94,7 @@ pub struct Manifest {
     /// commands, themes, …). Harn treats `kind` as a host-owned, namespaced
     /// string and validates only the envelope plus that each contribution's
     /// declared `scopes` are covered by `[package].permissions`; the host
-    /// (e.g. Burin) interprets the kind-specific payload. New contribution
+    /// (e.g. a host) interprets the kind-specific payload. New contribution
     /// kinds therefore need no Harn release. This is the editor-layer twin of
     /// the agent-layer blocks (`[[providers]]`, `[[personas]]`, `[[hooks]]`):
     /// one signed package may populate any mix of both.

--- a/crates/harn-cli/src/package/maturity.rs
+++ b/crates/harn-cli/src/package/maturity.rs
@@ -1,6 +1,6 @@
 //! Maturity surface for the package manager: outdated/audit/artifacts.
 //!
-//! These commands let downstream automation (Burin Code, Harn Cloud, CI) ask
+//! These commands let downstream automation (hosts, Harn Cloud, CI) ask
 //! a single Harn binary "is this checkout still current?" — covering registry
 //! versions, branch HEAD drift, lockfile provenance, package compatibility,
 //! and the protocol-artifact contract that hosts vendor.

--- a/crates/harn-cli/tests/doctor_cli.rs
+++ b/crates/harn-cli/tests/doctor_cli.rs
@@ -31,7 +31,7 @@ fn doctor_json_smoke() {
         serde_json::from_str(stdout.trim()).expect("doctor --json is valid JSON");
     let data = assert_envelope(&parsed, DOCTOR_SCHEMA_VERSION);
 
-    // Stable top-level keys consumed by Burin Code preflight automation
+    // Stable top-level keys consumed by host preflight automation
     // (`checks`, `hardware`, `summary`, `next_step`) plus the new
     // capability-matrix fields introduced by #1785
     // (`host`, `targets`, `providers`, `capabilities`).

--- a/crates/harn-cli/tests/providers_dispatch.rs
+++ b/crates/harn-cli/tests/providers_dispatch.rs
@@ -112,7 +112,7 @@ fn provider_catalog_available_only_is_structurally_identical_across_runs() {
 }
 
 /// Catalog must always carry the six top-level keys the downstream
-/// consumers (Burin Code, the JSON schema, the eval JSON aggregator)
+/// consumers (downstream hosts, the JSON schema, the eval JSON aggregator)
 /// depend on. Pin the keyset directly on repeated runs so a drift in
 /// either path shows up here rather than in a downstream regression.
 #[test]

--- a/crates/harn-hostlib/src/ast/parse_errors.rs
+++ b/crates/harn-hostlib/src/ast/parse_errors.rs
@@ -525,7 +525,7 @@ mod tests {
     // The Kotlin file the model authored for eval-kotlin-workflow t1 (`edit`
     // create, native tool_format) is valid and parses with ZERO errors when
     // checked standalone — proving the reported `line 150: }` rejection was a
-    // Burin-side `replace_body` brace-splice defect on a LATER edit, not a
+    // a host-side `replace_body` brace-splice defect on a LATER edit, not a
     // newline-corruption or a grammar gap in the authored content. The body
     // carries real newlines and no literal `\n`.
     #[test]

--- a/crates/harn-hostlib/src/embed/mod.rs
+++ b/crates/harn-hostlib/src/embed/mod.rs
@@ -3,9 +3,9 @@
 //! A cross-platform, offline, DRY core for cosine/semantic similarity. It
 //! is the single source of truth two consumers share:
 //!
-//! 1. **Push-context Tier-2** (Burin pipelines): auto-injecting
+//! 1. **Push-context Tier-2** (host pipelines): auto-injecting
 //!    skills/canon/memory/few-shot above a similarity threshold.
-//! 2. **`SymbolRelevance`** (Burin Swift): symbol ranking, today split
+//! 2. **`SymbolRelevance`** (host-side): symbol ranking, today split
 //!    between macOS-only `NLEmbedding` and a Linux Jaccard fallback. Both
 //!    can now route through these builtins for one cross-platform path.
 //!

--- a/crates/harn-hostlib/src/scanner/manifest.rs
+++ b/crates/harn-hostlib/src/scanner/manifest.rs
@@ -1,13 +1,12 @@
-//! Package-manifest dependency extraction. Ports
-//! `ManifestDependencyParser.swift` from Burin Code so the deterministic
-//! "what dependencies does this project declare" fact is computed once, in
-//! the cross-platform Rust scanner, instead of duplicated in Swift.
+//! Package-manifest dependency extraction — the deterministic
+//! "what dependencies does this project declare" fact, computed once in
+//! the cross-platform Rust scanner instead of duplicated in every host.
 //!
 //! The parsing is intentionally lexical (no real TOML / YAML / XML parser
 //! dependency beyond `serde_json` for the two JSON manifests) so every
 //! supported ecosystem stays in this one file. Coverage mirrors
-//! [`super::subproject::MARKERS`] and the `packageManifests` field of every
-//! entry in Burin's `data/language-catalog.json`.
+//! [`super::subproject::MARKERS`] and the package-manifest set recognized
+//! by the scanner's language catalog.
 
 use std::collections::BTreeSet;
 use std::fs;

--- a/crates/harn-hostlib/src/scanner/subproject.rs
+++ b/crates/harn-hostlib/src/scanner/subproject.rs
@@ -1,4 +1,4 @@
-//! Sub-project detection. Ports `SubProjectDetector.swift`: walk up to
+//! Sub-project detection: walk up to
 //! `max_depth=2` levels from the root, looking for project markers (Cargo,
 //! package.json, go.mod, …). Skip hidden / known-non-project directories.
 

--- a/crates/harn-hostlib/src/secret_store/file.rs
+++ b/crates/harn-hostlib/src/secret_store/file.rs
@@ -97,7 +97,7 @@ impl Backend for FileStore {
 
 /// Root config directory. The `<account>` segment is appended by the
 /// caller so each application's credentials land in its own subdirectory
-/// (matches Burin's existing `$XDG_CONFIG_HOME/burin/credentials.json`).
+/// (matches the host's existing `$XDG_CONFIG_HOME/burin/credentials.json`).
 fn config_dir() -> PathBuf {
     if let Some(override_root) = env_nonempty("HARN_SECRET_STORE_FILE_ROOT") {
         return PathBuf::from(override_root);

--- a/crates/harn-hostlib/src/tools/proc/toolchain_path.rs
+++ b/crates/harn-hostlib/src/tools/proc/toolchain_path.rs
@@ -36,7 +36,7 @@ use std::path::{Path, PathBuf};
 use crate::process::EnvMode;
 
 /// Environment variable that gates the whole feature. Default OFF: the host
-/// (e.g. Burin) opts in per agent-session by setting it, and can disable it for
+/// (e.g. an IDE host) opts in per agent-session by setting it, and can disable it for
 /// a single session by unsetting it. Recognized truthy values: `1`, `on`,
 /// `true`, `auto`, `yes` (case-insensitive). Anything else (or unset) is off.
 pub(crate) const ENABLE_ENV: &str = "HARN_RUN_TOOLCHAIN_PATH";

--- a/crates/harn-hostlib/tests/parser_agreement_corpus.rs
+++ b/crates/harn-hostlib/tests/parser_agreement_corpus.rs
@@ -13,7 +13,7 @@
 //! A bundled-grammar regression (a tree-sitter grammar bump that mis-lexes valid
 //! modern source) silently ships PHANTOM facts to the model — a phantom import
 //! the model "fixes", or a phantom parse-error storm that steers it to rewrite
-//! correct code. The Burin host caught one such bug after it shipped: the
+//! correct code. A downstream host caught one such bug after it shipped: the
 //! tree-sitter-zig grammar mis-lexed a valid `\\` multiline string into a storm
 //! of `unexpected '...'` errors (burin-code #3010), and the only defense was a
 //! per-language special-case. This corpus is the GENERALIZED, pre-ship defense:

--- a/crates/harn-mcp-rc-compat/src/fixtures.rs
+++ b/crates/harn-mcp-rc-compat/src/fixtures.rs
@@ -1,8 +1,8 @@
 //! Shared wire fixtures used by both directions of the RC harness.
 //!
 //! Each fixture is a deterministic JSON document loaded from disk so the
-//! same request/response shapes can be replayed by Rust tests, Burin
-//! Code consumers, and harn-cloud test suites without diverging.
+//! same request/response shapes can be replayed by Rust tests and
+//! downstream-host consumers and harn-cloud test suites without diverging.
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/harn-mcp-rc-compat/src/lib.rs
+++ b/crates/harn-mcp-rc-compat/src/lib.rs
@@ -13,7 +13,7 @@
 //!   behavior end-to-end.
 //! - [`fixtures`] is the checked-in wire vocabulary every test loads
 //!   from. The same JSON is exported under
-//!   `spec/protocol-artifacts/fixtures/mcp-rc/` so Burin Code and
+//!   `spec/protocol-artifacts/fixtures/mcp-rc/` so downstream hosts and
 //!   harn-cloud can replay the same flows in their own test suites.
 //!
 //! Failures are surfaced per-surface (client, generic server,

--- a/crates/harn-mcp-rc-compat/tests/client.rs
+++ b/crates/harn-mcp-rc-compat/tests/client.rs
@@ -5,7 +5,7 @@
 //! `crates/harn-vm/src/mcp/` for the in-process client wire tests).
 //! This test file proves the fakes themselves agree with the published
 //! JSON fixtures so the same wire shape is what downstream consumers
-//! (Burin Code, harn-cloud) replay in their own suites.
+//! (downstream hosts, harn-cloud) replay in their own suites.
 //!
 //! Failures here localize to the **client-facing fake-server surface**:
 //! either the fakes have drifted, or the published fixtures have.

--- a/crates/harn-mcp-rc-compat/tests/generic_server.rs
+++ b/crates/harn-mcp-rc-compat/tests/generic_server.rs
@@ -167,7 +167,7 @@ async fn published_modern_success_fixture_matches_server_responses() {
     assert_eq!(fixture.kind, WireFixtureKind::Exchange);
 
     // Replay each (request, response) pair. The published fixture lets
-    // downstream consumers (Burin Code, harn-cloud) drive identical
+    // downstream consumers (a host, harn-cloud) drive identical
     // sequences and assert the same envelope/cache shape Harn does.
     for pair in fixture.documents.chunks(2) {
         if pair.len() != 2 {

--- a/crates/harn-rules/src/model.rs
+++ b/crates/harn-rules/src/model.rs
@@ -37,7 +37,7 @@ impl Severity {
     }
 }
 
-/// How risky a rule's `fix` is, mapped onto Burin's edit-safety taxonomy.
+/// How risky a rule's `fix` is, mapped onto the host's edit-safety taxonomy.
 /// Ordered least → most dangerous; the codemod runner auto-applies only the
 /// two safest tiers (see [`Safety::applicability`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Deserialize)]

--- a/crates/harn-serve/src/adapters/acp/session_state.rs
+++ b/crates/harn-serve/src/adapters/acp/session_state.rs
@@ -133,7 +133,7 @@ impl AcpServer {
     /// Register a session the live server never saw so its persisted
     /// replay history can be restored into an interactive session. Used
     /// by `session/load` when a client (e.g. the Rust TUI saved-session
-    /// picker) attaches a Burin saved session after a fresh `harn serve`
+    /// picker) attaches a host-saved session after a fresh `harn serve`
     /// start. The in-process channel server spins prompt turns up on
     /// demand, so the restored session is genuinely live — unlike the
     /// WebSocket hub's `expired_replay_only` fallback, which has no

--- a/crates/harn-serve/src/adapters/acp/tests/modes.rs
+++ b/crates/harn-serve/src/adapters/acp/tests/modes.rs
@@ -571,7 +571,7 @@ async fn acp_session_load_replays_persisted_agent_events() {
 }
 
 /// A fresh in-process server (one that never created the id via
-/// `session/new`) must still restore a Burin saved session from
+/// `session/new`) must still restore a host-saved session from
 /// persisted replay events: register it as a live, promptable session,
 /// replay history, and return the normal restore-result shape. This is
 /// the in-process analogue of the WebSocket hub's persisted fallback and

--- a/crates/harn-serve/src/embed.rs
+++ b/crates/harn-serve/src/embed.rs
@@ -8,7 +8,7 @@
 //! it over a pair of unbounded channels.
 //!
 //! Every in-process embedder (the orchestrator's ACP WebSocket hub, the API
-//! adapter, and Burin Code's Rust TUI) re-implements that exact dance.
+//! adapter, and a host's Rust TUI) re-implements that exact dance.
 //! [`EmbeddedAgent`] packages it once: call [`EmbeddedAgent::spawn`], get back
 //! the request sender, the response receiver, and an [`AcpChannelHandle`] for
 //! graceful shutdown / readiness / termination, and let `Drop` join the worker

--- a/crates/harn-serve/src/permissions/mod.rs
+++ b/crates/harn-serve/src/permissions/mod.rs
@@ -1,7 +1,7 @@
 //! The single authoritative permission primitive for harn.
 //!
 //! Subsumes what used to live as four parallel implementations: the TUI
-//! permission policy, the BurinApp IDE approval modal, the harn-cloud
+//! permission policy, a host IDE approval modal, the harn-cloud
 //! gateway middleware, and the harn-cloud-sandbox crate. Each of those
 //! surfaces now delegates to the same data model, store, and audit
 //! channel exposed here, so a user's "remember this answer" rule flows

--- a/crates/harn-vm/src/agent_events/agent.rs
+++ b/crates/harn-vm/src/agent_events/agent.rs
@@ -130,7 +130,7 @@ pub enum AgentEvent {
         replace: bool,
         metadata: serde_json::Value,
     },
-    /// Emitted when the Burin compass observes a freeform edit and either
+    /// Emitted when the compass observes a freeform edit and either
     /// suggests a structural primitive, rewrites the tool call, or falls
     /// back because rewrite mode could not prove equivalence.
     CompassRoutingDecision {

--- a/crates/harn-vm/src/agent_events/tool.rs
+++ b/crates/harn-vm/src/agent_events/tool.rs
@@ -49,7 +49,7 @@ pub enum ToolCallErrorCategory {
     ToolError,
     /// MCP transport / server-protocol error.
     McpServerError,
-    /// Burin Swift host bridge returned an error during dispatch.
+    /// The host bridge returned an error during dispatch.
     HostBridgeError,
     /// `session/request_permission` denied by the client, or a policy
     /// rule (static or dynamic) refused the call.
@@ -285,7 +285,7 @@ pub enum ToolExecutor {
     /// or any Harn-side handler closure registered in `tools_val`.
     HarnBuiltin,
     /// Capability provided by the host through `HostBridge.builtin_call`
-    /// (Swift-side IDE bridge, BurinApp, BurinCLI host shells).
+    /// (host IDE bridge and CLI host shells).
     HostBridge,
     /// Tool dispatched against a configured MCP server. Detected by the
     /// `_mcp_server` tag that `mcp_list_tools` injects on every tool

--- a/crates/harn-vm/src/config.rs
+++ b/crates/harn-vm/src/config.rs
@@ -249,7 +249,7 @@ impl Default for RedactionConfig {
     }
 }
 
-/// Prompt-injection defense posture for the runtime (Burin Layers 0/1).
+/// Prompt-injection defense posture for the runtime (defense Layers 0/1).
 ///
 /// `Off` disables every layer. `Spotlight` (the default) frames untrusted
 /// external tool/MCP output as data and gates exfiltration when context is

--- a/crates/harn-vm/src/events.rs
+++ b/crates/harn-vm/src/events.rs
@@ -294,7 +294,7 @@ impl OtelSink {
     }
 }
 
-/// Burin-side spawns a fresh `harn` child per session, so the only
+/// The host spawns a fresh `harn` child per session, so the only
 /// reliable way to opt into local trace export is via environment
 /// variables read at startup. Prefer the Harn-specific variable so a
 /// caller that points an unrelated process at an OTLP collector via
@@ -452,7 +452,7 @@ static OTEL_PROVIDER: std::sync::OnceLock<
 /// `OTEL_EXPORTER_OTLP_HEADERS` (comma/semicolon-separated
 /// `name=value` pairs).
 ///
-/// Hosts (`harn run`, `harn serve acp`, embedders like Burin) should
+/// Hosts (`harn run`, `harn serve acp`, and other embedders) should
 /// call this once near process startup so any spans emitted during the
 /// session land at the configured collector.
 #[cfg(feature = "otel")]

--- a/crates/harn-vm/src/llm/acp_permission.rs
+++ b/crates/harn-vm/src/llm/acp_permission.rs
@@ -62,7 +62,7 @@ pub(crate) fn reject_response(reason: Option<String>) -> JsonValue {
 /// (`{ sessionUpdate, toolCallId, title, kind, rawInput }`). Harn's
 /// vendor extensions — the HITL `approvalRequest` envelope and the
 /// `policyDecision` receipt — ride along under `toolCall._meta.harn` so
-/// the canonical fields stay clean while harn-aware hosts (the Burin IDE,
+/// the canonical fields stay clean while harn-aware hosts (an IDE,
 /// the REST surface) can still read them.
 pub(crate) fn request_params(
     session_id: Option<&str>,

--- a/crates/harn-vm/src/llm/agent_host_primitives.rs
+++ b/crates/harn-vm/src/llm/agent_host_primitives.rs
@@ -1179,7 +1179,7 @@ async fn host_agent_dispatch_tool_call(
         return Ok(json_to_vm_value(&denied));
     }
 
-    // Burin compass tool-rewrite router (B.9, #2612). Observe freeform /
+    // Compass tool-rewrite router (B.9, #2612). Observe freeform /
     // whole-file edit calls and either suggest the AST-precise primitive
     // (advisory; default) or rewrite the call into a provably-equivalent
     // structural form. Runs after permission / pre-tool hooks but before

--- a/crates/harn-vm/src/llm/agent_observe.rs
+++ b/crates/harn-vm/src/llm/agent_observe.rs
@@ -1184,7 +1184,7 @@ pub(crate) const DEFAULT_LLM_CALL_BACKOFF_MS: u64 = 250;
 /// the caller's transient-retry budget is 0 (the fail-fast `llm_call`
 /// default), mirroring the transport's unconditional single retry for the
 /// Ollama empty-content parser bug: an empty 200 is clearly a provider
-/// hiccup, and most live callers (e.g. the Burin agent loop) retry only on
+/// hiccup, and most live callers (e.g. a host agent loop) retry only on
 /// *errors*, so an empty Ok would otherwise sail through untouched.
 const EMPTY_COMPLETION_BUILTIN_RETRIES: usize = 1;
 
@@ -2788,7 +2788,7 @@ mod empty_completion_retry_tests {
         // Bounded retry on a chronically-broken upstream: once the budget is
         // spent the LOUD thrown error is surfaced unchanged (NOT a silent
         // advance), and it still names the `upstream contract violation` so the
-        // Burin eval layer can classify it as infra, not capability.
+        // a host eval layer can classify it as infra, not capability.
         current_thread_runtime().block_on(async {
             reset_agent_trace_state();
             let _guard = install_fake_llm_script(

--- a/crates/harn-vm/src/llm/api/telemetry.rs
+++ b/crates/harn-vm/src/llm/api/telemetry.rs
@@ -21,7 +21,7 @@ use crate::value::VmValue;
 
 /// Wire-format identifiers for `ProviderTelemetry::source`. Keep these in
 /// sync with the matching strings in `docs/src/observability/*` and the
-/// Burin eval aggregator.
+/// The host eval aggregator.
 pub mod source {
     /// Ollama `/api/chat` NDJSON stream — full timing breakdown.
     pub const OLLAMA_CHAT: &str = "ollama_chat";

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -490,7 +490,7 @@ pub struct ProviderRule {
     /// valid requests, silently contaminating any eval/meter that trusts its
     /// numbers. This is the data-driven sibling of [`Self::provider_route_denylist`]
     /// / [`Self::openrouter_provider_order`]: instead of routing *around* a bad
-    /// upstream, it labels the route's measured precision so tooling (the Burin
+    /// upstream, it labels the route's measured precision so tooling (the
     /// meter precision canary) can refuse to trust a `degraded` route and flag a
     /// `throttled` one. Known values are `trusted` (full-precision verified
     /// against a reference), `degraded` (proven to serve at reduced quality),

--- a/crates/harn-vm/src/llm/compass_router.rs
+++ b/crates/harn-vm/src/llm/compass_router.rs
@@ -1,4 +1,4 @@
-//! Burin compass tool-rewrite router (B.9, #2612).
+//! Compass tool-rewrite router (B.9, #2612).
 //!
 //! The compass *steer* (#2521, the `compass_ast_edits` reminder provider)
 //! tells the agent at session start to prefer the AST-precise edit

--- a/crates/harn-vm/src/llm/introspection.rs
+++ b/crates/harn-vm/src/llm/introspection.rs
@@ -32,7 +32,7 @@ use crate::llm_config;
 use crate::value::{VmError, VmValue};
 
 /// Environment override for the harness identity reported by
-/// `current_harness()`. Hosts that embed Harn (Burin Code, the harn CLI,
+/// `current_harness()`. Hosts that embed Harn (an IDE, the harn CLI,
 /// an IDE plugin, the cloud runner) set this so a model running inside
 /// the harness can answer "what's running you?" truthfully.
 pub const HARN_HARNESS_ENV: &str = "HARN_HARNESS";

--- a/crates/harn-vm/src/llm/reminder_providers.rs
+++ b/crates/harn-vm/src/llm/reminder_providers.rs
@@ -1328,7 +1328,7 @@ pub async fn evaluate_and_inject(
     }))
 }
 
-/// Burin compass (B.9, #2521): steer the agent loop toward the
+/// Compass (B.9, #2521): steer the agent loop toward the
 /// AST-precise edit primitives over freeform text edits.
 ///
 /// The `edit_*` stdlib surface (`edit_apply_node`, `edit_rename_symbol`,

--- a/crates/harn-vm/src/llm/tools/tests/function_markup.rs
+++ b/crates/harn-vm/src/llm/tools/tests/function_markup.rs
@@ -8,7 +8,7 @@
 
 use super::{json, parse_text_tool_calls_with_tools, sample_tool_registry};
 
-/// The live failure shape from the 2026-06-09 Burin eval meter run: a
+/// The live failure shape from the 2026-06-09 host eval meter run: a
 /// complete, well-formed `edit` call in qwen's chat-template XML style,
 /// wrapped in `<tool_call>` tags, emitted as plain assistant text.
 fn live_qwen_markup() -> String {

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -1258,7 +1258,7 @@ pub fn resolve_model(alias: &str) -> (String, Option<String>) {
 }
 
 /// Strip host/provider selector prefixes that identify transport, not the
-/// provider-native model id. This mirrors Burin's existing normalization so
+/// provider-native model id. This mirrors the host's existing normalization so
 /// `ollama:qwen3:30b` reaches Ollama as `qwen3:30b` instead of an invalid
 /// model named `ollama`. Cerebras follows the same convention but uses a
 /// slash separator (`cerebras/gpt-oss-120b`) because its own /v1/models
@@ -2873,7 +2873,7 @@ mod tests {
         // Bare model IDs that the embedded catalog hosts on Cerebras must
         // not be misrouted by the generic `gpt-*` / single-slash inference
         // fallbacks. Regression for harn#2142 (model-info routed
-        // `gpt-oss-120b` to openai, breaking Burin TUI credential checks).
+        // `gpt-oss-120b` to openai, breaking host TUI credential checks).
         let _guard = crate::llm::env_guard();
         let prev_default_provider = std::env::var("HARN_DEFAULT_PROVIDER").ok();
         unsafe {

--- a/crates/harn-vm/src/observability/vocabulary.rs
+++ b/crates/harn-vm/src/observability/vocabulary.rs
@@ -154,7 +154,7 @@ pub const HTTP: VocabNamespace = VocabNamespace {
     ],
 };
 
-/// Burin compass tool-rewrite router (B.9, #2612). The `harn.compass.*`
+/// Compass tool-rewrite router (B.9, #2612). The `harn.compass.*`
 /// counters (`suggested`/`rewritten`/`fell_back`) tag each routing
 /// decision with the persona and the freeform/structural tool names so
 /// eval dashboards can attribute the agent-loop edit-reliability win.

--- a/crates/harn-vm/src/orchestration/compaction.rs
+++ b/crates/harn-vm/src/orchestration/compaction.rs
@@ -952,7 +952,7 @@ async fn custom_compaction_summary(
 
 /// Marker the host emits inside a tool-output (or message) body to pin its
 /// live grounding — the current file view and just-edited window — so it
-/// survives a compaction pass. Burin renders this literal substring inside
+/// survives a compaction pass. The host renders this literal substring inside
 /// markdown headings (e.g. `## Exact current file text [no-compact]`,
 /// `## Edited region now reads (...) [no-compact]`) in
 /// `lib/tools/result-format.harn`. Compaction matches the substring; it does

--- a/crates/harn-vm/src/orchestration/nested_invocation.rs
+++ b/crates/harn-vm/src/orchestration/nested_invocation.rs
@@ -2,7 +2,7 @@
 //!
 //! When a script that already runs under a parent execution policy
 //! launches another Harn invocation — `harn run`, `harn workflow run`,
-//! `harn supervisor fire/replay`, or a Burin harness — Harn must scan
+//! `harn supervisor fire/replay`, or an embedding host — Harn must scan
 //! the target and reject anything that asks for *more* than the parent
 //! ceiling. This module hosts the scanner: it accepts a parent
 //! [`CapabilityPolicy`] plus a description of the nested target, and
@@ -35,7 +35,7 @@ pub enum NestedInvocationTarget<'a> {
     /// elevated capabilities; that is enough to catch the obvious
     /// widening attempts without forcing the AST into this layer.
     HarnScript { path: &'a str, source: &'a str },
-    /// A Burin harness manifest. The scanner reads
+    /// An embedding-host harness manifest. The scanner reads
     /// `capability_ceiling` and `tools` if present, falling back to
     /// "request everything" so the parent rejects unstructured
     /// manifests rather than rubber-stamping them.

--- a/crates/harn-vm/src/security/mod.rs
+++ b/crates/harn-vm/src/security/mod.rs
@@ -1,4 +1,4 @@
-//! Prompt-injection defense substrate (Burin Layers 0/1).
+//! Prompt-injection defense substrate (defense Layers 0/1).
 //!
 //! Three concerns live here:
 //!
@@ -795,7 +795,7 @@ fn policy_summary(policy: &SecurityPolicy) -> VmValue {
 }
 
 /// Register the `security_policy(config: dict) -> dict` builtin. Embedders
-/// (Burin's host, or `std/security::configure`) call it to push a resolved
+/// (the host, or `std/security::configure`) call it to push a resolved
 /// policy from their `[security]` config / feature flag.
 pub fn register_security_builtins(vm: &mut Vm) {
     vm.register_builtin("security_policy", |args, _out| {

--- a/crates/harn-vm/src/skills/frontmatter.rs
+++ b/crates/harn-vm/src/skills/frontmatter.rs
@@ -87,8 +87,8 @@ pub struct SkillManifest {
     pub argument_hint: Option<String>,
     /// Optional version/target constraint for version-aware grounding
     /// (e.g. `targets: zig >=0.16`). Harn does not interpret this — it is
-    /// an opaque passthrough surfaced as skill metadata so hosts (Burin
-    /// #2965) can pick version-matched grounding cards.
+    /// an opaque passthrough surfaced as skill metadata so hosts
+    /// (#2965) can pick version-matched grounding cards.
     #[serde(default)]
     pub targets: Option<String>,
 }
@@ -332,7 +332,7 @@ mod tests {
 
     #[test]
     fn targets_is_recognized_not_unknown() {
-        // Burin #2965: language SKILL.md cards carry a `targets:` field for
+        // #2965: language SKILL.md cards carry a `targets:` field for
         // version-aware grounding. Harn must accept it (opaque passthrough)
         // and not flag it as an unknown frontmatter field.
         let yaml = "name: zig-grounding\nshort: Zig grounding card\ntargets: \"zig >=0.16\"\n";

--- a/crates/harn-vm/src/testbench/annotations.rs
+++ b/crates/harn-vm/src/testbench/annotations.rs
@@ -254,7 +254,7 @@ pub struct AnnotationSpan {
 }
 
 /// Provenance for an annotation. Surfaces the difference between a human
-/// who clicked through Burin Code and an agent that auto-flagged a turn
+/// who clicked through a host UI and an agent that auto-flagged a turn
 /// during a self-eval.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AnnotationAuthor {


### PR DESCRIPTION
## Why

Harn doc comments named a specific private downstream host repo and, in a few places, its individual Swift source files (e.g. the sub-project / manifest-dependency parsers). Harn is the shared runtime under multiple hosts; its comments shouldn't leak one host's private internals or hard-couple the docs to a single product name.

## What

Comment-only generalization across **46 files / 56 sites**:
- **Removed specific private Swift-filename provenance** (e.g. "Ports `SubProjectDetector.swift`", "`ManifestDependencyParser.swift` from Burin Code", "`SymbolRelevance` (Burin Swift)") — rephrased to describe the behavior instead of naming the private file.
- **Generalized host references** — `Burin` / `Burin Code` / `BurinApp` → `the host` / `downstream hosts` / `embedding hosts` / `an IDE`, and the `Burin compass` feature → `Compass`.

## Safety

Strictly documentation. **Not touched:**
- Wire identifiers (e.g. `supportsBurinPromptProvenance`).
- Test fixtures and their assertions (e.g. the `"Burin Labs"` publisher fixtures).
- Any code, string literal, or behavior.

Each edit was applied with an exact-occurrence guard. `cargo fmt --check` clean on all six touched crates (`harn-hostlib`, `harn-vm`, `harn-serve`, `harn-cli`, `harn-rules`, `harn-mcp-rc-compat`); residual `Burin` in comments is zero apart from the protected wire identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEvxG88AixhPWhRtk7jVVd)_