### PR TITLE
[codex] Fix Windows nightly path-sensitive tests

### DIFF
--- a/changelog.d/windows-nightly-paths.fixed.md
+++ b/changelog.d/windows-nightly-paths.fixed.md
@@ -1,0 +1,2 @@
+- Normalize `harn pack` logical SBOM and skipped-asset paths to `/` separators
+  across platforms, and make Windows nightly path/process tests platform-aware.

--- a/crates/harn-cli/src/commands/pack.rs
+++ b/crates/harn-cli/src/commands/pack.rs
@@ -80,6 +80,13 @@ struct PackJsonOutput {
     warnings: Vec<JsonWarning>,
 }
 
+fn logical_bundle_path(path: &Path) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 impl JsonOutput for PackJsonOutput {
     const SCHEMA_VERSION: u32 = PACK_SCHEMA_VERSION;
     type Data = PackJsonData;
@@ -351,6 +358,7 @@ pub fn build(args: &BuildArgs) -> Result<PackOutcome, PackError> {
             ),
         )
     })?;
+    let entrypoint_id = logical_bundle_path(&entrypoint_rel);
 
     let prior = match &args.upgrade {
         Some(path) => Some(load_workflow_bundle_any_version(path).map_err(|err| {
@@ -405,7 +413,7 @@ pub fn build(args: &BuildArgs) -> Result<PackOutcome, PackError> {
                 license: None,
             });
             sbom_relationships.push(SBOMRelationship {
-                from: format!("entrypoint:{}", entrypoint_rel.display()),
+                from: format!("entrypoint:{entrypoint_id}"),
                 to: format!("std/{stdlib_name}"),
                 relationship_type: "depends_on".to_string(),
             });
@@ -509,15 +517,16 @@ pub fn build(args: &BuildArgs) -> Result<PackOutcome, PackError> {
             contents.push(HarnpackEntry::new(module_archive_path, artifact_bytes));
         }
 
+        let module_id = logical_bundle_path(&rel);
         if module_path != &entrypoint {
             sbom_relationships.push(SBOMRelationship {
-                from: format!("entrypoint:{}", entrypoint_rel.display()),
-                to: format!("module:{}", rel.display()),
+                from: format!("entrypoint:{entrypoint_id}"),
+                to: format!("module:{module_id}"),
                 relationship_type: "depends_on".to_string(),
             });
         }
         sbom_packages.push(SBOMPackage {
-            name: format!("module:{}", rel.display()),
+            name: format!("module:{module_id}"),
             version: Some(harn_version.clone()),
             package_hash_blake3: Some(source_hash),
             license: None,
@@ -534,7 +543,7 @@ pub fn build(args: &BuildArgs) -> Result<PackOutcome, PackError> {
                 ),
             });
             skipped_assets.push(SkippedAsset {
-                path: asset.rel.clone(),
+                path: logical_bundle_path(&asset.rel),
                 reason: "secret_path".to_string(),
             });
             continue;
@@ -550,19 +559,20 @@ pub fn build(args: &BuildArgs) -> Result<PackOutcome, PackError> {
             )
         })?;
         let asset_hash = blake3_hash(&bytes);
+        let asset_id = logical_bundle_path(&asset.rel);
         contents.push(HarnpackEntry::new(
             PathBuf::from("sources").join(&asset.rel),
             bytes,
         ));
         sbom_packages.push(SBOMPackage {
-            name: format!("asset:{}", asset.rel.display()),
+            name: format!("asset:{asset_id}"),
             version: Some(harn_version.clone()),
             package_hash_blake3: Some(asset_hash),
             license: None,
         });
         sbom_relationships.push(SBOMRelationship {
-            from: format!("entrypoint:{}", entrypoint_rel.display()),
-            to: format!("asset:{}", asset.rel.display()),
+            from: format!("entrypoint:{entrypoint_id}"),
+            to: format!("asset:{asset_id}"),
             relationship_type: "depends_on".to_string(),
         });
     }
@@ -592,7 +602,7 @@ pub fn build(args: &BuildArgs) -> Result<PackOutcome, PackError> {
         license: None,
     });
     sbom_relationships.push(SBOMRelationship {
-        from: format!("entrypoint:{}", entrypoint_rel.display()),
+        from: format!("entrypoint:{entrypoint_id}"),
         to: "harn-provider-catalog".to_string(),
         relationship_type: "depends_on".to_string(),
     });
@@ -622,7 +632,7 @@ pub fn build(args: &BuildArgs) -> Result<PackOutcome, PackError> {
             license: None,
         });
         sbom_relationships.push(SBOMRelationship {
-            from: format!("entrypoint:{}", entrypoint_rel.display()),
+            from: format!("entrypoint:{entrypoint_id}"),
             to: format!("tool:{}", tool.name),
             relationship_type: "depends_on".to_string(),
         });
@@ -853,7 +863,7 @@ struct ImportedAsset {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct SkippedAsset {
-    path: PathBuf,
+    path: String,
     reason: String,
 }
 

--- a/crates/harn-cli/tests/test_bench_cli.rs
+++ b/crates/harn-cli/tests/test_bench_cli.rs
@@ -270,17 +270,14 @@ fn process_tape_persist_and_load_round_trip() {
 
     let temp = TempDir::new().unwrap();
     let tape_path = temp.path().join("process.tape");
+    let (echo_cmd, echo_args) = echo_command_for_process_tape();
 
     // Record a real invocation via the sandbox command_output entry.
     {
         let tape = Arc::new(ProcessTape::recording());
         let _guard = install_process_tape(Arc::clone(&tape));
-        let _output = command_output(
-            "/bin/echo",
-            &["hello-tape".to_string()],
-            &ProcessCommandConfig::default(),
-        )
-        .expect("real subprocess");
+        let _output = command_output(echo_cmd, &echo_args, &ProcessCommandConfig::default())
+            .expect("real subprocess");
         tape.persist(&tape_path).expect("persist tape");
         let recorded = tape.recorded();
         assert_eq!(recorded.len(), 1);
@@ -293,14 +290,25 @@ fn process_tape_persist_and_load_round_trip() {
 
     let replay_tape = Arc::new(loaded);
     let _guard = install_process_tape(Arc::clone(&replay_tape));
-    let output = command_output(
-        "/bin/echo",
-        &["hello-tape".to_string()],
-        &ProcessCommandConfig::default(),
-    )
-    .expect("replay should succeed");
+    let output = command_output(echo_cmd, &echo_args, &ProcessCommandConfig::default())
+        .expect("replay should succeed");
     assert!(String::from_utf8_lossy(&output.stdout).contains("hello-tape"));
     assert!(replay_tape.fully_consumed());
+}
+
+fn echo_command_for_process_tape() -> (&'static str, Vec<String>) {
+    if cfg!(windows) {
+        (
+            "cmd",
+            vec![
+                "/C".to_string(),
+                "echo".to_string(),
+                "hello-tape".to_string(),
+            ],
+        )
+    } else {
+        ("/bin/echo", vec!["hello-tape".to_string()])
+    }
 }
 
 #[test]

--- a/crates/harn-cli/tests/trigger_replay_cli.rs
+++ b/crates/harn-cli/tests/trigger_replay_cli.rs
@@ -198,19 +198,26 @@ fn trigger_replay_diff_reports_structured_drift() {
     let temp = TempDir::new().unwrap();
     let workspace_root = temp.path().to_path_buf();
     write_manifest(&workspace_root);
+    let child_replay_expr = if cfg!(windows) {
+        r#"shell("echo|set /p=%HARN_REPLAY%").stdout"#
+    } else {
+        r#"shell("printf '%s' \"$HARN_REPLAY\"").stdout"#
+    };
     write_lib(
         &workspace_root,
-        r#"
+        &format!(
+            r#"
 import "std/triggers"
 
-pub fn on_issue(event: TriggerEvent) -> dict {
-  return {
+pub fn on_issue(event: TriggerEvent) -> dict {{
+  return {{
     event_id: event.id,
     replay_env: env("HARN_REPLAY"),
-    child_replay_env: shell("printf '%s' \"$HARN_REPLAY\"").stdout,
-  }
-}
+    child_replay_env: {child_replay_expr},
+  }}
+}}
 "#,
+        ),
     );
 
     let report = run_in_harn_runtime(move || async move {

--- a/crates/harn-guard/src/resolve.rs
+++ b/crates/harn-guard/src/resolve.rs
@@ -52,7 +52,9 @@ mod tests {
     #[test]
     fn nonexistent_path_selector_errors() {
         let store = GuardStore::at_root(std::env::temp_dir().join("harn-guard-resolve-path"));
-        let err = resolve_dir(&store, "/no/such/guard/model/dir").unwrap_err();
+        let missing = store.root().join("no-such").join("guard-model-dir");
+        let selector = missing.to_string_lossy();
+        let err = resolve_dir(&store, &selector).unwrap_err();
         assert!(matches!(err, GuardError::PathNotFound(_)));
     }
 }

--- a/crates/harn-skills/src/lib.rs
+++ b/crates/harn-skills/src/lib.rs
@@ -451,7 +451,8 @@ mod tests {
                 skill.name
             );
             assert!(
-                skill.source.contains(&format!("name: {}\n", skill.name)),
+                skill.source.contains(&format!("name: {}\n", skill.name))
+                    || skill.source.contains(&format!("name: {}\r\n", skill.name)),
                 "{} source missing canonical name field",
                 skill.name
             );


### PR DESCRIPTION
## Summary
- normalize harn pack logical SBOM/skipped-asset paths to `/` separators across platforms
- make Windows-sensitive nightly tests use platform-aware path and shell/process fixtures
- keep CRLF skill source round-tripping accepted without weakening metadata validation

## Verification
- cargo fmt --package harn-cli --package harn-guard --package harn-skills -- --check
- CARGO_TARGET_DIR=/Users/ksinder/.cache/harn-cargo-target/windows-nightly-path-tests cargo test -p harn-cli --test pack_cli
- CARGO_TARGET_DIR=/Users/ksinder/.cache/harn-cargo-target/windows-nightly-path-tests cargo test -p harn-guard nonexistent_path_selector_errors
- CARGO_TARGET_DIR=/Users/ksinder/.cache/harn-cargo-target/windows-nightly-path-tests cargo test -p harn-skills source_round_trips_to_frontmatter_and_body
- CARGO_TARGET_DIR=/Users/ksinder/.cache/harn-cargo-target/windows-nightly-path-tests cargo test -p harn-cli --test test_bench_cli process_tape_persist_and_load_round_trip
- CARGO_TARGET_DIR=/Users/ksinder/.cache/harn-cargo-target/windows-nightly-path-tests cargo test -p harn-cli --test trigger_replay_cli trigger_replay_diff_reports_structured_drift
- git -c core.fsmonitor=false diff --check
- pre-push checks passed

Root cause: the scheduled Windows workspace nextest job exercises tests not covered by required PR CI; several used Unix path separators or Unix shell/process assumptions. The pack path change fixes the production artifact boundary rather than only relaxing assertions.