### PR TITLE
fix(fmt): parenthesize a range nested in another expression

### DIFF
--- a/changelog.d/range-paren-nested.fixed.md
+++ b/changelog.d/range-paren-nested.fixed.md
@@ -1,0 +1,8 @@
+- **`harn fmt` keeps parentheses around a nested range.** A range (`a to b`)
+  binds looser than ternary, comparison, and another range, so it can only
+  appear bare at the top of an expression. The formatter dropped the parens when
+  a range was nested as a ternary condition/branch, a binary operand, or another
+  range's bound, producing output that either failed to re-parse
+  (`c ? (a to b) : d` → `c ? a to b : d`) or silently changed meaning
+  (`(a to b) < c` → `a to b < c`, i.e. `a to (b < c)`). Such ranges are now
+  parenthesized at those sites.

--- a/crates/harn-fmt/src/formatter/expressions.rs
+++ b/crates/harn-fmt/src/formatter/expressions.rs
@@ -238,9 +238,12 @@ impl Formatter<'_> {
                 true_expr,
                 false_expr,
             } => {
-                let cond = self.format_expr(condition, indent);
-                let t = self.format_expr(true_expr, indent);
-                let f = self.format_expr(false_expr, indent);
+                // A range bound to a ternary part must be parenthesized: a bare
+                // range as the condition would swallow the `?:` into its end
+                // bound, and as a branch it simply fails to re-parse.
+                let cond = paren_if_range(self.format_expr(condition, indent), &condition.node);
+                let t = paren_if_range(self.format_expr(true_expr, indent), &true_expr.node);
+                let f = paren_if_range(self.format_expr(false_expr, indent), &false_expr.node);
                 format!("{cond} ? {t} : {f}")
             }
             Node::Assignment {
@@ -290,8 +293,10 @@ impl Formatter<'_> {
                 end,
                 inclusive,
             } => {
-                let s = self.format_expr(start, indent);
-                let e = self.format_expr(end, indent);
+                // A range bound that is itself a range needs parens; `a to b to c`
+                // is non-associative and would not re-parse.
+                let s = paren_if_range(self.format_expr(start, indent), &start.node);
+                let e = paren_if_range(self.format_expr(end, indent), &end.node);
                 if *inclusive {
                     format!("{s} to {e}")
                 } else {

--- a/crates/harn-fmt/src/helpers.rs
+++ b/crates/harn-fmt/src/helpers.rs
@@ -128,6 +128,18 @@ pub(crate) fn needs_parens_as_postfix_object(node: &Node) -> bool {
     )
 }
 
+/// Wrap an already-formatted expression in parens when `node` is a range.
+/// Used for contexts a range can't legally occupy bare — a ternary
+/// condition/branch, or another range's bound — where omitting the parens
+/// would change the meaning or fail to re-parse.
+pub(crate) fn paren_if_range(formatted: String, node: &Node) -> String {
+    if matches!(node, Node::RangeExpr { .. }) {
+        format!("({formatted})")
+    } else {
+        formatted
+    }
+}
+
 /// Whether `node` needs parentheses as the operand of a unary prefix (`!`, `-`).
 pub(crate) fn needs_parens_as_unary_operand(node: &Node) -> bool {
     matches!(
@@ -143,6 +155,13 @@ pub(crate) fn needs_parens_as_unary_operand(node: &Node) -> bool {
 /// a parent BinaryOp.  Covers both correctness (semantics-preserving) and
 /// clarity (`&&` / `||` mixing).
 pub(crate) fn child_needs_parens(parent_op: &str, child: &Node, is_right: bool) -> bool {
+    // A range (`a to b`) binds looser than every binary operator, so as an
+    // operand of one it must be parenthesized — both to preserve grouping and
+    // to stay parseable, since the parser only accepts a bare range at the top
+    // of an expression (`parse_range` sits just above `|>`).
+    if matches!(child, Node::RangeExpr { .. }) {
+        return true;
+    }
     if let Node::BinaryOp { op: child_op, .. } = child {
         let p = op_precedence(parent_op);
         let c = op_precedence(child_op);

--- a/crates/harn-fmt/src/tests.rs
+++ b/crates/harn-fmt/src/tests.rs
@@ -24,6 +24,35 @@ fn test_roundtrip_basic() {
 }
 
 #[test]
+fn range_nested_in_subexpression_keeps_parens_and_round_trips() {
+    // A range (`a to b`) binds looser than ternary, comparison, and another
+    // range, so it must stay parenthesized in those positions. Before the fix
+    // the formatter dropped the parens, producing output that either failed to
+    // re-parse or silently changed meaning.
+
+    // Parse-failure cases — assert_roundtrip re-parses the formatted output,
+    // which panicked here before the fix (`Unexpected "to"`).
+    assert_roundtrip("pipeline default(task) { let x = c ? (a to b) : d }");
+    assert_roundtrip("pipeline default(task) { let x = (a to b) to c }");
+
+    // Silent-semantic-change cases — the formatted output re-parses cleanly but
+    // to a different AST, so idempotence alone wouldn't catch it; assert the
+    // parens survive.
+    for src in [
+        "pipeline default(task) { let x = (a to b) ? c : d }",
+        "pipeline default(task) { let x = c ? d : (a to b) }",
+        "pipeline default(task) { let x = (a to b) < c }",
+    ] {
+        let formatted = format_source(src).unwrap();
+        assert!(
+            formatted.contains("(a to b)"),
+            "range subexpression must stay parenthesized:\n{formatted}"
+        );
+        assert_roundtrip(src);
+    }
+}
+
+#[test]
 fn test_roundtrip_mutex_bare() {
     assert_roundtrip("pipeline default(task) { mutex { log(1) } }");
 }


### PR DESCRIPTION
## Summary

A range (`a to b`) binds looser than ternary, comparison, and another range — `parse_range` sits just above `|>`, so the parser only accepts a bare range at the top of an expression. The formatter knew ranges sometimes need parens (postfix/unary already list `RangeExpr`) but missed three nesting positions, so it produced output that **fails to re-parse** or **silently changes meaning**:

| Input | Old fmt output | Effect |
|---|---|---|
| `c ? (a to b) : d` | `c ? a to b : d` | **fails to re-parse** (`Unexpected "to"`) |
| `(a to b) to c` | `a to b to c` | **fails to re-parse** (range is non-associative) |
| `(a to b) ? c : d` | `a to b ? c : d` | re-parses as `a to (b ? c : d)` — **meaning changed** |
| `(a to b) < c` | `a to b < c` | re-parses as `a to (b < c)` — **meaning changed** |
| `c ? d : (a to b)` | `c ? d : a to b` | re-parses as `(c ? d : a) to b` — **meaning changed** |

Fix: parenthesize a `RangeExpr` when it's a binary operand (`child_needs_parens`), a ternary condition/branch, or another range's bound — via a small `paren_if_range` helper, mirroring how `??`/`**` are already handled.

## Verification

- `cargo test -p harn-fmt` → all pass, incl. the new `range_nested_in_subexpression_keeps_parens_and_round_trips` (it panicked on the parse-failure cases before the fix).
- `cargo clippy -p harn-fmt --all-targets` → clean.
- Changelog fragment included. No agent mechanism touched.

> **Scope note:** this PR originally also carried a `harn-vm` change to promote `i64::MIN / -1` (division overflow) to float instead of wrapping. I **pulled that out**: the wrap turns out to be a *deliberate, documented contract*, not an oversight — `harn-codegen`'s Cranelift lowering (`lower_idiv`) and its reference evaluator intentionally wrap to match the VM (test `integer_min_div_neg_one_does_not_trap_or_deopt`), whereas `+`/`-`/`*`/negation deopt-and-promote. Making division consistent (deopt-and-promote in both backends) is a real improvement but a coordinated VM + JIT-backend change that overrides a deliberate decision — better as its own reviewed PR than smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)