### PR TITLE
fix(ci): stop the changelog gate treating nested source files as pip manifests

### DIFF
--- a/.github/scripts/changelog-fragment-check.sh
+++ b/.github/scripts/changelog-fragment-check.sh
@@ -76,7 +76,7 @@ fi
 # Dependency manager manifests and lockfiles are not Harn release notes. A
 # source/runtime edit in the same PR still fails below; this branch only covers
 # diffs whose non-ignored files are dependency metadata.
-dependency_metadata_pattern='(^|.*/)(Cargo\.toml|Cargo\.lock|package\.json|package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb|bun\.lock|go\.mod|go\.sum|requirements.*\.txt|constraints.*\.txt|pyproject\.toml|poetry\.lock|uv\.lock|Pipfile|Pipfile\.lock|Gemfile|Gemfile\.lock|composer\.json|composer\.lock|pom\.xml|build\.gradle(\.kts)?|settings\.gradle(\.kts)?|gradle\.lockfile|mix\.exs|mix\.lock|rebar\.config|rebar\.lock|Package\.swift|Package\.resolved|pubspec\.yaml|pubspec\.lock|[^/]+\.csproj|packages\.lock\.json|Directory\.Packages\.props)$'
+dependency_metadata_pattern='(^|.*/)(Cargo\.toml|Cargo\.lock|package\.json|package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb|bun\.lock|go\.mod|go\.sum|requirements[^/]*\.txt|constraints[^/]*\.txt|pyproject\.toml|poetry\.lock|uv\.lock|Pipfile|Pipfile\.lock|Gemfile|Gemfile\.lock|composer\.json|composer\.lock|pom\.xml|build\.gradle(\.kts)?|settings\.gradle(\.kts)?|gradle\.lockfile|mix\.exs|mix\.lock|rebar\.config|rebar\.lock|Package\.swift|Package\.resolved|pubspec\.yaml|pubspec\.lock|[^/]+\.csproj|packages\.lock\.json|Directory\.Packages\.props)$'
 non_dependency=$(printf '%s\n' "$nontrivial" | grep -Ev "$dependency_metadata_pattern" || true)
 if [ -z "$non_dependency" ]; then
   echo "::notice title=Changelog fragment gate::only dependency manifest/lockfile paths touched; pass."

--- a/changelog.d/changelog-gate-requirements-glob.fixed.md
+++ b/changelog.d/changelog-gate-requirements-glob.fixed.md
@@ -1,0 +1,7 @@
+- **Changelog-fragment gate no longer treats nested source files as pip
+  manifests.** The dependency-metadata allowlist matched `requirements.*\.txt` /
+  `constraints.*\.txt`, where `.*` crossed `/`, so a non-dependency path such as
+  `crates/.../requirements_helpers/seed.txt` matched and could slip a
+  source-only change past the changelog gate without a fragment. Tightened both
+  to a single path segment (`requirements[^/]*\.txt`, `constraints[^/]*\.txt`);
+  genuine `requirements*.txt` / `constraints*.txt` manifests are unaffected.

--- a/scripts/tests/changelog_fragment_check_test.sh
+++ b/scripts/tests/changelog_fragment_check_test.sh
@@ -91,4 +91,30 @@ commit_all "$mixed_repo" "change source with dependency"
 mixed_output=$(expect_fail "$mixed_repo" "$mixed_base")
 grep -q "crates/harn-vm/src/lib.rs" <<<"$mixed_output"
 
+# A nested, non-dependency file whose name merely starts with "requirements"
+# must NOT be mistaken for a pip requirements manifest. The dependency-metadata
+# allowlist previously used `requirements.*\.txt`, where `.*` crossed `/`, so a
+# path like `.../requirements_helpers/seed.txt` matched and silently bypassed the
+# gate. It must require a changelog fragment like any other source change.
+reqlike_repo=$(new_repo reqlike)
+mkdir -p "$reqlike_repo/crates/harn-vm/src/requirements_helpers"
+printf 'seed\n' > "$reqlike_repo/crates/harn-vm/src/requirements_helpers/seed.txt"
+commit_all "$reqlike_repo" base
+reqlike_base=$(git -C "$reqlike_repo" rev-parse HEAD)
+printf 'seed v2\n' > "$reqlike_repo/crates/harn-vm/src/requirements_helpers/seed.txt"
+commit_all "$reqlike_repo" "edit a requirements-prefixed source file"
+reqlike_output=$(expect_fail "$reqlike_repo" "$reqlike_base")
+grep -q "crates/harn-vm/src/requirements_helpers/seed.txt" <<<"$reqlike_output"
+
+# A genuine pip requirements file (single path segment) still counts as
+# dependency metadata and passes without a fragment.
+req_repo=$(new_repo requirements)
+printf 'flask==2.0.0\n' > "$req_repo/requirements-dev.txt"
+commit_all "$req_repo" base
+req_base=$(git -C "$req_repo" rev-parse HEAD)
+printf 'flask==2.0.1\n' > "$req_repo/requirements-dev.txt"
+commit_all "$req_repo" "bump python dependency"
+req_output=$(expect_pass "$req_repo" "$req_base")
+grep -q "only dependency manifest/lockfile paths touched" <<<"$req_output"
+
 echo "changelog_fragment_check_test: ok"


### PR DESCRIPTION
## Summary

The changelog-fragment gate's dependency-metadata allowlist matched `requirements.*\.txt` / `constraints.*\.txt`. In that ERE `.*` also matches `/`, so after the `(^|.*/)` prefix a **nested non-dependency** path like `crates/harn-vm/src/requirements_helpers/seed.txt` matched the allowlist. A PR whose only non-ignored change was such a file then passed the gate with *"only dependency manifest/lockfile paths touched"* and **no changelog fragment** — a real (if narrow) loosening of the gate.

Fix: tighten both alternatives to a single path segment so the match can't cross a directory separator:

```diff
-requirements.*\.txt|constraints.*\.txt
+requirements[^/]*\.txt|constraints[^/]*\.txt
```

Genuine `requirements*.txt` / `constraints*.txt` manifests (including `requirements-dev.txt`, nested under any directory) still count as dependency metadata.

## Notes for reviewers

- Extends `scripts/tests/changelog_fragment_check_test.sh` with two cases: a nested `requirements_helpers/seed.txt` source file now correctly **requires** a fragment (`expect_fail`), and a real `requirements-dev.txt` bump still **passes** without one (`expect_pass`).
- Verified the new test **fails against the old regex** (the nested file slipped through as "dependency metadata") and **passes with the fix** — so it genuinely pins the behavior.
- Added a `changelog.d/` fragment because the test file under `scripts/tests/` is a non-ignored path for the gate.
- No agent mechanism touched, so the mechanism-contract gate does not apply.
- Second of the guard-script robustness follow-ups noted on #3610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCGBVUG5oETH3m15zw6BSS)_