### PR TITLE
Make loop-control progress outcome-aware so a thrash can't extend its own budget

### DIFF
--- a/changelog.d/loop-no-net-progress-extend-guard.fixed.md
+++ b/changelog.d/loop-no-net-progress-extend-guard.fixed.md
@@ -1,0 +1,20 @@
+- **`std/agent`: the adaptive loop-control extension policy is now outcome-aware,
+  so a thrash can no longer extend its own iteration budget without bound.**
+  `agent_loop_is_progressing` keyed "progress" on `progress.changed`, an
+  *activity* signal that fires merely because the model issued tool calls — so a
+  run thrashing through the same compile/test failure every turn (lots of
+  edits/verifies, no error draining toward a green build) read as "progressing"
+  every turn and kept hitting the `extend` rule at the budget boundary (observed
+  24→32→…→72 on a run that should have been cut). A new default-OFF guard
+  (`stall_diagnostics.no_net_progress_extend_guard`, after
+  `no_net_progress_extend_after` turns, default 3) sets `progress.no_net_advance`
+  when the verify-bearing failing path is *not advancing* — the same failure
+  signature has recurred past threshold (the stall detector's
+  `same_diagnostic_streak`) — and `agent_loop_is_progressing` then declines to
+  extend. Outcome-aware and conservative: a productive edit changes the error
+  signature (streak resets → still progress), a passing test clears the failure
+  model (→ still progress), and read-only/explore turns with no failing
+  verification never arm it, so genuinely-advancing and exploring runs keep their
+  budget. New pub `agent_stall_no_net_progress`. Pairs with Burin's product-side
+  no-net-progress ripcord: the loop now neither extends a thrash nor lets it run
+  unaided.

--- a/crates/harn-stdlib/src/stdlib/agent/control.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/control.harn
@@ -90,27 +90,47 @@ fn __agent_loop_state(args) -> AgentLoopState {
       verdict: args.completion_verdict,
       feedback: args.completion_feedback,
     },
-    progress: {changed: args.progress_changed, summary: args.progress_summary},
+    progress: {
+      changed: args.progress_changed,
+      summary: args.progress_summary,
+      no_net_advance: args.progress_no_net_advance ?? false,
+    },
   }
 }
 
 /**
  * Single source of truth for "the agent is still advancing the task."
- * `progress.changed` (computed once in `agent_loop_snapshot_state`) already
- * covers tool calls, successful tool results, AND visible text — so a turn that
- * is pure planning/narration toward the next edit (no tool call *this* turn) is
- * still forward progress. This is deliberately NOT re-gated on a tool call here:
- * an earlier inline `progress.changed && tool_call_count > 0` denied the
- * extension whenever the budget boundary happened to land on a planning turn,
- * cutting a productive multi-file refactor off mid-work (a methodical model
- * editing across ~6 files stopped at its initial cap because one interleaved
- * planning turn was treated as "no progress"). Degenerate narration that never
- * acts is bounded independently by the iteration max and the stall detector, so
- * progress alone is the correct extension signal. Keep this the *only* place
- * that defines "progress" so a second, competing notion can't be ANDed in.
+ * `progress.changed` (computed once in `agent_loop_snapshot_state`) covers tool
+ * calls, successful tool results, AND visible text — so a turn that is pure
+ * planning/narration toward the next edit (no tool call *this* turn) is still
+ * forward progress. This is deliberately NOT re-gated on a tool call here: an
+ * earlier inline `progress.changed && tool_call_count > 0` denied the extension
+ * whenever the budget boundary happened to land on a planning turn, cutting a
+ * productive multi-file refactor off mid-work (a methodical model editing across
+ * ~6 files stopped at its initial cap because one interleaved planning turn was
+ * treated as "no progress"). Degenerate narration that never acts is bounded
+ * independently by the iteration max and the stall detector.
+ *
+ * The ONE principled override is `progress.no_net_advance`: activity-without-
+ * advancement is NOT progress. `progress.changed` is an ACTIVITY signal — it
+ * fires merely because the model issued tool calls — which makes a thrashing run
+ * (lots of edits/verifies, the SAME compile/test failure recurring turn after
+ * turn, no error draining toward a green build) read as "progressing" every
+ * turn and lets the loop extend its own budget without bound (observed
+ * 24->32->...->72 on a run that should have been cut). `no_net_advance` is set
+ * ONLY on the verify-bearing failing path when the verification OUTCOME is not
+ * advancing (the same failure signature has recurred past a threshold, i.e. the
+ * stall detector's same-diagnostic streak). It is the harn-side twin of burin's
+ * no-net-progress ripcord. Crucially it is OUTCOME-AWARE, not a second activity
+ * notion: a productive edit changes the error signature (streak resets => still
+ * progress) or a test passes (failure model clears => still progress), and
+ * read-only / explore turns with no failing verification never set it. So this
+ * AND only suppresses an extension for a *measured* no-net-advancement thrash;
+ * every genuinely-advancing run keeps its budget. Keep this the *only* place
+ * that defines "progress" so no other competing notion can be ANDed in.
  */
 fn agent_loop_is_progressing(state: AgentLoopState) -> bool {
-  return state.progress.changed
+  return state.progress.changed && !(state.progress?.no_net_advance ?? false)
 }
 
 /**
@@ -230,9 +250,19 @@ fn __agent_record_budget_decision(
   )
 }
 
-fn __agent_progress_summary_text(completion_vetoed: bool, tool_count: int, visible_text: string) -> string {
+fn __agent_progress_summary_text(
+  completion_vetoed: bool,
+  tool_count: int,
+  visible_text: string,
+  no_net_advance: bool,
+) -> string {
   if completion_vetoed {
     return "completion gate vetoed"
+  }
+  // Activity present but the verification outcome is not advancing (same failure
+  // recurring): name the thrash so the recorded loop decision is auditable.
+  if no_net_advance {
+    return "tool activity without net verification progress"
   }
   if tool_count > 0 {
     return "executed " + to_string(tool_count) + " tool call(s)"
@@ -268,7 +298,13 @@ pub fn agent_loop_snapshot_state(args) -> AgentLoopState {
   let turn_successful = args.turn_successful
   let progress_changed = tool_count > 0 || len(turn_successful) > 0
     || trim(visible_text) != ""
-  let progress_summary = __agent_progress_summary_text(completion_vetoed, tool_count, visible_text)
+  // Outcome-aware override: the caller (the loop) passes `progress_no_net_advance`
+  // when this turn is on the verify-bearing failing path AND the verification
+  // outcome is not advancing (same-diagnostic streak past threshold). It only
+  // suppresses the extension when there WAS activity to begin with — a thrash —
+  // never when there is genuinely no activity (that case is already "no progress").
+  let no_net_advance = progress_changed && (args.progress_no_net_advance ?? false)
+  let progress_summary = __agent_progress_summary_text(completion_vetoed, tool_count, visible_text, no_net_advance)
   return __agent_loop_state(
     {
       iteration: args.iteration,
@@ -294,6 +330,7 @@ pub fn agent_loop_snapshot_state(args) -> AgentLoopState {
       completion_verdict: completion_verdict,
       completion_feedback: completion_feedback,
       progress_changed: progress_changed,
+      progress_no_net_advance: no_net_advance,
       progress_summary: progress_summary,
     },
   )

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -40,6 +40,7 @@ import {
   agent_stall_done_judge_due,
   agent_stall_initial_state,
   agent_stall_inject_feedback,
+  agent_stall_no_net_progress,
   agent_stall_observe_tool_calls,
   agent_stall_repair_config,
 } from "std/agent/stall"
@@ -3878,6 +3879,7 @@ fn __agent_loop_run(message, session, initial_opts) {
           )
         }
       }
+      let loop_no_net_progress = agent_stall_no_net_progress(turn_opts?.stall_diagnostics, stall_state)
       let loop_state = agent_loop_snapshot_state(
         {
           iteration: iteration,
@@ -3894,6 +3896,7 @@ fn __agent_loop_run(message, session, initial_opts) {
           missing_required_tools: missing_required_for_loop,
           completion_proposed: outcome.kind == "break",
           verdict: verdict_record,
+          progress_no_net_advance: loop_no_net_progress,
         }
           + __agent_loop_state_budget_fields(
           session.session_id,

--- a/crates/harn-stdlib/src/stdlib/agent/stall.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/stall.harn
@@ -58,6 +58,20 @@ const STALL_REPEAT_CONTEXT_WINDOW_ERROR = 2
 // before the detector trips the "stuck_same_diagnostic" strategy-shift nudge.
 const STALL_STUCK_SAME_DIAGNOSTIC_AFTER = 3
 
+// Budget-extension guard (default OFF, gated by `no_net_progress_extend_guard`):
+// how many turns the SAME failure signature may recur on the verify-bearing path
+// before a turn stops counting as "progress" for the loop's budget-extension
+// decision. The loop's default extension policy treats any tool-calling turn as
+// progress and keeps extending its own iteration budget; a model thrashing
+// through the same compile/test failure therefore buys unbounded runway. Once
+// the same-diagnostic streak reaches this many turns the verification outcome is
+// provably not advancing, so the turn no longer extends the budget and the loop
+// stops at its current cap. Conservative + outcome-aware: a productive edit
+// changes the signature (streak resets) and a pass clears the failure model, so
+// genuine progress is never suppressed. Set at the same depth as the stuck nudge
+// so the strategy-shift nudge fires before/with the extension cut, not after.
+const STALL_NO_NET_PROGRESS_EXTEND_AFTER = 3
+
 // consecutive un-recovered trips before a hard stop is recommended. A trip
 // "recovers" when a turn produces a step that does not itself trip (the agent
 // broke the loop). Past this many back-to-back trips the detector flags
@@ -107,6 +121,8 @@ type AgentStallConfig = {
   repair_aware: bool,
   stuck_same_diagnostic_after: int,
   post_edit_reverify: bool,
+  no_net_progress_extend_guard: bool,
+  no_net_progress_extend_after: int,
 }
 
 type AgentStallWarning = {
@@ -206,6 +222,8 @@ fn __agent_stall_default_config() -> AgentStallConfig {
     repair_aware: false,
     stuck_same_diagnostic_after: STALL_STUCK_SAME_DIAGNOSTIC_AFTER,
     post_edit_reverify: true,
+    no_net_progress_extend_guard: false,
+    no_net_progress_extend_after: STALL_NO_NET_PROGRESS_EXTEND_AFTER,
   }
 }
 
@@ -260,6 +278,8 @@ fn __agent_stall_config(value) -> AgentStallConfig {
     repair_aware: __agent_stall_bool(value?.repair_aware, false, "repair_aware"),
     stuck_same_diagnostic_after: __agent_stall_int(value?.stuck_same_diagnostic_after, STALL_STUCK_SAME_DIAGNOSTIC_AFTER, 2),
     post_edit_reverify: __agent_stall_bool(value?.post_edit_reverify, true, "post_edit_reverify"),
+    no_net_progress_extend_guard: __agent_stall_bool(value?.no_net_progress_extend_guard, false, "no_net_progress_extend_guard"),
+    no_net_progress_extend_after: __agent_stall_int(value?.no_net_progress_extend_after, STALL_NO_NET_PROGRESS_EXTEND_AFTER, 2),
   }
 }
 
@@ -1260,7 +1280,41 @@ pub fn agent_stall_repair_config(raw_config) -> dict {
     repair_aware: config.repair_aware,
     post_edit_reverify: config.post_edit_reverify,
     stuck_same_diagnostic_after: config.stuck_same_diagnostic_after,
+    no_net_progress_extend_guard: config.no_net_progress_extend_guard,
+    no_net_progress_extend_after: config.no_net_progress_extend_after,
   }
+}
+
+/**
+ * agent_stall_no_net_progress reports whether THIS turn is a no-net-advancement
+ * thrash for the purpose of the loop's budget-extension decision. It is the
+ * harn-side twin of burin's no-net-progress ripcord: the default extension
+ * policy treats any tool-calling turn as "progress" and keeps extending the
+ * iteration budget, so a model re-hitting the SAME compile/test failure every
+ * turn (no error draining toward a green build) buys unbounded runway. This
+ * returns true ONLY when the guard is enabled AND the loop is on the verify-
+ * bearing FAILING path (`last_diagnostic_class == "fail"`) AND the same failure
+ * signature has recurred for at least `no_net_progress_extend_after` turns
+ * (`same_diagnostic_streak`, which the diagnostic fold advances on the SAME
+ * signature even across edits and RESETS when a productive edit changes the
+ * error or a test passes). So it never fires for a genuinely-advancing run
+ * (signature changes => streak resets) and never fires on read-only / explore
+ * turns (no failing verification => class != "fail"). Default OFF: when the
+ * guard is disabled it always returns false, preserving today's behavior.
+ *
+ * @effects: []
+ * @errors: []
+ * @api_stability: experimental
+ */
+pub fn agent_stall_no_net_progress(raw_config, stall_state: AgentStallState) -> bool {
+  let config = __agent_stall_config(raw_config)
+  if !config.no_net_progress_extend_guard {
+    return false
+  }
+  if stall_state.last_diagnostic_class != "fail" {
+    return false
+  }
+  return stall_state.same_diagnostic_streak >= config.no_net_progress_extend_after
 }
 
 /**

--- a/tests/agent/loop_control_test.harn
+++ b/tests/agent/loop_control_test.harn
@@ -40,6 +40,22 @@ fn _state(progress_changed, tool_call_count, remaining, vetoed, required_ok) {
   }
 }
 
+/**
+ * Like `_state` but also sets `progress.no_net_advance` — the outcome-aware
+ * thrash signal the loop sets when the same failing diagnostic recurs past
+ * threshold. When true it must veto the "recent turn made progress" extension.
+ */
+fn _state_with_advance(progress_changed, no_net_advance, remaining, vetoed, required_ok) {
+  return {
+    iteration: 10,
+    budget: {remaining: remaining},
+    turn: {tool_call_count: 3},
+    session: {required_tools_satisfied: required_ok},
+    completion: {vetoed: vetoed},
+    progress: {changed: progress_changed, no_net_advance: no_net_advance},
+  }
+}
+
 pipeline test_text_only_progress_extends(task) {
   // Visible-text progress, ZERO tool calls this turn, at the boundary → extend.
   // This is the bug the rule table fixed.
@@ -79,6 +95,41 @@ pipeline test_completion_veto_extends(task) {
 pipeline test_required_tools_missing_extends(task) {
   // Required tools not yet satisfied extends even with no fresh progress.
   let cmd = agent_loop_control_invoke({}, BUDGET, _state(false, 0, 0, false, false))
+  assert_eq(cmd.action, "extend")
+  assert_eq(cmd.reason, "required tools missing")
+}
+
+pipeline test_thrash_no_net_advance_does_not_extend(task) {
+  // Activity present (progress.changed true, 3 tool calls) but the verification
+  // OUTCOME is not advancing (no_net_advance set by the loop because the same
+  // failing diagnostic recurred past threshold). At the boundary this must NOT
+  // extend — the thrash stops buying itself budget. This is the runaway-budget
+  // root fix: pre-fix this state extended 24->32->...->72.
+  let cmd = agent_loop_control_invoke({}, BUDGET, _state_with_advance(true, true, 0, false, true))
+  assert_eq(cmd.action, "none")
+}
+
+pipeline test_real_progress_still_extends_with_advance_field(task) {
+  // A genuinely-advancing run (changed true, no_net_advance FALSE — error count
+  // draining / signature changing) still reads as progress and keeps its budget.
+  let cmd = agent_loop_control_invoke({}, BUDGET, _state_with_advance(true, false, 0, false, true))
+  assert_eq(cmd.action, "extend")
+  assert_eq(cmd.reason, "recent turn made progress")
+}
+
+pipeline test_no_net_advance_yields_to_completion_veto(task) {
+  // The thrash override only suppresses the PROGRESS rule. A vetoed completion
+  // gate is ordered ahead of progress and still extends even on a thrash turn,
+  // so completion-driven repair is never starved by the budget guard.
+  let cmd = agent_loop_control_invoke({}, BUDGET, _state_with_advance(true, true, 0, true, true))
+  assert_eq(cmd.action, "extend")
+  assert_eq(cmd.reason, "completion gate vetoed")
+}
+
+pipeline test_no_net_advance_yields_to_required_tools(task) {
+  // Likewise, required-tools-missing is ordered ahead of progress and still
+  // extends on a thrash turn.
+  let cmd = agent_loop_control_invoke({}, BUDGET, _state_with_advance(true, true, 0, false, false))
   assert_eq(cmd.action, "extend")
   assert_eq(cmd.reason, "required tools missing")
 }

--- a/tests/agent/stall_test.harn
+++ b/tests/agent/stall_test.harn
@@ -10,6 +10,7 @@ import {
   agent_stall_clear_current_failure,
   agent_stall_current_failure,
   agent_stall_initial_state,
+  agent_stall_no_net_progress,
   agent_stall_observe_tool_calls,
 } from "std/agent/stall"
 
@@ -370,4 +371,101 @@ pipeline test_clear_current_failure_on_success(task) {
   assert(cleared.last_diagnostic_class == "pass")
   assert(cleared.same_diagnostic_streak == 0)
   assert(!cleared.reverify_owed)
+}
+
+// -------------------------------------------------------------------------------------------------
+
+// Budget-extension guard: agent_stall_no_net_progress. This is the harn-side
+// twin of burin's no-net-progress ripcord. The default loop extension policy
+// treats any tool-calling turn as "progress" and keeps extending the iteration
+// budget; this guard reports when a turn is a no-net-advancement thrash so the
+// loop can stop extending. Default OFF, gated on the verify-bearing failing
+// path, and resets on genuine progress.
+
+// -------------------------------------------------------------------------------------------------
+
+// Guard ON; same threshold (3) as the stuck nudge for these tests.
+const GUARD_CONFIG = {
+  enabled: true,
+  repair_aware: true,
+  stuck_same_diagnostic_after: 3,
+  post_edit_reverify: true,
+  no_net_progress_extend_guard: true,
+  no_net_progress_extend_after: 3,
+}
+
+fn _fold_guarded(state, prev_dispatch, prior_made_edit) {
+  return agent_stall_observe_tool_calls(
+    "unit-guard",
+    _run_call(),
+    1,
+    GUARD_CONFIG,
+    state,
+    true,
+    prev_dispatch,
+    "",
+    false,
+    prior_made_edit,
+  )
+}
+
+pipeline test_no_net_progress_default_off(task) {
+  // (a)/(default) Guard OFF (REPAIR_CONFIG has no guard flag): even a long thrash
+  // streak never reports no-net-progress => today's behavior is preserved.
+  let o1 = _fold(agent_stall_initial_state(), _fail_dispatch("boom"), false)
+  let o2 = _fold(o1.state, _fail_dispatch("boom"), false)
+  let o3 = _fold(o2.state, _fail_dispatch("boom"), false)
+  assert(o3.state.same_diagnostic_streak == 3)
+  assert(!agent_stall_no_net_progress(REPAIR_CONFIG, o3.state))
+}
+
+pipeline test_no_net_progress_thrash_trips_once_armed(task) {
+  // (a) Guard ON: a thrash (same failure recurring every turn, no draining)
+  // crosses the threshold and IS reported as no-net-progress, so the loop stops
+  // extending. Below threshold it is NOT reported (conservative).
+  let o1 = _fold_guarded(agent_stall_initial_state(), _fail_dispatch("boom"), false)
+  assert(o1.state.same_diagnostic_streak == 1)
+  assert(!agent_stall_no_net_progress(GUARD_CONFIG, o1.state))
+  let o2 = _fold_guarded(o1.state, _fail_dispatch("boom"), false)
+  assert(o2.state.same_diagnostic_streak == 2)
+  assert(!agent_stall_no_net_progress(GUARD_CONFIG, o2.state))
+  let o3 = _fold_guarded(o2.state, _fail_dispatch("boom"), false)
+  assert(o3.state.same_diagnostic_streak == 3)
+  assert(agent_stall_no_net_progress(GUARD_CONFIG, o3.state))
+}
+
+pipeline test_no_net_progress_productive_run_keeps_budget(task) {
+  // (b) Guard ON: a genuinely-progressing run where each turn changes the error
+  // (a productive edit shifts the signature => streak resets to 1) NEVER reports
+  // no-net-progress, so its budget is preserved. Errors draining is progress.
+  let o1 = _fold_guarded(agent_stall_initial_state(), _fail_dispatch("error A"), true)
+  let o2 = _fold_guarded(o1.state, _fail_dispatch("error B"), true)
+  let o3 = _fold_guarded(o2.state, _fail_dispatch("error C"), true)
+  assert(o3.state.same_diagnostic_streak == 1)
+  assert(!agent_stall_no_net_progress(GUARD_CONFIG, o3.state))
+}
+
+pipeline test_no_net_progress_pass_keeps_budget(task) {
+  // (b) Guard ON: a turn whose verification PASSES clears the failure model
+  // (class != "fail") so it never reports no-net-progress even after a prior
+  // thrash streak — a failing-then-passing run still progresses.
+  let o1 = _fold_guarded(agent_stall_initial_state(), _fail_dispatch("boom"), false)
+  let o2 = _fold_guarded(o1.state, _fail_dispatch("boom"), false)
+  let op = _fold_guarded(o2.state, _ok_dispatch(), false)
+  assert(op.state.last_diagnostic_class == "pass")
+  assert(!agent_stall_no_net_progress(GUARD_CONFIG, op.state))
+}
+
+pipeline test_no_net_progress_explore_turn_not_starved(task) {
+  // (c) Guard ON: a read-only / explore turn has no failing verification, so the
+  // failure model is never armed (class stays "") and the guard NEVER reports
+  // no-net-progress. Legitimately-exploring turns are not starved of budget.
+  let initial = agent_stall_initial_state()
+  assert(initial.last_diagnostic_class != "fail")
+  assert(!agent_stall_no_net_progress(GUARD_CONFIG, initial))
+  // A turn with no verification result (e.g. pure read/list) leaves the model
+  // untouched => still not reported.
+  let o = _fold_guarded(initial, nil, false)
+  assert(o.state.last_diagnostic_class != "fail")
+  assert(!agent_stall_no_net_progress(GUARD_CONFIG, o.state))
 }


### PR DESCRIPTION
## Problem

The adaptive loop-control extension policy (`std/agent/control`) keyed "progress" on `progress.changed`, which is an **activity** signal — it fires merely because the model issued tool calls. A model thrashing through varied compile errors (lots of edits/verifies, **no net progress** toward a green build) therefore read as "progressing" every turn, so `__agent_default_loop_control` kept choosing `action=extend` at the budget boundary and bought the thrash unlimited runway (observed iteration cap **24→32→…→72** on a forensic eval pass that should have been cut).

This is the harn-side twin of Burin's product-side `no_net_progress` ripcord. This fix stops the loop from *causing* the runaway budget.

## Root cause (file:line)

- `agent_loop_is_progressing` (`crates/harn-stdlib/src/stdlib/agent/control.harn`) returned `state.progress.changed`.
- `progress.changed` is computed in `agent_loop_snapshot_state` as `tool_count > 0 || len(turn_successful) > 0 || trim(visible_text) != ""` — pure activity.

## Fix (outcome-aware, conservative, default-OFF)

- `agent_loop_is_progressing` now returns `state.progress.changed && !progress.no_net_advance`. The long doc comment is updated to explain why this is the one principled override (it does not re-introduce the tool-call re-gate that the rule-table refactor removed).
- New pub `agent_stall_no_net_progress(stall_config, stall_state)` in `std/agent/stall`: returns true **only** when the guard is enabled **and** the loop is on the verify-bearing failing path (`last_diagnostic_class == "fail"`) **and** the same failure signature has recurred for `>= no_net_progress_extend_after` turns (the stall detector's `same_diagnostic_streak`, which advances on the SAME signature even across edits and resets when a productive edit changes the error or a test passes).
- The loop (`agent/loop.harn`) computes this from the already-folded `stall_state` and threads `progress_no_net_advance` into the snapshot that feeds the budget decision.
- Gated behind a new **default-OFF** config knob `stall_diagnostics.no_net_progress_extend_guard` (+ tunable `no_net_progress_extend_after`, default 3). Guard OFF ⇒ always false ⇒ today's behavior is preserved exactly.

### Why it's behavior-preserving for real progress

- A **productive edit** changes the error signature ⇒ `same_diagnostic_streak` resets ⇒ still progress, keeps its budget.
- A **passing test** clears the failure model (`class != "fail"`) ⇒ still progress.
- **Read-only / explore** turns never arm a failing diagnostic ⇒ never suppressed (not starved).
- Only a *measured* no-net-advancement thrash (same failure recurring past threshold) stops extending.
- The thrash override only suppresses the *progress* extension rule; `completion gate vetoed` and `required tools missing` are ordered ahead of it and still extend on a thrash turn (repair is never starved).

## Tests

- `tests/agent/loop_control_test.harn`: thrash (`changed` + `no_net_advance`) does NOT extend; real progress (`changed`, `no_net_advance` false) still extends; veto/required-tools rules still win over the thrash override.
- `tests/agent/stall_test.harn`: default-OFF is inert; thrash trips once armed (and not below threshold); productive-run (signature changing) keeps budget; failing-then-passing keeps budget; explore/no-verification turn not starved.
- All **55** `tests/agent/` pipelines pass. `harn fmt --check` and `harn lint` clean on touched stdlib (`harn-stdlib` crate test confirms the embedded sources still parse/typecheck). The two `loop.harn` `HARN-LNT-052` clock warnings are pre-existing and untouched.

## Follow-ons (not in this PR)

- Default-ON gate: once Burin's eval meter confirms the guard is strictly-better on the verify-bearing path (paired 95% CI lower bound > 0), consider flipping `no_net_progress_extend_guard` default-ON for code-editing runs.
- Mechanism-fitness mini-eval: a manufactured mock-model fixture scripting the exact thrash event sequence (per the harn mechanism-fitness onramp convention) would lock this in below the gauntlet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)