### PR TITLE
fix(agent): verify stop-after-tool completions

### DIFF
--- a/changelog.d/stop-after-verify.fixed.md
+++ b/changelog.d/stop-after-verify.fixed.md
@@ -1,0 +1,1 @@
+- Ensure `agent_loop` runs configured completion verification when `stop_after_successful_tools` ends a turn.

--- a/conformance/tests/agents/agent_loop_stop_after_successful_tools_verify_completion.expected
+++ b/conformance/tests/agents/agent_loop_stop_after_successful_tools_verify_completion.expected
@@ -1,0 +1,3 @@
+done
+2
+true

--- a/conformance/tests/agents/agent_loop_stop_after_successful_tools_verify_completion.harn
+++ b/conformance/tests/agents/agent_loop_stop_after_successful_tools_verify_completion.harn
@@ -1,0 +1,52 @@
+import { with_llm_script } from "std/testing"
+
+fn edit_tools() {
+  let tools = tool_registry()
+  return tool_define(
+    tools,
+    "apply_fix",
+    "Apply a corrective edit",
+    {
+      handler: { _args -> "edit applied" },
+      parameters: {},
+      returns: {type: "string"},
+      annotations: {kind: "edit", side_effect_level: "workspace_write"},
+    },
+  )
+}
+
+fn verify_after_tool_stop(payload) {
+  if payload.stop_reason == "natural" && payload.iteration == 0 {
+    return "verification required after edit"
+  }
+  return nil
+}
+
+pipeline default() {
+  with_llm_script(
+    [
+      {text: "", tool_calls: [{id: "edit-1", name: "apply_fix", arguments: {}}]},
+      {text: "verified now ##DONE##"},
+    ],
+    { ->
+      let result = agent_loop(
+        "Apply the fix and finish only after verification.",
+        nil,
+        {
+          provider: "mock",
+          tools: edit_tools(),
+          tool_format: "native",
+          loop_until_done: true,
+          max_iterations: 4,
+          session_id: "stop-after-verify-" + uuid(),
+          done_sentinel: "##DONE##",
+          stop_after_successful_tools: ["apply_fix"],
+          verify_completion: verify_after_tool_stop,
+        },
+      )
+      __io_println(result.status)
+      __io_println(result.llm.iterations)
+      __io_println(contains(json_stringify(llm_mock_calls()), "verification required after edit"))
+    },
+  )
+}

--- a/crates/harn-stdlib/src/stdlib/agent/postturn.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/postturn.harn
@@ -1066,7 +1066,7 @@ pub fn agent_compute_post_turn(session, llm_result, dispatch, opts, iteration) {
   }
   if __stop_after_successful_tools(opts, dispatch) {
     return __post_turn_with_narrowing(
-      {kind: "break", stop_reason: "natural", needs_verify: false, done_judge_due: false},
+      __completion_result(opts, payload, "natural") + {done_judge_due: false},
       narrowing,
     )
   }


### PR DESCRIPTION
## Summary
- make `stop_after_successful_tools` route through the same completion verification decision as sentinel/natural completion when a verifier is configured
- add a deterministic conformance regression proving a successful tool stop is vetoed by `verify_completion` before final done
- add a changelog fragment

## Validation
- `cargo run --quiet --bin harn -- check conformance/tests/agents/agent_loop_stop_after_successful_tools_verify_completion.harn`
- `cargo run --quiet --bin harn -- test conformance --filter agent_loop_stop_after_successful_tools_verify_completion`
- `cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/agent/postturn.harn conformance/tests/agents/agent_loop_stop_after_successful_tools_verify_completion.harn`
- `git diff --check`
- pre-commit hook: Harn format/lint, markdown, CI ratchets
- pre-push hook: targeted local checks, affected Harn format/lint, generated highlight check
