### PR TITLE
fix(agent): admit bootstrapped MCP tools into the agent tool ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ keeps condensed series summaries instead of full per-patch history.
 
 ### Fixed
 
+- Bootstrapped MCP tools are now admitted into a non-empty agent policy tool
+  ceiling when `agent_mcp_bootstrap_if_needed` adds them to the tool catalog, so
+  an agent that can see a runtime-discovered MCP tool can also dispatch it.
+  Empty `policy.tools` lists still mean "no ceiling" and remain open.
 - **Changelog-fragment gate no longer treats nested source files as pip
   manifests.** The dependency-metadata allowlist matched `requirements.*\.txt` /
   `constraints.*\.txt`, where `.*` crossed `/`, so a non-dependency path such as

--- a/crates/harn-stdlib/src/stdlib/agent/mcp.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/mcp.harn
@@ -22,5 +22,56 @@ pub fn agent_mcp_bootstrap_if_needed(session, opts) {
     []
   }
   let reg = {_type: "tool_registry", tools: existing_tools + result.tools_added}
-  return out + {tools: reg}
+  return __with_mcp_tool_ceiling(out + {tools: reg}, result.tools_added)
+}
+
+/**
+ * Admit the just-bootstrapped MCP tools into the execution-policy tool
+ * ceiling so the agent that can SEE them in its catalog can also CALL them.
+ *
+ * The catalog merge above adds the `server__tool` entries to `opts.tools`,
+ * which is what makes the model aware of them; without a matching entry in
+ * `opts.policy.tools` (the ceiling enforced by
+ * `enforce_current_policy_for_tool`) every dispatch is denied with
+ * "exceeds tool ceiling". An MCP tool is a runtime projection — its name is
+ * not known until `tools/list` returns — so the ceiling can only learn it
+ * here, at boot time, not from the host's static surface declaration.
+ *
+ * An EMPTY `policy.tools` means "no ceiling" (allow any tool), so we only
+ * extend a non-empty ceiling: adding names to an empty list would flip an
+ * open policy into a closed one and silently forbid the host's own tools.
+ * Idempotent: never double-adds a name already present.
+ */
+fn __with_mcp_tool_ceiling(opts, tools_added) {
+  let policy = opts?.policy
+  if type_of(policy) != "dict" {
+    return opts
+  }
+  let ceiling = policy?.tools
+  if type_of(ceiling) != "list" || len(ceiling) == 0 {
+    return opts
+  }
+  var names = []
+  for entry in tools_added {
+    let name = __mcp_tool_ceiling_name(entry)
+    if name != "" && !ceiling.contains(name) && !names.contains(name) {
+      names = names + [name]
+    }
+  }
+  if len(names) == 0 {
+    return opts
+  }
+  return opts + {policy: policy + {tools: ceiling + names}}
+}
+
+/** Resolve a bootstrapped tool entry's dispatch name (flat or OpenAI-shape). */
+fn __mcp_tool_ceiling_name(entry) {
+  if type_of(entry) != "dict" {
+    return ""
+  }
+  let flat = to_string(entry?.name ?? "")
+  if flat != "" {
+    return flat
+  }
+  return to_string(entry?.function?.name ?? "")
 }

--- a/crates/harn-vm/tests/agent_mcp_tool_ceiling.rs
+++ b/crates/harn-vm/tests/agent_mcp_tool_ceiling.rs
@@ -1,0 +1,175 @@
+#![recursion_limit = "256"]
+//! Mechanism-fitness coverage for `agent_mcp_bootstrap_if_needed`'s tool-
+//! ceiling admission (the "Burin agent can USE an MCP server's tools" fix).
+//!
+//! Before this fix, bootstrapping an MCP server merged its `server__tool`
+//! entries into the agent's tool CATALOG (`opts.tools`) — so the model could
+//! SEE them — but never into the execution-policy tool CEILING
+//! (`opts.policy.tools`). Every dispatch was then denied with
+//! "exceeds tool ceiling". These tests drive `agent_mcp_bootstrap_if_needed`
+//! with a stubbed `__host_mcp_bootstrap` and assert that:
+//!   (a) a non-empty ceiling is EXTENDED with the bootstrapped tool names
+//!       (so the tool becomes callable), and is idempotent;
+//!   (b) an EMPTY ceiling (== "no ceiling, allow any tool") is left empty —
+//!       we must not flip an open policy closed and forbid the host's own
+//!       tools;
+//!   (c) when no MCP servers are configured the opts are returned unchanged.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use harn_vm::value::{VmError, VmValue};
+
+/// Run a harn program with a stubbed `__host_mcp_bootstrap` that returns the
+/// given `tools_added` names (each as a flat `{name: ...}` tool descriptor,
+/// the shape `tag_mcp_tool` emits). Returns the `[harn] `-prefixed log lines.
+fn run_with_stub(source: &str, tools_added: &[&str]) -> Result<Vec<String>, String> {
+    harn_vm::reset_thread_local_state();
+    let chunk = harn_vm::compile_source(source)?;
+    let tools: Vec<VmValue> = tools_added
+        .iter()
+        .map(|name| {
+            let mut dict: BTreeMap<String, VmValue> = BTreeMap::new();
+            dict.insert("name".to_string(), VmValue::string(*name));
+            VmValue::dict(dict)
+        })
+        .collect();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| e.to_string())?;
+    rt.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let mut vm = harn_vm::Vm::new();
+                harn_vm::register_vm_stdlib(&mut vm);
+                // Override the runtime-only host builtin with a deterministic
+                // stub so the test never opens a real MCP connection.
+                let stub_tools = Arc::new(tools);
+                vm.register_builtin("__host_mcp_bootstrap", move |_args, _out| {
+                    let mut result: BTreeMap<String, VmValue> = BTreeMap::new();
+                    result.insert("tools_added".to_string(), VmValue::List(stub_tools.clone()));
+                    result.insert(
+                        "server_info".to_string(),
+                        VmValue::List(Arc::new(Vec::new())),
+                    );
+                    result.insert("errors".to_string(), VmValue::List(Arc::new(Vec::new())));
+                    Ok(VmValue::dict(result))
+                });
+                vm.execute(&chunk)
+                    .await
+                    .map_err(|e: VmError| format!("{e:?}"))?;
+                Ok(vm.output().to_string())
+            })
+            .await
+    })
+    .map(|raw| {
+        raw.lines()
+            .filter_map(|l| l.strip_prefix("[harn] ").map(str::to_string))
+            .collect()
+    })
+}
+
+/// Harn snippet: bootstrap one MCP server and echo the resulting catalog tool
+/// names and the policy ceiling, so the Rust side can assert on both.
+fn bootstrap_snippet(mcp_servers: &str, policy: &str) -> String {
+    format!(
+        r#"
+import {{ agent_mcp_bootstrap_if_needed }} from "std/agent/mcp"
+pipeline main(task) {{
+  let session = {{session_id: "sess-mcp-ceiling"}}
+  let opts = {{
+    mcp_servers: {mcp_servers},
+    tools: {{_type: "tool_registry", tools: [{{name: "look"}}]}},
+    policy: {policy},
+  }}
+  let out = agent_mcp_bootstrap_if_needed(session, opts)
+  let catalog = (out?.tools?.tools ?? []).map({{ t -> to_string(t?.name ?? "") }})
+  let ceiling = out?.policy?.tools ?? []
+  log("catalog=" + join(catalog, ","))
+  log("ceiling=" + join(ceiling, ","))
+  log("ceiling_type=" + type_of(out?.policy?.tools))
+}}
+"#
+    )
+}
+
+fn field<'a>(lines: &'a [String], key: &str) -> &'a str {
+    lines
+        .iter()
+        .find_map(|l| l.strip_prefix(&format!("{key}=")))
+        .unwrap_or("<missing>")
+}
+
+#[test]
+fn nonempty_ceiling_admits_bootstrapped_mcp_tools() {
+    let lines = run_with_stub(
+        &bootstrap_snippet(
+            r#"[{name: "burin-harness-debugger"}]"#,
+            r#"{tools: ["look", "search"]}"#,
+        ),
+        &[
+            "burin-harness-debugger__list_runs",
+            "burin-harness-debugger__trial_failure_cause",
+        ],
+    )
+    .expect("snippet runs");
+
+    // Catalog gained the MCP tools (model can see them).
+    let catalog = field(&lines, "catalog");
+    assert!(
+        catalog.contains("burin-harness-debugger__list_runs"),
+        "MCP tool must enter the catalog: {catalog}"
+    );
+
+    // CEILING gained them too (model can now call them — the fix).
+    let ceiling = field(&lines, "ceiling");
+    assert!(
+        ceiling.contains("burin-harness-debugger__list_runs"),
+        "MCP tool must be admitted into the tool ceiling: {ceiling}"
+    );
+    assert!(
+        ceiling.contains("burin-harness-debugger__trial_failure_cause"),
+        "every bootstrapped MCP tool must be admitted: {ceiling}"
+    );
+    // Host's own tools are preserved, not replaced.
+    assert!(ceiling.contains("look"), "host tools preserved: {ceiling}");
+    assert!(
+        ceiling.contains("search"),
+        "host tools preserved: {ceiling}"
+    );
+}
+
+#[test]
+fn empty_ceiling_stays_open() {
+    // An empty `policy.tools` means "no ceiling". Adding names would flip it
+    // closed and silently forbid the host's own tools — so it must stay empty.
+    let lines = run_with_stub(
+        &bootstrap_snippet(r#"[{name: "burin-harness-debugger"}]"#, r#"{tools: []}"#),
+        &["burin-harness-debugger__list_runs"],
+    )
+    .expect("snippet runs");
+
+    assert_eq!(
+        field(&lines, "ceiling"),
+        "",
+        "open (empty) ceiling must stay open"
+    );
+    // Catalog still gains the tool regardless, so it stays callable under the
+    // open policy.
+    assert!(field(&lines, "catalog").contains("burin-harness-debugger__list_runs"));
+}
+
+#[test]
+fn no_mcp_servers_is_a_noop() {
+    let lines = run_with_stub(
+        &bootstrap_snippet("[]", r#"{tools: ["look", "search"]}"#),
+        &["burin-harness-debugger__list_runs"],
+    )
+    .expect("snippet runs");
+
+    // No servers configured -> bootstrap never ran -> ceiling untouched.
+    assert_eq!(field(&lines, "ceiling"), "look,search");
+    assert_eq!(field(&lines, "catalog"), "look");
+}

--- a/crates/harn-vm/tests/agent_mcp_tool_ceiling.rs
+++ b/crates/harn-vm/tests/agent_mcp_tool_ceiling.rs
@@ -146,7 +146,7 @@ fn empty_ceiling_stays_open() {
     // An empty `policy.tools` means "no ceiling". Adding names would flip it
     // closed and silently forbid the host's own tools — so it must stay empty.
     let lines = run_with_stub(
-        &bootstrap_snippet(r#"[{name: "burin-harness-debugger"}]"#, r#"{tools: []}"#),
+        &bootstrap_snippet(r#"[{name: "burin-harness-debugger"}]"#, r"{tools: []}"),
         &["burin-harness-debugger__list_runs"],
     )
     .expect("snippet runs");


### PR DESCRIPTION
## Problem

`agent_mcp_bootstrap_if_needed` (std/agent/mcp) connects each enabled MCP
server and merges its `server__tool` entries into the agent's tool
**catalog** (`opts.tools`) — so the model can **see** them — but never into
the execution-policy tool **ceiling** (`opts.policy.tools`). Every dispatch
of an MCP tool is then denied by `enforce_current_policy_for_tool` with
`"exceeds tool ceiling"`. A host (e.g. Burin Code) that wires up an MCP
server gets a discoverable-but-uncallable tool: the model finds
`burin-harness-debugger__list_runs`, calls it, and the call is rejected.

## Fix

After merging the bootstrapped tools into the catalog, also extend a
**non-empty** ceiling with those tool names. An MCP tool name is a runtime
projection (unknown until `tools/list` returns), so the ceiling can only
learn it here, at boot time, not from the host's static surface declaration.

An **empty** `policy.tools` means "no ceiling, allow any tool", so it is
left untouched — adding names would flip an open policy closed and silently
forbid the host's own tools. Idempotent; never double-adds. Per-tool
allowlist enforcement and dispatch stay exactly where they are.

## Test

New `crates/harn-vm/tests/agent_mcp_tool_ceiling.rs` drives
`agent_mcp_bootstrap_if_needed` with a stubbed `__host_mcp_bootstrap` across
three cases: non-empty ceiling is extended (and host tools preserved), empty
ceiling stays open, and no-configured-servers is a no-op. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)