### PR TITLE
fix: harden MCP and cache edge cases

### DIFF
--- a/changelog.d/mcp-cache-edge-cases.fixed.md
+++ b/changelog.d/mcp-cache-edge-cases.fixed.md
@@ -1,0 +1,4 @@
+- **MCP and local runtime edge cases.** MCP connects now reject unsupported
+  protocol versions locally and tolerate padded version strings, bytecode cache
+  writes avoid same-process temp-file collisions, and `harn local launch`
+  deduplicates default flags supplied as `--flag=value`.

--- a/crates/harn-cli/src/commands/local/launch.rs
+++ b/crates/harn-cli/src/commands/local/launch.rs
@@ -549,12 +549,16 @@ fn filter_default_args(
     let mut kept = Vec::with_capacity(default_args.len());
     let mut iter = default_args.iter().peekable();
     while let Some(arg) = iter.next() {
-        if arg.starts_with("--") && explicit_keys.contains(arg.as_str()) {
+        if arg.starts_with("--") && explicit_keys.contains(default_arg_key(arg)) {
             // Skip this flag, and its value too when the next token is not
             // itself a flag (covers valued flags like `--flash-attn on`).
-            if let Some(next) = iter.peek() {
-                if !next.starts_with("--") {
-                    iter.next();
+            // `--flag=value` carries its value inline, so only that one token
+            // is skipped.
+            if !arg.contains('=') {
+                if let Some(next) = iter.peek() {
+                    if !next.starts_with("--") {
+                        iter.next();
+                    }
                 }
             }
             continue;
@@ -562,6 +566,10 @@ fn filter_default_args(
         kept.push(arg.clone());
     }
     kept
+}
+
+fn default_arg_key(arg: &str) -> &str {
+    arg.split_once('=').map(|(key, _)| key).unwrap_or(arg)
 }
 
 fn push_arg(out: &mut Vec<String>, key: Option<&str>, value: impl ToString) {
@@ -840,6 +848,38 @@ mod tests {
             .windows(2)
             .any(|pair| pair == ["--flash-attn", "auto"]));
         assert!(!built.windows(2).any(|pair| pair == ["--flash-attn", "on"]));
+    }
+
+    #[test]
+    fn build_managed_args_dedups_equals_form_default_args() {
+        let mut runtime = runtime();
+        runtime.default_args = vec![
+            "--flash-attn=off".to_string(),
+            "--reasoning-format=none".to_string(),
+            "--jinja".to_string(),
+        ];
+        let mut args = cli_args();
+        args.flash_attn = Some("auto".to_string());
+        args.reasoning_format = Some("deepseek".to_string());
+
+        let built = build_managed_args(
+            &args,
+            &runtime,
+            "/models/qwen.gguf",
+            "qwen3.6-35b-a3b-ud-q4-k-xl",
+            "127.0.0.1",
+            8001,
+            8192,
+        );
+
+        assert!(!built.iter().any(|arg| arg == "--flash-attn=off"));
+        assert!(!built.iter().any(|arg| arg == "--reasoning-format=none"));
+        assert!(built
+            .windows(2)
+            .any(|pair| pair == ["--flash-attn", "auto"]));
+        assert!(built
+            .windows(2)
+            .any(|pair| pair == ["--reasoning-format", "deepseek"]));
     }
 
     #[test]

--- a/crates/harn-vm/src/bytecode_cache.rs
+++ b/crates/harn-vm/src/bytecode_cache.rs
@@ -382,11 +382,7 @@ fn encode_artifact(key: &CacheKey, kind: u8, payload: &[u8]) -> Vec<u8> {
 }
 
 fn write_atomic(target: &Path, buf: &[u8]) -> io::Result<()> {
-    let tmp_name = match target.file_name() {
-        Some(name) => format!(".{}.{}.tmp", name.to_string_lossy(), std::process::id()),
-        None => format!(".harn-cache.{}.tmp", std::process::id()),
-    };
-    let tmp_path = target.with_file_name(tmp_name);
+    let tmp_path = atomic_tmp_path(target);
     let mut tmp_file = fs::File::create(&tmp_path)?;
     tmp_file.write_all(buf)?;
     tmp_file.sync_all()?;
@@ -398,6 +394,21 @@ fn write_atomic(target: &Path, buf: &[u8]) -> io::Result<()> {
             Err(err)
         }
     }
+}
+
+fn atomic_tmp_path(target: &Path) -> PathBuf {
+    static NEXT_TMP_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let id = NEXT_TMP_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp_name = match target.file_name() {
+        Some(name) => format!(
+            ".{}.{}.{}.tmp",
+            name.to_string_lossy(),
+            std::process::id(),
+            id
+        ),
+        None => format!(".harn-cache.{}.{}.tmp", std::process::id(), id),
+    };
+    target.with_file_name(tmp_name)
 }
 
 /// Parsed cache header. Read by both the chunk and module loaders so the
@@ -933,6 +944,17 @@ mod tests {
         let on_disk_bytes = std::fs::read(&on_disk).unwrap();
         let in_memory_bytes = serialize_chunk_artifact(&key, &chunk).expect("serialize");
         assert_eq!(in_memory_bytes, on_disk_bytes);
+    }
+
+    #[test]
+    fn atomic_temp_paths_are_unique_within_process() {
+        let target = Path::new("entry.harnbc");
+        let first = atomic_tmp_path(target);
+        let second = atomic_tmp_path(target);
+        assert_ne!(
+            first, second,
+            "same-process concurrent cache writes must not share a temp file"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/mcp/connect.rs
+++ b/crates/harn-vm/src/mcp/connect.rs
@@ -57,14 +57,10 @@ pub(crate) async fn mcp_connect_http_impl(
     let client = reqwest::Client::builder()
         .build()
         .map_err(|e| VmError::Runtime(format!("MCP HTTP client error: {e}")))?;
-    let protocol_mode = resolve_protocol_mode(
+    let options = resolve_connect_protocol_options(
         spec.protocol_mode.as_deref(),
         spec.protocol_version.as_deref(),
     )?;
-    let protocol_version = spec
-        .protocol_version
-        .clone()
-        .unwrap_or_else(|| default_protocol_version(protocol_mode).to_string());
     let resolved_auth = resolve_http_auth_token_source(spec).await;
 
     let handle = VmMcpClientHandle {
@@ -75,8 +71,8 @@ pub(crate) async fn mcp_connect_http_impl(
             auth_token: resolved_auth.token,
             auth_token_source: resolved_auth.source,
             token_exchange: spec.token_exchange.clone().map(Arc::new),
-            protocol_mode,
-            protocol_version,
+            protocol_mode: options.protocol_mode,
+            protocol_version: options.protocol_version,
             session_id: None,
             next_id: 1,
             proxy_server_name: spec.proxy_server_name.clone(),
@@ -167,20 +163,16 @@ pub async fn connect_mcp_server_from_spec(
 ) -> Result<VmMcpClientHandle, VmError> {
     let mut handle = match spec.transport {
         McpTransport::Stdio => {
-            let protocol_mode = resolve_protocol_mode(
+            let options = resolve_connect_protocol_options(
                 spec.protocol_mode.as_deref(),
                 spec.protocol_version.as_deref(),
             )?;
-            let protocol_version = spec
-                .protocol_version
-                .clone()
-                .unwrap_or_else(|| default_protocol_version(protocol_mode).to_string());
             mcp_connect_stdio_impl(
                 &spec.command,
                 &spec.args,
                 &spec.env,
-                protocol_mode,
-                protocol_version,
+                options.protocol_mode,
+                options.protocol_version,
             )
             .await?
         }

--- a/crates/harn-vm/src/mcp/protocol.rs
+++ b/crates/harn-vm/src/mcp/protocol.rs
@@ -53,10 +53,7 @@ pub(crate) fn resolve_protocol_mode(
 
 pub(crate) fn mcp_connect_options(value: Option<&VmValue>) -> Result<McpConnectOptions, VmError> {
     let Some(value) = value else {
-        return Ok(McpConnectOptions {
-            protocol_mode: McpProtocolMode::Legacy,
-            protocol_version: PROTOCOL_VERSION.to_string(),
-        });
+        return resolve_connect_protocol_options(None, None);
     };
     let VmValue::Dict(options) = value else {
         return Err(VmError::Runtime(format!(
@@ -66,12 +63,32 @@ pub(crate) fn mcp_connect_options(value: Option<&VmValue>) -> Result<McpConnectO
     };
     let protocol_mode_value = options.get("protocol_mode").map(|value| value.display());
     let protocol_version_value = options.get("protocol_version").map(|value| value.display());
-    let protocol_mode = resolve_protocol_mode(
+    resolve_connect_protocol_options(
         protocol_mode_value.as_deref(),
         protocol_version_value.as_deref(),
-    )?;
+    )
+}
+
+pub(crate) fn resolve_connect_protocol_options(
+    protocol_mode_value: Option<&str>,
+    protocol_version_value: Option<&str>,
+) -> Result<McpConnectOptions, VmError> {
+    let protocol_mode_value = protocol_mode_value
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let protocol_version_value = protocol_version_value
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let protocol_mode = resolve_protocol_mode(protocol_mode_value, protocol_version_value)?;
     let protocol_version = protocol_version_value
-        .unwrap_or_else(|| default_protocol_version(protocol_mode).to_string());
+        .unwrap_or_else(|| default_protocol_version(protocol_mode))
+        .to_string();
+    if !crate::mcp_protocol::is_supported_protocol_version(&protocol_version) {
+        return Err(VmError::Runtime(format!(
+            "mcp_connect: unsupported protocol_version {protocol_version:?}; expected one of {}",
+            crate::mcp_protocol::supported_protocol_versions().join(", ")
+        )));
+    }
     Ok(McpConnectOptions {
         protocol_mode,
         protocol_version,

--- a/crates/harn-vm/src/mcp/tests.rs
+++ b/crates/harn-vm/src/mcp/tests.rs
@@ -64,6 +64,26 @@ fn http_spec(url: &str, auth_token: Option<&str>) -> McpServerSpec {
     }
 }
 
+#[test]
+fn connect_protocol_options_reject_unsupported_versions() {
+    let error = match resolve_connect_protocol_options(None, Some("2099-01-01")) {
+        Ok(_) => panic!("unsupported protocol version must fail locally"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("unsupported protocol_version"),
+        "{error}"
+    );
+}
+
+#[test]
+fn connect_protocol_options_trim_before_mode_inference() {
+    let options = resolve_connect_protocol_options(None, Some(" DRAFT-2026-v1 "))
+        .expect("trimmed draft protocol version");
+    assert_eq!(options.protocol_mode, McpProtocolMode::Modern);
+    assert_eq!(options.protocol_version, DRAFT_PROTOCOL_VERSION);
+}
+
 #[tokio::test]
 async fn http_auth_resolution_prefers_explicit_token() {
     let spec = http_spec("https://mcp.example/mcp", Some("configured"));


### PR DESCRIPTION
## Summary
- Reject unsupported MCP protocol versions locally and trim protocol option strings before mode inference.
- Avoid same-process bytecode-cache temp-file collisions.
- Deduplicate managed local runtime defaults supplied as `--flag=value`.
- Add a changelog fragment.

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-target cargo test -p harn-cli build_managed_args_dedups_equals_form_default_args` (running locally)