### PR TITLE
Refresh protocol contribution tracking docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -271,6 +271,7 @@
 ## Protocol contributions
 
 - [Protocol contribution RFCs](./protocol-contributions/README.md)
+  - [Filing status ledger](./protocol-contributions/status-ledger.md)
   - [ACP: `session/inject_reminder`](./protocol-contributions/acp-session-inject-reminder.md)
   - [A2A: `tasks/inject_reminder`](./protocol-contributions/a2a-message-kind-reminder.md)
   - [MCP: `notifications/reminder`](./protocol-contributions/mcp-notifications-reminder.md)

--- a/docs/src/protocol-contributions/README.md
+++ b/docs/src/protocol-contributions/README.md
@@ -20,10 +20,12 @@ The Harn convention for cross-protocol primitives is:
    questions for maintainers. The wire-format snippet matches the
    upstream repo's preferred dialect (TypeScript for ACP, JSON Schema
    for MCP, A2A JSON-RPC envelope for A2A).
-3. **Open an upstream discussion** when the RFC is ready. Use the RFC
-   doc as the source of truth for the discussion body so reviewers
-   work from a single shared text. Do not expand scope inside the
-   filed thread — drift looks bad and complicates maintainer triage.
+3. **Open an upstream discussion** when the RFC is ready. Treat the
+   RFC doc as source material, then do a public-filing pass before
+   posting: lead with neutral protocol semantics, deployed peer
+   behavior, and public prior art rather than Harn or Burin-specific
+   adoption claims. Keep the scope fixed inside the filed thread so
+   maintainers can triage one proposal at a time.
 4. **Track outcomes here.** When a proposal lands upstream, update the
    RFC's "Status" header and migrate the Harn `_meta` envelope to the
    standardized field locations in a follow-up PR. When a proposal is
@@ -31,6 +33,10 @@ The Harn convention for cross-protocol primitives is:
    stable for downstream consumers.
 
 ## Current RFCs
+
+Statuses below were last verified on 2026-06-27. See the
+[filing status ledger](./status-ledger.md) for the upstream PR,
+discussion, and issue states checked during triage.
 
 ### Ambient reminder injection ([#1829][1829])
 
@@ -44,8 +50,8 @@ The Harn convention for cross-protocol primitives is:
 
 | RFC | Upstream | Status | Reference impl |
 |---|---|---|---|
-| [ACP `session/suspend`](./acp-session-suspend.md) | agentclientprotocol/agent-client-protocol | Draft (not yet filed upstream) | `__host_worker_suspend` builtin + `_meta.harn.suspend`-decorated session updates; sibling to the already-shipped `session/resume` ([ACP #1726](https://github.com/agentclientprotocol/agent-client-protocol/discussions/1726)) |
-| [A2A `TaskState.PAUSED`](./a2a-paused-state.md) | a2aproject/A2A | Draft (not yet filed upstream) | `metadata.harn.pause`-decorated `tasks/statusUpdate` SSE events |
+| [ACP `session/suspend`](./acp-session-suspend.md) | agentclientprotocol/agent-client-protocol | Discussion open ([ACP #1233](https://github.com/agentclientprotocol/agent-client-protocol/discussions/1233)); no maintainer reply as of 2026-06-27 | `__host_worker_suspend` builtin + `_meta.harn.suspend`-decorated session updates; sibling to the already-shipped `session/resume` ([ACP #1726](https://github.com/agentclientprotocol/agent-client-protocol/discussions/1726)) |
+| [A2A `TaskState.PAUSED`](./a2a-paused-state.md) | a2aproject/A2A | Discussion open ([A2A #1858](https://github.com/a2aproject/A2A/discussions/1858)); community feedback favors one `PAUSED` state plus structured `pause` metadata; no maintainer/TSC reply as of 2026-06-27 | `metadata.harn.pause`-decorated `tasks/statusUpdate` SSE events |
 
 [1848]: https://github.com/burin-labs/harn/issues/1848
 
@@ -53,7 +59,7 @@ The Harn convention for cross-protocol primitives is:
 
 Authoring RFC documents in this repository is in scope for these PRs.
 **Filing upstream discussions, issues, or PRs is the maintainer's
-explicit action — not a step any Harn contributor should take without
+explicit action - not a step any Harn contributor should take without
 the project owner asking for it.** See [#1829][1829] for the upstream
 work that remains open.
 
@@ -61,15 +67,18 @@ work that remains open.
 
 ## Related
 
-- [Harn ACP/MCP extensions v1](../spec/harn-extensions/v1.md) — the
+- [Harn ACP/MCP extensions v1](../spec/harn-extensions/v1.md) - the
   authoritative list of Harn-owned `_meta` fields that ride alongside
   upstream protocol payloads today.
-- [System reminders](../system-reminders.md) — the language-level
+- [System reminders](../system-reminders.md) - the language-level
   reminder primitive the reminder-injection RFCs are proposing to
   standardize.
-- [Transcript architecture](../transcript-architecture.md) — the
+- [Transcript architecture](../transcript-architecture.md) - the
   underlying transcript event model that produces and consumes
   reminders.
-- [`suspend_agent` / `resume_agent` builtins](../builtins.md) — the
+- [`suspend_agent` / `resume_agent` builtins](../builtins.md) - the
   language-level cooperative suspend primitive the
   suspend/resume RFCs are proposing to standardize.
+- [Filing status ledger](./status-ledger.md) - direct links and
+  verification notes for the current upstream discussions, PRs, and
+  issues.

--- a/docs/src/protocol-contributions/a2a-paused-state.md
+++ b/docs/src/protocol-contributions/a2a-paused-state.md
@@ -1,29 +1,35 @@
 # A2A RFC: explicit `PAUSED` task state + `tasks/pause` / `tasks/resume`
 
 **Upstream repo:** [a2aproject/A2A][a2a]
-**Status:** Draft (not yet filed upstream).
+**Discussion:** [A2A #1858 - `TaskState.PAUSED`][a2a-1858].
+**Status:** Open upstream discussion. As of the 2026-06-27
+recheck, community feedback favored one `PAUSED` state with a
+structured `pause` object over separate `PAUSED_BY_CLIENT` /
+`PAUSED_BY_AGENT` enum values; no maintainer/TSC reply was present.
 **Authors:** Burin Labs
 **Reference impl:** `harn-vm` cooperative suspend primitive
-([`crates/harn-vm/src/stdlib/agents.rs`][agents-rs] —
-`__host_worker_suspend` + `WorkerSuspension`) and `harn-serve` A2A
-adapter
+([`crates/harn-vm/src/stdlib/agents.rs`][agents-rs] -
+`__host_worker_suspend`; [`agents_workers/mod.rs`][workers-rs] -
+`WorkerSuspension`) and `harn-serve` A2A adapter
 ([`crates/harn-serve/src/adapters/a2a/`][a2a-dir]).
-**Sibling discussions:** [A2A #1857 — idempotency on
+**Sibling discussions:** [A2A #1857 - idempotency on
 `tasks/send`][a2a-1857] covers a different concern (request
 idempotency). A first-class paused state is still open.
 
 [a2a]: https://github.com/a2aproject/A2A
 [a2a-1857]: https://github.com/a2aproject/A2A/discussions/1857
+[a2a-1858]: https://github.com/a2aproject/A2A/discussions/1858
 [a2a-dir]: https://github.com/burin-labs/harn/tree/main/crates/harn-serve/src/adapters/a2a
 [agents-rs]: https://github.com/burin-labs/harn/blob/main/crates/harn-vm/src/stdlib/agents.rs
+[workers-rs]: https://github.com/burin-labs/harn/blob/main/crates/harn-vm/src/stdlib/agents_workers/mod.rs
 
 ## Problem statement
 
 A2A's `TaskState` enum models task lifecycle as a state machine. The
 current non-terminal "waiting" states are:
 
-- `INPUT_REQUIRED` — the peer needs end-user input to continue.
-- `AUTH_REQUIRED` — the peer needs the caller to refresh credentials
+- `INPUT_REQUIRED` - the peer needs end-user input to continue.
+- `AUTH_REQUIRED` - the peer needs the caller to refresh credentials
   or complete an auth flow.
 
 Both are **callee-initiated soft-pauses** that exist to signal "I
@@ -33,20 +39,22 @@ prompt, an OAuth flow trigger).
 
 A2A has no first-class state for **either**:
 
-1. **`PAUSED_BY_CLIENT`** — the caller asked the peer to pause. The
-   peer is fine; it just shouldn't make any further turns until told
-   to.
-2. **`PAUSED_BY_AGENT`** — the peer voluntarily parked itself waiting
-   on an external condition (a file change, a CI build completion, a
-   scheduled wake-up time) that's neither user input nor an auth
-   refresh.
+1. **Caller-initiated pause** - the caller asked the peer to pause.
+   The peer can continue, but should not make further turns until
+   told to resume.
+2. **Peer-initiated self-park** - the peer voluntarily parked itself
+   waiting on an external condition (a file change, a CI build
+   completion, a scheduled wake-up time) that is neither user input
+   nor an auth refresh.
 
 These are different shapes. Today A2A peers conflate them with
 `INPUT_REQUIRED` (with a synthetic prompt the user is supposed to
 ignore), `AUTH_REQUIRED` (definitely wrong), or `WORKING` (the
 caller-side cancel button still nukes the task). All three workarounds
 lose information: the caller's UI can't distinguish "paused, will
-resume on its own" from "blocked, needs your input."
+resume on its own" from "blocked, needs your input." The upstream
+discussion converged on keeping that distinction in `pause.initiatedBy`
+rather than multiplying the top-level enum surface.
 
 ### Why this matters in practice
 
@@ -55,8 +63,8 @@ Concrete scenarios we hit shipping Harn:
 - **Caller-driven pause for review.** A coordinator agent wants to
   pause a delegated worker, inspect its progress, then decide whether
   to resume or cancel. The coordinator needs to call `tasks/pause`
-  and observe `PAUSED_BY_CLIENT` rather than send `INPUT_REQUIRED`
-  back to itself.
+  and observe `state: "paused"` with `pause.initiatedBy: "client"`
+  rather than send `INPUT_REQUIRED` back to itself.
 - **Agent self-park on long waitpoints.** A peer agent calls a tool
   that spawns a CI build. The agent has nothing useful to do for
   minutes (possibly hours). Today it has to either burn idle turns
@@ -67,8 +75,8 @@ Concrete scenarios we hit shipping Harn:
   involved beyond observing the paused state.
 - **Cost / budget interrupts.** A policy engine wants to pause every
   task that exceeds a token budget. The right state is
-  `PAUSED_BY_CLIENT` (with a reason); the caller can decide whether
-  to refill and resume or cancel.
+  `PAUSED` with `pause.initiatedBy: "client"` and a reason; the
+  caller can decide whether to refill and resume or cancel.
 - **Cross-protocol bridges.** Harn's `harn-serve` adapter today maps
   ACP `session/resume` (#1726) and Harn's `__host_worker_suspend`
   envelope onto A2A. With no `PAUSED` shape, the adapter has to
@@ -96,15 +104,17 @@ breaks the existing client contract:
 - Resume callers MUST send a `Message` to flip out of
   `INPUT_REQUIRED`; we want to flip out of `PAUSED` with a verb
   (`tasks/resume`) that doesn't pollute the message stream.
-- `INPUT_REQUIRED` is a single state; we need to distinguish
-  caller-initiated from agent-initiated pauses for UI and audit.
+- `INPUT_REQUIRED` is a single state; a `PAUSED` state can use the
+  same compatibility-friendly pattern while carrying pause-specific
+  initiator metadata for UI and audit.
 
 ## Proposed wire format
 
 ### `TaskState` additions
 
-Two new non-terminal states, sibling to `INPUT_REQUIRED` /
-`AUTH_REQUIRED`:
+One new non-terminal state, sibling to `INPUT_REQUIRED` /
+`AUTH_REQUIRED`, with initiator and resumability details carried in a
+structured `pause` payload:
 
 ```typescript
 export enum TaskState {
@@ -119,19 +129,31 @@ export enum TaskState {
   REJECTED = "rejected",
 
   /**
-   * Caller asked the peer to pause via `tasks/pause`. Peer commits
-   * no further turns until `tasks/resume` is called or the task is
-   * canceled.
+   * Task is intentionally parked at a resumable boundary. Inspect
+   * `Task.pause` to determine who initiated the pause and how it can
+   * be resumed.
    */
-  PAUSED_BY_CLIENT = "paused-by-client",
+  PAUSED = "paused",
+}
 
-  /**
-   * Peer voluntarily parked itself waiting on an external condition
-   * declared via `tasks/await_resumption`. Peer resumes when the
-   * condition fires, the timeout elapses, or `tasks/resume` is
-   * called explicitly.
-   */
-  PAUSED_BY_AGENT = "paused-by-agent",
+export interface TaskPause {
+  /** Caller requested the pause, or the peer parked itself. */
+  initiatedBy: "client" | "agent"
+  /** Human-readable reason or stable reason code. */
+  reason?: string
+  /** When the task entered the paused state. */
+  pausedAt: string
+  /** Optional lease or deadline after which callers should not assume
+   * the pause remains valid. */
+  pausedUntil?: string
+  /** Opaque consume-once resume token. */
+  resumeToken: string
+  /** Whether the task accepts an explicit `tasks/resume`. */
+  resumable: boolean
+  /** Optional peer-declared resume condition. */
+  conditions?: Record<string, unknown>
+  /** Optional mode hint for how resume input is expected. */
+  resumeMode?: "client_message" | "external_event" | "timeout"
 }
 ```
 
@@ -139,16 +161,16 @@ export enum TaskState {
 
 Allowed transitions (additions only, existing transitions unchanged):
 
-- `WORKING` → `PAUSED_BY_CLIENT` (via `tasks/pause`)
-- `WORKING` → `PAUSED_BY_AGENT` (via `tasks/await_resumption`)
-- `PAUSED_BY_CLIENT` → `WORKING` (via `tasks/resume`)
-- `PAUSED_BY_AGENT` → `WORKING` (via `tasks/resume`, or when the
-  agent's declared resume condition fires)
-- `PAUSED_BY_CLIENT` → `CANCELED` (via `tasks/cancel`)
-- `PAUSED_BY_AGENT` → `CANCELED` (via `tasks/cancel`)
-- `PAUSED_BY_*` → `FAILED` (timeout elapsed with `on_timeout: "fail"`)
+- `WORKING` → `PAUSED` with `pause.initiatedBy: "client"` (via
+  `tasks/pause`)
+- `WORKING` → `PAUSED` with `pause.initiatedBy: "agent"` (via
+  `tasks/await_resumption`)
+- `PAUSED` → `WORKING` (via `tasks/resume`, or when the peer's
+  declared resume condition fires)
+- `PAUSED` → `CANCELED` (via `tasks/cancel`)
+- `PAUSED` → `FAILED` (timeout elapsed with `on_timeout: "fail"`)
 
-Notably **disallowed**: `INPUT_REQUIRED` ↔ `PAUSED_BY_*` direct
+Notably **disallowed**: `INPUT_REQUIRED` <-> `PAUSED` direct
 transitions. A peer that needs user input while paused must first
 flip to `WORKING` and then to `INPUT_REQUIRED`; the two state
 families don't compose because they have different unblock channels.
@@ -177,10 +199,14 @@ Response:
   "id": "req-019abf6b-...",
   "result": {
     "taskId": "task-019abf6b-7d51-7c1d-bb02-...",
-    "state": "paused-by-client",
-    "handle": "suspend-019abf6b-...",
-    "pausedAt": "2026-04-30T12:34:56.789Z",
-    "reason": "operator review"
+    "state": "paused",
+    "pause": {
+      "initiatedBy": "client",
+      "resumeToken": "suspend-019abf6b-...",
+      "pausedAt": "2026-04-30T12:34:56.789Z",
+      "reason": "operator review",
+      "resumable": true
+    }
   }
 }
 ```
@@ -224,9 +250,21 @@ Response:
   "id": "req-019abf6b-...",
   "result": {
     "taskId": "task-019abf6b-7d51-7c1d-bb02-...",
-    "state": "paused-by-agent",
-    "handle": "suspend-019abf6b-...",
-    "pausedAt": "2026-04-30T12:34:56.789Z"
+    "state": "paused",
+    "pause": {
+      "initiatedBy": "agent",
+      "resumeToken": "suspend-019abf6b-...",
+      "pausedAt": "2026-04-30T12:34:56.789Z",
+      "reason": "waiting on ci/build:1234",
+      "conditions": {
+        "onEvent": "ci.build.completed:1234",
+        "timeout": {
+          "durationMinutes": 30,
+          "onTimeout": "fail"
+        }
+      },
+      "resumable": true
+    }
   }
 }
 ```
@@ -240,7 +278,7 @@ Response:
   "method": "tasks/resume",
   "params": {
     "taskId": "task-019abf6b-7d51-7c1d-bb02-...",
-    "handle": "suspend-019abf6b-...",
+    "resumeToken": "suspend-019abf6b-...",
     "input": null,
     "continueTranscript": true,
     "metadata": {}
@@ -266,12 +304,15 @@ state-update notifications:
   "method": "tasks/statusUpdate",
   "params": {
     "taskId": "task-019abf6b-7d51-7c1d-bb02-...",
-    "state": "paused-by-client",
-    "handle": "suspend-019abf6b-...",
-    "reason": "operator review",
-    "initiator": "client",
-    "pausedAt": "2026-04-30T12:34:56.789Z",
-    "conditions": null
+    "state": "paused",
+    "pause": {
+      "initiatedBy": "client",
+      "resumeToken": "suspend-019abf6b-...",
+      "reason": "operator review",
+      "pausedAt": "2026-04-30T12:34:56.789Z",
+      "conditions": null,
+      "resumable": true
+    }
   }
 }
 ```
@@ -285,7 +326,7 @@ and the symmetric resumed shape:
   "params": {
     "taskId": "task-019abf6b-7d51-7c1d-bb02-...",
     "state": "working",
-    "previousState": "paused-by-agent",
+    "previousState": "paused",
     "cause": "condition_fired",
     "hadResumeInput": false,
     "continueTranscript": true,
@@ -329,7 +370,7 @@ Errors follow A2A's existing JSON-RPC error envelope:
 | `-32602` | Malformed `params` (missing `taskId`, unknown enum value on `mode` / `onTimeout`, etc.). |
 | `-32004` | Unknown `taskId`. |
 | `-32011` | Task is in a state that does not allow pause (e.g. already terminal). |
-| `-32012` | Resume `handle` does not match the recorded suspension handle. |
+| `-32012` | Resume `resumeToken` does not match the recorded suspension token. |
 | `-32601` | Peer does not implement `tasks/pause` (i.e., capability missing). |
 
 ## Compatibility and migration
@@ -345,14 +386,15 @@ Harn-as-A2A-peer currently:
   decorating with `metadata.harn.pause` carrying the actual paused
   status, handle, reason, and resume conditions.
 - Maps Harn's `WorkerSuspension` envelope (verbatim from
-  [`crates/harn-vm/src/stdlib/agents.rs`][agents-rs]) onto the
+  [`crates/harn-vm/src/stdlib/agents_workers/mod.rs`][workers-rs]) onto the
   `metadata.harn.pause` shape.
 
 Migration when the standardized state lands:
 
 1. Promote paused state from `metadata.harn.pause.state` to top-level
-   `TaskState.PAUSED_BY_CLIENT` / `PAUSED_BY_AGENT` on
-   `tasks/statusUpdate` events.
+   `TaskState.PAUSED` on `tasks/statusUpdate` events, with
+   `metadata.harn.pause.initiator` mapped to `pause.initiatedBy`.
+   Map the existing suspension `handle` to `pause.resumeToken`.
 2. Implement `tasks/pause`, `tasks/await_resumption`, and
    `tasks/resume` as canonical inbound paths. Keep
    `metadata.harn.pause` reads as a fall-back for one A2A minor
@@ -368,7 +410,7 @@ Migration when the standardized state lands:
 Peers that don't model pause internally can satisfy `tasks/pause` by
 cancelling any in-flight tool calls (or letting them complete in
 `wait_for_completion` mode), persisting the task's last known
-state pointer, and returning a `handle` they can re-open on
+state pointer, and returning a `resumeToken` they can re-open on
 `tasks/resume`. That's strictly stronger than the
 `INPUT_REQUIRED`-with-fake-prompt workaround and requires no message
 schema work. Implementing `tasks/await_resumption` is optional and
@@ -378,8 +420,8 @@ only needed by peers that want to self-park.
 
 | Surface | Status | Notes |
 |---|---|---|
-| `__host_worker_suspend` Rust builtin | Shipping (v0.8.x) | `crates/harn-vm/src/stdlib/agents.rs` — cooperative suspend at the next turn boundary; backs both caller- and agent-initiated paths. |
-| `agent_await_resumption` script builtin | Shipping (v0.8.x) | `crates/harn-stdlib/src/stdlib/agent/workers.harn` — exposes the agent-initiated dual. |
+| `__host_worker_suspend` Rust builtin | Shipping (v0.8.x) | `crates/harn-vm/src/stdlib/agents.rs` - cooperative suspend at the next turn boundary; backs both caller- and agent-initiated paths. |
+| `agent_await_resumption` script builtin | Shipping (v0.8.x) | `crates/harn-stdlib/src/stdlib/agent/workers.harn` - exposes the agent-initiated dual. |
 | `WorkerSuspension` JSON envelope | Shipping | Shared verbatim with the [ACP RFC](./acp-session-suspend.md). |
 | `ResumeConditions` validator (`parse_resume_conditions`) | Shipping | Validates `trigger` / `timeout` / `on_event` shape; backs the proposed `conditions` field field-for-field. |
 | Suspend/resume conformance suite (S-11, #1847) | Shipping | Seven paired `.harn` / `.expected` fixtures cover caller suspend, agent self-park, timeout, double-resume race, close-while-suspended. |
@@ -389,28 +431,24 @@ only needed by peers that want to self-park.
 | A2A adapter `metadata.harn.pause` outbound emission | Reference impl tracked under harn#1848 | Will emit under `metadata.harn.pause` until upstream lands. |
 | Agent card `capabilities.supportsPause` advertisement | Pending upstream schema | Currently advertised under `capabilities._meta.harn.pause` (alongside `capabilities._meta.harn.reminders` from the [reminders RFC](./a2a-message-kind-reminder.md)). |
 
-The canonical lifecycle struct ([`WorkerSuspension`][agents-rs]) is
+The canonical lifecycle struct ([`WorkerSuspension`][workers-rs]) is
 shared verbatim with the [ACP RFC](./acp-session-suspend.md); field
 names round-trip through the A2A JSON shape with conventional
 camelCase translation.
 
 ## Open questions for upstream maintainers
 
-1. **Two states vs one + initiator field.** We propose
-   `PAUSED_BY_CLIENT` and `PAUSED_BY_AGENT` as separate states for
-   the same reason we proposed `tasks/pause` and
-   `tasks/await_resumption` as separate methods: the unblock channels
-   differ (caller call vs condition / timeout / explicit resume) and
-   client UIs render them differently. Maintainers may prefer a
-   single `PAUSED` state plus an `initiator` discriminator on the
-   status notification; we'd accept either, but the typed shape
-   simplifies state-machine validators.
-2. **Naming.** `PAUSED_BY_*` is verbose but unambiguous. Alternatives
-   include `SUSPENDED_BY_CLIENT` (matches the ACP `session/suspend`
-   verb), `STOPPED_BY_*` (overloaded with cancellation in some
-   client UIs), or just `PAUSED` + `initiator` field. We've used
-   `PAUSED_BY_*` to match Temporal's existing `WORKFLOW_PAUSED` /
-   `WORKFLOW_PAUSED_BY_*` taxonomy.
+1. **Exact `pause` field set.** The current discussion points toward
+   `initiatedBy`, `pausedAt`, optional lease/deadline metadata such as
+   `pausedUntil`, `resumeMode`, `resumeToken`, and `resumable`.
+   Maintainers should decide which fields are core versus extension
+   metadata.
+2. **External side-effect pointer.** Community feedback raised an
+   optional `lastSideEffectRef` / `lastExternalEffectRef` digest so a
+   caller can reconcile world state before resuming a task that may
+   already have crossed an external side-effect boundary. That is
+   useful for duplicate-side-effect safety, but it may be too
+   domain-specific for the base pause object.
 3. **`mode` semantics.** Should `tasks/pause` honor the same
    `interrupt_immediate` / `finish_step` / `wait_for_completion`
    delivery modes as the ACP sibling? Our reference impl defaults to
@@ -420,7 +458,7 @@ camelCase translation.
    `trigger`, `timeout`). A2A maintainers may prefer a single opaque
    `Conditions` value the peer is free to parse, leaving the schema
    to peer extension. We've found the typed shape essential for
-   replay determinism — peers that round-trip a condition need a
+   replay determinism; peers that round-trip a condition need a
    stable schema for hashing.
 5. **`continueTranscript` semantics.** Defaulting to `true` preserves
    the existing assumption that resumed tasks pick up where they left
@@ -428,9 +466,9 @@ camelCase translation.
    matches the "fresh turn with a digest" pattern most production
    agents want. We've defaulted to `true` to match the ACP sibling.
 6. **Push notification interaction.** A2A push notifications already
-   exist; should `tasks/statusUpdate` with the new states piggyback
+   exist; should `tasks/statusUpdate` with the new state piggyback
    on them or stay on the SSE stream? Our reference impl uses SSE
-   only — push payloads weren't designed for the back-and-forth
+   only; push payloads weren't designed for the back-and-forth
    pause/resume conversation.
 7. **Capability granularity.** Is `capabilities.supportsPause` /
    `supportsAwaitResumption` the right shape, or should they fold
@@ -439,15 +477,16 @@ camelCase translation.
 8. **Relationship to the ACP RFC.** We've filed a parallel [ACP
    RFC](./acp-session-suspend.md) for `session/suspend` /
    `session/await_resumption`. The two RFCs deliberately share
-   field names (`handle`, `reason`, `conditions`, `cause`) so
+   field names (`resumeToken`, `reason`, `conditions`, `cause`) so
    cross-protocol bridges round-trip verbatim. If A2A's shape
    diverges substantially from ACP's, the cross-protocol story gets
    noisier.
 
 ## References
 
-- [A2A #1857 — `tasks/send` idempotency][a2a-1857] (separate concern;
+- [A2A #1857 - `tasks/send` idempotency][a2a-1857] (separate concern;
   not a substitute for explicit paused state)
+- [A2A #1858 - `TaskState.PAUSED` discussion][a2a-1858]
 - [Sibling ACP RFC: `session/suspend`](./acp-session-suspend.md)
 - [Sibling A2A RFC: `tasks/inject_reminder`](./a2a-message-kind-reminder.md)
 - [`__host_worker_suspend` builtin][agents-rs]

--- a/docs/src/protocol-contributions/acp-session-suspend.md
+++ b/docs/src/protocol-contributions/acp-session-suspend.md
@@ -1,24 +1,30 @@
 # ACP RFC: `session/suspend` + `session/await_resumption`
 
 **Upstream repo:** [agentclientprotocol/agent-client-protocol][acp]
-**Sibling discussions:** [ACP #1220 — `session/inject`][acp-1220],
-[ACP #1224 — `session/remind`][acp-1224] (covered by the [sibling
+**Sibling discussions:** [ACP #1220 - `session/inject`][acp-1220],
+[ACP #1224 - `session/remind`][acp-1224] (covered by the [sibling
 `session/inject_reminder` RFC](./acp-session-inject-reminder.md));
 this RFC is the suspend-side companion to the already-shipped
 `session/resume` ([ACP #1726][acp-1726]).
-**Status:** Draft (not yet filed upstream).
+**Discussion:** [ACP #1233 - `session/suspend` +
+`session/await_resumption`][acp-1233].
+**Status:** Open upstream discussion; no maintainer reply was present
+when rechecked on 2026-06-27.
 **Authors:** Burin Labs
 **Reference impl:** `harn-vm` cooperative suspend primitive
-([`crates/harn-vm/src/stdlib/agents.rs`][agents-rs] —
-`__host_worker_suspend` + `WorkerSuspension`) and `harn-serve` ACP
-adapter ([`crates/harn-serve/src/adapters/acp/mod.rs`][acp-mod-rs] —
+([`crates/harn-vm/src/stdlib/agents.rs`][agents-rs] -
+`__host_worker_suspend`; [`agents_workers/mod.rs`][workers-rs] -
+`WorkerSuspension`) and `harn-serve` ACP adapter
+([`crates/harn-serve/src/adapters/acp/mod.rs`][acp-mod-rs] -
 `handle_session_resume`).
 
 [acp]: https://github.com/agentclientprotocol/agent-client-protocol
 [acp-1220]: https://github.com/agentclientprotocol/agent-client-protocol/discussions/1220
 [acp-1224]: https://github.com/agentclientprotocol/agent-client-protocol/discussions/1224
+[acp-1233]: https://github.com/agentclientprotocol/agent-client-protocol/discussions/1233
 [acp-1726]: https://github.com/agentclientprotocol/agent-client-protocol/discussions/1726
 [agents-rs]: https://github.com/burin-labs/harn/blob/main/crates/harn-vm/src/stdlib/agents.rs
+[workers-rs]: https://github.com/burin-labs/harn/blob/main/crates/harn-vm/src/stdlib/agents_workers/mod.rs
 [acp-mod-rs]: https://github.com/burin-labs/harn/blob/main/crates/harn-serve/src/adapters/acp/mod.rs
 
 ## Problem statement

--- a/docs/src/protocol-contributions/status-ledger.md
+++ b/docs/src/protocol-contributions/status-ledger.md
@@ -1,0 +1,65 @@
+# Protocol filing status ledger
+
+Last verified: 2026-06-27 UTC.
+
+This ledger records direct upstream reads for the protocol-contribution
+threads that back the RFCs in this directory. It is intentionally factual:
+only record a state here after fetching the upstream discussion, PR, or
+issue directly.
+
+In [Diataxis](https://diataxis.fr/) terms, this is reference material.
+It lists current facts and links; it is not a how-to guide or a design
+explanation.
+
+## Public follow-up posture
+
+Upstream comments and PRs should use neutral ecosystem evidence, peer
+behavior, and public prior art. Do not lead with Harn or Burin-specific
+adoption claims. A local implementation can inform our internal
+confidence, but public posts should stand on protocol semantics and
+independently checkable examples.
+
+## ACP
+
+| Item | Verified state | Notes |
+|---|---|---|
+| [`agentclientprotocol/agent-client-protocol#1220`](https://github.com/agentclientprotocol/agent-client-protocol/discussions/1220) | Open discussion. | A maintainer invited an RFD. The follow-up RFD is PR [`#1261`](https://github.com/agentclientprotocol/agent-client-protocol/pull/1261). |
+| [`agentclientprotocol/agent-client-protocol#1261`](https://github.com/agentclientprotocol/agent-client-protocol/pull/1261) | Open PR, review required, merge-conflicting as of 2026-06-27. | Most review threads were answered; one non-outdated thread remains visible around adapter-owned message IDs. |
+| [`agentclientprotocol/agent-client-protocol#484`](https://github.com/agentclientprotocol/agent-client-protocol/pull/484) | Closed in favor of `#1261`. | Relevant predecessor for prompt queueing / steer-via-yield framing. |
+| [`agentclientprotocol/agent-client-protocol#1224`](https://github.com/agentclientprotocol/agent-client-protocol/discussions/1224) | Open discussion, no comments as of 2026-06-27. | Ambient system-role context injection / reminder sibling of `#1220`. |
+| [`agentclientprotocol/agent-client-protocol#1233`](https://github.com/agentclientprotocol/agent-client-protocol/discussions/1233) | Open discussion, no comments as of 2026-06-27. | `session/suspend` + `session/await_resumption`. |
+| [`agentclientprotocol/registry#397`](https://github.com/agentclientprotocol/registry/pull/397) | Open PR, mergeable, no checks or review comments as of 2026-06-27. | Harn ACP Registry submission. |
+
+## A2A
+
+| Item | Verified state | Notes |
+|---|---|---|
+| [`a2aproject/A2A#1857`](https://github.com/a2aproject/A2A/discussions/1857) | Open discussion. | Separate idempotency / post-cancel semantics thread; not a pause/reminder substitute. |
+| [`a2aproject/A2A#1858`](https://github.com/a2aproject/A2A/discussions/1858) | Open discussion, no maintainer/TSC reply visible as of 2026-06-27. | Good-faith community feedback converged toward one `PAUSED` state plus a structured `pause` object with `initiatedBy`, lease/deadline metadata, `resumeToken`, and optional side-effect reconciliation pointer discussion. |
+
+## MCP and OAuth Identity
+
+| Item | Verified state | Notes |
+|---|---|---|
+| [`modelcontextprotocol/modelcontextprotocol#2736`](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/2736) | Open discussion, one non-maintainer support comment, no maintainer response as of 2026-06-27. | Per-call budget caps for `sampling/createMessage`; separate from reminder notifications. |
+| [`modelcontextprotocol/modelcontextprotocol#214`](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/214) | Closed. | Maintainer guidance on 2026-01-16 pointed custom auth pieces toward [`modelcontextprotocol/ext-auth`](https://github.com/modelcontextprotocol/ext-auth). |
+| [`modelcontextprotocol/ext-auth#13`](https://github.com/modelcontextprotocol/ext-auth/issues/13) | Open. | Maintainer response says Enterprise-Managed Authorization does not currently support distinguishing agent vs user identity and points to ID-JAG issue `#73`. |
+| [`oauth-wg/oauth-identity-assertion-authz-grant#73`](https://github.com/oauth-wg/oauth-identity-assertion-authz-grant/issues/73) | Open. | Proposal for workload / agent identity SSO and explicit delegated on-behalf-of access. |
+| [`oauth-wg/oauth-identity-assertion-authz-grant#80`](https://github.com/oauth-wg/oauth-identity-assertion-authz-grant/issues/80) | Closed, no visible comments. | Optional `actor_token` proposal split out from `#73`; no acceptance decision was visible in the fetched issue. |
+
+## Local follow-up candidates
+
+- Refresh ACP PR `#1261` against upstream `main`, resolve conflicts,
+  and keep the public framing about queue/steer anchored in existing
+  editor/agent behavior rather than local adoption.
+- Consider an A2A `#1858` follow-up or draft PR only after narrowing
+  the field set to the single-state `PAUSED` + `pause` object that the
+  thread already converged toward.
+- File A2A reminder and MCP reminder proposals only from neutral
+  ambient-context examples such as editor file-watchers, build/test
+  watchers, CI/review notifications, and existing host-hook/rules
+  systems.
+- For MCP identity, follow `ext-auth#13` / ID-JAG `#73` rather than
+  reopening the closed MCP `#214`; keep any public comment focused on
+  the protocol distinction between OAuth client continuity and runtime
+  actor identity.


### PR DESCRIPTION
## Summary

- refresh protocol-contribution status for already-filed ACP/A2A suspend threads
- update the A2A paused-state RFC to match the current single-PAUSED + structured pause discussion
- add a factual filing status ledger and link it from the docs summary
- clarify that public upstream filings should be neutral, evidence-first prose rather than Harn/Burin adoption claims

## Validation

- make check-docs-snippets
- pre-commit markdownlint and language spec sync
- pre-push markdownlint and docs language-spec mirror check
