### PR TITLE
[codex] Fix no-net-progress hard cap

### DIFF
--- a/changelog.d/stuck-ripcord-hard-cap.fixed.md
+++ b/changelog.d/stuck-ripcord-hard-cap.fixed.md
@@ -1,0 +1,7 @@
+- **`std/agent`: no-net-progress stall detection now has a hard failing-verify
+  floor.** When `stall_diagnostics.no_net_progress_extend_guard` is enabled,
+  Harn counts failing verification turns across changing diagnostic signatures
+  and successful edit calls, resets only on a clean verification pass, and emits
+  a terminal `no_net_progress_hard_cap` stuck warning once the hard cap is
+  crossed. This prevents slow-draining red-build loops from evading the existing
+  same-diagnostic no-net-progress guard.

--- a/conformance/tests/agents/no_net_progress_hard_cap_stops_varied_failures.expected
+++ b/conformance/tests/agents/no_net_progress_hard_cap_stops_varied_failures.expected
@@ -1,0 +1,7 @@
+stuck
+thrash_hard_stop
+1
+no_net_progress_hard_cap
+3
+true
+1

--- a/conformance/tests/agents/no_net_progress_hard_cap_stops_varied_failures.harn
+++ b/conformance/tests/agents/no_net_progress_hard_cap_stops_varied_failures.harn
@@ -1,0 +1,92 @@
+import { agent_capture_events } from "std/agent/events"
+import { with_llm_script } from "std/testing"
+
+/**
+ * No-net-progress hard cap: varied failing verification signatures must not
+ * evade terminal recovery. The same-diagnostic streak remains 1 throughout, but
+ * the independent failing-verify counter reaches the hard cap and stops through
+ * the existing `stuck` path.
+ */
+fn events_of(events, kind) {
+  return events.filter({ event -> event.type == kind })
+}
+
+fn define_failing_tool(tools, name, message) {
+  return tool_define(
+    tools,
+    name,
+    "Run one verification",
+    {
+      handler: { _args ->
+        throw message
+      },
+      parameters: {},
+      returns: {type: "string"},
+      annotations: {kind: "read"},
+    },
+  )
+}
+
+fn repair_tools() {
+  var tools = tool_registry()
+  tools = define_failing_tool(tools, "verify_a", "error A")
+  tools = define_failing_tool(tools, "verify_b", "error B")
+  tools = define_failing_tool(tools, "verify_c", "error C")
+  tools = define_failing_tool(tools, "verify_d", "error D")
+  return tools
+}
+
+fn verify_call(id, name) {
+  return {text: "", tool_calls: [{id: id, name: name, arguments: {}}]}
+}
+
+pipeline default() {
+  with_llm_script(
+    [
+      verify_call("a", "verify_a"),
+      verify_call("b", "verify_b"),
+      verify_call("c", "verify_c"),
+      verify_call("d", "verify_d"),
+    ],
+    { ->
+      let session = "no-net-hard-cap-" + uuid()
+      let captured = agent_capture_events(
+        session,
+        fn() { return agent_loop(
+          "Make the failing verification pass.",
+          nil,
+          {
+            provider: "mock",
+            tools: repair_tools(),
+            tool_format: "native",
+            loop_until_done: true,
+            max_iterations: 8,
+            session_id: session,
+            done_sentinel: "##DONE##",
+            stall_diagnostics: {
+              enabled: true,
+              repair_aware: false,
+              post_edit_reverify: true,
+              no_net_progress_extend_guard: true,
+              no_net_progress_extend_after: 99,
+              no_net_progress_hard_cap_after: 3,
+              repeat_same_error: 99,
+              repeat_same_observation: 99,
+              no_progress_messages: 99,
+              ping_pong_cycles: 99,
+            },
+          },
+        ) },
+      )
+      __io_println(captured.result.status)
+      __io_println(captured.result.stop_reason)
+      let stalls = events_of(captured.events, "agent_loop_stall_warning")
+      let hard_caps = stalls.filter({ s -> s.warning.pattern == "no_net_progress_hard_cap" })
+      __io_println(len(hard_caps))
+      __io_println(hard_caps[0].warning.pattern)
+      __io_println(hard_caps[0].warning.count)
+      __io_println(hard_caps[0].warning.hard_stop)
+      __io_println(captured.result?.current_failure?.same_diagnostic_streak)
+    },
+  )
+}

--- a/crates/harn-stdlib/src/stdlib/agent/presets.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/presets.harn
@@ -202,12 +202,22 @@ fn __tool_using_defaults(kind) {
       repair_aware: false,
       stuck_same_diagnostic_after: 3,
       post_edit_reverify: true,
+      no_net_progress_extend_guard: false,
+      no_net_progress_extend_after: 3,
+      no_net_progress_hard_cap_after: 16,
     },
     // Discovery surface (#repair-diagnostics). Mirrors the repair knobs above
     // so consumers (e.g. Burin, via a feature flag) can find and opt into the
     // evidence-aware repair loop without spelunking `stall_diagnostics`.
     // Subsumes Burin's futile-retry-guard.harn.
-    repair_diagnostics: {repair_aware: false, stuck_same_diagnostic_after: 3, post_edit_reverify: true},
+    repair_diagnostics: {
+      repair_aware: false,
+      stuck_same_diagnostic_after: 3,
+      post_edit_reverify: true,
+      no_net_progress_extend_guard: false,
+      no_net_progress_extend_after: 3,
+      no_net_progress_hard_cap_after: 16,
+    },
   }
 }
 

--- a/crates/harn-stdlib/src/stdlib/agent/stall.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/stall.harn
@@ -72,6 +72,14 @@ const STALL_STUCK_SAME_DIAGNOSTIC_AFTER = 3
 // so the strategy-shift nudge fires before/with the extension cut, not after.
 const STALL_NO_NET_PROGRESS_EXTEND_AFTER = 3
 
+// Hard no-net-progress floor (default OFF with `no_net_progress_extend_guard`):
+// a varied/slow-draining failure can dodge the same-diagnostic streak by
+// occasionally changing the failing signature while still never producing a
+// clean verification. Count failing verification turns independently and force a
+// terminal stuck stop once this cap is crossed. It resets ONLY on a clean
+// non-edit verification pass; edit success is not proof the build is green.
+const STALL_NO_NET_PROGRESS_HARD_CAP_AFTER = 16
+
 // Reserved terminal-verify guard (default OFF, gated by
 // `reserved_terminal_verify`): how many iterations are HELD BACK from the main
 // loop as a terminal allowance the normal iterations cannot consume. When the
@@ -137,6 +145,7 @@ type AgentStallConfig = {
   post_edit_reverify: bool,
   no_net_progress_extend_guard: bool,
   no_net_progress_extend_after: int,
+  no_net_progress_hard_cap_after: int,
   reserved_terminal_verify: bool,
   reserved_terminal_verify_iterations: int,
 }
@@ -181,6 +190,7 @@ type AgentStallState = {
   last_diagnostic_snippet: string,
   write_epoch: int,
   same_diagnostic_streak: int,
+  failing_verify_turns: int,
   edit_since_failure: bool,
   reverify_owed: bool,
 }
@@ -240,6 +250,9 @@ fn __agent_stall_default_config() -> AgentStallConfig {
     post_edit_reverify: true,
     no_net_progress_extend_guard: false,
     no_net_progress_extend_after: STALL_NO_NET_PROGRESS_EXTEND_AFTER,
+    no_net_progress_hard_cap_after: STALL_NO_NET_PROGRESS_HARD_CAP_AFTER,
+    reserved_terminal_verify: false,
+    reserved_terminal_verify_iterations: STALL_RESERVED_TERMINAL_VERIFY_ITERATIONS,
   }
 }
 
@@ -296,6 +309,7 @@ fn __agent_stall_config(value) -> AgentStallConfig {
     post_edit_reverify: __agent_stall_bool(value?.post_edit_reverify, true, "post_edit_reverify"),
     no_net_progress_extend_guard: __agent_stall_bool(value?.no_net_progress_extend_guard, false, "no_net_progress_extend_guard"),
     no_net_progress_extend_after: __agent_stall_int(value?.no_net_progress_extend_after, STALL_NO_NET_PROGRESS_EXTEND_AFTER, 2),
+    no_net_progress_hard_cap_after: __agent_stall_int(value?.no_net_progress_hard_cap_after, STALL_NO_NET_PROGRESS_HARD_CAP_AFTER, 2),
     reserved_terminal_verify: __agent_stall_bool(value?.reserved_terminal_verify, false, "reserved_terminal_verify"),
     reserved_terminal_verify_iterations: __agent_stall_int(
       value?.reserved_terminal_verify_iterations,
@@ -335,6 +349,7 @@ pub fn agent_stall_initial_state() -> AgentStallState {
     last_diagnostic_snippet: "",
     write_epoch: 0,
     same_diagnostic_streak: 0,
+    failing_verify_turns: 0,
     edit_since_failure: false,
     reverify_owed: false,
   }
@@ -581,6 +596,7 @@ fn __agent_stall_fold_diagnostic(state: AgentStallState, prev_dispatch, turn_mad
       last_diagnostic_snippet: "",
       write_epoch: new_write_epoch,
       same_diagnostic_streak: 0,
+      failing_verify_turns: 0,
       edit_since_failure: false,
       reverify_owed: false,
     }
@@ -599,6 +615,7 @@ fn __agent_stall_fold_diagnostic(state: AgentStallState, prev_dispatch, turn_mad
   } else {
     1
   }
+  let failing_turns = state.failing_verify_turns + 1
   // This is a verification result, so the post-edit re-verify mandate (if any)
   // has now been satisfied: clear reverify_owed and the edit-since marker. The
   // NEXT edit after this failure re-arms them.
@@ -609,6 +626,7 @@ fn __agent_stall_fold_diagnostic(state: AgentStallState, prev_dispatch, turn_mad
     last_diagnostic_snippet: __agent_stall_result_snippet(result),
     write_epoch: new_write_epoch,
     same_diagnostic_streak: new_streak,
+    failing_verify_turns: failing_turns,
     edit_since_failure: false,
     reverify_owed: false,
   }
@@ -669,6 +687,9 @@ fn __agent_stall_feedback_text(warning: AgentStallWarning) -> string {
     "your previous turn ended with a provider error and emitted no tool call ("
       + count
       + " in a row) — re-emit the intended tool call"
+  } else if pattern == "no_net_progress_hard_cap" {
+    count
+      + " failing verification turns occurred without a clean passing verify"
   } else if pattern == "ping_pong" {
     "the loop is ping-ponging between two actions (" + count + " cycles)"
   } else if pattern == "repeated_context_window_error" {
@@ -804,6 +825,14 @@ fn __agent_stall_update_ping_pong(state: AgentStallState, signature: string) -> 
 fn __agent_stall_register_trip(state: AgentStallState, config: AgentStallConfig) -> AgentStallState {
   let trips = state.consecutive_trips + 1
   return state + {consecutive_trips: trips, hard_stop: trips >= config.hard_stop_after_trips}
+}
+
+/**
+ * Apply a terminal hard-stop trip. Used for safety floors that should stop the
+ * run immediately rather than waiting for several warning/recovery cycles.
+ */
+fn __agent_stall_register_immediate_hard_stop(state: AgentStallState) -> AgentStallState {
+  return state + {consecutive_trips: state.consecutive_trips + 1, hard_stop: true}
 }
 
 /**
@@ -1193,6 +1222,40 @@ fn __agent_stall_apply_repair(
     return observation
   }
   let folded = __agent_stall_fold_diagnostic(observation.state, prev_dispatch, turn_made_edit)
+  let hard_cap_due = config.no_net_progress_extend_guard
+    && folded.last_diagnostic_class == "fail"
+    && folded.failing_verify_turns >= config.no_net_progress_hard_cap_after
+    && observation.state.failing_verify_turns < config.no_net_progress_hard_cap_after
+  if hard_cap_due {
+    let tripped = __agent_stall_register_immediate_hard_stop(folded)
+    let warning = __agent_stall_warning_record(
+      iteration,
+      "",
+      {},
+      tripped.last_diagnostic_signature,
+      "no_net_progress_hard_cap",
+      tripped.failing_verify_turns,
+      tripped.consecutive_trips,
+      true,
+      config,
+      config.no_net_progress_hard_cap_after,
+    )
+      + {
+      diagnostic_class: tripped.last_diagnostic_class,
+      diagnostic_signature: tripped.last_diagnostic_signature,
+      diagnostic_snippet: tripped.last_diagnostic_snippet,
+    }
+    let emitted = __agent_stall_maybe_emit(session_id, warning, config, tripped, defer_feedback)
+    let next_state = emitted.state + {warnings: emitted.state.warnings.push(warning)}
+    return {
+      state: next_state,
+      enabled: true,
+      warning: warning,
+      feedback_deferred: emitted.feedback_deferred ?? false,
+      config: config,
+      hard_stop: true,
+    }
+  }
   if !config.repair_aware {
     return observation + {state: folded}
   }
@@ -1312,6 +1375,7 @@ pub fn agent_stall_repair_config(raw_config) -> dict {
     stuck_same_diagnostic_after: config.stuck_same_diagnostic_after,
     no_net_progress_extend_guard: config.no_net_progress_extend_guard,
     no_net_progress_extend_after: config.no_net_progress_extend_after,
+    no_net_progress_hard_cap_after: config.no_net_progress_hard_cap_after,
     reserved_terminal_verify: config.reserved_terminal_verify,
     reserved_terminal_verify_iterations: config.reserved_terminal_verify_iterations,
   }
@@ -1326,13 +1390,13 @@ pub fn agent_stall_repair_config(raw_config) -> dict {
  * turn (no error draining toward a green build) buys unbounded runway. This
  * returns true ONLY when the guard is enabled AND the loop is on the verify-
  * bearing FAILING path (`last_diagnostic_class == "fail"`) AND the same failure
- * signature has recurred for at least `no_net_progress_extend_after` turns
- * (`same_diagnostic_streak`, which the diagnostic fold advances on the SAME
- * signature even across edits and RESETS when a productive edit changes the
- * error or a test passes). So it never fires for a genuinely-advancing run
- * (signature changes => streak resets) and never fires on read-only / explore
- * turns (no failing verification => class != "fail"). Default OFF: when the
- * guard is disabled it always returns false, preserving today's behavior.
+ * signature has recurred for at least `no_net_progress_extend_after` turns OR
+ * the hard failing-verify floor has crossed `no_net_progress_hard_cap_after`.
+ * The same-signature path catches flat stalls early. The hard floor catches
+ * varied/slow-draining failures that keep changing signatures but still never
+ * produce a clean verification. It never fires on read-only / explore turns (no
+ * failing verification => class != "fail"). Default OFF: when the guard is
+ * disabled it always returns false, preserving today's behavior.
  *
  * @effects: []
  * @errors: []
@@ -1347,6 +1411,7 @@ pub fn agent_stall_no_net_progress(raw_config, stall_state: AgentStallState) -> 
     return false
   }
   return stall_state.same_diagnostic_streak >= config.no_net_progress_extend_after
+    || stall_state.failing_verify_turns >= config.no_net_progress_hard_cap_after
 }
 
 /**
@@ -1387,7 +1452,12 @@ pub fn agent_stall_current_failure(stall_state: AgentStallState) {
  */
 pub fn agent_stall_clear_current_failure(stall_state: AgentStallState) -> AgentStallState {
   return stall_state
-    + {last_diagnostic_class: "pass", same_diagnostic_streak: 0, reverify_owed: false}
+    + {
+    last_diagnostic_class: "pass",
+    same_diagnostic_streak: 0,
+    failing_verify_turns: 0,
+    reverify_owed: false,
+  }
 }
 
 /**

--- a/docs/src/dev/repair-diagnostics.md
+++ b/docs/src/dev/repair-diagnostics.md
@@ -136,6 +136,17 @@ tool-using defaults preset (`presets.harn`), default-safe-off:
 - `repair_aware` (bool, default `false`)
 - `stuck_same_diagnostic_after` (int, default `3`)
 - `post_edit_reverify` (bool, default `true`)
+- `no_net_progress_extend_guard` (bool, default `false`)
+- `no_net_progress_extend_after` (int, default `3`)
+- `no_net_progress_hard_cap_after` (int, default `16`)
+
+When `no_net_progress_extend_guard` is enabled, Harn now uses two complementary
+signals. The same-diagnostic threshold catches flat stalls early and suppresses
+adaptive budget extension. The hard cap counts every failing verification turn
+and resets only on a clean non-edit verification pass, so a model cannot evade
+recovery by slowly changing error signatures or interleaving successful edits
+with still-red verifies. Crossing the hard cap emits
+`no_net_progress_hard_cap` and terminates through the existing `stuck` path.
 
 ## Subsumption of Burin's futile-retry-guard.harn
 

--- a/tests/agent/stall_test.harn
+++ b/tests/agent/stall_test.harn
@@ -415,6 +415,7 @@ const GUARD_CONFIG = {
   post_edit_reverify: true,
   no_net_progress_extend_guard: true,
   no_net_progress_extend_after: 3,
+  no_net_progress_hard_cap_after: 16,
 }
 
 fn _fold_guarded(state, prev_dispatch, prior_made_edit) {
@@ -491,4 +492,83 @@ pipeline test_no_net_progress_explore_turn_not_starved(task) {
   let o = _fold_guarded(initial, nil, false)
   assert(o.state.last_diagnostic_class != "fail")
   assert(!agent_stall_no_net_progress(GUARD_CONFIG, o.state))
+}
+
+const HARD_CAP_CONFIG = {
+  enabled: true,
+  repair_aware: false,
+  post_edit_reverify: true,
+  no_net_progress_extend_guard: true,
+  no_net_progress_extend_after: 99,
+  no_net_progress_hard_cap_after: 3,
+  repeat_same_error: 99,
+  repeat_same_observation: 99,
+  no_progress_messages: 99,
+  ping_pong_cycles: 99,
+}
+
+fn _fold_hard_cap(state, prev_dispatch, prior_made_edit) {
+  return agent_stall_observe_tool_calls(
+    "unit-hard-cap",
+    _run_call(),
+    1,
+    HARD_CAP_CONFIG,
+    state,
+    true,
+    prev_dispatch,
+    "",
+    false,
+    prior_made_edit,
+  )
+}
+
+pipeline test_no_net_progress_hard_cap_trips_on_varied_failures(task) {
+  // A slow-draining failing run can keep changing the error signature, so the
+  // same-diagnostic streak never reaches the no-net threshold. The hard cap is
+  // deliberately signature-agnostic: three failing verify turns without a clean
+  // pass trips the terminal stuck path anyway.
+  let o1 = _fold_hard_cap(agent_stall_initial_state(), _fail_dispatch("error A"), false)
+  assert(o1.state.same_diagnostic_streak == 1)
+  assert(o1.state.failing_verify_turns == 1)
+  assert(o1.warning == nil)
+  assert(!agent_stall_no_net_progress(HARD_CAP_CONFIG, o1.state))
+  let o2 = _fold_hard_cap(o1.state, _fail_dispatch("error B"), false)
+  assert(o2.state.same_diagnostic_streak == 1)
+  assert(o2.state.failing_verify_turns == 2)
+  assert(o2.warning == nil)
+  assert(!agent_stall_no_net_progress(HARD_CAP_CONFIG, o2.state))
+  let o3 = _fold_hard_cap(o2.state, _fail_dispatch("error C"), false)
+  assert(o3.state.same_diagnostic_streak == 1)
+  assert(o3.state.failing_verify_turns == 3)
+  assert(o3.warning != nil)
+  assert(o3.warning.pattern == "no_net_progress_hard_cap")
+  assert(o3.hard_stop)
+  assert(o3.state.hard_stop)
+  assert(agent_stall_no_net_progress(HARD_CAP_CONFIG, o3.state))
+}
+
+pipeline test_no_net_progress_hard_cap_resets_only_on_clean_verify(task) {
+  let o1 = _fold_hard_cap(agent_stall_initial_state(), _fail_dispatch("error A"), false)
+  let o2 = _fold_hard_cap(o1.state, _fail_dispatch("error B"), false)
+  assert(o2.state.failing_verify_turns == 2)
+  let pass = _fold_hard_cap(o2.state, _ok_dispatch(), false)
+  assert(pass.state.last_diagnostic_class == "pass")
+  assert(pass.state.failing_verify_turns == 0)
+  assert(!agent_stall_no_net_progress(HARD_CAP_CONFIG, pass.state))
+  let fail_after_pass = _fold_hard_cap(pass.state, _fail_dispatch("error C"), false)
+  assert(fail_after_pass.state.failing_verify_turns == 1)
+  assert(fail_after_pass.warning == nil)
+}
+
+pipeline test_no_net_progress_hard_cap_preserves_across_edit_success(task) {
+  // Edit success is not a clean verification. It should preserve the failing
+  // verify counter so a model cannot evade the cap by interleaving successful
+  // writes with still-red verifies.
+  let o1 = _fold_hard_cap(agent_stall_initial_state(), _fail_dispatch("error A"), false)
+  let edit_ok = _fold_hard_cap(o1.state, _ok_dispatch(), true)
+  assert(edit_ok.state.reverify_owed)
+  assert(edit_ok.state.failing_verify_turns == 1)
+  let o2 = _fold_hard_cap(edit_ok.state, _fail_dispatch("error B"), false)
+  assert(o2.state.failing_verify_turns == 2)
+  assert(o2.warning == nil)
 }


### PR DESCRIPTION
## Summary

- add a Harn-owned hard failing-verify floor to `stall_diagnostics.no_net_progress_extend_guard`
- count failing verification turns across changing diagnostic signatures and successful edit calls, resetting only on a clean non-edit verify pass
- emit a terminal `no_net_progress_hard_cap` stall warning through the existing `stuck` / `loop_control_decision` path
- mirror the new threshold in the tool-using preset discovery surface and document it

## Why

The existing no-net-progress guard only caught flat same-diagnostic stalls. A slow-draining or varied failure can keep resetting the same-diagnostic streak while still never producing a green verify, which lets adaptive loop control keep reading tool activity as progress. That also makes escalation arms falsely inert when escalation rides the stuck/ripcord path.

This keeps the fix centralized in Harn orchestration: no Burin-side wrapper, no new hook surface, no new feature flag. The existing no-net-progress guard remains the opt-in, and the hard cap is a conservative floor under that same guard.

## Verification

- `cargo run --quiet --bin harn -- check crates/harn-stdlib/src/stdlib/agent/stall.harn crates/harn-stdlib/src/stdlib/agent/presets.harn tests/agent/stall_test.harn conformance/tests/agents/no_net_progress_hard_cap_stops_varied_failures.harn`
- `cargo run --quiet --bin harn -- test tests/agent/stall_test.harn`
- `cargo run --quiet --bin harn -- test conformance --filter no_net_progress_hard_cap_stops_varied_failures`
- `cargo run --quiet --bin harn -- test conformance --filter repair`
- `cargo run --quiet --bin harn -- test conformance --filter agent_loop_stall`
- `make fmt-harn`
- `make lint-harn`
- pre-commit hooks
- pre-push hooks
- `git diff --check`
