### PR TITLE
fix(scripts): make crate-package include guards portable to BSD/macOS grep

### DIFF
--- a/changelog.d/verify-crate-packages-bsd-grep.fixed.md
+++ b/changelog.d/verify-crate-packages-bsd-grep.fixed.md
@@ -1,0 +1,8 @@
+- **Release packaging guard works on BSD/macOS grep again.** The
+  `verify_crate_packages.sh` checks that fail when a packaged `harn-stdlib` /
+  `harn-modules` crate still contains workspace-relative consumer includes used
+  GNU-only BRE alternation (`\(vm\|modules\)`). On BSD/macOS grep `\|` matches
+  literally, so the guards silently never matched and passed even on a broken
+  package — a no-op on the primary dev platform where `release_gate.sh` is run.
+  Switched both to portable ERE (`grep -RE '(vm|modules)'` /
+  `'(vm|stdlib)'`); behavior on GNU grep is unchanged.

--- a/scripts/verify_crate_packages.sh
+++ b/scripts/verify_crate_packages.sh
@@ -194,7 +194,10 @@ while IFS= read -r source; do
   fi
 done < <(find crates/harn-stdlib/src/stdlib -maxdepth 1 -name 'stdlib*.harn' -print | sort)
 
-if grep -R '\.\./harn-\(vm\|modules\)' "$stdlib_pkg/src" >/dev/null; then
+# ERE (-E) so the alternation is portable: BRE `\|` is a GNU-grep extension and
+# matches literally on BSD/macOS grep, which would make this guard a silent no-op
+# on the primary dev platform.
+if grep -RE '\.\./harn-(vm|modules)' "$stdlib_pkg/src" >/dev/null; then
   echo "error: packaged harn-stdlib contains workspace-relative consumer includes" >&2
   exit 1
 fi
@@ -221,7 +224,8 @@ if [[ -e "$modules_pkg/src/stdlib" ]]; then
   exit 1
 fi
 
-if grep -R '\.\./harn-\(vm\|stdlib\)' "$modules_pkg/src" >/dev/null; then
+# ERE (-E): see the harn-stdlib guard above — BRE `\|` no-ops on BSD/macOS grep.
+if grep -RE '\.\./harn-(vm|stdlib)' "$modules_pkg/src" >/dev/null; then
   echo "error: packaged harn-modules contains workspace-relative stdlib includes" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

`scripts/verify_crate_packages.sh` fails the release if a packaged `harn-stdlib` / `harn-modules` crate still contains workspace-relative consumer includes (e.g. `include_str!("../harn-vm/…")`). Both guards used **GNU-only BRE alternation**:

```sh
grep -R '\.\./harn-\(vm\|modules\)' "$stdlib_pkg/src"   # line 197
grep -R '\.\./harn-\(vm\|stdlib\)'  "$modules_pkg/src"   # line 224
```

On BSD/macOS grep, `\|` is a **literal pipe**, so the pattern only matches the literal string `../harn-(vm|modules)` — which never appears in any source file. The guard therefore **silently never matches and passes**, even on a broken package. `release_gate.sh` runs this package-audit lane locally on the macOS-first dev platform, so the guard was a no-op exactly where maintainers rely on it; only `ubuntu-latest` CI (GNU grep) was catching the case.

Fix: switch both checks to portable ERE, which behaves identically on GNU and BSD/macOS grep:

```sh
grep -RE '\.\./harn-(vm|modules)' …
grep -RE '\.\./harn-(vm|stdlib)'  …
```

## Notes for reviewers

- Behavior on GNU grep is unchanged — verified the ERE pattern matches the same intended strings (`../harn-vm`, `../harn-modules`, `../harn-stdlib`) and rejects non-include lines like `harn_vm::run()`.
- Added a `changelog.d/` fragment (`scripts/` is a non-ignored path for the changelog gate).
- No agent mechanism (termination/escalation/judge/routing) is touched — this is a release-packaging shell guard — so the mechanism-contract gate does not apply.
- Surfaced during an adversarial sweep of `harn`'s non-Rust guard/codegen scripts; the rest checked out sound. A couple of lower-severity latent items were noted but left alone pending maintainer preference (a `tomllib`-missing soft-skip in `nextest_filters_from_paths.sh`, an over-broad `requirements.*\.txt` pattern in the changelog gate) — happy to follow up if wanted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCGBVUG5oETH3m15zw6BSS)_