### PR TITLE
Preserve pipeline loop_stuck events

### DIFF
--- a/changelog.d/2265.fixed.md
+++ b/changelog.d/2265.fixed.md
@@ -1,0 +1,1 @@
+- Preserve pipeline-authored `loop_stuck` event payloads emitted through `agent_emit_event`.

--- a/changelog.d/host-naming-generalization.changed.md
+++ b/changelog.d/host-naming-generalization.changed.md
@@ -1,1 +1,3 @@
-- Generalized internal documentation comments to vendor-neutral language, removing references to a specific downstream host's private Swift source files and product name. No behavior, wire identifiers, or fixtures changed.
+- Generalized internal documentation comments to vendor-neutral language, removing references to a
+  specific downstream host's private Swift source files and product name. No behavior, wire
+  identifiers, or fixtures changed.

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -1429,6 +1429,12 @@ impl AgentEventSink for AcpAgentEventSink {
                     }),
                 );
             }
+            AgentEvent::LoopStuckSignal {
+                session_id,
+                payload,
+            } => {
+                self.emit_agent_event_ext("loop_stuck", session_id, payload.clone());
+            }
             AgentEvent::DaemonWatchdogTripped {
                 session_id,
                 attempts,

--- a/crates/harn-serve/src/adapters/acp/events/tests.rs
+++ b/crates/harn-serve/src/adapters/acp/events/tests.rs
@@ -2043,6 +2043,15 @@ fn internal_agent_events_never_emit_session_updates() {
         last_iteration: 4,
         tail_excerpt: "tail".to_string(),
     });
+    sink.handle_event(&AgentEvent::LoopStuckSignal {
+        session_id: "session-1".to_string(),
+        payload: serde_json::json!({
+            "schema": "burin.stuck_handoff.v1",
+            "action": "handoff",
+            "terminal": true,
+            "pattern": "no_progress_terminator",
+        }),
+    });
     sink.handle_event(&AgentEvent::DaemonWatchdogTripped {
         session_id: "session-1".to_string(),
         attempts: 3,
@@ -2066,8 +2075,37 @@ fn internal_agent_events_never_emit_session_updates() {
         );
     }
     assert_eq!(
-        count, 7,
+        count, 8,
         "expected one ExtNotification per fed AgentEvent, got {count}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn loop_stuck_signal_forwards_pipeline_payload() {
+    let actual = collect_notifications(vec![AgentEvent::LoopStuckSignal {
+        session_id: "session-1".to_string(),
+        payload: serde_json::json!({
+            "schema": "burin.stuck_handoff.v1",
+            "action": "handoff",
+            "terminal": true,
+            "pattern": "no_progress_terminator",
+            "message": "I am stuck after repeated verification failures.",
+        }),
+    }])
+    .await;
+
+    let notification = &actual[0];
+    assert_eq!(notification["method"], HARN_AGENT_EVENT_METHOD);
+    let params = &notification["params"];
+    assert_eq!(params["kind"], "loop_stuck");
+    assert_eq!(params["sessionId"], "session-1");
+    assert_eq!(params["schema"], "burin.stuck_handoff.v1");
+    assert_eq!(params["action"], "handoff");
+    assert_eq!(params["terminal"], true);
+    assert_eq!(params["pattern"], "no_progress_terminator");
+    assert_eq!(
+        params["message"],
+        "I am stuck after repeated verification failures."
     );
 }
 

--- a/crates/harn-vm/src/agent_events/agent.rs
+++ b/crates/harn-vm/src/agent_events/agent.rs
@@ -362,6 +362,15 @@ pub enum AgentEvent {
         last_iteration: usize,
         tail_excerpt: String,
     },
+    /// Pipeline-authored stuck/escalation signal emitted through
+    /// `agent_emit_event("loop_stuck", payload)`. The runtime-level
+    /// `LoopStuck` variant above remains the built-in max-nudge terminal event;
+    /// this variant preserves the pipeline payload so hosts can surface richer
+    /// handoff/escalation details without inventing another wire kind.
+    LoopStuckSignal {
+        session_id: String,
+        payload: serde_json::Value,
+    },
     /// Emitted when the daemon idle-wait loop trips its watchdog because
     /// every configured wake source returned `None` for N consecutive
     /// attempts. Exists so a broken daemon doesn't hang the session
@@ -822,6 +831,7 @@ impl AgentEvent {
             | Self::BudgetExhausted { session_id, .. }
             | Self::BudgetCircuitBreaker { session_id, .. }
             | Self::LoopStuck { session_id, .. }
+            | Self::LoopStuckSignal { session_id, .. }
             | Self::DaemonWatchdogTripped { session_id, .. }
             | Self::SkillActivated { session_id, .. }
             | Self::SkillDeactivated { session_id, .. }

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -1851,6 +1851,7 @@ async fn host_agent_emit_event(
             | "tool_call_audit"
             | "budget_exhausted"
             | "budget_circuit_breaker"
+            | "loop_stuck"
             | "context_overflow_recovery"
             | "loop_checkpoint"
     ) {
@@ -2189,6 +2190,10 @@ fn build_agent_event(
             kind: get_string("kind"),
             consecutive_count: get_usize("consecutive_count"),
             paused_for_ms: get_u64("paused_for_ms"),
+        }),
+        "loop_stuck" => Ok(AgentEvent::LoopStuckSignal {
+            session_id: session_id.to_string(),
+            payload: payload.clone(),
         }),
         "tool_search_query" => Ok(AgentEvent::ToolSearchQuery {
             session_id: session_id.to_string(),

--- a/crates/harn-vm/src/llm/agent_session_host_tests.rs
+++ b/crates/harn-vm/src/llm/agent_session_host_tests.rs
@@ -1,10 +1,12 @@
 use serde_json::json;
 
+use crate::agent_events::AgentEvent;
+
 use super::{
-    agent_turn_made_no_llm_call, assistant_message_from_llm_result, canonical_acp_stop_reason,
-    canonical_provider_stop_reason, initial_user_content, is_length_truncation,
-    last_assistant_text, text_has_tool_call_prefix, tool_result_message_for_provider,
-    truncated_tool_call_should_continue, vm_to_json,
+    agent_turn_made_no_llm_call, assistant_message_from_llm_result, build_agent_event,
+    canonical_acp_stop_reason, canonical_provider_stop_reason, initial_user_content,
+    is_length_truncation, last_assistant_text, text_has_tool_call_prefix,
+    tool_result_message_for_provider, truncated_tool_call_should_continue, vm_to_json,
 };
 
 #[test]
@@ -25,6 +27,30 @@ fn real_turn_is_not_flagged_as_no_llm_call() {
     assert!(!agent_turn_made_no_llm_call("error", false, 0, 0, 0));
     assert!(!agent_turn_made_no_llm_call("failed", false, 0, 0, 0));
     assert!(!agent_turn_made_no_llm_call("", true, 0, 0, 0));
+}
+
+#[test]
+fn agent_emit_loop_stuck_preserves_pipeline_payload() {
+    let payload = json!({
+        "schema": "burin.stuck_handoff.v1",
+        "action": "handoff",
+        "terminal": true,
+        "pattern": "no_progress_terminator",
+        "message": "I am stuck after repeated verification failures.",
+    });
+
+    let event = build_agent_event("session-1", "loop_stuck", &payload).expect("loop_stuck event");
+
+    match event {
+        AgentEvent::LoopStuckSignal {
+            session_id,
+            payload: event_payload,
+        } => {
+            assert_eq!(session_id, "session-1");
+            assert_eq!(event_payload, payload);
+        }
+        other => panic!("expected LoopStuckSignal, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/harn-vm/src/orchestration/merge_captain_audit.rs
+++ b/crates/harn-vm/src/orchestration/merge_captain_audit.rs
@@ -622,6 +622,23 @@ pub fn audit_transcript(
                     tools: vec![],
                 });
             }
+            AgentEvent::LoopStuckSignal { payload, .. } => {
+                let terminal = payload
+                    .get("terminal")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(true);
+                if terminal {
+                    saw_terminal = true;
+                    findings.push(AuditFinding {
+                        category: FindingCategory::ExtraModelCall,
+                        severity: FindingSeverity::Error,
+                        message: "loop stuck on pipeline no-progress signal".into(),
+                        event_indices: vec![env.index],
+                        state_step: None,
+                        tools: vec![],
+                    });
+                }
+            }
             AgentEvent::Handoff { .. } => {
                 saw_terminal = true;
                 // Approval-gate step (default) consumes any pending
@@ -1224,6 +1241,16 @@ mod tests {
         )
     }
 
+    fn loop_stuck_signal(index: u64, session: &str, terminal: bool) -> PersistedAgentEvent {
+        env(
+            index,
+            AgentEvent::LoopStuckSignal {
+                session_id: session.into(),
+                payload: json!({"terminal": terminal}),
+            },
+        )
+    }
+
     #[test]
     fn pass_minimal_green_pr_default_rules() {
         let events = vec![
@@ -1340,6 +1367,30 @@ mod tests {
                 .findings
                 .iter()
                 .any(|f| f.category == FindingCategory::MissingApproval),
+            "findings: {:?}",
+            report.findings
+        );
+    }
+
+    #[test]
+    fn non_terminal_loop_stuck_signal_does_not_complete_transcript() {
+        let events = vec![iteration_start(1, "s", 1), loop_stuck_signal(2, "s", false)];
+        let report = audit_transcript(&events, None);
+        assert!(report
+            .findings
+            .iter()
+            .any(|f| f.category == FindingCategory::IncompleteTranscript));
+    }
+
+    #[test]
+    fn terminal_loop_stuck_signal_completes_transcript() {
+        let events = vec![iteration_start(1, "s", 1), loop_stuck_signal(2, "s", true)];
+        let report = audit_transcript(&events, None);
+        assert!(
+            !report
+                .findings
+                .iter()
+                .any(|f| f.category == FindingCategory::IncompleteTranscript),
             "findings: {:?}",
             report.findings
         );


### PR DESCRIPTION
## Summary
- Add a transcript-backed `loop_stuck` event builder that preserves pipeline payloads as `LoopStuckSignal`.
- Forward pipeline stuck signals over ACP as `_harn/agentEvent` kind `loop_stuck`.
- Treat only terminal stuck signals as terminal in merge-captain audits.
- Wrap upstream changelog fragments so markdown lint is clean on the rebased base.

## Verification
- make lint-md
- cargo fmt --check
- cargo test -p harn-vm agent_emit_loop_stuck_preserves_pipeline_payload
- cargo test -p harn-vm loop_stuck_signal
- cargo test -p harn-serve loop_stuck_signal_forwards_pipeline_payload
- cargo test -p harn-serve internal_agent_events_never_emit_session_updates
- pre-commit hook: markdown, Rust formatting, clippy for harn-vm/harn-serve
- pre-push hook: markdown and targeted local checks