### PR TITLE
[codex] enforce post-edit reverify at loop cap

### DIFF
--- a/changelog.d/post-edit-final-reverify.fixed.md
+++ b/changelog.d/post-edit-final-reverify.fixed.md
@@ -1,0 +1,3 @@
+- Agent loops now enforce post-edit verification after a live failure
+  independently of repair-aware nudges, including edits made on the final
+  iteration.

--- a/conformance/tests/agents/repair_diagnostics_off_is_noop.harn
+++ b/conformance/tests/agents/repair_diagnostics_off_is_noop.harn
@@ -2,12 +2,10 @@ import { agent_capture_events } from "std/agent/events"
 import { llm_text, with_llm_script } from "std/testing"
 
 /**
- * Evidence-aware repair loop (#repair-diagnostics): BACKWARD-COMPATIBILITY.
- * With `repair_aware:false` (the default) the feature is fully inert: a
- * repair-shaped script (fail -> edit -> done) emits NO `stuck_same_diagnostic`
- * warnings, forces NO post-edit re-verify, and the result carries NO
- * `current_failure` block. The loop behaves exactly as it did before the
- * feature existed.
+ * Explicit post-edit verification opt-out. `repair_aware:false` disables the
+ * strategy-shift nudge, but no longer disables the core final-verification
+ * invariant. A caller that wants the old fully-inert behavior must opt out of
+ * post-edit verification directly with `post_edit_reverify:false`.
  */
 fn events_of(events, kind) {
   return events.filter({ event -> event.type == kind })
@@ -65,10 +63,11 @@ pipeline default() {
             max_iterations: 6,
             session_id: session,
             done_sentinel: "##DONE##",
-            // verify_completion present to prove that even WITH a verify closure,
-            // repair_aware:false forces no extra verification.
+            // verify_completion present to prove that the explicit
+            // post_edit_reverify:false knob, not repair_aware:false, disables
+            // the extra verification.
             verify_completion: { _info -> nil },
-            stall_diagnostics: {enabled: true, repair_aware: false},
+            stall_diagnostics: {enabled: true, repair_aware: false, post_edit_reverify: false},
           },
         ) },
       )

--- a/conformance/tests/agents/repair_no_stop_before_reverify.harn
+++ b/conformance/tests/agents/repair_no_stop_before_reverify.harn
@@ -2,11 +2,10 @@ import { agent_capture_events } from "std/agent/events"
 import { llm_text, with_llm_script } from "std/testing"
 
 /**
- * Evidence-aware repair loop (#repair-diagnostics): a successful corrective edit
- * that ALSO proposes completion (done-sentinel) must not terminate the loop
- * "done" until the post-edit re-verify has run. When the verify closure vetoes,
- * the loop continues instead of stopping — the edit was re-verified, not taken
- * on faith.
+ * Current-failure loop: a successful corrective edit that ALSO proposes
+ * completion (done-sentinel) must not terminate the loop "done" until the
+ * post-edit re-verify has run. When the verify closure vetoes, the loop
+ * continues instead of stopping — the edit was re-verified, not taken on faith.
  */
 fn repair_tools() {
   var tools = tool_registry()
@@ -72,7 +71,7 @@ pipeline default() {
             session_id: session,
             done_sentinel: "##DONE##",
             verify_completion: verify_once_then_confirm,
-            stall_diagnostics: {enabled: true, repair_aware: true, post_edit_reverify: true, stuck_same_diagnostic_after: 3},
+            stall_diagnostics: {enabled: true, repair_aware: false, post_edit_reverify: true, stuck_same_diagnostic_after: 3},
           },
         ) },
       )

--- a/conformance/tests/agents/repair_post_edit_reverify_mandate.expected
+++ b/conformance/tests/agents/repair_post_edit_reverify_mandate.expected
@@ -1,2 +1,8 @@
 true
+true
 false
+done
+post_edit_reverify
+budget_exhausted
+max_iterations
+true

--- a/conformance/tests/agents/repair_post_edit_reverify_mandate.harn
+++ b/conformance/tests/agents/repair_post_edit_reverify_mandate.harn
@@ -1,17 +1,18 @@
+import { agent_capture_events } from "std/agent/events"
 import { llm_text, with_llm_script } from "std/testing"
 
 /**
- * Evidence-aware repair loop (#repair-diagnostics): the post-edit re-verify
- * mandate. When the repair loop is enabled, a turn that makes a successful
- * corrective edit on top of a LIVE failure must force a verification before the
- * loop continues — a successful edit is not proof the failure is resolved. The
- * verify routes through the EXISTING `verify_completion` entrypoint.
+ * Current-failure loop: the post-edit re-verify mandate. A turn that makes a
+ * successful corrective edit on top of a LIVE failure must force a verification
+ * before the loop continues — a successful edit is not proof the failure is
+ * resolved. The verify routes through the EXISTING `verify_completion`
+ * entrypoint.
  *
- * Positive: repair_aware:true => after the fail->edit sequence the mandate fires
- * `verify_completion` with stop_reason "post_edit_reverify" (observed via the
- * veto feedback injected into the next LLM turn).
- * Negative control: repair_aware:false => no forced verify, the marker feedback
- * never appears.
+ * Positive: repair_aware true OR false => after the fail->edit sequence the
+ * mandate fires `verify_completion` with stop_reason "post_edit_reverify"
+ * (observed via the veto feedback injected into the next LLM turn).
+ * Negative control: post_edit_reverify:false => no forced verify, the marker
+ * feedback never appears.
  */
 fn repair_tools() {
   var tools = tool_registry()
@@ -55,7 +56,7 @@ fn reverify_probe(info) {
   nil
 }
 
-fn run_scenario(repair_aware) {
+fn run_scenario(repair_aware, post_edit_reverify) {
   return with_llm_script(
     [
       // Turn 1: run the tests -> fail.
@@ -83,7 +84,7 @@ fn run_scenario(repair_aware) {
           stall_diagnostics: {
             enabled: true,
             repair_aware: repair_aware,
-            post_edit_reverify: true,
+            post_edit_reverify: post_edit_reverify,
             stuck_same_diagnostic_after: 3,
           },
         },
@@ -94,9 +95,80 @@ fn run_scenario(repair_aware) {
   )
 }
 
+fn first_event(events, event_type) {
+  for event in events {
+    if event.type == event_type {
+      return event
+    }
+  }
+  return nil
+}
+
+fn confirm_post_edit_reverify(info) {
+  if info.stop_reason == "post_edit_reverify" {
+    return nil
+  }
+  return "unexpected verification reason: " + to_string(info.stop_reason)
+}
+
+fn veto_post_edit_reverify(info) {
+  if info.stop_reason == "post_edit_reverify" {
+    return "still red after the edit"
+  }
+  return nil
+}
+
+fn run_cap_scenario(verify_completion) {
+  return with_llm_script(
+    [
+      // Turn 1: run the tests -> fail.
+      {text: "", tool_calls: [{id: "t1", name: "run_test", arguments: {}}]},
+      // Turn 2: apply a fix at the iteration cap. The loop must verify this
+      // edit before deciding whether it can finish.
+      {text: "", tool_calls: [{id: "e1", name: "apply_fix", arguments: {}}]},
+    ],
+    { ->
+      let session = "repair-reverify-cap-" + uuid()
+      return agent_capture_events(
+        session,
+        fn() { return agent_loop(
+          "Make the tests pass.",
+          nil,
+          {
+            provider: "mock",
+            tools: repair_tools(),
+            tool_format: "native",
+            loop_until_done: true,
+            max_iterations: 2,
+            final_wrapup: false,
+            session_id: session,
+            done_sentinel: "##DONE##",
+            verify_completion: verify_completion,
+            stall_diagnostics: {enabled: true, repair_aware: false, post_edit_reverify: true, stuck_same_diagnostic_after: 3},
+          },
+        ) },
+      )
+    },
+  )
+}
+
 pipeline default() {
-  // Positive: the mandate fires after fail->edit.
-  __io_println(run_scenario(true))
-  // Negative control: repair_aware:false => mandate never fires.
-  __io_println(run_scenario(false))
+  // Positive: the mandate fires after fail->edit with repair nudges enabled.
+  __io_println(run_scenario(true, true))
+  // Positive: the same mandate fires with repair nudges disabled.
+  __io_println(run_scenario(false, true))
+  // Negative control: callers may explicitly disable post-edit reverify.
+  __io_println(run_scenario(false, false))
+  // Green post-edit verification can close a last-iteration edit without
+  // requiring one more model turn just to say "done".
+  let cap_confirmed = run_cap_scenario(confirm_post_edit_reverify)
+  __io_println(cap_confirmed.result.status)
+  __io_println(cap_confirmed.result.stop_reason)
+  // Red post-edit verification at the cap stays exhausted and carries the
+  // current failure instead of silently completing.
+  let cap_vetoed = run_cap_scenario(veto_post_edit_reverify)
+  let budget_event = first_event(cap_vetoed.events, "budget_exhausted")
+  __io_println(cap_vetoed.result.status)
+  __io_println(budget_event.kind)
+  __io_println(cap_vetoed.result?.current_failure != nil)
 }

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -1632,7 +1632,11 @@ fn __intra_turn_failure_poisons_resource(result) -> bool {
   // other than an affirmative `false`. Only a host-confirmed pre-apply rejection
   // (view unchanged) skips poisoning. Guards the safety property: unknown stays
   // conservative, exactly like today.
-  return __intra_turn_result_mutated(result) != false
+  let mutated = __intra_turn_result_mutated(result)
+  if type_of(mutated) == "bool" && !mutated {
+    return false
+  }
+  return true
 }
 
 fn __intra_turn_has_keyed_mutating_calls(tool_calls, tools, options = {}) -> bool {
@@ -2089,15 +2093,15 @@ fn __tool_names_by_status(dispatch, want_ok) {
 
 // Workspace-mutating annotation kinds (mirrors postturn's tool-surface
 // classifier vocabulary). A successful call to a tool of one of these kinds is
-// a corrective edit for the evidence-aware repair loop's `write_epoch`.
+// a corrective edit for the current-failure model's `write_epoch`.
 const __REPAIR_EDIT_KINDS = ["edit", "write", "scaffold", "delete", "mutation", "mutate"]
 
 /**
  * __turn_made_edit reports whether `dispatch` (a single turn's dispatch
  * results) contains a SUCCESSFUL workspace-mutating tool call, by looking up
  * each successful tool's annotation kind in the registry. Reuses
- * `__tool_names_by_status` + `__tool_registry_entry`; only consulted when the
- * evidence-aware repair loop is enabled.
+ * `__tool_names_by_status` + `__tool_registry_entry`; only consulted when
+ * post-edit verification or repair-aware diagnostics are enabled.
  */
 fn __turn_made_edit(dispatch, tools) -> bool {
   if dispatch == nil {
@@ -2112,6 +2116,18 @@ fn __turn_made_edit(dispatch, tools) -> bool {
     }
   }
   return false
+}
+
+fn __agent_loop_verify_closure_exists(turn_opts) -> bool {
+  return turn_opts?.verify_completion != nil || turn_opts?.verify_completion_judge != nil
+}
+
+fn __agent_loop_post_edit_reverify_mandated(repair_cfg, turn_opts, stall_state, dispatch, tools) -> bool {
+  let has_live_failure = stall_state.last_diagnostic_class == "fail" || stall_state.reverify_owed
+  return repair_cfg.post_edit_reverify
+    && __agent_loop_verify_closure_exists(turn_opts)
+    && has_live_failure
+    && __turn_made_edit(dispatch, tools)
 }
 
 fn __merge_tool_names(existing, additions) {
@@ -3824,17 +3840,10 @@ fn __agent_loop_run(message, session, initial_opts) {
       )
       opts = __apply_post_turn_options(opts, outcome)
       let repair_cfg = agent_stall_repair_config(turn_opts?.stall_diagnostics)
-      let has_live_failure = stall_state.last_diagnostic_class == "fail" || stall_state.reverify_owed
-      let this_turn_made_edit = __turn_made_edit(dispatch, opts?.tools)
-      let verify_closure_exists = turn_opts?.verify_completion != nil
-        || turn_opts?.verify_completion_judge != nil
-      let reverify_mandated = repair_cfg.repair_aware
-        && repair_cfg.post_edit_reverify
-        && verify_closure_exists
-        && has_live_failure
-        && this_turn_made_edit
+      let reverify_mandated = __agent_loop_post_edit_reverify_mandated(repair_cfg, turn_opts, stall_state, dispatch, opts?.tools)
       var should_continue = outcome.kind == "continue" || bridge_step_delivered > 0
       var verdict_record = nil
+      var post_edit_reverify_confirmed = false
       if should_continue && reverify_mandated && verify_attempts < max_verify_attempts {
         let reverify_opts = turn_opts
           + {
@@ -3860,6 +3869,7 @@ fn __agent_loop_run(message, session, initial_opts) {
           }
         } else {
           stall_state = stall_state + {reverify_owed: false}
+          post_edit_reverify_confirmed = true
         }
       }
       if should_continue {
@@ -3912,6 +3922,9 @@ fn __agent_loop_run(message, session, initial_opts) {
             break
           } else {
             stall_state = stall_state + {reverify_owed: false}
+            if reverify_mandated {
+              post_edit_reverify_confirmed = true
+            }
           }
         }
         let missing_now = agent_required_tools_missing_from_session(opts, successful_tools_seen)
@@ -3921,6 +3934,14 @@ fn __agent_loop_run(message, session, initial_opts) {
         }
         if !should_continue {
           stop_reason = outcome.stop_reason
+          break
+        }
+      }
+      if should_continue && post_edit_reverify_confirmed && iteration >= current_max {
+        let missing_after_reverify = agent_required_tools_missing_from_session(opts, successful_tools_seen)
+        if len(missing_after_reverify) == 0 {
+          final_status = "done"
+          stop_reason = "post_edit_reverify"
           break
         }
       }

--- a/crates/harn-stdlib/src/stdlib/agent/stall.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/stall.harn
@@ -89,13 +89,14 @@ const SOFT_PROGRESS_TOOLS = ["agent_progress"]
 
 /**
  * Evidence-aware repair loop (#repair-diagnostics), spanning AgentStallConfig /
- * AgentStallWarning / AgentStallState below. Default OFF: when `repair_aware`
- * is false every repair field is inert and the detector behaves exactly as
- * before. When ON, the loop tracks a current-failure model (signature + epoch)
- * instead of a blind counter, forces a post-edit re-verify, and nudges a
- * strategy shift after the same diagnostic recurs across
- * `stuck_same_diagnostic_after` repair turns.
- *   - Config knobs: repair_aware / stuck_same_diagnostic_after / post_edit_reverify.
+ * AgentStallWarning / AgentStallState below. The current-failure model is the
+ * shared invariant for post-edit verification and repair-aware nudges: when
+ * `post_edit_reverify` is enabled, Harn tracks the last live failure so a
+ * workspace write cannot be mistaken for proof that verification passed. When
+ * `repair_aware` is also enabled, the same model drives the strategy-shift nudge
+ * after the same diagnostic recurs across `stuck_same_diagnostic_after` repair
+ * turns.
+ *   - Config knobs: post_edit_reverify / repair_aware / stuck_same_diagnostic_after.
  *   - Warning extras (only on the "stuck_same_diagnostic" pattern):
  *     diagnostic_class / diagnostic_signature / diagnostic_snippet.
  *   - State (the current-failure model — folded by __agent_stall_fold_diagnostic
@@ -1144,12 +1145,14 @@ fn __agent_stall_observe_core(
 }
 
 /**
- * Evidence-aware repair overlay (#repair-diagnostics). Default OFF. When
- * `repair_aware` is enabled this:
- *   1. folds the current-failure model from the PRIOR turn's verification
- *      result + whether that turn made a successful edit (turn_made_edit), and
- *   2. trips the "stuck_same_diagnostic" strategy-shift nudge when the same
- *      diagnostic has survived `stuck_same_diagnostic_after` repair turns.
+ * Evidence-aware repair overlay (#repair-diagnostics). The current-failure
+ * fold is shared by post-edit verification and repair-aware nudges. When
+ * `post_edit_reverify` is enabled this folds the PRIOR turn's verification
+ * result + whether that turn made a successful edit (turn_made_edit), so the
+ * loop can require a final verify even when repair nudges are disabled. When
+ * `repair_aware` is also enabled this trips the "stuck_same_diagnostic"
+ * strategy-shift nudge when the same diagnostic has survived
+ * `stuck_same_diagnostic_after` repair turns.
  * The trip rides the EXISTING `agent_loop_stall_warning` event +
  * `__agent_stall_register_trip` escalation; no new event type is introduced.
  * When the core observation already produced a warning this turn we keep it
@@ -1164,10 +1167,14 @@ fn __agent_stall_apply_repair(
   turn_made_edit: bool,
   defer_feedback: bool,
 ) -> AgentStallObservation {
-  if !config.repair_aware {
+  let should_fold_current_failure = config.post_edit_reverify || config.repair_aware
+  if !should_fold_current_failure {
     return observation
   }
   let folded = __agent_stall_fold_diagnostic(observation.state, prev_dispatch, turn_made_edit)
+  if !config.repair_aware {
+    return observation + {state: folded}
+  }
   // Trip ONCE when the streak first crosses the threshold, so the strategy-shift
   // nudge fires a single time per stuck episode rather than on every subsequent
   // identical failure. Require that the streak ADVANCED this turn (a fresh
@@ -1214,12 +1221,13 @@ fn __agent_stall_apply_repair(
 }
 
 /**
- * agent_stall_observe_tool_calls detects degenerate agent loops and, when the
- * evidence-aware repair loop is enabled (`stall_diagnostics.repair_aware`),
- * folds a current-failure model and nudges a strategy shift on a stuck
- * diagnostic. `turn_made_edit` reports whether the PRIOR turn (the one
- * `prev_dispatch` describes) made a successful workspace-mutating edit; it is
- * inert unless `repair_aware` is set.
+ * agent_stall_observe_tool_calls detects degenerate agent loops, folds the
+ * current-failure model when post-edit verification is enabled, and when the
+ * evidence-aware repair nudge is enabled (`stall_diagnostics.repair_aware`)
+ * nudges a strategy shift on a stuck diagnostic. `turn_made_edit` reports
+ * whether the PRIOR turn (the one `prev_dispatch` describes) made a successful
+ * workspace-mutating edit; it is inert unless `post_edit_reverify` or
+ * `repair_aware` is set.
  *
  * @effects: [agent]
  * @errors: [agent_loop]

--- a/tests/agent/stall_test.harn
+++ b/tests/agent/stall_test.harn
@@ -304,11 +304,19 @@ pipeline test_fold_different_failure_resets_streak(task) {
   assert(o3.warning == nil)
 }
 
-pipeline test_fold_repair_off_is_inert(task) {
-  // repair_aware:false => the fold is a no-op: no current-failure model, no
-  // new fields populated beyond their initial defaults.
-  let off_config = {enabled: true, repair_aware: false}
-  let o = agent_stall_observe_tool_calls(
+pipeline test_fold_repair_off_tracks_for_reverify_without_nudge(task) {
+  // repair_aware:false disables the strategy-shift nudge, not the
+  // current-failure model used by post-edit final verification.
+  let off_config = {
+    enabled: true,
+    repair_aware: false,
+    stuck_same_diagnostic_after: 2,
+    repeat_same_error: 99,
+    repeat_same_observation: 99,
+    no_progress_messages: 99,
+    ping_pong_cycles: 99,
+  }
+  let o1 = agent_stall_observe_tool_calls(
     "unit-repair-off",
     _run_call(),
     1,
@@ -320,9 +328,24 @@ pipeline test_fold_repair_off_is_inert(task) {
     false,
     false,
   )
-  assert(o.state.last_diagnostic_class == "")
-  assert(o.state.same_diagnostic_streak == 0)
-  assert(o.warning == nil)
+  assert(o1.state.last_diagnostic_class == "fail")
+  assert(o1.state.same_diagnostic_streak == 1)
+  assert(!o1.state.reverify_owed)
+  assert(o1.warning == nil)
+  let o2 = agent_stall_observe_tool_calls(
+    "unit-repair-off",
+    _run_call(),
+    2,
+    off_config,
+    o1.state,
+    true,
+    _fail_dispatch("boom"),
+    "",
+    false,
+    false,
+  )
+  assert(o2.warning == nil)
+  assert(o2.state.same_diagnostic_streak == 2)
 }
 
 pipeline test_reset_action_preserves_failure_model(task) {


### PR DESCRIPTION
## Summary

- Decouples Harn's current-failure tracking from the optional `repair_aware` strategy-shift nudge so `post_edit_reverify` is enforced as a core agent-loop invariant.
- Makes post-edit verification run for a successful workspace edit after a live failure even when repair nudges are disabled.
- Allows a green post-edit verifier to close a final-iteration edit as `done`; a red verifier at the cap remains budget-exhausted and retains current-failure evidence.
- Updates conformance fixtures to make `post_edit_reverify:false` the explicit opt-out and adds the max-iteration final-edit regression.

## Root Cause

The residual eval audit showed failed cells where the final event was an edit and no verification followed. Harn already had a current-failure model, but it only folded that model when `stall_diagnostics.repair_aware` was true, and the loop's post-edit reverify predicate also gated on `repair_aware`. Burin's fixed-stack baseline had `agent.post_edit_verify_loop:on` while `agent.repair_diagnostics:off`, so the generic Harn safety invariant was accidentally hidden behind an optional repair-nudge feature.

## Validation

- `cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/agent/stall.harn crates/harn-stdlib/src/stdlib/agent/loop.harn conformance/tests/agents/repair_post_edit_reverify_mandate.harn conformance/tests/agents/repair_no_stop_before_reverify.harn conformance/tests/agents/repair_diagnostics_off_is_noop.harn`
- `cargo run --quiet --bin harn -- check conformance/tests/agents/repair_post_edit_reverify_mandate.harn`
- `cargo run --quiet --bin harn -- check conformance/tests/agents/repair_no_stop_before_reverify.harn`
- `cargo run --quiet --bin harn -- check conformance/tests/agents/repair_diagnostics_off_is_noop.harn`
- `cargo run --quiet --bin harn -- test conformance --filter repair_post_edit_reverify_mandate`
- `cargo run --quiet --bin harn -- test conformance --filter repair_no_stop_before_reverify`
- `cargo run --quiet --bin harn -- test conformance --filter repair_diagnostics_off_is_noop`
- `cargo run --quiet --bin harn -- test conformance --filter repair_`
- `git diff --check`
- `cargo run --quiet --bin harn -- lint crates/harn-stdlib/src/stdlib/agent/stall.harn crates/harn-stdlib/src/stdlib/agent/loop.harn conformance/tests/agents/repair_post_edit_reverify_mandate.harn conformance/tests/agents/repair_no_stop_before_reverify.harn conformance/tests/agents/repair_diagnostics_off_is_noop.harn` (reports only existing ambient-clock warnings in `loop.harn`)
- `cargo test -p harn-vm agent`
- pre-commit hooks
- pre-push hooks

No convergence or meter-pass claim is made here; this is mechanism coverage for the audited final-edit-without-verify failure class. Meter evidence still requires paired N>=5 downstream after release/repin.