### PR TITLE
Add code index repo map query

### DIFF
--- a/changelog.d/2030.added.md
+++ b/changelog.d/2030.added.md
@@ -1,0 +1,3 @@
+- Add `code_index.repo_map`, a read-only hostlib query that ranks typed symbol
+  definitions with personalized PageRank and returns a prompt-budgeted
+  structural map for agent grounding.

--- a/changelog.d/edit-precision-replace.added.md
+++ b/changelog.d/edit-precision-replace.added.md
@@ -1,1 +1,9 @@
-`code_index.rename_symbol` now accepts an optional `replacement_text` field. When supplied, the builtin overwrites every true-identifier occurrence of the symbol (still skipping strings and comments) with arbitrary text instead of renaming it — turning the one-shot atomic, syntax-validated, all-or-nothing cross-file primitive into a symbol-grounded find/replace. This collapses a cross-file API migration such as `oldFn` -> `client.newFn(` into a single call. The identifier-validity and shadow-conflict checks (which are rename-only concerns) are skipped in replace mode, but the post-edit syntax-validation safety net still aborts with no write if any rewritten file fails to re-parse.
+`code_index.rename_symbol` now accepts an optional `replacement_text` field.
+When supplied, the builtin overwrites every true-identifier occurrence of the
+symbol (still skipping strings and comments) with arbitrary text instead of
+renaming it, turning the one-shot atomic, syntax-validated, all-or-nothing
+cross-file primitive into a symbol-grounded find/replace. This collapses a
+cross-file API migration such as `oldFn` -> `client.newFn(` into a single call.
+The identifier-validity and shadow-conflict checks (which are rename-only
+concerns) are skipped in replace mode, but the post-edit syntax-validation
+safety net still aborts with no write if any rewritten file fails to re-parse.

--- a/changelog.d/skill-resolve-precedence.fixed.md
+++ b/changelog.d/skill-resolve-precedence.fixed.md
@@ -1,1 +1,7 @@
-`load_skill` and `skill_who_signed` now resolve a bare-name collision deterministically by `source` layer precedence (project > user > host, matching the `Layer` priority table) instead of failing the turn with an "ambiguous" error. Hosts already collapse name collisions before building the registry, so this is defense-in-depth: a registry that still contains two same-named entries resolves to the higher-priority layer rather than erroring, keeping `load_skill` consistent with the catalog the model sees.
+`load_skill` and `skill_who_signed` now resolve a bare-name collision
+deterministically by `source` layer precedence (project > user > host, matching
+the `Layer` priority table) instead of failing the turn with an "ambiguous"
+error. Hosts already collapse name collisions before building the registry, so
+this is defense-in-depth: a registry that still contains two same-named entries
+resolves to the higher-priority layer rather than erroring, keeping `load_skill`
+consistent with the catalog the model sees.

--- a/changelog.d/structured-floor-effort-budget-dry.changed.md
+++ b/changelog.d/structured-floor-effort-budget-dry.changed.md
@@ -1,1 +1,8 @@
-Make the canonical reasoning effort -> token budget mapping the single source of truth. The `std/llm/safe` reasoning-aware structured floor previously re-hardcoded the same `low/medium/high -> 1024/4096/12000` numbers that `budget_for_reasoning_level` already owns in `reasoning_policy.rs`. A new `llm_reasoning_effort_budget(level)` builtin exposes that mapping, and the structured-floor fallback now delegates to it instead of duplicating the constants. Behavior-preserving: the gpt-oss low-effort floor stays 1792 and non-reasoning routes stay 512.
+Make the canonical reasoning effort -> token budget mapping the single source of
+truth. The `std/llm/safe` reasoning-aware structured floor previously
+re-hardcoded the same `low/medium/high -> 1024/4096/12000` numbers that
+`budget_for_reasoning_level` already owns in `reasoning_policy.rs`. A new
+`llm_reasoning_effort_budget(level)` builtin exposes that mapping, and the
+structured-floor fallback now delegates to it instead of duplicating the
+constants. Behavior-preserving: the gpt-oss low-effort floor stays 1792 and
+non-reasoning routes stay 512.

--- a/crates/harn-hostlib/schemas/code_index/repo_map.request.json
+++ b/crates/harn-hostlib/schemas/code_index/repo_map.request.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/code_index/repo_map.request.json",
+  "title": "code_index.repo_map request",
+  "description": "Compute a personalized PageRank over the typed symbol graph and render a compact structural repo map.",
+  "type": "object",
+  "properties": {
+    "task": {
+      "type": "string",
+      "description": "Current user task text. Identifier-like terms boost matching symbols."
+    },
+    "context_files": {
+      "type": "array",
+      "description": "Workspace-relative or absolute files already in context. Symbols in these files receive a stronger personalization boost.",
+      "items": { "type": "string" }
+    },
+    "max_entries": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 12,
+      "description": "Maximum ranked definition entries to return before token-budget rendering."
+    },
+    "token_budget": {
+      "type": "integer",
+      "minimum": 0,
+      "default": 800,
+      "description": "Approximate token budget for the rendered map. The renderer caps output at 4 * token_budget characters."
+    }
+  },
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/schemas/code_index/repo_map.response.json
+++ b/crates/harn-hostlib/schemas/code_index/repo_map.response.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://harnlang.com/schemas/hostlib/code_index/repo_map.response.json",
+  "title": "code_index.repo_map response",
+  "type": "object",
+  "properties": {
+    "rendered": {
+      "type": "string",
+      "description": "Token-budgeted, path-grouped symbol map suitable for prompt injection."
+    },
+    "entries": {
+      "type": "array",
+      "description": "Ranked definition entries before token-budget rendering truncates the text.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": { "type": "string" },
+          "line": { "type": "integer", "minimum": 1 },
+          "kind": { "type": "string", "enum": ["Function", "Type"] },
+          "name": { "type": "string" },
+          "signature": { "type": "string" },
+          "score": { "type": "number" },
+          "reasons": {
+            "type": "array",
+            "items": { "type": "string", "enum": ["task_symbol", "context_file"] }
+          }
+        },
+        "required": ["path", "line", "kind", "name", "signature", "score", "reasons"],
+        "additionalProperties": false
+      }
+    },
+    "truncated": {
+      "type": "boolean",
+      "description": "True when max_entries or token_budget omitted ranked entries from rendered output."
+    },
+    "overlay": {
+      "type": ["string", "null"],
+      "description": "Name of the active branch overlay that served this query, if any."
+    }
+  },
+  "required": ["rendered", "entries", "truncated", "overlay"],
+  "additionalProperties": false
+}

--- a/crates/harn-hostlib/src/code_index/mod.rs
+++ b/crates/harn-hostlib/src/code_index/mod.rs
@@ -42,6 +42,8 @@
 //! - **`freshness`**: per-file hash + mtime comparison against the
 //!   indexed snapshot; consumers detect staleness without forcing a
 //!   rebuild.
+//! - **`repo_map`**: personalized PageRank over the typed graph, rendered
+//!   as a token-budgeted symbol map for agent grounding.
 //!
 //! ### Cross-file safe rename (added in #2508)
 //!
@@ -68,6 +70,7 @@ mod imports;
 mod overlay;
 mod readonly;
 mod rename;
+mod repo_map;
 mod snapshot;
 mod state;
 mod symbol_graph;
@@ -438,6 +441,13 @@ impl HostlibCapability for CodeIndexCapability {
             builtins::BUILTIN_CYPHER,
             "cypher",
             builtins::run_cypher,
+        );
+        register(
+            registry,
+            self.index.clone(),
+            repo_map::BUILTIN,
+            "repo_map",
+            repo_map::run,
         );
         register(
             registry,

--- a/crates/harn-hostlib/src/code_index/repo_map.rs
+++ b/crates/harn-hostlib/src/code_index/repo_map.rs
@@ -1,0 +1,371 @@
+//! `code_index.repo_map` — personalized structural symbol map.
+//!
+//! This is a read-only query over the typed symbol graph. It keeps the
+//! graph-ranking policy in hostlib so hosts can inject the resulting map
+//! without reimplementing PageRank or graph traversal in product glue.
+
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use harn_vm::VmValue;
+
+use super::builtins::SharedIndex;
+use super::file_table::FileId;
+use super::state::IndexState;
+use super::symbol_graph::{Node, NodeId, NodeKind, SymbolGraph};
+use crate::error::HostlibError;
+use crate::tools::args::{
+    build_dict, dict_arg, optional_int, optional_string, optional_string_list, str_value,
+};
+
+pub(super) const BUILTIN: &str = "hostlib_code_index_repo_map";
+
+const DEFAULT_MAX_ENTRIES: usize = 12;
+const DEFAULT_TOKEN_BUDGET: usize = 800;
+const TASK_BOOST: f64 = 10.0;
+const CONTEXT_FILE_BOOST: f64 = 50.0;
+const DAMPING: f64 = 0.85;
+const ITERATIONS: usize = 20;
+
+pub(super) fn run(index: &SharedIndex, args: &[VmValue]) -> Result<VmValue, HostlibError> {
+    let raw = dict_arg(BUILTIN, args)?;
+    let dict = raw.as_ref();
+    let task = optional_string(BUILTIN, dict, "task")?.unwrap_or_default();
+    let context_files = optional_string_list(BUILTIN, dict, "context_files")?;
+    let max_entries = positive_usize_arg(
+        "max_entries",
+        optional_int(BUILTIN, dict, "max_entries", DEFAULT_MAX_ENTRIES as i64)?,
+    )?;
+    let token_budget = non_negative_usize_arg(
+        "token_budget",
+        optional_int(BUILTIN, dict, "token_budget", DEFAULT_TOKEN_BUDGET as i64)?,
+    )?;
+
+    let guard = index.lock().expect("code_index mutex poisoned");
+    let Some(state) = guard.as_ref() else {
+        return Ok(empty_response(None));
+    };
+
+    let graph = state.overlays.graph(&state.symbols);
+    let context_file_ids = context_file_ids(state, &context_files);
+    let task_terms = task_terms(&task);
+    let ranks = personalized_pagerank(graph, &task_terms, &context_file_ids);
+    let mut entries = ranked_definition_entries(graph, &ranks, &task_terms, &context_file_ids);
+    let truncated_by_entries = entries.len() > max_entries;
+    if truncated_by_entries {
+        entries.truncate(max_entries);
+    }
+    let (rendered, truncated_by_budget) = render_entries(&entries, token_budget);
+
+    Ok(build_dict([
+        ("rendered", str_value(rendered)),
+        (
+            "entries",
+            VmValue::List(Arc::new(entries.iter().map(entry_to_vm).collect())),
+        ),
+        (
+            "truncated",
+            VmValue::Bool(truncated_by_entries || truncated_by_budget),
+        ),
+        (
+            "overlay",
+            state
+                .overlays
+                .active()
+                .map(str_value)
+                .unwrap_or(VmValue::Nil),
+        ),
+    ]))
+}
+
+fn empty_response(overlay: Option<&str>) -> VmValue {
+    build_dict([
+        ("rendered", str_value("")),
+        ("entries", VmValue::List(Arc::new(Vec::new()))),
+        ("truncated", VmValue::Bool(false)),
+        ("overlay", overlay.map(str_value).unwrap_or(VmValue::Nil)),
+    ])
+}
+
+fn positive_usize_arg(param: &'static str, value: i64) -> Result<usize, HostlibError> {
+    if value < 1 {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param,
+            message: format!("must be >= 1, got {value}"),
+        });
+    }
+    usize::try_from(value).map_err(|_| HostlibError::InvalidParameter {
+        builtin: BUILTIN,
+        param,
+        message: "does not fit in usize".to_string(),
+    })
+}
+
+fn non_negative_usize_arg(param: &'static str, value: i64) -> Result<usize, HostlibError> {
+    if value < 0 {
+        return Err(HostlibError::InvalidParameter {
+            builtin: BUILTIN,
+            param,
+            message: format!("must be >= 0, got {value}"),
+        });
+    }
+    usize::try_from(value).map_err(|_| HostlibError::InvalidParameter {
+        builtin: BUILTIN,
+        param,
+        message: "does not fit in usize".to_string(),
+    })
+}
+
+fn context_file_ids(state: &IndexState, raw_paths: &[String]) -> HashSet<FileId> {
+    raw_paths
+        .iter()
+        .filter_map(|path| state.lookup_path(path))
+        .collect()
+}
+
+fn task_terms(task: &str) -> HashSet<String> {
+    let mut out = HashSet::new();
+    let mut current = String::new();
+    for ch in task.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            current.push(ch.to_ascii_lowercase());
+        } else {
+            absorb_task_term(&mut out, &mut current);
+        }
+    }
+    absorb_task_term(&mut out, &mut current);
+    out
+}
+
+fn absorb_task_term(out: &mut HashSet<String>, current: &mut String) {
+    if current.len() >= 3 {
+        out.insert(std::mem::take(current));
+    } else {
+        current.clear();
+    }
+}
+
+fn personalized_pagerank(
+    graph: &SymbolGraph,
+    task_terms: &HashSet<String>,
+    context_file_ids: &HashSet<FileId>,
+) -> HashMap<NodeId, f64> {
+    let ids = graph.all_node_ids();
+    if ids.is_empty() {
+        return HashMap::new();
+    }
+    let index_by_id: HashMap<NodeId, usize> = ids
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(idx, id)| (id, idx))
+        .collect();
+    let adjacency: Vec<Vec<usize>> = ids
+        .iter()
+        .map(|id| {
+            graph
+                .outgoing(*id)
+                .iter()
+                .filter_map(|edge| index_by_id.get(&edge.to).copied())
+                .collect()
+        })
+        .collect();
+    let personalization = normalized_personalization(graph, &ids, task_terms, context_file_ids);
+    let mut ranks = personalization.clone();
+    for _ in 0..ITERATIONS {
+        let mut next: Vec<f64> = personalization
+            .iter()
+            .map(|weight| (1.0 - DAMPING) * weight)
+            .collect();
+        let mut dangling = 0.0;
+        for idx in 0..ids.len() {
+            let neighbors = &adjacency[idx];
+            if neighbors.is_empty() {
+                dangling += ranks[idx];
+                continue;
+            }
+            let share = ranks[idx] / neighbors.len() as f64;
+            for neighbor in neighbors.iter().copied() {
+                next[neighbor] += DAMPING * share;
+            }
+        }
+        if dangling > 0.0 {
+            for (idx, weight) in personalization.iter().enumerate() {
+                next[idx] += DAMPING * dangling * weight;
+            }
+        }
+        ranks = next;
+    }
+    ids.into_iter().zip(ranks).collect()
+}
+
+fn normalized_personalization(
+    graph: &SymbolGraph,
+    ids: &[NodeId],
+    task_terms: &HashSet<String>,
+    context_file_ids: &HashSet<FileId>,
+) -> Vec<f64> {
+    let mut weights: Vec<f64> = ids
+        .iter()
+        .map(|id| {
+            let Some(node) = graph.node(*id) else {
+                return 1.0;
+            };
+            let mut weight = 1.0;
+            if name_matches_task(node, task_terms) {
+                weight += TASK_BOOST;
+            }
+            if context_file_ids.contains(&node.file_id) {
+                weight += CONTEXT_FILE_BOOST;
+            }
+            weight
+        })
+        .collect();
+    let total: f64 = weights.iter().sum();
+    if total > 0.0 {
+        for weight in &mut weights {
+            *weight /= total;
+        }
+    }
+    weights
+}
+
+fn name_matches_task(node: &Node, task_terms: &HashSet<String>) -> bool {
+    if task_terms.is_empty() {
+        return false;
+    }
+    let name = node.name.to_ascii_lowercase();
+    if task_terms.contains(&name) {
+        return true;
+    }
+    identifier_terms(&name)
+        .iter()
+        .any(|term| task_terms.contains(term))
+}
+
+fn identifier_terms(name: &str) -> HashSet<String> {
+    let mut out = HashSet::new();
+    let mut current = String::new();
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() {
+            current.push(ch.to_ascii_lowercase());
+        } else {
+            absorb_task_term(&mut out, &mut current);
+        }
+    }
+    absorb_task_term(&mut out, &mut current);
+    out
+}
+
+#[derive(Debug, Clone)]
+struct RepoMapEntry {
+    path: String,
+    line: u32,
+    kind: &'static str,
+    name: String,
+    signature: String,
+    score: f64,
+    reasons: Vec<&'static str>,
+}
+
+fn ranked_definition_entries(
+    graph: &SymbolGraph,
+    ranks: &HashMap<NodeId, f64>,
+    task_terms: &HashSet<String>,
+    context_file_ids: &HashSet<FileId>,
+) -> Vec<RepoMapEntry> {
+    let mut entries: Vec<RepoMapEntry> = graph
+        .all_node_ids()
+        .into_iter()
+        .filter_map(|id| {
+            let node = graph.node(id)?;
+            if !matches!(node.kind, NodeKind::Function | NodeKind::Type) {
+                return None;
+            }
+            let mut reasons = Vec::new();
+            if name_matches_task(node, task_terms) {
+                reasons.push("task_symbol");
+            }
+            if context_file_ids.contains(&node.file_id) {
+                reasons.push("context_file");
+            }
+            Some(RepoMapEntry {
+                path: node.path.clone(),
+                line: node.line,
+                kind: node.kind.as_str(),
+                name: node.name.clone(),
+                signature: node.signature.clone(),
+                score: ranks.get(&id).copied().unwrap_or(0.0),
+                reasons,
+            })
+        })
+        .collect();
+    entries.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| a.path.cmp(&b.path))
+            .then_with(|| a.line.cmp(&b.line))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    entries
+}
+
+fn render_entries(entries: &[RepoMapEntry], token_budget: usize) -> (String, bool) {
+    let char_budget = token_budget.saturating_mul(4);
+    if char_budget == 0 {
+        return (String::new(), !entries.is_empty());
+    }
+    let mut remaining = char_budget;
+    let mut out = String::new();
+    let mut rendered_entries = 0usize;
+    let mut current_path = "";
+    for entry in entries {
+        let header = if current_path != entry.path {
+            format!("{}:\n", entry.path)
+        } else {
+            String::new()
+        };
+        let line = render_entry_line(entry);
+        if header.len() + line.len() > remaining {
+            return (out.trim_end().to_string(), true);
+        }
+        if !header.is_empty() {
+            out.push_str(&header);
+            remaining -= header.len();
+            current_path = &entry.path;
+        }
+        out.push_str(&line);
+        remaining -= line.len();
+        rendered_entries += 1;
+    }
+    (out.trim_end().to_string(), rendered_entries < entries.len())
+}
+
+fn render_entry_line(entry: &RepoMapEntry) -> String {
+    let detail = if entry.signature.trim().is_empty() {
+        format!("{} {}", entry.kind, entry.name)
+    } else {
+        entry.signature.trim().to_string()
+    };
+    format!("  L{} {}\n", entry.line, detail)
+}
+
+fn entry_to_vm(entry: &RepoMapEntry) -> VmValue {
+    build_dict([
+        ("path", str_value(&entry.path)),
+        ("line", VmValue::Int(entry.line as i64)),
+        ("kind", str_value(entry.kind)),
+        ("name", str_value(&entry.name)),
+        ("signature", str_value(&entry.signature)),
+        ("score", VmValue::Float(entry.score)),
+        (
+            "reasons",
+            VmValue::List(Arc::new(
+                entry.reasons.iter().copied().map(str_value).collect(),
+            )),
+        ),
+    ])
+}

--- a/crates/harn-hostlib/src/schemas.rs
+++ b/crates/harn-hostlib/src/schemas.rs
@@ -609,6 +609,18 @@ pub const SCHEMAS: &[(&str, &str, SchemaKind, &str)] = &[
     ),
     (
         "code_index",
+        "repo_map",
+        SchemaKind::Request,
+        include_str!("../schemas/code_index/repo_map.request.json"),
+    ),
+    (
+        "code_index",
+        "repo_map",
+        SchemaKind::Response,
+        include_str!("../schemas/code_index/repo_map.response.json"),
+    ),
+    (
+        "code_index",
         "branch_overlay",
         SchemaKind::Request,
         include_str!("../schemas/code_index/branch_overlay.request.json"),

--- a/crates/harn-hostlib/tests/code_index_graph_surface.rs
+++ b/crates/harn-hostlib/tests/code_index_graph_surface.rs
@@ -33,6 +33,36 @@ fn extract_dict(value: &VmValue) -> Arc<harn_vm::value::DictMap> {
     }
 }
 
+fn string_field(dict: &harn_vm::value::DictMap, key: &str) -> String {
+    match dict
+        .get(key)
+        .unwrap_or_else(|| panic!("missing field {key}"))
+    {
+        VmValue::String(s) => s.to_string(),
+        other => panic!("expected string field {key}, got {other:?}"),
+    }
+}
+
+fn bool_field(dict: &harn_vm::value::DictMap, key: &str) -> bool {
+    match dict
+        .get(key)
+        .unwrap_or_else(|| panic!("missing field {key}"))
+    {
+        VmValue::Bool(value) => *value,
+        other => panic!("expected bool field {key}, got {other:?}"),
+    }
+}
+
+fn list_field(dict: &harn_vm::value::DictMap, key: &str) -> Arc<Vec<VmValue>> {
+    match dict
+        .get(key)
+        .unwrap_or_else(|| panic!("missing field {key}"))
+    {
+        VmValue::List(value) => value.clone(),
+        other => panic!("expected list field {key}, got {other:?}"),
+    }
+}
+
 fn build_workspace() -> tempfile::TempDir {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
@@ -96,6 +126,89 @@ fn cypher_returns_function_by_name() {
         other => panic!("expected string path, got {other:?}"),
     };
     assert_eq!(path, "src/a.rs");
+}
+
+#[test]
+fn repo_map_prioritizes_task_named_symbols() {
+    let dir = build_workspace();
+    let (reg, _cap) = registry();
+    rebuild(&reg, dir.path());
+
+    let result = call(
+        &reg,
+        "hostlib_code_index_repo_map",
+        dict(&[
+            ("task", VmValue::String(arcstr::ArcStr::from("Fix alpha"))),
+            ("max_entries", VmValue::Int(4)),
+            ("token_budget", VmValue::Int(200)),
+        ]),
+    );
+    let outer = extract_dict(&result);
+    let rendered = string_field(&outer, "rendered");
+    assert!(rendered.contains("src/a.rs:"), "rendered map: {rendered}");
+    assert!(rendered.contains("alpha"), "rendered map: {rendered}");
+
+    let entries = list_field(&outer, "entries");
+    assert!(!entries.is_empty(), "repo map should return ranked entries");
+    let first = extract_dict(&entries[0]);
+    assert_eq!(string_field(&first, "name"), "alpha");
+    let reasons = list_field(&first, "reasons");
+    assert!(
+        reasons.iter().any(
+            |value| matches!(value, VmValue::String(reason) if reason.as_str() == "task_symbol")
+        ),
+        "task-named symbol should carry task_symbol reason"
+    );
+}
+
+#[test]
+fn repo_map_boosts_context_files_and_respects_budget() {
+    let dir = build_workspace();
+    let (reg, _cap) = registry();
+    rebuild(&reg, dir.path());
+
+    let result = call(
+        &reg,
+        "hostlib_code_index_repo_map",
+        dict(&[
+            (
+                "context_files",
+                VmValue::List(Arc::new(vec![VmValue::String(arcstr::ArcStr::from(
+                    "src/b.rs",
+                ))])),
+            ),
+            ("max_entries", VmValue::Int(4)),
+            ("token_budget", VmValue::Int(200)),
+        ]),
+    );
+    let outer = extract_dict(&result);
+    let entries = list_field(&outer, "entries");
+    assert!(!entries.is_empty(), "repo map should return ranked entries");
+    let first = extract_dict(&entries[0]);
+    assert_eq!(string_field(&first, "path"), "src/b.rs");
+    let reasons = list_field(&first, "reasons");
+    assert!(
+        reasons.iter().any(
+            |value| matches!(value, VmValue::String(reason) if reason.as_str() == "context_file")
+        ),
+        "context-file symbol should carry context_file reason"
+    );
+
+    let tiny = call(
+        &reg,
+        "hostlib_code_index_repo_map",
+        dict(&[
+            ("max_entries", VmValue::Int(4)),
+            ("token_budget", VmValue::Int(1)),
+        ]),
+    );
+    let tiny_outer = extract_dict(&tiny);
+    let rendered = string_field(&tiny_outer, "rendered");
+    assert!(rendered.len() <= 4, "rendered map must honor char budget");
+    assert!(
+        bool_field(&tiny_outer, "truncated"),
+        "tiny budget should truncate"
+    );
 }
 
 #[test]

--- a/crates/harn-hostlib/tests/registration.rs
+++ b/crates/harn-hostlib/tests/registration.rs
@@ -134,6 +134,7 @@ fn code_index_capability_registers_documented_methods() {
             "hostlib_code_index_current_agent_id",
             // Typed symbol graph + Cypher (#2434).
             "hostlib_code_index_cypher",
+            "hostlib_code_index_repo_map",
             "hostlib_code_index_branch_overlay",
             "hostlib_code_index_freshness",
             // Cross-file safe rename (#2508).


### PR DESCRIPTION
Part of burin-labs/burin-code#2030.

## Summary
- add hostlib_code_index_repo_map, a read-only code_index builtin that ranks functions/types with personalized PageRank over the symbol graph
- expose JSON schemas and registration metadata for the new query
- cover task-term ranking, context-file boosting, token-budget truncation, registration, and schema parsing

## Verification
- cargo fmt
- CARGO_TARGET_DIR=/Users/ksinder/projects/.cargo-targets/harn-2030-repo-map cargo test -p harn-hostlib --test code_index_graph_surface repo_map
- CARGO_TARGET_DIR=/Users/ksinder/projects/.cargo-targets/harn-2030-repo-map cargo test -p harn-hostlib --test registration code_index_capability_registers_documented_methods
- CARGO_TARGET_DIR=/Users/ksinder/projects/.cargo-targets/harn-2030-repo-map cargo test -p harn-hostlib --test code_index_graph_surface
- CARGO_TARGET_DIR=/Users/ksinder/projects/.cargo-targets/harn-2030-repo-map cargo test -p harn-hostlib --test registration
- git commit pre-commit hooks
- git push pre-push hooks