### PR TITLE
Fix macOS TMPDIR path alias assertions

### DIFF
--- a/changelog.d/process-tmpdir-canonicalize.fixed.md
+++ b/changelog.d/process-tmpdir-canonicalize.fixed.md
@@ -1,0 +1,1 @@
+- Fixed macOS process TMPDIR assertions to handle `/var` and `/private/var` path aliases.

--- a/crates/harn-hostlib/tests/process_tools_e2e.rs
+++ b/crates/harn-hostlib/tests/process_tools_e2e.rs
@@ -196,6 +196,8 @@ fn real_run_command_points_child_tmpdir_inside_the_workspace() {
     }
 
     let child_env = require_str(&resp, "stdout");
+    let expected =
+        std::fs::canonicalize(&expected).expect("workspace-local temp dir should canonicalize");
     let expected_line = format!("TMPDIR={}", expected.display());
     assert!(
         child_env.lines().any(|line| line == expected_line),

--- a/crates/harn-vm/src/stdlib/host.rs
+++ b/crates/harn-vm/src/stdlib/host.rs
@@ -1760,8 +1760,12 @@ mod tests {
                 "sandboxed child must receive a non-empty TMPDIR"
             );
             let tmpdir_path = std::path::PathBuf::from(&tmpdir);
+            let canonical_tmpdir = std::fs::canonicalize(&tmpdir_path)
+                .expect("workspace-local TMPDIR should canonicalize");
+            let canonical_workspace =
+                std::fs::canonicalize(workspace.path()).expect("workspace should canonicalize");
             assert!(
-                tmpdir_path.starts_with(workspace.path()),
+                canonical_tmpdir.starts_with(&canonical_workspace),
                 "child TMPDIR {tmpdir:?} must live inside the workspace {:?}",
                 workspace.path()
             );


### PR DESCRIPTION
## Summary
- canonicalize workspace-local TMPDIR paths in the Harn VM process.exec test before checking workspace containment
- canonicalize the expected workspace .harn-tmp path in the harn-hostlib e2e env assertion
- add a changelog fragment for the macOS path-alias fix

## Verification
- cargo test -p harn-vm stdlib::host::tests::process_exec_injects_workspace_local_tmpdir -- --nocapture
- cargo test -p harn-hostlib real_run_command_points_child_tmpdir_inside_the_workspace -- --nocapture
- cargo fmt --check
- git diff --check
- pre-commit hook: markdown, Rust formatting, Rust prompt-prose ratchet, changed-package clippy, highlight keyword check
- pre-push hook: markdown, targeted local checks, highlight keyword check