### PR TITLE
fix(agent): reserved-budget terminal verify guard (budget-exit half of declared-done-red)

### DIFF
--- a/changelog.d/3631.added.md
+++ b/changelog.d/3631.added.md
@@ -1,0 +1,8 @@
+- Added a default-OFF reserved-budget terminal-verify guard
+  (`stall_diagnostics.reserved_terminal_verify`): when an agent loop would
+  terminate on a budget / token / wall-clock boundary with an unverified source
+  write, it spends a small held-back iteration reserve on a final
+  verify(+bounded repair) instead of ending blind on a red build. Closes the
+  budget-exit half of declared-done-with-red-build (the loop-cap half landed in
+  the previous release). A new `reserved_terminal_verify` agent event surfaces
+  the guard's grant / verify_passed / verify_failed phases.

--- a/conformance/protocols/schemas/acp-session-update.schema.json
+++ b/conformance/protocols/schemas/acp-session-update.schema.json
@@ -126,6 +126,7 @@
                 "mcp_catalog_changed",
                 "mcp_notification",
                 "progress_reported",
+                "reserved_terminal_verify",
                 "scope_classifier_verdict",
                 "session_closed",
                 "structural_validator_decision",

--- a/conformance/tests/agents/reserved_terminal_verify_guard.expected
+++ b/conformance/tests/agents/reserved_terminal_verify_guard.expected
@@ -1,0 +1,8 @@
+case1.status=done
+case1.grant=true
+case1.verify_passed=true
+case2.status=budget_exhausted
+case2.verify_failed=true
+case2.grants=3
+case3.status=budget_exhausted
+case3.reserved_events=0

--- a/conformance/tests/agents/reserved_terminal_verify_guard.harn
+++ b/conformance/tests/agents/reserved_terminal_verify_guard.harn
@@ -1,0 +1,183 @@
+import { agent_capture_events } from "std/agent/events"
+import { with_llm_script } from "std/testing"
+
+/**
+ * Reserved-budget terminal-verify guard (#reserved-terminal-verify): the
+ * budget-exit half of the declared-done-with-red-build fix.
+ *
+ * The sentinel path (a model emitting a done marker after an unverified edit) is
+ * already vetoed by the completion gate. But a model that writes source and then
+ * runs OUT of iteration/budget runway used to terminate `budget_exhausted` with
+ * NO terminal verify — ending the run blind on a red build. The reserved guard
+ * holds back a small iteration reserve the normal loop cannot consume; when the
+ * loop would otherwise exhaust with an unverified source write, it spends the
+ * reserve on a final verify(+repair) before terminating.
+ *
+ * This is the dominant zig-feat failure mode (exits `budget_exhausted`), so the
+ * guard is the budget-exit counterpart to the sentinel-path completion gate.
+ *
+ * Cases:
+ *  1. ON, repair lands green: edit -> iteration budget exhausts -> reserved verify
+ *     fires (red) -> reserve grants a repair turn -> re-verify passes -> the run
+ *     terminates `done` (NOT a silent `budget_exhausted`), with the guard's grant
+ *     + verify_passed events observable.
+ *  2. ON, repair never lands: the reserve is spent, a final verify RUNS and
+ *     surfaces the red (stop_reason `reserved_terminal_verify_failed`) instead of
+ *     a blind exhaust. Bounded: the reserve cannot loop forever.
+ *  3. OFF (control): identical script with the flag off terminates
+ *     `budget_exhausted` and emits NO `reserved_terminal_verify` events —
+ *     behavior is byte-identical to today.
+ */
+fn build_tools() {
+  var tools = tool_registry()
+  tools = tool_define(
+    tools,
+    "apply_fix",
+    "Apply a corrective edit to the workspace",
+    {
+      handler: { _args -> "edit applied" },
+      parameters: {},
+      returns: {type: "string"},
+      annotations: {kind: "edit", side_effect_level: "workspace_write"},
+    },
+  )
+  return tools
+}
+
+fn count_events(events, kind) {
+  var n = 0
+  for event in events {
+    if event.type == kind {
+      n = n + 1
+    }
+  }
+  return n
+}
+
+fn has_phase(events, phase) {
+  for event in events {
+    if event.type == "reserved_terminal_verify" && (event?.payload?.phase ?? "") == phase {
+      return true
+    }
+  }
+  return false
+}
+
+// Scenario harness: the model only ever edits (never proposes completion and
+// never runs a green test on its own), so a passing build can ONLY come from the
+// reserved guard's terminal verify. The declared verifier reports green once the
+// loop has reached `green_at_iteration` (a stable, observable signal that
+// survives the nested agent_loop execution, unlike a closure-captured counter):
+// with a low value the repair lands within the reserve (case 1), with a value
+// the reserve can never reach the repair never lands (case 2).
+fn run_scenario(reserved_on, reserve_iterations, green_at_iteration) {
+  return with_llm_script(
+    [
+      {text: "", tool_calls: [{id: "e1", name: "apply_fix", arguments: {}}]},
+      {text: "", tool_calls: [{id: "e2", name: "apply_fix", arguments: {}}]},
+      {text: "", tool_calls: [{id: "e3", name: "apply_fix", arguments: {}}]},
+      {text: "", tool_calls: [{id: "e4", name: "apply_fix", arguments: {}}]},
+      {text: "", tool_calls: [{id: "e5", name: "apply_fix", arguments: {}}]},
+    ],
+    { ->
+      let session = "reserved-verify-" + uuid()
+      let captured = agent_capture_events(
+        session,
+        fn() { return agent_loop(
+          "Make the build green.",
+          nil,
+          {
+            provider: "mock",
+            tools: build_tools(),
+            tool_format: "native",
+            loop_until_done: true,
+            max_iterations: 2,
+            max_nudges: 10,
+            session_id: session,
+            // The declared verifier: red until the loop reaches the configured
+            // iteration, then green. nil verdict == pass. Keyed off the stable
+            // iteration count so the verdict is deterministic across the nested
+            // agent_loop execution.
+            verify_completion: { info ->
+              if info.stop_reason == "reserved_terminal_verify" {
+                if info.iteration >= green_at_iteration {
+                  return nil
+                }
+                return "build still red: fix it"
+              }
+              nil
+            },
+            stall_diagnostics: {
+              enabled: true,
+              repair_aware: true,
+              post_edit_reverify: true,
+              reserved_terminal_verify: reserved_on,
+              reserved_terminal_verify_iterations: reserve_iterations,
+            },
+          },
+        ) },
+      )
+      return {status: captured.result.status, events: captured.events}
+    },
+  )
+}
+
+// A terminal verify provably RAN when the guard emitted either a verify outcome
+// phase (the closure was invoked and its verdict surfaced).
+fn terminal_verify_ran(events) -> bool {
+  return has_phase(events, "verify_passed") || has_phase(events, "verify_failed")
+}
+
+pipeline default() {
+  // Case 1: ON, repair lands green. First terminal verify (iter 2) is red and
+  // grants a repair turn; the re-verify at iter 3 is green -> the run completes
+  // `done` instead of a silent `budget_exhausted`.
+  let case1 = run_scenario(true, 2, 3)
+  __io_println("case1.status=" + case1.status)
+  __io_println("case1.grant=" + to_string(has_phase(case1.events, "grant")))
+  __io_println("case1.verify_passed=" + to_string(has_phase(case1.events, "verify_passed")))
+  assert(
+    case1.status == "done",
+    "case1: run must terminate done after a passing reserved verify, not a blind budget_exhausted",
+  )
+  assert(
+    has_phase(case1.events, "grant"),
+    "case1: a red terminal verify must spend a reserve iteration on a repair turn",
+  )
+  assert(
+    has_phase(case1.events, "verify_passed"),
+    "case1: the terminal verify must run and ultimately pass",
+  )
+  // Case 2: ON, repair never lands (verifier never green) — the reserve is spent
+  // and the FINAL state is a verify that RAN and surfaced the red build, never a
+  // blind exhaust. Bounded: the reserve cannot loop forever (one grant here).
+  let case2 = run_scenario(true, 1, 999)
+  __io_println("case2.status=" + case2.status)
+  __io_println("case2.verify_failed=" + to_string(has_phase(case2.events, "verify_failed")))
+  __io_println("case2.grants=" + to_string(count_events(case2.events, "reserved_terminal_verify")))
+  assert(
+    terminal_verify_ran(case2.events),
+    "case2: a terminal verify must RUN even when repair never lands",
+  )
+  assert(
+    has_phase(case2.events, "verify_failed"),
+    "case2: the unrepaired red build must be surfaced, not swallowed",
+  )
+  assert(case2.status != "done", "case2: an unrepaired red build must not terminate done")
+  // Case 3: OFF control — byte-identical to today. No reserved-verify events,
+  // no terminal verify, plain budget_exhausted.
+  let case3 = run_scenario(false, 2, 3)
+  __io_println("case3.status=" + case3.status)
+  __io_println(
+    "case3.reserved_events=" + to_string(count_events(case3.events, "reserved_terminal_verify")),
+  )
+  assert(
+    case3.status == "budget_exhausted",
+    "case3: with the guard OFF the run exhausts its budget unchanged",
+  )
+  assert(
+    count_events(case3.events, "reserved_terminal_verify") == 0,
+    "case3: OFF must emit no reserved-verify events",
+  )
+  assert(!terminal_verify_ran(case3.events), "case3: OFF must never run a terminal reserved verify")
+}

--- a/crates/harn-serve/src/adapters/acp/events.rs
+++ b/crates/harn-serve/src/adapters/acp/events.rs
@@ -1435,6 +1435,12 @@ impl AgentEventSink for AcpAgentEventSink {
             } => {
                 self.emit_agent_event_ext("loop_stuck", session_id, payload.clone());
             }
+            AgentEvent::ReservedTerminalVerify {
+                session_id,
+                payload,
+            } => {
+                self.emit_agent_event_ext("reserved_terminal_verify", session_id, payload.clone());
+            }
             AgentEvent::DaemonWatchdogTripped {
                 session_id,
                 attempts,

--- a/crates/harn-serve/src/adapters/acp/schema.rs
+++ b/crates/harn-serve/src/adapters/acp/schema.rs
@@ -76,6 +76,7 @@ pub const HARN_AGENT_EVENT_KINDS: &[&str] = &[
     "mcp_catalog_changed",
     "mcp_notification",
     "progress_reported",
+    "reserved_terminal_verify",
     "scope_classifier_verdict",
     "session_closed",
     "structural_validator_decision",

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -2130,6 +2130,45 @@ fn __agent_loop_post_edit_reverify_mandated(repair_cfg, turn_opts, stall_state, 
     && __turn_made_edit(dispatch, tools)
 }
 
+// Terminal statuses the reserved-verify guard may intercept: a run that ran out
+// of iteration/wall-clock/cost runway (`budget_exhausted`) or was stopped as a
+// thrash (`stuck`). Other terminals (suspended / verify_capped / scope_alert /
+// done) are deliberate and must not be reinterpreted.
+const __RESERVED_VERIFY_TERMINAL_STATUSES = ["budget_exhausted", "stuck"]
+
+/**
+ * __agent_loop_should_spend_reserve decides whether the reserved terminal-verify
+ * guard should run a final verify(+repair) before the run terminates. It fires
+ * ONLY when the guard is enabled, the run is terminating on a budget/stuck
+ * boundary, the transcript still has an UNVERIFIED source write (the model
+ * edited then ran out of runway without a passing verification), a
+ * `verify_completion`/`verify_completion_judge` closure exists to run, and the
+ * shared verify-attempt cap has not been hit. Default OFF: when
+ * `reserved_terminal_verify` is false this always returns false, so behavior is
+ * byte-identical to today. The `write_unverified` signal REUSES the existing
+ * post-edit re-verify bookkeeping (it is true whenever a turn made a workspace
+ * edit that no passing verification has cleared), the same notion the in-loop
+ * `reverify_owed` mandate keys on. This is the budget-exit counterpart to the
+ * loop-cap `iteration >= current_max` done-conversion (#3629), which only fires
+ * when an in-loop reverify ALREADY confirmed green; this guard runs the verifier
+ * on the terminal budget/stuck break where NO reverify fired. The guard verifies
+ * first and only spends a reserve iteration on a repair turn when the verify
+ * comes back red and reserve remains, so this predicate gates the verify.
+ */
+fn __agent_loop_should_spend_reserve(
+  repair_cfg,
+  turn_opts,
+  final_status,
+  write_unverified: bool,
+  verify_allowed: bool,
+) -> bool {
+  return repair_cfg.reserved_terminal_verify
+    && contains(__RESERVED_VERIFY_TERMINAL_STATUSES, final_status)
+    && write_unverified
+    && verify_allowed
+    && __agent_loop_verify_closure_exists(turn_opts)
+}
+
 fn __merge_tool_names(existing, additions) {
   var merged = existing ?? []
   let values = additions ?? []
@@ -3154,237 +3193,282 @@ fn __agent_loop_run(message, session, initial_opts) {
     var budget_exhausted_emitted = false
     var last_tool_count = 0
     let loop_start_ms = __agent_loop_clock_now_ms()
-    while iteration < current_max {
-      let boundary_exhaustion = __agent_loop_budget_exhaustion(
-        session.session_id,
-        budget,
-        iteration,
-        nil,
-        loop_start_ms,
-        current_max,
-      )
-      if boundary_exhaustion.exhausted {
-        __agent_loop_emit_budget_exhausted(session.session_id, boundary_exhaustion)
-        budget_exhausted_emitted = true
-        budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, boundary_exhaustion.kind)
-        final_status = "budget_exhausted"
-        stop_reason = boundary_exhaustion.kind
-        break
-      }
-      let checkpoint = __agent_loop_suspend_checkpoint(session, iteration)
-      if checkpoint != nil {
-        __drain_audit_flushes(audit_background_tasks)
-        audit_background_tasks = []
-        suspend_result = checkpoint
-        final_status = "suspended"
-        stop_reason = "suspended"
-        break
-      }
-      if agent_budget_pre_call_blocked(session, opts) {
-        final_status = "budget_exhausted"
-        break
-      }
-      let iteration_index = iteration
-      let iteration_opts = __agent_loop_effective_llm_options(opts)
-      agent_emit_event(
-        session.session_id,
-        "iteration_start",
-        {
-          iteration: iteration_index + 1,
-          provider: iteration_opts?.provider ?? "",
-          model: iteration_opts?.model ?? "",
-        },
-      )
-      try {
-        __host_drain_file_edits(session.session_id)
-      } catch (e) {
-        nil
-      }
-      __agent_loop_checkpoint(session.session_id, "iteration_start", {iteration: iteration_index + 1})
-      var turn_opts = agent_skills_match(session, iteration_opts, iteration_index)
-      if turn_opts?._skill_activated_this_turn ?? false {
-        opts = agent_reset_tool_surface_narrowing(opts)
-        turn_opts = agent_reset_tool_surface_narrowing(turn_opts)
-      }
-      turn_opts = agent_tool_search_inject_if_needed(turn_opts)
-      turn_opts = agent_apply_tool_surface_narrowing(turn_opts)
-      let turn_llm_opts = __agent_loop_effective_llm_options(turn_opts)
-      __agent_loop_checkpoint(session.session_id, "pre_compact", {iteration: iteration_index + 1})
-      agent_autocompact_if_needed(session, turn_llm_opts)
-      __agent_loop_checkpoint(session.session_id, "post_compact", {iteration: iteration_index + 1})
-      let scope_verdict = __run_pre_turn_scope_classifier(
-        turn_llm_opts?._pre_turn_scope_classifier ?? opts?._pre_turn_scope_classifier,
-        session,
-        message,
-        turn_llm_opts,
-        iteration_index,
-      )
-      if __scope_classifier_skip_main(scope_verdict) {
-        __scope_classifier_record_skip_turn(session, scope_verdict, iteration_index)
-        iteration = iteration + 1
-        final_status = "scope_alert"
-        stop_reason = "out_of_scope"
-        break
-      }
-      let turn_prompt = __agent_loop_build_turn_prompt(session, turn_llm_opts, iteration_index)
-      let llm_opts = turn_llm_opts
-        + {
-        messages: turn_prompt.messages,
-        session_id: session.session_id,
-        tool_format: turn_llm_opts.tool_format,
-        _iteration: iteration_index + 1,
-        _system_fragments: turn_prompt.fragments,
-      }
-      var call = __invoke_llm_with_autocontinue(
-        message,
-        turn_prompt.system,
-        llm_opts,
-        turn_opts,
-        session.session_id,
-        iteration_index,
-      )
-      if !call.ok && __agent_loop_is_context_overflow(call?.error) {
-        call = __agent_loop_recover_context_overflow(
-          call,
+    let __reserve_cfg = agent_stall_repair_config(opts?.stall_diagnostics)
+    var terminal_write_unverified = false
+    var terminal_verify_reserve_remaining = if __reserve_cfg.reserved_terminal_verify {
+      __reserve_cfg.reserved_terminal_verify_iterations
+    } else {
+      0
+    }
+    var in_terminal_verify_reserve = false
+    while true {
+      while iteration < current_max {
+        let boundary_exhaustion = __agent_loop_budget_exhaustion(
+          session.session_id,
+          budget,
+          iteration,
+          nil,
+          loop_start_ms,
+          current_max,
+        )
+        if boundary_exhaustion.exhausted {
+          __agent_loop_emit_budget_exhausted(session.session_id, boundary_exhaustion)
+          budget_exhausted_emitted = true
+          budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, boundary_exhaustion.kind)
+          final_status = "budget_exhausted"
+          stop_reason = boundary_exhaustion.kind
+          break
+        }
+        let checkpoint = __agent_loop_suspend_checkpoint(session, iteration)
+        if checkpoint != nil {
+          __drain_audit_flushes(audit_background_tasks)
+          audit_background_tasks = []
+          suspend_result = checkpoint
+          final_status = "suspended"
+          stop_reason = "suspended"
+          break
+        }
+        if agent_budget_pre_call_blocked(session, opts) {
+          final_status = "budget_exhausted"
+          break
+        }
+        let iteration_index = iteration
+        let iteration_opts = __agent_loop_effective_llm_options(opts)
+        agent_emit_event(
+          session.session_id,
+          "iteration_start",
+          {
+            iteration: iteration_index + 1,
+            provider: iteration_opts?.provider ?? "",
+            model: iteration_opts?.model ?? "",
+          },
+        )
+        try {
+          __host_drain_file_edits(session.session_id)
+        } catch (e) {
+          nil
+        }
+        __agent_loop_checkpoint(session.session_id, "iteration_start", {iteration: iteration_index + 1})
+        var turn_opts = agent_skills_match(session, iteration_opts, iteration_index)
+        if turn_opts?._skill_activated_this_turn ?? false {
+          opts = agent_reset_tool_surface_narrowing(opts)
+          turn_opts = agent_reset_tool_surface_narrowing(turn_opts)
+        }
+        turn_opts = agent_tool_search_inject_if_needed(turn_opts)
+        turn_opts = agent_apply_tool_surface_narrowing(turn_opts)
+        let turn_llm_opts = __agent_loop_effective_llm_options(turn_opts)
+        __agent_loop_checkpoint(session.session_id, "pre_compact", {iteration: iteration_index + 1})
+        agent_autocompact_if_needed(session, turn_llm_opts)
+        __agent_loop_checkpoint(session.session_id, "post_compact", {iteration: iteration_index + 1})
+        let scope_verdict = __run_pre_turn_scope_classifier(
+          turn_llm_opts?._pre_turn_scope_classifier ?? opts?._pre_turn_scope_classifier,
+          session,
+          message,
+          turn_llm_opts,
+          iteration_index,
+        )
+        if __scope_classifier_skip_main(scope_verdict) {
+          __scope_classifier_record_skip_turn(session, scope_verdict, iteration_index)
+          iteration = iteration + 1
+          final_status = "scope_alert"
+          stop_reason = "out_of_scope"
+          break
+        }
+        let turn_prompt = __agent_loop_build_turn_prompt(session, turn_llm_opts, iteration_index)
+        let llm_opts = turn_llm_opts
+          + {
+          messages: turn_prompt.messages,
+          session_id: session.session_id,
+          tool_format: turn_llm_opts.tool_format,
+          _iteration: iteration_index + 1,
+          _system_fragments: turn_prompt.fragments,
+        }
+        var call = __invoke_llm_with_autocontinue(
           message,
           turn_prompt.system,
           llm_opts,
           turn_opts,
-          session,
+          session.session_id,
           iteration_index,
         )
-      }
-      if !call.ok {
-        let failure_config = __agent_loop_consecutive_failure_config(budget)
-        if __agent_loop_tracks_failure(call?.error, failure_config) {
-          iteration = iteration + 1
-          consecutive_failure_count = consecutive_failure_count + 1
-          let failure_aggregates = __agent_loop_budget_aggregates(session.session_id, nil, loop_start_ms)
-          agent_emit_event(
-            session.session_id,
-            "iteration_end",
-            {
-              iteration: iteration_index + 1,
-              iteration_info: failure_aggregates
-                + {
-                dispatch_skipped: true,
-                skip_reason: "provider_failure",
-                provider_error: call?.error ?? {},
-                consecutive_failures: consecutive_failure_count,
-              },
-            },
+        if !call.ok && __agent_loop_is_context_overflow(call?.error) {
+          call = __agent_loop_recover_context_overflow(
+            call,
+            message,
+            turn_prompt.system,
+            llm_opts,
+            turn_opts,
+            session,
+            iteration_index,
           )
-          if consecutive_failure_count >= failure_config.max {
-            let paused_for_ms = failure_config?.paused_for_ms ?? 0
+        }
+        if !call.ok {
+          let failure_config = __agent_loop_consecutive_failure_config(budget)
+          if __agent_loop_tracks_failure(call?.error, failure_config) {
+            iteration = iteration + 1
+            consecutive_failure_count = consecutive_failure_count + 1
+            let failure_aggregates = __agent_loop_budget_aggregates(session.session_id, nil, loop_start_ms)
             agent_emit_event(
               session.session_id,
-              "budget_circuit_breaker",
+              "iteration_end",
               {
-                kind: "consecutive_failures",
-                consecutive_count: consecutive_failure_count,
-                paused_for_ms: paused_for_ms,
+                iteration: iteration_index + 1,
+                iteration_info: failure_aggregates
+                  + {
+                  dispatch_skipped: true,
+                  skip_reason: "provider_failure",
+                  provider_error: call?.error ?? {},
+                  consecutive_failures: consecutive_failure_count,
+                },
               },
             )
-            if paused_for_ms > 0 {
-              __agent_loop_clock_sleep_ms(paused_for_ms)
+            if consecutive_failure_count >= failure_config.max {
+              let paused_for_ms = failure_config?.paused_for_ms ?? 0
+              agent_emit_event(
+                session.session_id,
+                "budget_circuit_breaker",
+                {
+                  kind: "consecutive_failures",
+                  consecutive_count: consecutive_failure_count,
+                  paused_for_ms: paused_for_ms,
+                },
+              )
+              if paused_for_ms > 0 {
+                __agent_loop_clock_sleep_ms(paused_for_ms)
+              }
+              let exhaustion = __agent_loop_budget_aggregates(session.session_id, nil, loop_start_ms)
+                + {exhausted: true, kind: "consecutive_failures", iteration: iteration, max_iterations: current_max}
+              __agent_loop_emit_budget_exhausted(session.session_id, exhaustion)
+              budget_exhausted_emitted = true
+              budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, exhaustion.kind)
+              final_status = "budget_exhausted"
+              stop_reason = "circuit_breaker"
+              terminal_error = call?.error
+              break
             }
-            let exhaustion = __agent_loop_budget_aggregates(session.session_id, nil, loop_start_ms)
-              + {exhausted: true, kind: "consecutive_failures", iteration: iteration, max_iterations: current_max}
-            __agent_loop_emit_budget_exhausted(session.session_id, exhaustion)
-            budget_exhausted_emitted = true
-            budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, exhaustion.kind)
-            final_status = "budget_exhausted"
-            stop_reason = "circuit_breaker"
-            terminal_error = call?.error
-            break
+            continue
           }
-          continue
-        }
-        let failed_provider = to_string(turn_llm_opts?.provider ?? "")
-        let failed_model = to_string(turn_llm_opts?.model ?? "")
-        let was_escalated = (primary_provider != "" || primary_model != "")
-          && (failed_provider != primary_provider || failed_model != primary_model)
-        let can_retry_primary = was_escalated && !escalation_retry_pending
-        __agent_loop_emit_provider_error(
-          session.session_id,
-          iteration_index,
-          call,
-          turn_llm_opts,
-          loop_start_ms,
-          can_retry_primary,
-        )
-        if can_retry_primary {
-          opts = opts
-            + {
-            provider: primary_provider,
-            model: primary_model,
-            llm_options: (opts?.llm_options ?? {})
-              + {provider: primary_provider, model: primary_model},
+          let failed_provider = to_string(turn_llm_opts?.provider ?? "")
+          let failed_model = to_string(turn_llm_opts?.model ?? "")
+          let was_escalated = (primary_provider != "" || primary_model != "")
+            && (failed_provider != primary_provider || failed_model != primary_model)
+          let can_retry_primary = was_escalated && !escalation_retry_pending
+          __agent_loop_emit_provider_error(
+            session.session_id,
+            iteration_index,
+            call,
+            turn_llm_opts,
+            loop_start_ms,
+            can_retry_primary,
+          )
+          if can_retry_primary {
+            opts = opts
+              + {
+              provider: primary_provider,
+              model: primary_model,
+              llm_options: (opts?.llm_options ?? {})
+                + {provider: primary_provider, model: primary_model},
+            }
+            escalation_retry_pending = true
+            iteration = iteration + 1
+            continue
           }
-          escalation_retry_pending = true
-          iteration = iteration + 1
-          continue
+          final_status = call.status
+          stop_reason = call?.stop_reason ?? call.status
+          terminal_error = call?.error
+          break
         }
-        final_status = call.status
-        stop_reason = call?.stop_reason ?? call.status
-        terminal_error = call?.error
-        break
-      }
-      escalation_retry_pending = false
-      let llm_result = call.value
-      consecutive_failure_count = 0
-      iteration = iteration + 1
-      let raw_text = llm_result?.text ?? ""
-      let parsed = agent_parse_tool_calls(raw_text, turn_opts?.tools, turn_opts?.tool_format)
-      let visible_text = __visible_text(parsed, raw_text)
-      let normalized = llm_result
-        + {text: visible_text, visible_text: visible_text, _agent_tool_format: turn_opts?.tool_format ?? ""}
-      let fallback_outcome = __detect_native_fallback(
-        llm_result,
-        parsed,
-        turn_opts,
-        fallback_index,
-        session.session_id,
-        iteration_index,
-      )
-      fallback_index = fallback_outcome.fallback_index
-      let tool_calls = if fallback_outcome.triggered {
-        fallback_outcome.calls ?? []
-      } else {
-        __resolve_tool_calls(llm_result, parsed)
-      }
-      let recorded_assistant = if fallback_outcome.triggered && fallback_outcome.accepted {
-        normalized + {tool_calls: tool_calls, native_tool_calls: tool_calls}
-      } else {
-        normalized
-      }
-      agent_session_record_assistant(session.session_id, recorded_assistant)
-      let had_parse_errors_base = __maybe_inject_parse_error_feedback(session.session_id, parsed, tool_calls, turn_opts)
-      let had_blank_name_drop = if fallback_outcome.triggered {
-        false
-      } else {
-        __maybe_inject_blank_name_feedback(
-          session.session_id,
+        escalation_retry_pending = false
+        let llm_result = call.value
+        consecutive_failure_count = 0
+        iteration = iteration + 1
+        let raw_text = llm_result?.text ?? ""
+        let parsed = agent_parse_tool_calls(raw_text, turn_opts?.tools, turn_opts?.tool_format)
+        let visible_text = __visible_text(parsed, raw_text)
+        let normalized = llm_result
+          + {text: visible_text, visible_text: visible_text, _agent_tool_format: turn_opts?.tool_format ?? ""}
+        let fallback_outcome = __detect_native_fallback(
           llm_result,
           parsed,
-          len(tool_calls),
           turn_opts,
+          fallback_index,
+          session.session_id,
+          iteration_index,
         )
-      }
-      let had_parse_errors = had_parse_errors_base || had_blank_name_drop
-      let await_call = __agent_await_resumption_call(tool_calls)
-      if await_call != nil {
-        let await_result = try {
-          __agent_loop_await_resumption(session, iteration, await_call, opts)
+        fallback_index = fallback_outcome.fallback_index
+        let tool_calls = if fallback_outcome.triggered {
+          fallback_outcome.calls ?? []
+        } else {
+          __resolve_tool_calls(llm_result, parsed)
         }
-        if is_err(await_result) {
-          let await_error = unwrap_err(await_result)
-          agent_session_inject_feedback(
+        let recorded_assistant = if fallback_outcome.triggered && fallback_outcome.accepted {
+          normalized + {tool_calls: tool_calls, native_tool_calls: tool_calls}
+        } else {
+          normalized
+        }
+        agent_session_record_assistant(session.session_id, recorded_assistant)
+        let had_parse_errors_base = __maybe_inject_parse_error_feedback(session.session_id, parsed, tool_calls, turn_opts)
+        let had_blank_name_drop = if fallback_outcome.triggered {
+          false
+        } else {
+          __maybe_inject_blank_name_feedback(
             session.session_id,
-            "agent_await_resumption",
-            __agent_loop_invalid_await_resumption_feedback(await_error),
+            llm_result,
+            parsed,
+            len(tool_calls),
+            turn_opts,
           )
-          let await_totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
+        }
+        let had_parse_errors = had_parse_errors_base || had_blank_name_drop
+        let await_call = __agent_await_resumption_call(tool_calls)
+        if await_call != nil {
+          let await_result = try {
+            __agent_loop_await_resumption(session, iteration, await_call, opts)
+          }
+          if is_err(await_result) {
+            let await_error = unwrap_err(await_result)
+            agent_session_inject_feedback(
+              session.session_id,
+              "agent_await_resumption",
+              __agent_loop_invalid_await_resumption_feedback(await_error),
+            )
+            let await_totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
+            agent_emit_event(
+              session.session_id,
+              "iteration_end",
+              {
+                iteration: iteration_index + 1,
+                iteration_info: __agent_loop_iteration_info(
+                  session.session_id,
+                  llm_result,
+                  len(tool_calls),
+                  visible_text,
+                  await_totals,
+                  loop_start_ms,
+                )
+                  + {dispatch_skipped: true, skip_reason: "invalid_agent_await_resumption"},
+              },
+            )
+            let await_exhaustion = __agent_loop_budget_exhaustion(
+              session.session_id,
+              budget,
+              iteration,
+              await_totals,
+              loop_start_ms,
+              current_max,
+            )
+            if await_exhaustion.exhausted {
+              __agent_loop_emit_budget_exhausted(session.session_id, await_exhaustion)
+              budget_exhausted_emitted = true
+              budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, await_exhaustion.kind)
+              final_status = "budget_exhausted"
+              stop_reason = await_exhaustion.kind
+              break
+            }
+            continue
+          }
+          suspend_result = unwrap(await_result)
+          let _totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
           agent_emit_event(
             session.session_id,
             "iteration_end",
@@ -3395,250 +3479,61 @@ fn __agent_loop_run(message, session, initial_opts) {
                 llm_result,
                 len(tool_calls),
                 visible_text,
-                await_totals,
-                loop_start_ms,
-              )
-                + {dispatch_skipped: true, skip_reason: "invalid_agent_await_resumption"},
-            },
-          )
-          let await_exhaustion = __agent_loop_budget_exhaustion(
-            session.session_id,
-            budget,
-            iteration,
-            await_totals,
-            loop_start_ms,
-            current_max,
-          )
-          if await_exhaustion.exhausted {
-            __agent_loop_emit_budget_exhausted(session.session_id, await_exhaustion)
-            budget_exhausted_emitted = true
-            budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, await_exhaustion.kind)
-            final_status = "budget_exhausted"
-            stop_reason = await_exhaustion.kind
-            break
-          }
-          continue
-        }
-        suspend_result = unwrap(await_result)
-        let _totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
-        agent_emit_event(
-          session.session_id,
-          "iteration_end",
-          {
-            iteration: iteration_index + 1,
-            iteration_info: __agent_loop_iteration_info(
-              session.session_id,
-              llm_result,
-              len(tool_calls),
-              visible_text,
-              _totals,
-              loop_start_ms,
-            ),
-          },
-        )
-        final_status = "suspended"
-        stop_reason = "suspended"
-        break
-      }
-      let stall_judge_due = agent_stall_done_judge_due(turn_opts, done_judge_invocations, iteration_index + 1)
-      let stall_prev_turn_made_edit = __turn_made_edit(stall_prev_dispatch, opts?.tools)
-      let stall_observation = agent_stall_observe_tool_calls(
-        session.session_id,
-        tool_calls,
-        iteration_index + 1,
-        turn_opts?.stall_diagnostics,
-        stall_state,
-        stall_judge_due,
-        stall_prev_dispatch,
-        visible_text,
-        had_parse_errors,
-        stall_prev_turn_made_edit,
-        llm_result?.stop_reason ?? "",
-      )
-      stall_state = stall_observation.state
-      stall_enabled_seen = stall_enabled_seen || stall_observation.enabled
-      let stall_warning = stall_observation.warning
-      let structural_verdict = __run_structural_validator(
-        opts?._structural_validator,
-        session.session_id,
-        normalized + {raw_text: raw_text},
-        tool_calls,
-        parsed,
-        llm_opts,
-        turn_opts,
-        successful_tools_seen,
-        rejected_tools_seen,
-        structural_validator_attempts,
-      )
-      if structural_verdict.vetoed {
-        let on_failure = structural_verdict?.on_failure ?? "regenerate_with_feedback"
-        if on_failure == "raise" {
-          throw structural_verdict?.diagnostic
-            ?? "structural validator rejected assistant turn"
-        }
-        structural_validator_attempts = structural_validator_attempts + 1
-        __agent_loop_pop_structural_veto_turn(session.session_id)
-        let feedback = to_string(structural_verdict?.feedback ?? "")
-        if feedback != "" {
-          agent_session_inject_feedback(session.session_id, "structural_validator", feedback)
-        }
-        let structural_totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
-        agent_emit_event(
-          session.session_id,
-          "iteration_end",
-          {
-            iteration: iteration_index + 1,
-            iteration_info: __agent_loop_iteration_info(
-              session.session_id,
-              llm_result,
-              0,
-              visible_text,
-              structural_totals,
-              loop_start_ms,
-            )
-              + {
-              dispatch_skipped: true,
-              skip_reason: "structural_validator_revise",
-              structural_validator_attempts: structural_validator_attempts,
-              structural_validator_rule: structural_verdict?.rule ?? "",
-            },
-          },
-        )
-        let structural_exhaustion = __agent_loop_budget_exhaustion(
-          session.session_id,
-          budget,
-          iteration,
-          structural_totals,
-          loop_start_ms,
-          current_max,
-        )
-        if structural_exhaustion.exhausted {
-          __agent_loop_emit_budget_exhausted(session.session_id, structural_exhaustion)
-          budget_exhausted_emitted = true
-          budget_decisions = __agent_loop_record_budget_stop(
-            budget_decisions,
-            iteration,
-            current_max,
-            structural_exhaustion.kind,
-          )
-          final_status = "budget_exhausted"
-          stop_reason = structural_exhaustion.kind
-          break
-        }
-        continue
-      } else if !(structural_verdict?.skipped ?? false) {
-        structural_validator_attempts = 0
-      }
-      if stall_judge_due && stall_warning != nil {
-        let stall_verify_opts = turn_opts
-          + {
-          _done_judge_due: true,
-          _done_judge_trigger: "stalled",
-          _done_judge_invocations: done_judge_invocations,
-        }
-        let stall_verdict = agent_verify_or_continue(session, stall_verify_opts, "stalled", visible_text, iteration_index + 1)
-        if stall_verdict?.done_judge_invoked ?? false {
-          done_judge_invocations = done_judge_invocations + 1
-        }
-        if stall_verdict?.done_judge_cap_reached ?? false {
-          final_status = "verify_capped"
-          stop_reason = "done_judge_cap_reached"
-          break
-        }
-        if stall_verdict.vetoed {
-          if stall_verdict?.done_judge_invoked ?? false {
-            done_judge_vetoes = done_judge_vetoes + 1
-          }
-          if stall_observation.feedback_deferred {
-            stall_state = agent_stall_inject_feedback(
-              session.session_id,
-              stall_warning,
-              stall_observation.config,
-              stall_state,
-            )
-          }
-        } else {
-          let stall_totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
-          let tool_count = len(tool_calls)
-          agent_emit_event(
-            session.session_id,
-            "iteration_end",
-            {
-              iteration: iteration_index + 1,
-              iteration_info: __agent_loop_iteration_info(
-                session.session_id,
-                llm_result,
-                tool_count,
-                visible_text,
-                stall_totals,
+                _totals,
                 loop_start_ms,
               ),
             },
           )
-          let stall_exhaustion = __agent_loop_budget_exhaustion(
-            session.session_id,
-            budget,
-            iteration,
-            stall_totals,
-            loop_start_ms,
-            current_max,
-          )
-          if stall_exhaustion.exhausted {
-            __agent_loop_emit_budget_exhausted(session.session_id, stall_exhaustion)
-            budget_exhausted_emitted = true
-            budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, stall_exhaustion.kind)
-            final_status = "budget_exhausted"
-            stop_reason = stall_exhaustion.kind
-            break
-          }
-          let stalled_done_checkpoint = __agent_loop_checkpoint(session.session_id, "iteration_end", {iteration: iteration_index + 1})
-          if stalled_done_checkpoint.delivered > 0 {
-            continue
-          }
-          final_status = "done"
-          stop_reason = "stalled_done_judge"
+          final_status = "suspended"
+          stop_reason = "suspended"
           break
         }
-      }
-      if stall_observation.hard_stop {
-        agent_emit_event(
+        let stall_judge_due = agent_stall_done_judge_due(turn_opts, done_judge_invocations, iteration_index + 1)
+        let stall_prev_turn_made_edit = __turn_made_edit(stall_prev_dispatch, opts?.tools)
+        let stall_observation = agent_stall_observe_tool_calls(
           session.session_id,
-          "loop_control_decision",
-          {
-            iteration: iteration_index + 1,
-            action: "stop",
-            old_limit: current_max,
-            new_limit: current_max,
-            reason: "thrash_hard_stop",
-            status: "stuck",
-          },
-        )
-        final_status = "stuck"
-        stop_reason = "thrash_hard_stop"
-        break
-      }
-      if turn_opts?.step_judge != nil {
-        let remaining_iterations = current_max - iteration_index
-        let step_verdict = agent_step_judge(
-          session,
-          llm_result,
-          turn_opts,
+          tool_calls,
           iteration_index + 1,
-          stall_warning,
-          step_judge_attempts,
-          remaining_iterations,
+          turn_opts?.stall_diagnostics,
+          stall_state,
+          stall_judge_due,
+          stall_prev_dispatch,
+          visible_text,
+          had_parse_errors,
+          stall_prev_turn_made_edit,
+          llm_result?.stop_reason ?? "",
         )
-        if step_verdict.vetoed {
-          step_judge_attempts = step_judge_attempts + 1
-          let on_veto = step_verdict?.on_veto ?? "replace"
-          if on_veto == "replace" {
-            agent_session_pop_last_assistant(session.session_id)
+        stall_state = stall_observation.state
+        stall_enabled_seen = stall_enabled_seen || stall_observation.enabled
+        if stall_state.last_diagnostic_class == "pass" {
+          terminal_write_unverified = false
+        }
+        let stall_warning = stall_observation.warning
+        let structural_verdict = __run_structural_validator(
+          opts?._structural_validator,
+          session.session_id,
+          normalized + {raw_text: raw_text},
+          tool_calls,
+          parsed,
+          llm_opts,
+          turn_opts,
+          successful_tools_seen,
+          rejected_tools_seen,
+          structural_validator_attempts,
+        )
+        if structural_verdict.vetoed {
+          let on_failure = structural_verdict?.on_failure ?? "regenerate_with_feedback"
+          if on_failure == "raise" {
+            throw structural_verdict?.diagnostic
+              ?? "structural validator rejected assistant turn"
           }
-          let critique = step_verdict?.feedback ?? step_verdict?.critique ?? ""
-          if critique != "" {
-            agent_session_inject_feedback(session.session_id, "step_judge", critique)
+          structural_validator_attempts = structural_validator_attempts + 1
+          __agent_loop_pop_structural_veto_turn(session.session_id)
+          let feedback = to_string(structural_verdict?.feedback ?? "")
+          if feedback != "" {
+            agent_session_inject_feedback(session.session_id, "structural_validator", feedback)
           }
-          let step_totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
+          let structural_totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
           agent_emit_event(
             session.session_id,
             "iteration_end",
@@ -3649,42 +3544,257 @@ fn __agent_loop_run(message, session, initial_opts) {
                 llm_result,
                 0,
                 visible_text,
-                step_totals,
+                structural_totals,
                 loop_start_ms,
               )
                 + {
                 dispatch_skipped: true,
-                skip_reason: "step_judge_revise",
-                on_veto: on_veto,
-                step_judge_attempts: step_judge_attempts,
+                skip_reason: "structural_validator_revise",
+                structural_validator_attempts: structural_validator_attempts,
+                structural_validator_rule: structural_verdict?.rule ?? "",
               },
             },
           )
-          let step_exhaustion = __agent_loop_budget_exhaustion(
+          let structural_exhaustion = __agent_loop_budget_exhaustion(
             session.session_id,
             budget,
             iteration,
-            step_totals,
+            structural_totals,
             loop_start_ms,
             current_max,
           )
-          if step_exhaustion.exhausted {
-            __agent_loop_emit_budget_exhausted(session.session_id, step_exhaustion)
+          if structural_exhaustion.exhausted {
+            __agent_loop_emit_budget_exhausted(session.session_id, structural_exhaustion)
             budget_exhausted_emitted = true
-            budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, step_exhaustion.kind)
+            budget_decisions = __agent_loop_record_budget_stop(
+              budget_decisions,
+              iteration,
+              current_max,
+              structural_exhaustion.kind,
+            )
             final_status = "budget_exhausted"
-            stop_reason = step_exhaustion.kind
+            stop_reason = structural_exhaustion.kind
             break
           }
           continue
-        } else if !(step_verdict?.skipped ?? false) {
-          step_judge_attempts = 0
+        } else if !(structural_verdict?.skipped ?? false) {
+          structural_validator_attempts = 0
         }
-      }
-      let pre_dispatch_checkpoint = __agent_loop_checkpoint(session.session_id, "pre_tool_dispatch", {iteration: iteration_index + 1})
-      if pre_dispatch_checkpoint.dispatch_skipped {
-        let tool_count_skipped = len(tool_calls)
-        let totals_skipped = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
+        if stall_judge_due && stall_warning != nil {
+          let stall_verify_opts = turn_opts
+            + {
+            _done_judge_due: true,
+            _done_judge_trigger: "stalled",
+            _done_judge_invocations: done_judge_invocations,
+          }
+          let stall_verdict = agent_verify_or_continue(session, stall_verify_opts, "stalled", visible_text, iteration_index + 1)
+          if stall_verdict?.done_judge_invoked ?? false {
+            done_judge_invocations = done_judge_invocations + 1
+          }
+          if stall_verdict?.done_judge_cap_reached ?? false {
+            final_status = "verify_capped"
+            stop_reason = "done_judge_cap_reached"
+            break
+          }
+          if stall_verdict.vetoed {
+            if stall_verdict?.done_judge_invoked ?? false {
+              done_judge_vetoes = done_judge_vetoes + 1
+            }
+            if stall_observation.feedback_deferred {
+              stall_state = agent_stall_inject_feedback(
+                session.session_id,
+                stall_warning,
+                stall_observation.config,
+                stall_state,
+              )
+            }
+          } else {
+            let stall_totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
+            let tool_count = len(tool_calls)
+            agent_emit_event(
+              session.session_id,
+              "iteration_end",
+              {
+                iteration: iteration_index + 1,
+                iteration_info: __agent_loop_iteration_info(
+                  session.session_id,
+                  llm_result,
+                  tool_count,
+                  visible_text,
+                  stall_totals,
+                  loop_start_ms,
+                ),
+              },
+            )
+            let stall_exhaustion = __agent_loop_budget_exhaustion(
+              session.session_id,
+              budget,
+              iteration,
+              stall_totals,
+              loop_start_ms,
+              current_max,
+            )
+            if stall_exhaustion.exhausted {
+              __agent_loop_emit_budget_exhausted(session.session_id, stall_exhaustion)
+              budget_exhausted_emitted = true
+              budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, stall_exhaustion.kind)
+              final_status = "budget_exhausted"
+              stop_reason = stall_exhaustion.kind
+              break
+            }
+            let stalled_done_checkpoint = __agent_loop_checkpoint(session.session_id, "iteration_end", {iteration: iteration_index + 1})
+            if stalled_done_checkpoint.delivered > 0 {
+              continue
+            }
+            final_status = "done"
+            stop_reason = "stalled_done_judge"
+            break
+          }
+        }
+        if stall_observation.hard_stop {
+          agent_emit_event(
+            session.session_id,
+            "loop_control_decision",
+            {
+              iteration: iteration_index + 1,
+              action: "stop",
+              old_limit: current_max,
+              new_limit: current_max,
+              reason: "thrash_hard_stop",
+              status: "stuck",
+            },
+          )
+          final_status = "stuck"
+          stop_reason = "thrash_hard_stop"
+          break
+        }
+        if turn_opts?.step_judge != nil {
+          let remaining_iterations = current_max - iteration_index
+          let step_verdict = agent_step_judge(
+            session,
+            llm_result,
+            turn_opts,
+            iteration_index + 1,
+            stall_warning,
+            step_judge_attempts,
+            remaining_iterations,
+          )
+          if step_verdict.vetoed {
+            step_judge_attempts = step_judge_attempts + 1
+            let on_veto = step_verdict?.on_veto ?? "replace"
+            if on_veto == "replace" {
+              agent_session_pop_last_assistant(session.session_id)
+            }
+            let critique = step_verdict?.feedback ?? step_verdict?.critique ?? ""
+            if critique != "" {
+              agent_session_inject_feedback(session.session_id, "step_judge", critique)
+            }
+            let step_totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
+            agent_emit_event(
+              session.session_id,
+              "iteration_end",
+              {
+                iteration: iteration_index + 1,
+                iteration_info: __agent_loop_iteration_info(
+                  session.session_id,
+                  llm_result,
+                  0,
+                  visible_text,
+                  step_totals,
+                  loop_start_ms,
+                )
+                  + {
+                  dispatch_skipped: true,
+                  skip_reason: "step_judge_revise",
+                  on_veto: on_veto,
+                  step_judge_attempts: step_judge_attempts,
+                },
+              },
+            )
+            let step_exhaustion = __agent_loop_budget_exhaustion(
+              session.session_id,
+              budget,
+              iteration,
+              step_totals,
+              loop_start_ms,
+              current_max,
+            )
+            if step_exhaustion.exhausted {
+              __agent_loop_emit_budget_exhausted(session.session_id, step_exhaustion)
+              budget_exhausted_emitted = true
+              budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, step_exhaustion.kind)
+              final_status = "budget_exhausted"
+              stop_reason = step_exhaustion.kind
+              break
+            }
+            continue
+          } else if !(step_verdict?.skipped ?? false) {
+            step_judge_attempts = 0
+          }
+        }
+        let pre_dispatch_checkpoint = __agent_loop_checkpoint(session.session_id, "pre_tool_dispatch", {iteration: iteration_index + 1})
+        if pre_dispatch_checkpoint.dispatch_skipped {
+          let tool_count_skipped = len(tool_calls)
+          let totals_skipped = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
+          agent_emit_event(
+            session.session_id,
+            "iteration_end",
+            {
+              iteration: iteration_index + 1,
+              iteration_info: __agent_loop_iteration_info(
+                session.session_id,
+                llm_result,
+                tool_count_skipped,
+                visible_text,
+                totals_skipped,
+                loop_start_ms,
+              )
+                + {dispatch_skipped: true, skip_reason: "interrupt_immediate"},
+            },
+          )
+          let skipped_exhaustion = __agent_loop_budget_exhaustion(
+            session.session_id,
+            budget,
+            iteration,
+            totals_skipped,
+            loop_start_ms,
+            current_max,
+          )
+          if skipped_exhaustion.exhausted {
+            __agent_loop_emit_budget_exhausted(session.session_id, skipped_exhaustion)
+            budget_exhausted_emitted = true
+            budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, skipped_exhaustion.kind)
+            final_status = "budget_exhausted"
+            stop_reason = skipped_exhaustion.kind
+            break
+          }
+          if agent_budget_post_call_blocked(totals_skipped, turn_opts) {
+            final_status = "budget_exhausted"
+            break
+          }
+          consecutive_text_only = __next_text_only_count(0, consecutive_text_only)
+          turns_since_progress = __next_progress_count(false, turns_since_progress)
+          last_tool_count = 0
+          continue
+        }
+        let dispatched = __dispatch_tool_calls(
+          session.session_id,
+          tool_calls,
+          turn_opts
+            + {
+            _iteration: iteration_index + 1,
+            _tool_caller: opts?._tool_caller,
+            _stop_reason: llm_result?.stop_reason ?? "",
+          },
+        )
+        let dispatch = dispatched.dispatch
+        stall_prev_dispatch = dispatch
+        audit_background_tasks = __spawn_audit_flushes(audit_background_tasks, dispatched.audit_flushes)
+        opts = __sync_tool_search_state(opts, dispatched.turn_opts)
+        successful_tools_seen = __merge_tool_names(successful_tools_seen, __tool_names_by_status(dispatch, true))
+        rejected_tools_seen = __merge_tool_names(rejected_tools_seen, __tool_names_by_status(dispatch, false))
+        let totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
+        let tool_count = len(tool_calls)
         agent_emit_event(
           session.session_id,
           "iteration_end",
@@ -3693,349 +3803,362 @@ fn __agent_loop_run(message, session, initial_opts) {
             iteration_info: __agent_loop_iteration_info(
               session.session_id,
               llm_result,
-              tool_count_skipped,
+              tool_count,
               visible_text,
-              totals_skipped,
+              totals,
               loop_start_ms,
-            )
-              + {dispatch_skipped: true, skip_reason: "interrupt_immediate"},
+            ),
           },
         )
-        let skipped_exhaustion = __agent_loop_budget_exhaustion(
+        let post_dispatch_checkpoint = __agent_loop_checkpoint(session.session_id, "post_tool_dispatch", {iteration: iteration_index + 1})
+        let bridge_step_delivered = post_dispatch_checkpoint.delivered
+        let exhaustion = __agent_loop_budget_exhaustion(
           session.session_id,
           budget,
           iteration,
-          totals_skipped,
+          totals,
           loop_start_ms,
           current_max,
         )
-        if skipped_exhaustion.exhausted {
-          __agent_loop_emit_budget_exhausted(session.session_id, skipped_exhaustion)
+        if exhaustion.exhausted {
+          __agent_loop_emit_budget_exhausted(session.session_id, exhaustion)
           budget_exhausted_emitted = true
-          budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, skipped_exhaustion.kind)
+          budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, exhaustion.kind)
           final_status = "budget_exhausted"
-          stop_reason = skipped_exhaustion.kind
+          stop_reason = exhaustion.kind
           break
         }
-        if agent_budget_post_call_blocked(totals_skipped, turn_opts) {
+        if agent_budget_post_call_blocked(totals, turn_opts) {
           final_status = "budget_exhausted"
           break
         }
-        consecutive_text_only = __next_text_only_count(0, consecutive_text_only)
-        turns_since_progress = __next_progress_count(false, turns_since_progress)
-        last_tool_count = 0
-        continue
-      }
-      let dispatched = __dispatch_tool_calls(
-        session.session_id,
-        tool_calls,
-        turn_opts
-          + {
-          _iteration: iteration_index + 1,
-          _tool_caller: opts?._tool_caller,
-          _stop_reason: llm_result?.stop_reason ?? "",
-        },
-      )
-      let dispatch = dispatched.dispatch
-      stall_prev_dispatch = dispatch
-      audit_background_tasks = __spawn_audit_flushes(audit_background_tasks, dispatched.audit_flushes)
-      opts = __sync_tool_search_state(opts, dispatched.turn_opts)
-      successful_tools_seen = __merge_tool_names(successful_tools_seen, __tool_names_by_status(dispatch, true))
-      rejected_tools_seen = __merge_tool_names(rejected_tools_seen, __tool_names_by_status(dispatch, false))
-      let totals = agent_session_record_usage(session.session_id, llm_result, turn_llm_opts, iteration_index + 1)
-      let tool_count = len(tool_calls)
-      agent_emit_event(
-        session.session_id,
-        "iteration_end",
-        {
-          iteration: iteration_index + 1,
-          iteration_info: __agent_loop_iteration_info(
+        consecutive_text_only = __next_text_only_count(tool_count, consecutive_text_only)
+        last_tool_count = tool_count
+        let turn_successful = __tool_names_by_status(dispatch, true)
+        let turn_rejected = __tool_names_by_status(dispatch, false)
+        let made_progress = len(turn_successful) > 0
+        turns_since_progress = __next_progress_count(made_progress, turns_since_progress)
+        let turn_max_nudges = turn_opts?.max_nudges ?? 8
+        let turn_loop_until_done = turn_opts?.loop_until_done ?? false
+        let text_only_nudge_budget_exceeded = turn_loop_until_done
+          && tool_count == 0
+          && consecutive_text_only > turn_max_nudges
+        let missing_required_for_loop = agent_required_tools_missing_from_session(opts, successful_tools_seen)
+        let cadence_loop_state = agent_loop_snapshot_state(
+          {
+            iteration: iteration,
+            current_limit: current_max,
+            budget_max: budget.max,
+            extensions_used: extensions_used,
+            tool_count: tool_count,
+            turn_successful: turn_successful,
+            turn_rejected: turn_rejected,
+            visible_text: visible_text,
+            turn_native_fallback_used: fallback_outcome.triggered && fallback_outcome.accepted,
+            session_successful: successful_tools_seen,
+            session_rejected: rejected_tools_seen,
+            missing_required_tools: missing_required_for_loop,
+            completion_proposed: false,
+            verdict: nil,
+          }
+            + __agent_loop_state_budget_fields(
             session.session_id,
-            llm_result,
-            tool_count,
-            visible_text,
             totals,
             loop_start_ms,
+            budget,
+            consecutive_failure_count,
           ),
-        },
-      )
-      let post_dispatch_checkpoint = __agent_loop_checkpoint(session.session_id, "post_tool_dispatch", {iteration: iteration_index + 1})
-      let bridge_step_delivered = post_dispatch_checkpoint.delivered
-      let exhaustion = __agent_loop_budget_exhaustion(
-        session.session_id,
-        budget,
-        iteration,
-        totals,
-        loop_start_ms,
-        current_max,
-      )
-      if exhaustion.exhausted {
-        __agent_loop_emit_budget_exhausted(session.session_id, exhaustion)
-        budget_exhausted_emitted = true
-        budget_decisions = __agent_loop_record_budget_stop(budget_decisions, iteration, current_max, exhaustion.kind)
-        final_status = "budget_exhausted"
-        stop_reason = exhaustion.kind
-        break
-      }
-      if agent_budget_post_call_blocked(totals, turn_opts) {
-        final_status = "budget_exhausted"
-        break
-      }
-      consecutive_text_only = __next_text_only_count(tool_count, consecutive_text_only)
-      last_tool_count = tool_count
-      let turn_successful = __tool_names_by_status(dispatch, true)
-      let turn_rejected = __tool_names_by_status(dispatch, false)
-      let made_progress = len(turn_successful) > 0
-      turns_since_progress = __next_progress_count(made_progress, turns_since_progress)
-      let turn_max_nudges = turn_opts?.max_nudges ?? 8
-      let turn_loop_until_done = turn_opts?.loop_until_done ?? false
-      let text_only_nudge_budget_exceeded = turn_loop_until_done
-        && tool_count == 0
-        && consecutive_text_only > turn_max_nudges
-      let missing_required_for_loop = agent_required_tools_missing_from_session(opts, successful_tools_seen)
-      let cadence_loop_state = agent_loop_snapshot_state(
-        {
-          iteration: iteration,
-          current_limit: current_max,
-          budget_max: budget.max,
-          extensions_used: extensions_used,
-          tool_count: tool_count,
-          turn_successful: turn_successful,
-          turn_rejected: turn_rejected,
-          visible_text: visible_text,
-          turn_native_fallback_used: fallback_outcome.triggered && fallback_outcome.accepted,
-          session_successful: successful_tools_seen,
-          session_rejected: rejected_tools_seen,
-          missing_required_tools: missing_required_for_loop,
-          completion_proposed: false,
-          verdict: nil,
-        }
-          + __agent_loop_state_budget_fields(
-          session.session_id,
-          totals,
-          loop_start_ms,
-          budget,
-          consecutive_failure_count,
-        ),
-      )
-      let post_turn_opts = turn_opts
-        + {
-        _session_successful_tools: successful_tools_seen,
-        _session_rejected_tools: rejected_tools_seen,
-        _consecutive_text_only: consecutive_text_only,
-        _done_judge_invocations: done_judge_invocations,
-        _done_judge_loop_state: cadence_loop_state,
-        _turn_tool_call_feedback: (fallback_outcome.triggered && !fallback_outcome.accepted)
-          || had_parse_errors,
-      }
-      let outcome = __agent_loop_with_llm_render_context(
-        turn_llm_opts,
-        { _effective -> agent_compute_post_turn(
-          session,
-          normalized + {raw_text: raw_text, parsed_done_marker: parsed?.done_marker ?? ""},
-          dispatch,
-          post_turn_opts,
-          iteration_index,
-        ) },
-      )
-      opts = __apply_post_turn_options(opts, outcome)
-      let repair_cfg = agent_stall_repair_config(turn_opts?.stall_diagnostics)
-      let reverify_mandated = __agent_loop_post_edit_reverify_mandated(repair_cfg, turn_opts, stall_state, dispatch, opts?.tools)
-      var should_continue = outcome.kind == "continue" || bridge_step_delivered > 0
-      var verdict_record = nil
-      var post_edit_reverify_confirmed = false
-      if should_continue && reverify_mandated && verify_attempts < max_verify_attempts {
-        let reverify_opts = turn_opts
-          + {
-          _done_judge_due: false,
-          _done_judge_invocations: done_judge_invocations,
-          _verify_completion_judge_invocations: verify_completion_judge_invocations,
-        }
-        let reverdict = agent_verify_or_continue(
-          session,
-          reverify_opts,
-          "post_edit_reverify",
-          llm_result.text,
-          iteration_index,
         )
-        verdict_record = reverdict
-        if reverdict?.verify_completion_judge_invoked ?? false {
-          verify_completion_judge_invocations = verify_completion_judge_invocations + 1
+        let post_turn_opts = turn_opts
+          + {
+          _session_successful_tools: successful_tools_seen,
+          _session_rejected_tools: rejected_tools_seen,
+          _consecutive_text_only: consecutive_text_only,
+          _done_judge_invocations: done_judge_invocations,
+          _done_judge_loop_state: cadence_loop_state,
+          _turn_tool_call_feedback: (fallback_outcome.triggered && !fallback_outcome.accepted)
+            || had_parse_errors,
         }
-        if reverdict.vetoed {
-          verify_attempts = verify_attempts + 1
-          if reverdict?.verify_completion_judge_invoked ?? false {
-            verify_completion_judge_vetoes = verify_completion_judge_vetoes + 1
-          }
-        } else {
-          stall_state = stall_state + {reverify_owed: false}
-          post_edit_reverify_confirmed = true
+        let outcome = __agent_loop_with_llm_render_context(
+          turn_llm_opts,
+          { _effective -> agent_compute_post_turn(
+            session,
+            normalized + {raw_text: raw_text, parsed_done_marker: parsed?.done_marker ?? ""},
+            dispatch,
+            post_turn_opts,
+            iteration_index,
+          ) },
+        )
+        opts = __apply_post_turn_options(opts, outcome)
+        let repair_cfg = agent_stall_repair_config(turn_opts?.stall_diagnostics)
+        let reverify_mandated = __agent_loop_post_edit_reverify_mandated(repair_cfg, turn_opts, stall_state, dispatch, opts?.tools)
+        if __turn_made_edit(dispatch, opts?.tools) {
+          terminal_write_unverified = true
         }
-      }
-      if should_continue {
-        if opts?.daemon && len(tool_calls) == 0 {
-          agent_daemon_step(session, opts, iteration)
-        }
-      } else {
-        if outcome.needs_verify || reverify_mandated {
-          if verify_attempts >= max_verify_attempts {
-            final_status = "verify_exhausted"
-            stop_reason = outcome.stop_reason
-            break
-          }
-          let verify_opts = turn_opts
+        var should_continue = outcome.kind == "continue" || bridge_step_delivered > 0
+        var verdict_record = nil
+        var post_edit_reverify_confirmed = false
+        if should_continue && reverify_mandated && verify_attempts < max_verify_attempts {
+          let reverify_opts = turn_opts
             + {
-            _done_judge_due: outcome?.done_judge_due ?? true,
+            _done_judge_due: false,
             _done_judge_invocations: done_judge_invocations,
             _verify_completion_judge_invocations: verify_completion_judge_invocations,
           }
-          let verdict = agent_verify_or_continue(
+          let reverdict = agent_verify_or_continue(
             session,
-            verify_opts,
-            outcome.stop_reason,
+            reverify_opts,
+            "post_edit_reverify",
             llm_result.text,
             iteration_index,
           )
-          verdict_record = verdict
-          if verdict?.done_judge_invoked ?? false {
-            done_judge_invocations = done_judge_invocations + 1
-          }
-          if verdict?.verify_completion_judge_invoked ?? false {
+          verdict_record = reverdict
+          if reverdict?.verify_completion_judge_invoked ?? false {
             verify_completion_judge_invocations = verify_completion_judge_invocations + 1
           }
-          if verdict.vetoed {
+          if reverdict.vetoed {
             verify_attempts = verify_attempts + 1
-            should_continue = true
-            if verdict?.done_judge_invoked ?? false {
-              done_judge_vetoes = done_judge_vetoes + 1
-            }
-            if verdict?.verify_completion_judge_invoked ?? false {
+            if reverdict?.verify_completion_judge_invoked ?? false {
               verify_completion_judge_vetoes = verify_completion_judge_vetoes + 1
             }
-          } else if verdict?.verify_completion_judge_cap_reached ?? false {
-            final_status = "verify_capped"
-            stop_reason = "completion_judge_cap_reached"
-            break
-          } else if verdict?.done_judge_cap_reached ?? false {
-            final_status = "verify_capped"
-            stop_reason = "done_judge_cap_reached"
-            break
           } else {
             stall_state = stall_state + {reverify_owed: false}
-            if reverify_mandated {
-              post_edit_reverify_confirmed = true
-            }
+            post_edit_reverify_confirmed = true
+            terminal_write_unverified = false
           }
         }
-        let missing_now = agent_required_tools_missing_from_session(opts, successful_tools_seen)
-        if !should_continue && len(missing_now) > 0 {
-          agent_required_tools_inject_feedback(session.session_id, missing_now)
-          should_continue = true
+        if should_continue {
+          if opts?.daemon && len(tool_calls) == 0 {
+            agent_daemon_step(session, opts, iteration)
+          }
+        } else {
+          if outcome.needs_verify || reverify_mandated {
+            if verify_attempts >= max_verify_attempts {
+              final_status = "verify_exhausted"
+              stop_reason = outcome.stop_reason
+              break
+            }
+            let verify_opts = turn_opts
+              + {
+              _done_judge_due: outcome?.done_judge_due ?? true,
+              _done_judge_invocations: done_judge_invocations,
+              _verify_completion_judge_invocations: verify_completion_judge_invocations,
+            }
+            let verdict = agent_verify_or_continue(
+              session,
+              verify_opts,
+              outcome.stop_reason,
+              llm_result.text,
+              iteration_index,
+            )
+            verdict_record = verdict
+            if verdict?.done_judge_invoked ?? false {
+              done_judge_invocations = done_judge_invocations + 1
+            }
+            if verdict?.verify_completion_judge_invoked ?? false {
+              verify_completion_judge_invocations = verify_completion_judge_invocations + 1
+            }
+            if verdict.vetoed {
+              verify_attempts = verify_attempts + 1
+              should_continue = true
+              if verdict?.done_judge_invoked ?? false {
+                done_judge_vetoes = done_judge_vetoes + 1
+              }
+              if verdict?.verify_completion_judge_invoked ?? false {
+                verify_completion_judge_vetoes = verify_completion_judge_vetoes + 1
+              }
+            } else if verdict?.verify_completion_judge_cap_reached ?? false {
+              final_status = "verify_capped"
+              stop_reason = "completion_judge_cap_reached"
+              break
+            } else if verdict?.done_judge_cap_reached ?? false {
+              final_status = "verify_capped"
+              stop_reason = "done_judge_cap_reached"
+              break
+            } else {
+              stall_state = stall_state + {reverify_owed: false}
+              terminal_write_unverified = false
+              if reverify_mandated {
+                post_edit_reverify_confirmed = true
+              }
+            }
+          }
+          let missing_now = agent_required_tools_missing_from_session(opts, successful_tools_seen)
+          if !should_continue && len(missing_now) > 0 {
+            agent_required_tools_inject_feedback(session.session_id, missing_now)
+            should_continue = true
+          }
+          if !should_continue {
+            stop_reason = outcome.stop_reason
+            break
+          }
         }
-        if !should_continue {
-          stop_reason = outcome.stop_reason
-          break
+        if should_continue && post_edit_reverify_confirmed && iteration >= current_max {
+          let missing_after_reverify = agent_required_tools_missing_from_session(opts, successful_tools_seen)
+          if len(missing_after_reverify) == 0 {
+            final_status = "done"
+            stop_reason = "post_edit_reverify"
+            break
+          }
         }
-      }
-      if should_continue && post_edit_reverify_confirmed && iteration >= current_max {
-        let missing_after_reverify = agent_required_tools_missing_from_session(opts, successful_tools_seen)
-        if len(missing_after_reverify) == 0 {
-          final_status = "done"
-          stop_reason = "post_edit_reverify"
-          break
-        }
-      }
-      if should_continue {
-        if text_only_nudge_budget_exceeded {
-          final_status = "stuck"
-          stop_reason = "max_nudges"
-          break
-        }
-        agent_scratchpad_reorganize_if_due(
-          session,
-          opts,
-          iteration_index,
-          {
-            reason: "iteration_end",
-            outcome_kind: outcome.kind,
-            bridge_step_delivered: bridge_step_delivered,
-            tool_count: tool_count,
-          },
-        )
-        if turns_since_progress >= 2
-          && turns_since_progress <= turn_max_nudges
-          && !(outcome?.nudged_this_turn ?? false)
-          && len(turn_rejected) == 0 {
-          let has_tools = len(opts?.tools?.tools ?? []) > 0
-          let tool_mode = agent_tool_call_paradigm(turn_opts).kind
-          let made_tool_calls = tool_count > 0
-          agent_session_inject_feedback(
-            session.session_id,
-            "no_progress_streak",
-            __progress_nudge_text(turns_since_progress, has_tools, tool_mode, made_tool_calls),
-          )
-          agent_emit_event(
-            session.session_id,
-            "no_progress_streak_nudge",
+        if should_continue {
+          if text_only_nudge_budget_exceeded {
+            final_status = "stuck"
+            stop_reason = "max_nudges"
+            break
+          }
+          agent_scratchpad_reorganize_if_due(
+            session,
+            opts,
+            iteration_index,
             {
-              iteration: iteration_index,
-              turns_since_progress: turns_since_progress,
-              has_tools: has_tools,
-              made_tool_calls: made_tool_calls,
+              reason: "iteration_end",
+              outcome_kind: outcome.kind,
+              bridge_step_delivered: bridge_step_delivered,
+              tool_count: tool_count,
             },
           )
+          if turns_since_progress >= 2
+            && turns_since_progress <= turn_max_nudges
+            && !(outcome?.nudged_this_turn ?? false)
+            && len(turn_rejected) == 0 {
+            let has_tools = len(opts?.tools?.tools ?? []) > 0
+            let tool_mode = agent_tool_call_paradigm(turn_opts).kind
+            let made_tool_calls = tool_count > 0
+            agent_session_inject_feedback(
+              session.session_id,
+              "no_progress_streak",
+              __progress_nudge_text(turns_since_progress, has_tools, tool_mode, made_tool_calls),
+            )
+            agent_emit_event(
+              session.session_id,
+              "no_progress_streak_nudge",
+              {
+                iteration: iteration_index,
+                turns_since_progress: turns_since_progress,
+                has_tools: has_tools,
+                made_tool_calls: made_tool_calls,
+              },
+            )
+          }
+        }
+        let loop_no_net_progress = agent_stall_no_net_progress(turn_opts?.stall_diagnostics, stall_state)
+        let loop_state = agent_loop_snapshot_state(
+          {
+            iteration: iteration,
+            current_limit: current_max,
+            budget_max: budget.max,
+            extensions_used: extensions_used,
+            tool_count: tool_count,
+            turn_successful: turn_successful,
+            turn_rejected: turn_rejected,
+            visible_text: visible_text,
+            turn_native_fallback_used: fallback_outcome.triggered && fallback_outcome.accepted,
+            session_successful: successful_tools_seen,
+            session_rejected: rejected_tools_seen,
+            missing_required_tools: missing_required_for_loop,
+            completion_proposed: outcome.kind == "break",
+            verdict: verdict_record,
+            progress_no_net_advance: loop_no_net_progress,
+          }
+            + __agent_loop_state_budget_fields(
+            session.session_id,
+            totals,
+            loop_start_ms,
+            budget,
+            consecutive_failure_count,
+          ),
+        )
+        let command = agent_loop_control_invoke(opts, budget, loop_state)
+        let applied = agent_loop_apply_command(
+          {
+            command: command,
+            session_id: session.session_id,
+            iteration: iteration,
+            current_max: current_max,
+            extensions_used: extensions_used,
+            decisions: budget_decisions,
+            budget: budget,
+          },
+        )
+        current_max = applied.current_max
+        extensions_used = applied.extensions_used
+        budget_decisions = applied.decisions
+        if applied.stop {
+          final_status = applied.final_status
+          stop_reason = applied.stop_reason
+          break
         }
       }
-      let loop_no_net_progress = agent_stall_no_net_progress(turn_opts?.stall_diagnostics, stall_state)
-      let loop_state = agent_loop_snapshot_state(
-        {
-          iteration: iteration,
-          current_limit: current_max,
-          budget_max: budget.max,
-          extensions_used: extensions_used,
-          tool_count: tool_count,
-          turn_successful: turn_successful,
-          turn_rejected: turn_rejected,
-          visible_text: visible_text,
-          turn_native_fallback_used: fallback_outcome.triggered && fallback_outcome.accepted,
-          session_successful: successful_tools_seen,
-          session_rejected: rejected_tools_seen,
-          missing_required_tools: missing_required_for_loop,
-          completion_proposed: outcome.kind == "break",
-          verdict: verdict_record,
-          progress_no_net_advance: loop_no_net_progress,
+      if final_status == "" && iteration >= current_max && stop_reason == nil {
+        final_status = "budget_exhausted"
+        stop_reason = stop_reason ?? "max_iterations"
+      }
+      if __agent_loop_should_spend_reserve(
+        __reserve_cfg,
+        opts,
+        final_status,
+        terminal_write_unverified,
+        verify_attempts < max_verify_attempts,
+      ) {
+        in_terminal_verify_reserve = true
+        let terminal_verdict = agent_verify_or_continue(
+          session,
+          opts
+            + {
+            _done_judge_due: false,
+            _done_judge_invocations: done_judge_invocations,
+            _verify_completion_judge_invocations: verify_completion_judge_invocations,
+          },
+          "reserved_terminal_verify",
+          "",
+          iteration,
+        )
+        if terminal_verdict?.verify_completion_judge_invoked ?? false {
+          verify_completion_judge_invocations = verify_completion_judge_invocations + 1
         }
-          + __agent_loop_state_budget_fields(
+        if !terminal_verdict.vetoed {
+          terminal_write_unverified = false
+          stall_state = stall_state + {reverify_owed: false}
+          final_status = "done"
+          stop_reason = "reserved_terminal_verify"
+          agent_emit_event(
+            session.session_id,
+            "reserved_terminal_verify",
+            {phase: "verify_passed", iteration: iteration},
+          )
+          break
+        }
+        verify_attempts = verify_attempts + 1
+        if terminal_verdict?.verify_completion_judge_invoked ?? false {
+          verify_completion_judge_vetoes = verify_completion_judge_vetoes + 1
+        }
+        agent_emit_event(
           session.session_id,
-          totals,
-          loop_start_ms,
-          budget,
-          consecutive_failure_count,
-        ),
-      )
-      let command = agent_loop_control_invoke(opts, budget, loop_state)
-      let applied = agent_loop_apply_command(
-        {
-          command: command,
-          session_id: session.session_id,
-          iteration: iteration,
-          current_max: current_max,
-          extensions_used: extensions_used,
-          decisions: budget_decisions,
-          budget: budget,
-        },
-      )
-      current_max = applied.current_max
-      extensions_used = applied.extensions_used
-      budget_decisions = applied.decisions
-      if applied.stop {
-        final_status = applied.final_status
-        stop_reason = applied.stop_reason
-        break
+          "reserved_terminal_verify",
+          {phase: "verify_failed", iteration: iteration, terminal_status: final_status},
+        )
+        if terminal_verify_reserve_remaining > 0 && verify_attempts < max_verify_attempts {
+          terminal_verify_reserve_remaining = terminal_verify_reserve_remaining - 1
+          agent_emit_event(
+            session.session_id,
+            "reserved_terminal_verify",
+            {
+              phase: "grant",
+              reserve_remaining: terminal_verify_reserve_remaining,
+              iteration: iteration,
+              prior_status: final_status,
+            },
+          )
+          current_max = current_max + 1
+          final_status = ""
+          stop_reason = nil
+          budget_exhausted_emitted = false
+          continue
+        }
+        stop_reason = "reserved_terminal_verify_failed"
       }
-    }
-    if final_status == "" && iteration >= current_max && stop_reason == nil {
-      final_status = "budget_exhausted"
+      break
     }
     if final_status == "budget_exhausted" && !budget_exhausted_emitted {
       let terminal_exhaustion = __agent_loop_budget_aggregates(session.session_id, nil, loop_start_ms)
@@ -4145,6 +4268,48 @@ fn __agent_loop_run(message, session, initial_opts) {
   return unwrap(run)
 }
 
+// Reserved terminal-verify guard (default OFF). `terminal_write_unverified`
+// tracks whether the transcript has a source write that no passing
+// verification has cleared; `terminal_verify_reserve_remaining` is the
+// held-back iteration allowance the main loop cannot consume — it is only
+// granted (as a bounded extension of `current_max`) when the loop would
+// otherwise terminate on a budget/stuck boundary with an unverified red
+// edit, so the run runs a final verify(+repair) instead of stopping blind.
+// A genuine PASSING verification this turn (the diagnostic fold cleared the
+// current-failure model to "pass" on a non-edit turn) is real evidence the
+// workspace is green, so the reserved guard's unverified-write debt is
+// satisfied. Edit turns that report "pass" are the edit's own success, not
+// a verification, and the fold keeps the failure model armed there.
+// Reserved terminal-verify bookkeeping: any successful source edit leaves
+// the transcript with an unverified write until a verification passes.
+// Broader twin of `reverify_owed` (which arms only after a PRIOR failure);
+// the reserved guard fires on ANY unverified edit so a model that writes
+// source then exhausts budget without ever testing is still caught. Cleared
+// at every verify-pass point below (mirrors the `reverify_owed: false`
+// clears) and on a passing diagnostic fold above.
+// The iteration-count boundary (`while iteration < current_max` falling
+// through) terminates without setting `final_status`; resolve it to the
+// real budget terminal here so the reserved-verify guard below sees an
+// accurate status before deciding whether to spend the reserve.
+// Reserved terminal-verify guard (default OFF). The inner loop has stopped.
+// If the run is terminating on a budget/stuck boundary while a source write
+// is still unverified, run the declared verifier ONCE here (verify-first).
+// A green build completes the run `done`; a red build surfaces the actual
+// verifier failure (never a silent `budget_exhausted`) and, if reserve
+// iterations remain, grants exactly one bounded repair turn before
+// re-verifying on the next terminal pass. The reserve lives OUTSIDE the
+// main `current_max`, so normal iterations cannot consume it, and it is
+// hard-capped so it can never loop forever. This is the budget-exit
+// counterpart to #3629's loop-cap done-conversion (which fires only when an
+// in-loop reverify ALREADY confirmed green). When OFF the reserve is 0 and
+// this whole block is a no-op — byte-identical to today.
+// Green: the unverified write is now verified; complete the run.
+// Red: the verify RAN and its failure is surfaced (feedback already
+// injected by agent_verify_or_continue), so the run can never end blind.
+// Spend one reserve iteration on a bounded repair turn; the model reads
+// the injected verify failure and edits, then we re-verify next pass.
+// Reserve exhausted: keep the terminal status but stamp that the verify
+// ran and failed, so the terminal reflects the real (red) build state.
 // Whether THIS turn actually issued tool calls. When it did, the
 // "narration loop" framing is false (the model is acting, not narrating)
 // so the nudge steers toward a DIFFERENT change instead.

--- a/crates/harn-stdlib/src/stdlib/agent/stall.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/stall.harn
@@ -72,6 +72,19 @@ const STALL_STUCK_SAME_DIAGNOSTIC_AFTER = 3
 // so the strategy-shift nudge fires before/with the extension cut, not after.
 const STALL_NO_NET_PROGRESS_EXTEND_AFTER = 3
 
+// Reserved terminal-verify guard (default OFF, gated by
+// `reserved_terminal_verify`): how many iterations are HELD BACK from the main
+// loop as a terminal allowance the normal iterations cannot consume. When the
+// loop would otherwise terminate on a budget/iteration boundary while the
+// transcript still has an UNVERIFIED source write (the model wrote source then
+// ran out of runway), the loop spends this reserve on a final verify(+repair)
+// pass instead of terminating blind on a red build. Bounded so the reserve can
+// never itself loop forever: the reserve grants at most this many extra
+// iterations, and the terminal-verify mandate forces a verification on each one
+// (a passing verify ends the run as `done`, a red build surfaces the actual
+// verifier failure rather than a silent `budget_exhausted`).
+const STALL_RESERVED_TERMINAL_VERIFY_ITERATIONS = 2
+
 // consecutive un-recovered trips before a hard stop is recommended. A trip
 // "recovers" when a turn produces a step that does not itself trip (the agent
 // broke the loop). Past this many back-to-back trips the detector flags
@@ -124,6 +137,8 @@ type AgentStallConfig = {
   post_edit_reverify: bool,
   no_net_progress_extend_guard: bool,
   no_net_progress_extend_after: int,
+  reserved_terminal_verify: bool,
+  reserved_terminal_verify_iterations: int,
 }
 
 type AgentStallWarning = {
@@ -281,6 +296,12 @@ fn __agent_stall_config(value) -> AgentStallConfig {
     post_edit_reverify: __agent_stall_bool(value?.post_edit_reverify, true, "post_edit_reverify"),
     no_net_progress_extend_guard: __agent_stall_bool(value?.no_net_progress_extend_guard, false, "no_net_progress_extend_guard"),
     no_net_progress_extend_after: __agent_stall_int(value?.no_net_progress_extend_after, STALL_NO_NET_PROGRESS_EXTEND_AFTER, 2),
+    reserved_terminal_verify: __agent_stall_bool(value?.reserved_terminal_verify, false, "reserved_terminal_verify"),
+    reserved_terminal_verify_iterations: __agent_stall_int(
+      value?.reserved_terminal_verify_iterations,
+      STALL_RESERVED_TERMINAL_VERIFY_ITERATIONS,
+      1,
+    ),
   }
 }
 
@@ -1274,8 +1295,9 @@ pub fn agent_stall_observe_tool_calls(
 
 /**
  * agent_stall_repair_config exposes the parsed evidence-aware repair knobs
- * (repair_aware / post_edit_reverify / stuck_same_diagnostic_after) so the
- * agent loop can decide whether to honor the post-edit re-verify mandate
+ * (repair_aware / post_edit_reverify / stuck_same_diagnostic_after /
+ * reserved_terminal_verify[_iterations]) so the agent loop can decide whether to
+ * honor the post-edit re-verify mandate and the reserved terminal-verify guard
  * without reaching into the private config parser.
  *
  * @effects: []
@@ -1290,6 +1312,8 @@ pub fn agent_stall_repair_config(raw_config) -> dict {
     stuck_same_diagnostic_after: config.stuck_same_diagnostic_after,
     no_net_progress_extend_guard: config.no_net_progress_extend_guard,
     no_net_progress_extend_after: config.no_net_progress_extend_after,
+    reserved_terminal_verify: config.reserved_terminal_verify,
+    reserved_terminal_verify_iterations: config.reserved_terminal_verify_iterations,
   }
 }
 

--- a/crates/harn-vm/src/agent_events/agent.rs
+++ b/crates/harn-vm/src/agent_events/agent.rs
@@ -371,6 +371,20 @@ pub enum AgentEvent {
         session_id: String,
         payload: serde_json::Value,
     },
+    /// Emitted by the reserved-budget terminal-verify guard
+    /// (`agent_emit_event("reserved_terminal_verify", payload)`). The guard
+    /// holds back a small iteration reserve the main loop cannot consume; when
+    /// the loop would otherwise terminate on a budget/stuck boundary with an
+    /// unverified source write, it spends the reserve on a final verify(+repair)
+    /// instead of ending blind on a red build. The payload's `phase` field tags
+    /// the step (`grant` / `verify_passed` / `verify_failed`) so replayers and
+    /// operators can see the guard fire and its outcome. Payload-preserving like
+    /// `LoopStuckSignal` so the guard can carry richer detail without inventing
+    /// another wire kind.
+    ReservedTerminalVerify {
+        session_id: String,
+        payload: serde_json::Value,
+    },
     /// Emitted when the daemon idle-wait loop trips its watchdog because
     /// every configured wake source returned `None` for N consecutive
     /// attempts. Exists so a broken daemon doesn't hang the session
@@ -832,6 +846,7 @@ impl AgentEvent {
             | Self::BudgetCircuitBreaker { session_id, .. }
             | Self::LoopStuck { session_id, .. }
             | Self::LoopStuckSignal { session_id, .. }
+            | Self::ReservedTerminalVerify { session_id, .. }
             | Self::DaemonWatchdogTripped { session_id, .. }
             | Self::SkillActivated { session_id, .. }
             | Self::SkillDeactivated { session_id, .. }

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -1852,6 +1852,7 @@ async fn host_agent_emit_event(
             | "budget_exhausted"
             | "budget_circuit_breaker"
             | "loop_stuck"
+            | "reserved_terminal_verify"
             | "context_overflow_recovery"
             | "loop_checkpoint"
     ) {
@@ -2192,6 +2193,10 @@ fn build_agent_event(
             paused_for_ms: get_u64("paused_for_ms"),
         }),
         "loop_stuck" => Ok(AgentEvent::LoopStuckSignal {
+            session_id: session_id.to_string(),
+            payload: payload.clone(),
+        }),
+        "reserved_terminal_verify" => Ok(AgentEvent::ReservedTerminalVerify {
             session_id: session_id.to_string(),
             payload: payload.clone(),
         }),

--- a/spec/protocol-artifacts/HarnProtocol.swift
+++ b/spec/protocol-artifacts/HarnProtocol.swift
@@ -102,6 +102,7 @@ public enum HarnProtocolConstants {
         "mcp_catalog_changed",
         "mcp_notification",
         "progress_reported",
+        "reserved_terminal_verify",
         "scope_classifier_verdict",
         "session_closed",
         "structural_validator_decision",

--- a/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
+++ b/spec/protocol-artifacts/go/harnprotocol/harnprotocol.go
@@ -185,6 +185,7 @@ var HarnAgentEventKinds = []HarnAgentEventKind{
 	"mcp_catalog_changed",
 	"mcp_notification",
 	"progress_reported",
+	"reserved_terminal_verify",
 	"scope_classifier_verdict",
 	"session_closed",
 	"structural_validator_decision",

--- a/spec/protocol-artifacts/harn-protocol.rs
+++ b/spec/protocol-artifacts/harn-protocol.rs
@@ -334,6 +334,7 @@ pub const HARN_AGENT_EVENT_KIND_MCP_AUTH_REQUIRED: &str = "mcp_auth_required";
 pub const HARN_AGENT_EVENT_KIND_MCP_CATALOG_CHANGED: &str = "mcp_catalog_changed";
 pub const HARN_AGENT_EVENT_KIND_MCP_NOTIFICATION: &str = "mcp_notification";
 pub const HARN_AGENT_EVENT_KIND_PROGRESS_REPORTED: &str = "progress_reported";
+pub const HARN_AGENT_EVENT_KIND_RESERVED_TERMINAL_VERIFY: &str = "reserved_terminal_verify";
 pub const HARN_AGENT_EVENT_KIND_SCOPE_CLASSIFIER_VERDICT: &str = "scope_classifier_verdict";
 pub const HARN_AGENT_EVENT_KIND_SESSION_CLOSED: &str = "session_closed";
 pub const HARN_AGENT_EVENT_KIND_STRUCTURAL_VALIDATOR_DECISION: &str = "structural_validator_decision";
@@ -364,6 +365,7 @@ pub const HARN_AGENT_EVENT_KINDS: &[&str] = &[
     "mcp_catalog_changed",
     "mcp_notification",
     "progress_reported",
+    "reserved_terminal_verify",
     "scope_classifier_verdict",
     "session_closed",
     "structural_validator_decision",

--- a/spec/protocol-artifacts/harn-protocol.ts
+++ b/spec/protocol-artifacts/harn-protocol.ts
@@ -149,6 +149,7 @@ export const HARN_AGENT_EVENT_KINDS = [
   "mcp_catalog_changed",
   "mcp_notification",
   "progress_reported",
+  "reserved_terminal_verify",
   "scope_classifier_verdict",
   "session_closed",
   "structural_validator_decision",

--- a/spec/protocol-artifacts/manifest.json
+++ b/spec/protocol-artifacts/manifest.json
@@ -100,6 +100,7 @@
       "mcp_catalog_changed",
       "mcp_notification",
       "progress_reported",
+      "reserved_terminal_verify",
       "scope_classifier_verdict",
       "session_closed",
       "structural_validator_decision",

--- a/spec/protocol-artifacts/python/harn_protocol.py
+++ b/spec/protocol-artifacts/python/harn_protocol.py
@@ -235,6 +235,7 @@ HARN_AGENT_EVENT_KINDS: tuple = (
     "mcp_catalog_changed",
     "mcp_notification",
     "progress_reported",
+    "reserved_terminal_verify",
     "scope_classifier_verdict",
     "session_closed",
     "structural_validator_decision",

--- a/spec/protocol-artifacts/schemas/acp-session-update.schema.json
+++ b/spec/protocol-artifacts/schemas/acp-session-update.schema.json
@@ -126,6 +126,7 @@
                 "mcp_catalog_changed",
                 "mcp_notification",
                 "progress_reported",
+                "reserved_terminal_verify",
                 "scope_classifier_verdict",
                 "session_closed",
                 "structural_validator_decision",


### PR DESCRIPTION
## The gap (after #3629)

#3628 closed the sentinel path of declared-done-with-red-build, and **#3629 added a loop-CAP done-conversion** that fires when an in-loop reverify ALREADY confirmed green at `iteration >= current_max`. **But the BUDGET / TOKEN / WALL-CLOCK exhaustion exit is still open.** In `crates/harn-stdlib/src/stdlib/agent/loop.harn`:

- `boundary_exhaustion.exhausted` break (~3150, wall-clock/cost)
- `agent_budget_post_call_blocked` breaks (~3704 / ~3764, token/cost)
- `exhaustion.exhausted` break (~3756)
- the natural `while iteration < current_max` fall-through

…all set `final_status = "budget_exhausted"` and break with **no terminal verify** when the model edited but no in-loop reverify fired (e.g. it wrote source and never ran a failing test, so `has_live_failure` was never set, so #3629's `post_edit_reverify_confirmed` is never true). A model that writes source then runs out of runway terminates RED. That is the dominant **zig-feat** failure mode (it exits `budget_exhausted`).

## Coverage verdict on #3629

#3629's only terminal addition is `if should_continue && post_edit_reverify_confirmed && iteration >= current_max { final_status = "done" }`. `post_edit_reverify_confirmed` is set **only** when an in-loop `reverify_mandated` verify ran and passed. It does **not** guard any of the budget/token/cost/wall-clock terminal breaks. So #3629 covers loop-cap-after-confirmed-green; this PR covers the budget-exit-after-unverified-edit residual. **Complementary, not duplicate** — this PR reuses #3629's `__agent_loop_verify_closure_exists` and `__agent_loop_post_edit_reverify_mandated` helpers.

## What this lands — the reserved-budget terminal verify

- **Default-OFF tracked flag** `stall_diagnostics.reserved_terminal_verify` + tunable `reserved_terminal_verify_iterations` (default 2), through the existing `agent_stall_repair_config` plumbing.
- `terminal_write_unverified`: set true on any successful source edit, cleared on any passing verification (reuses the `reverify_owed` clear points + the passing-diagnostic fold). Broader twin of the in-loop mandate, which only arms after a *prior* failure.
- **One centralized post-loop seam** (the main `while` is wrapped in an outer loop) runs the declared verifier once when the run would terminate `budget_exhausted`/`stuck` with an unverified write (**verify-first**). Green → `done`; red → surfaces the actual verifier failure (`reserved_terminal_verify_failed`) and, while reserve remains, spends one on a **bounded repair turn** before re-verifying. Reserve lives outside `current_max` (normal iterations can't consume it) and is hard-capped (can't loop forever). **The run never ends silently on an unverified red edit.**
- **OFF = byte-identical to today** — all 239 agents conformance tests pass, including #3629's `repair_post_edit_reverify_mandate`.
- New `reserved_terminal_verify` agent event (typed `ReservedTerminalVerify` variant, payload-preserving like `LoopStuckSignal`) on the transcript + ACP ext stream; added to `HARN_AGENT_EVENT_KINDS` + the acp-session-update schema; protocol artifacts regenerated.

## Proof

`conformance/tests/agents/reserved_terminal_verify_guard.harn` exercises the **exact residual #3629 cannot reach** (`max_iterations=2`, edit-only, no in-loop failing test → `post_edit_reverify_confirmed` is provably never set):
1. **ON, repair lands:** edit → iteration budget exhausts → reserved verify fires (red) → reserve grants a repair turn → re-verify passes → terminates `done`.
2. **ON, repair never lands:** reserve spent, the terminal verify still **runs** and surfaces the red, bounded.
3. **OFF control:** no reserved-verify events, plain `budget_exhausted` — byte-identical.

Local CI surface green: `harn fmt --check`, `cargo fmt --check`, `dump-protocol-artifacts --check`, `check_protocol_bindings.py`, 239 agents + 34 protocol conformance, `harn-vm`/`harn-serve` tests. (One pre-existing `harn-vm` test `process_exec_injects_workspace_local_tmpdir` fails identically on clean origin/main — macOS `/private/var` symlink quirk, unrelated.)

This is a conformance **spec edit**: adds a new behavioral test + a new agent-event kind; no existing `.expected` baseline changed.

## Owed gate

**Owes the paired N≥5 meter-holdout gate** (does it move zig-feat off 0/5 with a paired 95% CI lower bound > 0) before the flag may default ON. **No convergence flip is claimed here.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)