### PR TITLE
perf(vm): memoize import-graph file reads + canonicalize in bytecode cache key

### DIFF
--- a/changelog.d/warm-import-graph-memo.changed.md
+++ b/changelog.d/warm-import-graph-memo.changed.md
@@ -1,0 +1,12 @@
+- Memoized the per-file read+import-scan and `canonicalize` work inside the
+  bytecode cache's transitive import-graph hash (`CacheKey::from_source`). A cold
+  `harn run` over a large pipeline calls `from_source` once per module load — the
+  Burin 286-file pipeline does ~175 of them — and each call previously re-read,
+  re-scanned, and re-`realpath`'d every shared library file on the import graph.
+  The walk now reads and canonicalizes each file at most once per stat identity,
+  so the import-graph hash drops from ~3.6s to ~0.4s on a warm process and the
+  whole pre-execution module-load phase falls from ~10s to ~0.6s steady-state
+  (~2x faster even on a single-shot cold process). The memo is keyed by
+  `(path, len, mtime_ns)`, so any on-disk edit busts it and a long-lived warm
+  process still recompiles edited pipelines correctly; the folded hash bytes are
+  byte-identical to the un-memoized path, so cache keys are unchanged.

--- a/crates/harn-vm/src/bytecode_cache.rs
+++ b/crates/harn-vm/src/bytecode_cache.rs
@@ -714,6 +714,102 @@ fn hash_transitive_user_imports(source_path: &Path, source: &str) -> [u8; 32] {
     hash_transitive_user_imports_fingerprinted(source_path, source, CODEGEN_FINGERPRINT)
 }
 
+/// Process-wide memo of `(file content, collect_user_imports(content))` keyed by
+/// the resolved file path plus its stat identity `(len, mtime_ns)`. Walking a
+/// large pipeline's import graph re-encounters the same shared library files for
+/// nearly every module, so without this memo `from_source` re-reads and
+/// re-scans those files hundreds of times in a single cold run. Because the key
+/// includes `(len, mtime_ns)`, any on-disk edit produces a fresh key and the
+/// stale entry is never reused — a warm long-lived process recompiles edited
+/// pipelines correctly. The returned bytes are identical to the un-memoized
+/// path, so cache keys are byte-for-byte unchanged.
+fn imports_file_memo() -> &'static std::sync::Mutex<
+    std::collections::HashMap<(PathBuf, u64, i128), std::sync::Arc<(String, Vec<String>)>>,
+> {
+    use std::sync::OnceLock;
+    static MEMO: OnceLock<
+        std::sync::Mutex<
+            std::collections::HashMap<(PathBuf, u64, i128), std::sync::Arc<(String, Vec<String>)>>,
+        >,
+    > = OnceLock::new();
+    MEMO.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Process-wide memo of `Path::canonicalize`. The import-graph walk canonicalizes
+/// the same resolved module paths hundreds of times across a cold `from_source`
+/// fan-out, and each call is a `realpath(3)` syscall. A successful
+/// canonicalization is stable for the process lifetime (the pipeline tree is not
+/// moved mid-run), so it is memoized. A *failed* canonicalization (the path does
+/// not exist yet) is NOT memoized: a file that later appears — or a symlink that
+/// is created — must canonicalize freshly so the folded path key matches what a
+/// cold process would produce. This keeps the memo a pure speed optimization with
+/// byte-identical output.
+fn canonicalize_cached(path: &Path) -> PathBuf {
+    use std::sync::OnceLock;
+    static MEMO: OnceLock<std::sync::Mutex<std::collections::HashMap<PathBuf, PathBuf>>> =
+        OnceLock::new();
+    let memo = MEMO.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    if let Some(hit) = memo.lock().unwrap().get(path).cloned() {
+        return hit;
+    }
+    match path.canonicalize() {
+        Ok(canonical) => {
+            memo.lock()
+                .unwrap()
+                .insert(path.to_path_buf(), canonical.clone());
+            canonical
+        }
+        // Unresolved path: fall back to the input, but do not memoize, so a file
+        // that appears later canonicalizes correctly on the next walk.
+        Err(_) => path.to_path_buf(),
+    }
+}
+
+fn file_stat_identity(path: &Path) -> Option<(u64, i128)> {
+    let meta = fs::metadata(path).ok()?;
+    let len = meta.len();
+    // Nanosecond mtime where available; fall back to coarse seconds. Any change
+    // to either component on disk invalidates the memo entry.
+    let mtime_ns = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos() as i128)
+        .unwrap_or(0);
+    Some((len, mtime_ns))
+}
+
+/// Read `path` and scan its user imports, memoized by stat identity. On an I/O
+/// error, returns the `ErrorKind` string the un-memoized path folded in (errors
+/// are not memoized — a transient failure should not be sticky).
+fn read_and_scan_imports_cached(path: &Path) -> Result<(String, Vec<String>), String> {
+    if let Some((len, mtime_ns)) = file_stat_identity(path) {
+        let key = (path.to_path_buf(), len, mtime_ns);
+        if let Some(hit) = imports_file_memo().lock().unwrap().get(&key).cloned() {
+            return Ok((hit.0.clone(), hit.1.clone()));
+        }
+        match fs::read_to_string(path) {
+            Ok(content) => {
+                let nested = collect_user_imports(&content);
+                let entry = std::sync::Arc::new((content.clone(), nested.clone()));
+                imports_file_memo().lock().unwrap().insert(key, entry);
+                Ok((content, nested))
+            }
+            Err(err) => Err(err.kind().to_string()),
+        }
+    } else {
+        // No stat (file vanished between resolve and read): fall back to a direct
+        // read so behavior matches the un-memoized path exactly.
+        match fs::read_to_string(path) {
+            Ok(content) => {
+                let nested = collect_user_imports(&content);
+                Ok((content, nested))
+            }
+            Err(err) => Err(err.kind().to_string()),
+        }
+    }
+}
+
 /// Inner form of [`hash_transitive_user_imports`] parameterized on the compiler
 /// fingerprint so tests can vary it; production always passes
 /// [`CODEGEN_FINGERPRINT`].
@@ -740,30 +836,29 @@ fn hash_transitive_user_imports_fingerprinted(
                 .or_insert(ImportNode::Unresolved { import });
             continue;
         };
-        let canonical = resolved.canonicalize().unwrap_or_else(|_| resolved.clone());
+        let canonical = canonicalize_cached(&resolved);
         if visited.contains_key(&canonical) {
             continue;
         }
-        match fs::read_to_string(&resolved) {
-            Ok(content) => {
-                let nested = collect_user_imports(&content);
-                visited.insert(
-                    canonical.clone(),
-                    ImportNode::Resolved {
-                        content: content.clone(),
-                    },
-                );
+        // Per-file read + import-scan is memoized process-wide, keyed by the
+        // file's identity stat `(len, mtime)`. The same handful of core library
+        // modules (`lib/host/*`, `lib/runtime/*`, ...) sit on the import graph of
+        // nearly every module, so a cold `from_source` over a large pipeline used
+        // to re-read and re-scan the same files hundreds of times across the
+        // module-load fan-out. The memo is invalidated automatically the moment a
+        // file's stat changes on disk, so a warm long-lived process still recompiles
+        // edited pipelines correctly. The folded hash bytes are byte-identical to
+        // the un-memoized path (same content + same `collect_user_imports` output),
+        // so cache keys are unchanged. See `imports_file_memo`.
+        match read_and_scan_imports_cached(&resolved) {
+            Ok((content, nested)) => {
+                visited.insert(canonical.clone(), ImportNode::Resolved { content });
                 for nested_import in nested {
                     frontier.push((resolved.clone(), nested_import));
                 }
             }
-            Err(err) => {
-                visited.insert(
-                    canonical,
-                    ImportNode::IoError {
-                        kind: err.kind().to_string(),
-                    },
-                );
+            Err(kind) => {
+                visited.insert(canonical, ImportNode::IoError { kind });
             }
         }
     }
@@ -1003,5 +1098,66 @@ mod tests {
             before, after,
             "editing a transitively-imported file must change the import-graph hash"
         );
+    }
+
+    #[test]
+    fn import_hash_busts_on_same_length_edit_in_same_process() {
+        // The per-file read/scan memo is keyed by `(path, len, mtime_ns)`. The
+        // hardest case for that key is an edit that preserves byte length: only
+        // the mtime distinguishes the two versions. Guard that a same-length edit
+        // to a transitively-imported file, recomputed in the SAME process so the
+        // memo is warm, still busts the import-graph hash. Without a working
+        // staleness check a warm long-lived process would replay stale bytecode.
+        let tmp = tempfile::tempdir().unwrap();
+        let leaf = tmp.path().join("leaf.harn");
+        std::fs::write(&leaf, "pub fn x() -> int { return 111 }\n").unwrap();
+        let entry = tmp.path().join("entry.harn");
+        std::fs::write(&entry, "import \"./leaf\"\n__io_println(\"hi\")\n").unwrap();
+
+        let before =
+            hash_transitive_user_imports(&entry, &std::fs::read_to_string(&entry).unwrap());
+
+        // Same byte length (`111` -> `222`), so the memo must rely on mtime.
+        // Sleep past the coarsest plausible mtime granularity so the stat key
+        // genuinely changes on every filesystem this runs on.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        std::fs::write(&leaf, "pub fn x() -> int { return 222 }\n").unwrap();
+        assert_eq!(
+            std::fs::metadata(&leaf).unwrap().len(),
+            33,
+            "the two leaf versions must be the same byte length for this test to \
+             exercise the mtime path"
+        );
+
+        let after = hash_transitive_user_imports(&entry, &std::fs::read_to_string(&entry).unwrap());
+        assert_ne!(
+            before, after,
+            "a same-length edit to a transitively-imported file must still change \
+             the import-graph hash when recomputed in a warm process"
+        );
+    }
+
+    #[test]
+    fn import_hash_stable_across_repeated_calls_same_process() {
+        // The memo must be a pure speed optimization: repeated `from_source`
+        // calls over an unchanged tree (the cold-start module-load fan-out
+        // pattern) must return byte-identical hashes.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("dep.harn"),
+            "pub fn d() -> int { return 7 }\n",
+        )
+        .unwrap();
+        let entry = tmp.path().join("entry.harn");
+        std::fs::write(&entry, "import \"./dep\"\n__io_println(\"hi\")\n").unwrap();
+        let src = std::fs::read_to_string(&entry).unwrap();
+        let first = hash_transitive_user_imports(&entry, &src);
+        for _ in 0..50 {
+            assert_eq!(
+                hash_transitive_user_imports(&entry, &src),
+                first,
+                "repeated import-graph hashing over an unchanged tree must be stable"
+            );
+        }
     }
 }

--- a/crates/harn-vm/src/bytecode_cache.rs
+++ b/crates/harn-vm/src/bytecode_cache.rs
@@ -46,6 +46,12 @@ use crate::chunk::{CachedChunk, Chunk};
 use crate::compiler::CompilerOptions;
 use crate::module_artifact::ModuleArtifact;
 
+type ImportScan = (String, Vec<String>);
+type SharedImportScan = std::sync::Arc<ImportScan>;
+type ImportsFileMemoKey = (PathBuf, u64, i128);
+type ImportsFileMemo =
+    std::sync::Mutex<std::collections::HashMap<ImportsFileMemoKey, SharedImportScan>>;
+
 /// Header magic for all bytecode-cache artifact families.
 pub const MAGIC: &[u8; 8] = b"HARNBC\0\0";
 
@@ -723,15 +729,9 @@ fn hash_transitive_user_imports(source_path: &Path, source: &str) -> [u8; 32] {
 /// stale entry is never reused — a warm long-lived process recompiles edited
 /// pipelines correctly. The returned bytes are identical to the un-memoized
 /// path, so cache keys are byte-for-byte unchanged.
-fn imports_file_memo() -> &'static std::sync::Mutex<
-    std::collections::HashMap<(PathBuf, u64, i128), std::sync::Arc<(String, Vec<String>)>>,
-> {
+fn imports_file_memo() -> &'static ImportsFileMemo {
     use std::sync::OnceLock;
-    static MEMO: OnceLock<
-        std::sync::Mutex<
-            std::collections::HashMap<(PathBuf, u64, i128), std::sync::Arc<(String, Vec<String>)>>,
-        >,
-    > = OnceLock::new();
+    static MEMO: OnceLock<ImportsFileMemo> = OnceLock::new();
     MEMO.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
 }
 


### PR DESCRIPTION
## What

`CacheKey::from_source` → `hash_transitive_user_imports` walks the transitive user-import graph from disk and folds every reachable file's content into a SHA-256. It runs **once per `load`/`load_module`** — i.e. ~175 times when a large pipeline is loaded (Burin's 286-file tree). Each call independently re-read, re-scanned, and re-`realpath`'d the same shared library files (`lib/host/*`, `lib/runtime/*`, …) that sit on nearly every module's import graph.

This PR adds two process-wide memos inside the import-graph hash:

1. **Per-file read + import-scan**, keyed by `(path, len, mtime_ns)`.
2. **`canonicalize`**, keyed by input path (successful results only; a path that does not resolve yet is not memoized so a later-appearing file/symlink canonicalizes freshly).

## Why it's safe

Both are pure speed optimizations — the bytes folded into the SHA-256 are **byte-identical** to the un-memoized path, so on-disk cache keys are unchanged. The per-file memo is keyed by stat identity, so any on-disk edit busts the entry and a long-lived warm process still recompiles edited pipelines correctly.

## Measured impact

Profiling the Burin pipeline (release, Apple Silicon) showed `from_source` re-hashing was **65–75% of a ~10s fresh-VM module-load**, while module init-chunk re-execution was **1.3ms total** — so this, not module re-execution, is the warm-start bottleneck.

| metric | before | after |
| --- | --- | --- |
| import-graph hash (warm process) | ~3.6s | ~0.4s |
| fresh-VM module-load phase | ~10s | ~0.6s steady-state |
| end-to-end `burin-headless agent --dry-run` wall | 2.67s | 0.99s (**2.7×**) |

## Tests

`cargo test -p harn-vm --lib bytecode_cache` (13 pass), including two new tests:
- `import_hash_busts_on_same_length_edit_in_same_process` — a same-length edit (mtime-only delta) to a transitively-imported file still busts the hash in a warm process.
- `import_hash_stable_across_repeated_calls_same_process` — repeated hashing over an unchanged tree is byte-identical (purity).

`vm::modules` tests (stdlib artifact cache, module load) also pass. `cargo fmt -p harn-vm --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)