### PR TITLE
fix: make Qwen llama.cpp local profile memory-aware

### DIFF
--- a/changelog.d/3624.fixed.md
+++ b/changelog.d/3624.fixed.md
@@ -1,0 +1,3 @@
+Make the Qwen3.6 llama.cpp local profile choose context length from host memory
+facts instead of a fixed 65k cap, and remove the stale hybrid-cache reprocess
+gate.

--- a/crates/harn-cli/src/commands/hardware.rs
+++ b/crates/harn-cli/src/commands/hardware.rs
@@ -21,6 +21,8 @@ pub(crate) struct RamSnapshot {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct GpuSnapshot {
     pub kind: GpuKind,
+    pub total_memory_bytes: Option<u64>,
+    pub free_memory_bytes: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -53,6 +55,10 @@ pub(crate) fn bytes_to_gib_rounded(bytes: u64) -> u64 {
 
 pub(crate) fn bytes_to_gib_floor(bytes: u64) -> u64 {
     bytes / GIB
+}
+
+pub(crate) fn bytes_to_gib_f64(bytes: u64) -> f64 {
+    bytes as f64 / GIB as f64
 }
 
 fn detect_ram() -> RamSnapshot {
@@ -88,23 +94,49 @@ fn detect_gpu() -> GpuSnapshot {
     #[cfg(target_os = "macos")]
     {
         if Path::new("/System/Library/Frameworks/MetalPerformanceShaders.framework").exists() {
-            return GpuSnapshot { kind: GpuKind::Mps };
+            return GpuSnapshot {
+                kind: GpuKind::Mps,
+                total_memory_bytes: None,
+                free_memory_bytes: None,
+            };
         }
     }
 
-    if Command::new("nvidia-smi")
-        .arg("-L")
-        .output()
-        .is_ok_and(|output| output.status.success())
-    {
+    if let Some((total, free)) = detect_nvidia_memory_bytes() {
         return GpuSnapshot {
             kind: GpuKind::Cuda,
+            total_memory_bytes: Some(total),
+            free_memory_bytes: Some(free),
         };
     }
 
     GpuSnapshot {
         kind: GpuKind::None,
+        total_memory_bytes: None,
+        free_memory_bytes: None,
     }
+}
+
+fn detect_nvidia_memory_bytes() -> Option<(u64, u64)> {
+    let output = Command::new("nvidia-smi")
+        .args([
+            "--query-gpu=memory.total,memory.free",
+            "--format=csv,noheader,nounits",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_nvidia_memory_csv(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn parse_nvidia_memory_csv(text: &str) -> Option<(u64, u64)> {
+    let line = text.lines().find(|line| !line.trim().is_empty())?;
+    let mut parts = line.split(',').map(str::trim);
+    let total_mib = parts.next()?.parse::<u64>().ok()?;
+    let free_mib = parts.next()?.parse::<u64>().ok()?;
+    Some((total_mib * 1024 * 1024, free_mib * 1024 * 1024))
 }
 
 fn detect_disk(path: &Path) -> DiskSnapshot {
@@ -177,7 +209,10 @@ fn parse_page_count(value: &str) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
-    use super::{bytes_to_gib_rounded, parse_linux_meminfo, parse_macos_vm_stat, RamSnapshot, GIB};
+    use super::{
+        bytes_to_gib_rounded, parse_linux_meminfo, parse_macos_vm_stat, parse_nvidia_memory_csv,
+        RamSnapshot, GIB,
+    };
 
     #[test]
     fn linux_meminfo_reports_total_and_available_bytes() {
@@ -211,5 +246,13 @@ mod tests {
     fn gib_formatting_rounds_to_nearest_gib() {
         assert_eq!(bytes_to_gib_rounded(8 * GIB), 8);
         assert_eq!(bytes_to_gib_rounded(8 * GIB + GIB / 2), 9);
+    }
+
+    #[test]
+    fn nvidia_memory_csv_reports_first_gpu_bytes() {
+        assert_eq!(
+            parse_nvidia_memory_csv("32607, 20480\n24576, 12000\n"),
+            Some((32607 * 1024 * 1024, 20480 * 1024 * 1024))
+        );
     }
 }

--- a/crates/harn-cli/src/commands/local/launch.rs
+++ b/crates/harn-cli/src/commands/local/launch.rs
@@ -962,6 +962,8 @@ mod tests {
             },
             gpu: GpuSnapshot {
                 kind: GpuKind::None,
+                total_memory_bytes: None,
+                free_memory_bytes: None,
             },
             disk: DiskSnapshot {
                 path: PathBuf::from("."),

--- a/crates/harn-cli/src/commands/local/profile.rs
+++ b/crates/harn-cli/src/commands/local/profile.rs
@@ -7,7 +7,10 @@
 //! configuration.
 
 use crate::cli::LocalProfileArgs;
-use crate::commands::hardware::{bytes_to_gib_floor, GpuKind, HardwareSnapshot};
+use crate::commands::hardware::{
+    bytes_to_gib_f64, bytes_to_gib_floor, collect_hardware_snapshot, GpuKind, HardwareSnapshot,
+};
+use harn_vm::llm::local_profiles::RuntimeProfileHost;
 
 /// Recommended defaults the user can opt out of with `--ctx` / `--keep-alive`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -77,9 +80,19 @@ pub(crate) fn defaults_for(hardware: &HardwareSnapshot) -> LocalDefaults {
 }
 
 pub(crate) fn run(args: LocalProfileArgs) -> Result<(), String> {
-    let report = harn_vm::llm::local_profiles::local_runtime_profile_report(
-        &args.model,
-        args.provider.as_deref(),
+    let hardware = collect_hardware_snapshot();
+    let resolved = harn_vm::llm_config::resolve_model_info(&args.model);
+    let provider = args
+        .provider
+        .as_deref()
+        .map(str::trim)
+        .filter(|provider| !provider.is_empty())
+        .unwrap_or(&resolved.provider);
+    let report = harn_vm::llm::local_profiles::local_runtime_profile_report_for_host(
+        resolved.alias.as_deref(),
+        &resolved.id,
+        provider,
+        Some(runtime_profile_host(&hardware)),
     );
     if args.json {
         println!(
@@ -108,6 +121,13 @@ pub(crate) fn run(args: LocalProfileArgs) -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+pub(crate) fn runtime_profile_host(hardware: &HardwareSnapshot) -> RuntimeProfileHost {
+    RuntimeProfileHost {
+        system_available_gib: hardware.ram.available_bytes.map(bytes_to_gib_f64),
+        accelerator_free_gib: hardware.gpu.free_memory_bytes.map(bytes_to_gib_f64),
+    }
 }
 
 fn bucket_for(hardware: &HardwareSnapshot) -> ProfileBucket {
@@ -140,7 +160,11 @@ mod tests {
                 total_bytes: Some(total_gib * GIB),
                 available_bytes: Some(total_gib * GIB / 2),
             },
-            gpu: GpuSnapshot { kind: gpu },
+            gpu: GpuSnapshot {
+                kind: gpu,
+                total_memory_bytes: None,
+                free_memory_bytes: None,
+            },
             disk: DiskSnapshot {
                 path: PathBuf::from("/tmp"),
                 free_bytes: Some(128 * GIB),

--- a/crates/harn-cli/src/commands/local/switch.rs
+++ b/crates/harn-cli/src/commands/local/switch.rs
@@ -21,8 +21,8 @@ use std::path::Path;
 use std::time::Duration;
 
 use harn_vm::llm::local_profiles::{
-    evaluate_runtime_profile_gate, local_runtime_profile_report_for, LocalRuntimeProfileReport,
-    RuntimeProbeEvidence, RuntimeProfileGate,
+    evaluate_runtime_profile_gate, LocalRuntimeProfileReport, RuntimeProbeEvidence,
+    RuntimeProfileGate,
 };
 use harn_vm::llm::readiness::probe_provider_readiness;
 use harn_vm::llm::{
@@ -35,7 +35,7 @@ use serde::Serialize;
 use crate::cli::LocalSwitchArgs;
 use crate::commands::hardware::collect_hardware_snapshot;
 
-use super::profile::defaults_for;
+use super::profile::{defaults_for, runtime_profile_host};
 use super::runtime::{
     local_provider_ids, ollama_unload_model, resolve_provider_def, snapshot_provider, terminate_pid,
 };
@@ -78,8 +78,13 @@ pub(crate) async fn run(args: LocalSwitchArgs, base_dir: &Path) -> Result<(), St
             local_provider_ids(None).join(", ")
         ));
     }
-    let runtime_profile =
-        local_runtime_profile_report_for(resolved.alias.as_deref(), &resolved.id, &provider);
+    let hardware = collect_hardware_snapshot();
+    let runtime_profile = harn_vm::llm::local_profiles::local_runtime_profile_report_for_host(
+        resolved.alias.as_deref(),
+        &resolved.id,
+        &provider,
+        Some(runtime_profile_host(&hardware)),
+    );
     let evidence = load_runtime_probe_evidence(&args)?;
     let profile_gate = evaluate_runtime_profile_gate(&runtime_profile, &evidence, args.force);
     if !profile_gate.allowed {
@@ -92,9 +97,14 @@ pub(crate) async fn run(args: LocalSwitchArgs, base_dir: &Path) -> Result<(), St
 
     let def = resolve_provider_def(&provider)?;
     let base_url = llm_config::resolve_base_url(&def);
-    let hardware = collect_hardware_snapshot();
     let defaults = defaults_for(&hardware);
-    let ctx = args.ctx.unwrap_or(defaults.ctx);
+    let ctx = args.ctx.unwrap_or_else(|| {
+        runtime_profile
+            .selected
+            .recommended_num_ctx
+            .filter(|recommended| *recommended > defaults.ctx)
+            .unwrap_or(defaults.ctx)
+    });
     let keep_alive = args
         .keep_alive
         .clone()

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/80-local-runtimes.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/80-local-runtimes.toml
@@ -3,7 +3,7 @@
 name = "Qwen3.6 35B (Unsloth Q4_K_XL, llama.cpp)"
 provider = "llamacpp"
 context_window = 262144
-runtime_context_window = 65536
+runtime_context_window = 262144
 stream_timeout = 900.0
 capabilities = ["tools", "streaming", "thinking"]
 tier = "mid"
@@ -14,13 +14,13 @@ measured_resident_gib = 19.5
 measured_context_window = 8192
 measured_cache_type = "q8_0"
 base_resident_gib = 19.0
-kv_cache_gib_per_1k_ctx = 0.10
+kv_cache_gib_per_1k_ctx = 0.0135
 default_cache_type = "q8_0"
 safety_margin_gib = 4.0
-max_recommended_context = 65536
+max_recommended_context = 262144
 cache_type_multipliers = { q8_0 = 1.0, f16 = 2.0, q4_0 = 0.5, q4_1 = 0.5, q5_0 = 0.625, q5_1 = 0.625 }
-last_verified = "2026-06-05"
-notes = "Empirical llama-server RSS was about 19.5 GiB at ctx=8192 with q8_0 KV on Apple Silicon. Treat as a conservative launch guard, not an exact allocator model."
+last_verified = "2026-06-28"
+notes = "Empirical llama.cpp b9821 / CUDA 12.8 / RTX 5090 measurements with q8_0 KV showed SWA-capped KV growth of about 0.87 GiB per 65k tokens and full 262144 ctx fitting with headroom. Treat as a sizing estimate, not an allocator guarantee."
 [models."qwen3.6-35b-a3b-ud-q5-k-xl"]
 name = "Qwen3.6 35B (Unsloth Q5_K_XL, llama.cpp)"
 provider = "llamacpp"

--- a/crates/harn-vm/src/llm/local_profiles.rs
+++ b/crates/harn-vm/src/llm/local_profiles.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde::{Deserialize, Serialize};
 
 use super::tool_conformance::{report_satisfies_required_probe, ToolConformanceReport};
-use crate::llm_config;
+use crate::llm_config::{self, LocalMemoryDef, ModelDef};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -58,6 +58,12 @@ pub struct LocalRuntimeProfileReport {
     pub requires_probe_gate: bool,
     pub selected: RuntimeProfile,
     pub runtime_profiles: BTreeMap<String, RuntimeProfile>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct RuntimeProfileHost {
+    pub system_available_gib: Option<f64>,
+    pub accelerator_free_gib: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -133,8 +139,30 @@ pub fn local_runtime_profile_report_for(
     model_id: &str,
     provider: &str,
 ) -> LocalRuntimeProfileReport {
+    local_runtime_profile_report_for_host(alias, model_id, provider, None)
+}
+
+pub fn local_runtime_profile_report_for_host(
+    alias: Option<&str>,
+    model_id: &str,
+    provider: &str,
+    host: Option<RuntimeProfileHost>,
+) -> LocalRuntimeProfileReport {
     let family = model_family(alias, model_id);
-    let runtime_profiles = profiles_for_family(family);
+    let catalog_model = llm_config::model_catalog_entry(model_id);
+    let runtime_profiles = profiles_for_family(family)
+        .into_iter()
+        .map(|(runtime, profile)| {
+            let adjusted = adjust_profile_for_host(
+                family,
+                &runtime,
+                catalog_model.as_ref(),
+                profile,
+                host.as_ref(),
+            );
+            (runtime, adjusted)
+        })
+        .collect::<BTreeMap<_, _>>();
     let selected = runtime_profiles
         .get(provider)
         .cloned()
@@ -238,18 +266,15 @@ fn profiles_for_family(family: &str) -> BTreeMap<String, RuntimeProfile> {
                 "llamacpp".to_string(),
                 profile(
                     RuntimeProfileStatus::Experimental,
-                    &["tool_probe", "two_turn_cache_probe"],
+                    &["tool_probe"],
                     Some(65_536),
+                    &["inflated_input_token_accounting_on_repeated_turns"],
                     &[
-                        "full_prompt_reprocess_on_hybrid_cache",
-                        "inflated_input_token_accounting_on_repeated_turns",
+                        "Run a tool probe before write-heavy evals.",
+                        "Record llama.cpp build, ctx, cache type, and prefix-cache telemetry in eval receipts.",
                     ],
                     &[
-                        "Run a two-turn cache probe before write-heavy evals.",
-                        "Prefer short-lived scan/edit loops until cache telemetry is clean.",
-                    ],
-                    &[
-                        "Qwen3.6-family GGUF stacks can pass simple edits while still re-prefilling expensive prefixes.",
+                        "Current llama.cpp builds reuse two-turn Qwen3.6 hybrid-cache prefixes; keep token accounting visible in receipts.",
                     ],
                 ),
             ),
@@ -349,6 +374,67 @@ fn profiles_for_family(family: &str) -> BTreeMap<String, RuntimeProfile> {
     }
 }
 
+fn adjust_profile_for_host(
+    family: &str,
+    runtime: &str,
+    model: Option<&ModelDef>,
+    mut profile: RuntimeProfile,
+    host: Option<&RuntimeProfileHost>,
+) -> RuntimeProfile {
+    if family == "qwen3.6-a3b-hybrid" && runtime == "llamacpp" {
+        if let (Some(model), Some(host)) = (model, host) {
+            if let Some(ctx) = recommended_context_from_local_memory(model, host) {
+                profile.recommended_num_ctx = Some(ctx);
+            }
+        }
+    }
+    profile
+}
+
+fn recommended_context_from_local_memory(
+    model: &ModelDef,
+    host: &RuntimeProfileHost,
+) -> Option<u64> {
+    let memory = model.local_memory.as_ref()?;
+    let available_gib = host
+        .accelerator_free_gib
+        .or(host.system_available_gib)
+        .filter(|available| *available > 0.0)?;
+    let base = memory.base_resident_gib?;
+    let kv_per_1k = scaled_kv_cache_gib_per_1k(memory)?;
+    let safety = memory.safety_margin_gib.unwrap_or(4.0);
+    let usable_for_kv = available_gib - base - safety;
+    if usable_for_kv <= 0.0 {
+        return Some(8_192);
+    }
+
+    let by_memory = ((usable_for_kv / kv_per_1k) * 1_000.0).floor() as u64;
+    let ceiling = memory
+        .max_recommended_context
+        .or(model.runtime_context_window)
+        .unwrap_or(model.context_window)
+        .min(model.context_window);
+    let floor = 65_536_u64.min(ceiling).min(model.context_window);
+    Some(round_context_down(by_memory.min(ceiling).max(floor)))
+}
+
+fn scaled_kv_cache_gib_per_1k(memory: &LocalMemoryDef) -> Option<f64> {
+    let base = memory.kv_cache_gib_per_1k_ctx?;
+    let multiplier = memory
+        .default_cache_type
+        .as_ref()
+        .and_then(|cache_type| memory.cache_type_multipliers.get(cache_type))
+        .copied()
+        .unwrap_or(1.0);
+    let scaled = base * multiplier;
+    (scaled > 0.0).then_some(scaled)
+}
+
+fn round_context_down(ctx: u64) -> u64 {
+    const STEP: u64 = 8_192;
+    (ctx / STEP).max(1) * STEP
+}
+
 fn generic_profile(provider: &str) -> RuntimeProfile {
     RuntimeProfile {
         status: RuntimeProfileStatus::Unknown,
@@ -399,10 +485,39 @@ mod tests {
 
         let llamacpp = local_runtime_profile_report("local-qwen3.6", Some("llamacpp"));
         assert_eq!(llamacpp.selected_status, RuntimeProfileStatus::Experimental);
-        assert!(llamacpp
+        assert_eq!(llamacpp.selected.requires, vec!["tool_probe".to_string()]);
+        assert!(!llamacpp
             .selected
             .known_risks
             .contains(&"full_prompt_reprocess_on_hybrid_cache".to_string()));
+    }
+
+    #[test]
+    fn qwen_llamacpp_profile_raises_context_when_accelerator_memory_fits() {
+        let report = local_runtime_profile_report_for_host(
+            Some("local-qwen3.6"),
+            "qwen3.6-35b-a3b-ud-q4-k-xl",
+            "llamacpp",
+            Some(RuntimeProfileHost {
+                system_available_gib: None,
+                accelerator_free_gib: Some(32.0),
+            }),
+        );
+        assert_eq!(report.selected.recommended_num_ctx, Some(262_144));
+    }
+
+    #[test]
+    fn qwen_llamacpp_profile_keeps_conservative_context_when_memory_is_tight() {
+        let report = local_runtime_profile_report_for_host(
+            Some("local-qwen3.6"),
+            "qwen3.6-35b-a3b-ud-q4-k-xl",
+            "llamacpp",
+            Some(RuntimeProfileHost {
+                system_available_gib: None,
+                accelerator_free_gib: Some(24.0),
+            }),
+        );
+        assert_eq!(report.selected.recommended_num_ctx, Some(73_728));
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -2560,7 +2560,7 @@ strengths = ["coding", "agentic"]
 name = "Qwen3.6 35B (Unsloth Q4_K_XL, llama.cpp)"
 provider = "llamacpp"
 context_window = 262144
-runtime_context_window = 65536
+runtime_context_window = 262144
 stream_timeout = 900.0
 capabilities = ["tools", "streaming", "thinking"]
 tier = "mid"
@@ -2571,13 +2571,13 @@ measured_resident_gib = 19.5
 measured_context_window = 8192
 measured_cache_type = "q8_0"
 base_resident_gib = 19.0
-kv_cache_gib_per_1k_ctx = 0.10
+kv_cache_gib_per_1k_ctx = 0.0135
 default_cache_type = "q8_0"
 safety_margin_gib = 4.0
-max_recommended_context = 65536
+max_recommended_context = 262144
 cache_type_multipliers = { q8_0 = 1.0, f16 = 2.0, q4_0 = 0.5, q4_1 = 0.5, q5_0 = 0.625, q5_1 = 0.625 }
-last_verified = "2026-06-05"
-notes = "Empirical llama-server RSS was about 19.5 GiB at ctx=8192 with q8_0 KV on Apple Silicon. Treat as a conservative launch guard, not an exact allocator model."
+last_verified = "2026-06-28"
+notes = "Empirical llama.cpp b9821 / CUDA 12.8 / RTX 5090 measurements with q8_0 KV showed SWA-capped KV growth of about 0.87 GiB per 65k tokens and full 262144 ctx fitting with headroom. Treat as a sizing estimate, not an allocator guarantee."
 [models."qwen3.6-35b-a3b-ud-q5-k-xl"]
 name = "Qwen3.6 35B (Unsloth Q5_K_XL, llama.cpp)"
 provider = "llamacpp"

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -5952,7 +5952,7 @@
         "measured_context_window": 8192,
         "measured_cache_type": "q8_0",
         "base_resident_gib": 19.0,
-        "kv_cache_gib_per_1k_ctx": 0.1,
+        "kv_cache_gib_per_1k_ctx": 0.0135,
         "cache_type_multipliers": {
           "f16": 2.0,
           "q4_0": 0.5,
@@ -5963,11 +5963,11 @@
         },
         "default_cache_type": "q8_0",
         "safety_margin_gib": 4.0,
-        "max_recommended_context": 65536,
-        "last_verified": "2026-06-05",
-        "notes": "Empirical llama-server RSS was about 19.5 GiB at ctx=8192 with q8_0 KV on Apple Silicon. Treat as a conservative launch guard, not an exact allocator model."
+        "max_recommended_context": 262144,
+        "last_verified": "2026-06-28",
+        "notes": "Empirical llama.cpp b9821 / CUDA 12.8 / RTX 5090 measurements with q8_0 KV showed SWA-capped KV growth of about 0.87 GiB per 65k tokens and full 262144 ctx fitting with headroom. Treat as a sizing estimate, not an allocator guarantee."
       },
-      "runtime_context_window": 65536,
+      "runtime_context_window": 262144,
       "stream_timeout": 900.0,
       "modalities": {
         "input": [


### PR DESCRIPTION
## Summary
- make local runtime profiles accept host memory context and compute Qwen3.6 llama.cpp `recommended_num_ctx` from catalog `local_memory` facts
- detect NVIDIA total/free memory for `harn local profile` / `harn local switch` and use the profile recommendation only when it safely raises the machine default
- remove the stale Qwen3.6 `full_prompt_reprocess_on_hybrid_cache` gate, keep a tool-probe gate, and refresh the Q4 GGUF catalog sizing facts/artifact

Closes #3624

## Verification
- `cargo fmt -p harn-vm -p harn-cli -- --check`
- `cargo test -p harn-vm local_profiles --lib`
- `cargo test -p harn-cli local::profile --lib`
- `cargo test -p harn-cli commands::hardware --lib`
- `make gen-provider-catalog`
- `make check-provider-catalog`
- `cargo fmt --all -- --check`
- `cargo test -p harn-cli local::switch --lib`
- `cargo test -p harn-cli local::launch --lib`
- `cargo test -p harn-vm llm_config::tests::test_local_ollama_catalog_metadata --lib`
- pre-commit hook: passed, including clippy on changed `harn-cli`/`harn-vm` packages
- pre-push hook: passed targeted local checks