### PR TITLE
Reduce dependent-edit-skip churn: don't skip same-file edits after a non-mutating failure

### DIFF
--- a/changelog.d/3611.fixed.md
+++ b/changelog.d/3611.fixed.md
@@ -1,0 +1,6 @@
+Narrowed the same-turn dependent-edit skip guard so a later edit to the same file
+is only skipped when the earlier failure could actually have mutated the file. The
+dominant intra-turn failure — a pre-apply rejection (`old_string not found`) —
+leaves the file byte-identical, so a sibling edit is no longer stale and now runs,
+eliminating a wasted recovery round-trip. Post-apply diagnostics failures, opaque
+errors, and non-edit mutating tools still poison the resource (safety preserved).

--- a/conformance/tests/agents/agent_loop_intra_turn_resource_fail_fast.harn
+++ b/conformance/tests/agents/agent_loop_intra_turn_resource_fail_fast.harn
@@ -31,6 +31,17 @@ fn edit_tools(metadata_key = "annotations") {
     "Edit a workspace file.",
     {
       handler: { args ->
+        if args?.fail_noop ?? false {
+          return "Error: [Edit rejected] old_string not found. Your edit was NOT applied to "
+            + to_string(args?.path ?? "")
+            + " "
+            + to_string(args?.marker ?? "")
+        }
+        if args?.fail_applied ?? false {
+          return "## Diagnostics (1 errors, via zig ast-check)\n"
+            + "  L3 ERROR: expected ';' after statement\n"
+            + "-> Fix these errors before declaring done."
+        }
         if args?.fail ?? false {
           throw "rejected " + to_string(args?.path ?? "") + " " + to_string(args?.marker ?? "")
         }
@@ -50,6 +61,16 @@ fn edit_tools(metadata_key = "annotations") {
         marker: {type: "string", description: "Probe marker"},
         fail: {type: "boolean", description: "Whether this call rejects", required: false},
         fail_return: {type: "boolean", description: "Whether this call returns a product-level error", required: false},
+        fail_noop: {
+          type: "boolean",
+          description: "Whether this call fails WITHOUT mutating (applied: false)",
+          required: false,
+        },
+        fail_applied: {
+          type: "boolean",
+          description: "Whether this call fails AFTER mutating (applied: true)",
+          required: false,
+        },
         diagnostics: {
           type: "boolean",
           description: "Whether this call returns product-level diagnostics",
@@ -130,6 +151,28 @@ fn same_file_success_batch() {
       name: "edit",
       arguments: {path: "src/a.zig", marker: "first", fail: false, fail_return: false},
     },
+    {
+      id: "a2",
+      name: "edit",
+      arguments: {path: "src/a.zig", marker: "second", fail: false, fail_return: false},
+    },
+  ]
+}
+
+fn same_file_noop_failure_batch() {
+  return [
+    {id: "a1", name: "edit", arguments: {path: "src/a.zig", marker: "first", fail_noop: true}},
+    {
+      id: "a2",
+      name: "edit",
+      arguments: {path: "src/a.zig", marker: "second", fail: false, fail_return: false},
+    },
+  ]
+}
+
+fn same_file_applied_failure_batch() {
+  return [
+    {id: "a1", name: "edit", arguments: {path: "src/a.zig", marker: "first", fail_applied: true}},
     {
       id: "a2",
       name: "edit",
@@ -248,4 +291,28 @@ pipeline main() {
   __io_println(contains(parallel_requested.transcript, "skipped dependent `edit` call"))
   __io_println(!contains(parallel_requested.transcript, "applied src/a.zig second"))
   __io_println(contains(parallel_requested.transcript, "applied src/b.zig other"))
+  // Pre-apply REJECTION (`[Edit rejected] ... NOT applied`) leaves the view
+  // byte-identical, so an independent later same-file edit is NOT stale and MUST
+  // still run. Asserted directly (no golden line) so the safety/relaxation
+  // invariant is self-checking.
+  let noop_failure = run_scripted(same_file_noop_failure_batch())
+  assert(
+    contains(noop_failure.transcript, "applied src/a.zig second"),
+    "a pre-apply rejection (not-applied) failure must NOT skip a later same-file edit",
+  )
+  assert(
+    !contains(noop_failure.transcript, "skipped dependent `edit` call"),
+    "no skip marker should be emitted when the prior failure did not mutate the resource",
+  )
+  // Post-apply failure (`## Diagnostics ...`) means the edit DID land, so the
+  // later same-file edit's anchor may be stale and MUST still be skipped.
+  let applied_failure = run_scripted(same_file_applied_failure_batch())
+  assert(
+    contains(applied_failure.transcript, "skipped dependent `edit` call"),
+    "a post-apply (applied-then-flagged) failure must STILL skip a later same-file edit",
+  )
+  assert(
+    !contains(applied_failure.transcript, "applied src/a.zig second"),
+    "the later same-file edit must not run after a mutating failure (stale-anchor hazard)",
+  )
 }

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -1560,6 +1560,81 @@ fn __intra_turn_add_failed_keys(failed_keys, keys) {
   return out
 }
 
+/**
+ * Canonical NON-mutating write-failure vocabulary: failure shapes that a host
+ * emits when the write was REJECTED BEFORE TOUCHING the file, so the on-disk
+ * view is byte-identical to what the model already saw. Mirrors the same
+ * canonical strings the product-error classifier (`__tool_result_write_product_error_text`)
+ * already keys on, restricted to the pre-apply (no-mutation) subset. The
+ * post-apply `## diagnostics (...)` shape is DELIBERATELY excluded — that edit
+ * DID land, so a later same-resource sibling could be stale.
+ */
+fn __intra_turn_failure_text_is_nonmutating(text: string) -> bool {
+  let lower = lowercase(trim(text))
+  if lower == "" {
+    return false
+  }
+  // Post-apply diagnostics mean the write LANDED — never treat as non-mutating.
+  if lower.starts_with("## diagnostics (") || lower.contains("\n## diagnostics (") {
+    return false
+  }
+  return lower.contains("[edit rejected]")
+    || lower.contains("not applied")
+    || lower.contains("old_string not found")
+    || lower.starts_with("file already exists")
+    || lower.starts_with("missing required parameter")
+    || __tool_result_dispatch_rejection_text(lower)
+}
+
+/**
+ * Tri-state mutation verdict for a FAILED tool result: did the failure leave the
+ * workspace resource mutated?
+ *
+ *   `false` — the host reported the write was REJECTED before applying (a stale /
+ *             missing anchor, "old_string not found", "[Edit rejected] ... NOT
+ *             applied", an invalid-arguments/permission rejection). The view is
+ *             byte-identical, so a later same-resource sibling is NOT stale.
+ *   `nil`   — unknown. We cannot rule out a mutation (a post-apply diagnostic, an
+ *             opaque error, a non-edit mutating tool), so the caller poisons the
+ *             resource EXACTLY like today.
+ *
+ * Uses the SAME canonical write-failure vocabulary the dispatch classifier
+ * (`__tool_result_write_product_error_text`) already relies on, so it does not
+ * introduce a new, divergent text-matching surface. Conservative by
+ * construction: anything not affirmatively a pre-apply rejection stays `nil`,
+ * preserving today's safety property.
+ */
+fn __intra_turn_result_mutated(result) {
+  if type_of(result) != "dict" {
+    return nil
+  }
+  if !__tool_result_write_product_tool(result) {
+    // Only reason about edit/scaffold/write/run_codemod rejection vocabulary.
+    // Any other mutating tool stays unknown (poison), exactly as today.
+    return nil
+  }
+  for key in ["error", "rendered_result", "observation", "result", "output"] {
+    if result[key] != nil && __intra_turn_failure_text_is_nonmutating(to_string(result[key])) {
+      return false
+    }
+  }
+  return nil
+}
+
+/**
+ * True when a failing same-resource call must POISON the resource for later
+ * siblings — i.e. we cannot rule out that the failure left the resource mutated.
+ * Preserves the safety property: poison unless the failure is an affirmatively
+ * pre-apply (no-mutation) rejection.
+ */
+fn __intra_turn_failure_poisons_resource(result) -> bool {
+  // Poison on `nil` (unknown — cannot rule out a mutation) and on any verdict
+  // other than an affirmative `false`. Only a host-confirmed pre-apply rejection
+  // (view unchanged) skips poisoning. Guards the safety property: unknown stays
+  // conservative, exactly like today.
+  return __intra_turn_result_mutated(result) != false
+}
+
 fn __intra_turn_has_keyed_mutating_calls(tool_calls, tools, options = {}) -> bool {
   for call in tool_calls {
     if len(__intra_turn_resource_keys(call, tools, options)) > 0 {
@@ -1606,9 +1681,14 @@ fn __intra_turn_resource_blocked_result(call, keys) {
     + "A previous mutating tool call in the same assistant response failed for "
     + "the same workspace resource ("
     + rendered_keys
-    + "), so this call was "
-    + "NOT executed. Wait for the failure feedback, re-read the current file if "
-    + "needed, and issue the next edit in a later turn."
+    + "), so this call was NOT executed (its anchor may now be stale).\n"
+    + "Recover in ONE next turn: (1) read the failure feedback from that earlier "
+    + "call just above; (2) re-issue THIS `"
+    + name
+    + "` call now — re-anchor its "
+    + "`old_string` against the file's CURRENT contents (look at the resource first "
+    + "if the earlier call may have changed it). Do not wait extra turns and do not "
+    + "re-send the call that already failed unchanged."
   return {
     ok: false,
     status: "blocked_by_prior_same_resource_failure",
@@ -1816,7 +1896,13 @@ fn __dispatch_tool_calls_with_middleware(tool_calls, tools, options, cap) {
       }
       let result = __invoke_tool_with_index(call, index, tools, options)
       results = results.push(result)
-      if len(resource_keys) > 0 && !__tool_result_ok(result) {
+      // Poison this resource for later same-resource siblings only when the
+      // failure could have left it mutated. A host-confirmed no-op failure
+      // (rejected anchor / "old_string not found") leaves the view byte-identical,
+      // so an independent later edit to the same file is NOT stale and may run.
+      // Unknown (no structured signal) still poisons, preserving today's behavior.
+      if len(resource_keys) > 0 && !__tool_result_ok(result)
+        && __intra_turn_failure_poisons_resource(result) {
         failed_resource_keys = __intra_turn_add_failed_keys(failed_resource_keys, resource_keys)
       }
       if fanout_cap > 0 {


### PR DESCRIPTION
## Mechanic: intra-turn dependent-edit-skip churn

When one assistant turn issues several mutating calls to the **same** workspace resource and an earlier one FAILS, the intra-turn resource fail-fast guard (`__dispatch_tool_calls_with_middleware` in `crates/harn-stdlib/src/stdlib/agent/loop.harn`) skips every later same-resource sibling with a synthetic `[skipped dependent ...]` result — forcing a wasted round-trip even when the later edit was independent (a different anchor/region of the same file).

### Before
Any same-resource failure poisoned the resource, so **every** later same-file edit in the turn was skipped, regardless of whether the failure changed the file.

### After
The guard poisons the resource for later siblings **only when the failure could have mutated it**. The dominant intra-turn failure is a **pre-apply rejection** (anchor mismatch / `old_string not found` / `[Edit rejected] ... NOT applied`), which leaves the file **byte-identical** — so a later same-file edit is NOT stale and is safe to run. This **strictly preserves the safety property**: a post-apply failure (`## Diagnostics` — the edit landed), an opaque error, or any non-edit mutating tool still poisons exactly as before.

- New `__intra_turn_result_mutated` (tri-state) + `__intra_turn_failure_poisons_resource`, classifying the failure with the **same canonical write-failure vocabulary** the dispatch classifier (`__tool_result_write_product_error_text`) already relies on — no new divergent text-matching surface.
- Sharpened the skip feedback to give the model the exact **one-turn** recovery action (re-anchor against current contents and re-issue THIS call now), instead of "issue the next edit in a later turn".

### Tests
Extended `conformance/tests/agents/agent_loop_intra_turn_resource_fail_fast.harn` with two mechanism-fitness cases:
- a **pre-apply rejection** no longer skips the later same-file edit (the relaxation fires);
- a **post-apply** (applied-then-flagged) failure **still** skips it (safety preserved).

All 46 `agents/agent_loop*` conformance tests pass; `harn fmt` clean.

### Measured motivation
Trial `eval-zig-feat-20260627-051442` fired the `[skipped dependent]` path **5 times** in a run that died at the iteration ceiling — 5 wasted round-trips that each cost a turn of budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)