### PR TITLE
Make the review/merge demo prompts readable

### DIFF
--- a/crates/harn-cli/assets/demo/merge-captain/scenario.harn
+++ b/crates/harn-cli/assets/demo/merge-captain/scenario.harn
@@ -51,9 +51,29 @@ fn classify(pr) {
   return "merge"
 }
 
+let PR_PROMPT = """
+[merge_captain][pr={{ number }}][tag={{ tag }}]
+
+Decide: should PR #{{ number }} ({{ title }}) merge, hand off to
+review_captain, or block?
+
+  - Failing checks: {{ failing_checks }}
+  - Stale threads: {{ stale_threads }}
+  - Diff size: {{ diff_lines }} lines
+"""
+
 fn render_pr_prompt(pr) {
-  let header = "[merge_captain][pr=${pr.number}][tag=${pr.tag}]"
-  return "${header} Decide: should PR #${pr.number} (${pr.title}) merge, hand off to review_captain, or block? Failing checks: ${len(pr.failing_checks)}. Stale threads: ${len(pr.stale_threads)}. Diff size: ${pr.diff_lines} lines."
+  return render_string(
+    PR_PROMPT,
+    {
+      number: pr.number,
+      tag: pr.tag,
+      title: pr.title,
+      failing_checks: len(pr.failing_checks),
+      stale_threads: len(pr.stale_threads),
+      diff_lines: pr.diff_lines,
+    },
+  )
 }
 
 pipeline default(_task) {

--- a/crates/harn-cli/assets/demo/review-captain/scenario.harn
+++ b/crates/harn-cli/assets/demo/review-captain/scenario.harn
@@ -3,10 +3,14 @@
  * diff, asks one clarifying question (HITL surfaced via the structured
  * receipt), then emits a verdict with reasoning and a cost rollup.
  *
- * Designed to run fully offline against the bundled `tape.jsonl`
- * fixture under `assets/demo/review-captain/`. The same script also
- * runs against a real provider when invoked via `harn demo
- * review-captain --live`.
+ * The two model prompts are written as readable multi-line templates and
+ * filled with `render_string(template, bindings)`. The same templates can live
+ * in standalone `.harn.prompt` files rendered with `render_prompt(path, ...)`;
+ * this demo keeps them inline because the demo bundle is embedded in the binary.
+ *
+ * Runs fully offline against the bundled `tape.jsonl` fixture under
+ * `assets/demo/review-captain/`. The same script runs against a real provider
+ * via `harn demo review-captain --live`.
  */
 fn diff_summary() {
   return {
@@ -22,29 +26,64 @@ fn diff_summary() {
   }
 }
 
-fn render_review_prompt(diff) {
-  let total_added = diff.files[0].loc_added + diff.files[1].loc_added + diff.files[2].loc_added
-    + diff.files[3].loc_added
-    + diff.files[4].loc_added
-  return "[review_captain][pr=${diff.pr_number}][stage=review] Review this 5-file diff: src/retry.ts (+86/-12, high risk), src/retry.test.ts (+124/-0), src/http.ts (+14/-8), docs/retry.md (+38/-0), package.json (+1/-1). Total added: ${total_added}. Identify regressions, missing test coverage, and risky paths. Ask exactly one clarifying question, then propose a verdict."
+fn total_added(files) {
+  var total = 0
+  for f in files {
+    total = total + f.loc_added
+  }
+  return total
 }
 
-fn render_clarification_prompt(question) {
-  return "[review_captain][pr=502][stage=clarified] The author answered: \"${question}\" — emit the final verdict envelope as JSON with keys verdict, missing_tests, risky_paths, reasoning."
+let REVIEW_PROMPT = """
+[review_captain][pr={{ pr }}][stage=review]
+
+Review this {{ file_count }}-file diff:
+{{ for f in files }}
+  - {{ f.path }} (+{{ f.loc_added }}/-{{ f.loc_removed }}, {{ f.risk }} risk)
+{{ end }}
+
+Total lines added: {{ total_added }}.
+
+Identify regressions, missing test coverage, and risky paths. Ask exactly one
+clarifying question, then propose a verdict.
+"""
+
+let CLARIFICATION_PROMPT = """
+[review_captain][pr={{ pr }}][stage=clarified]
+
+The author answered: "{{ answer }}"
+
+Emit the final verdict envelope as JSON with keys verdict, missing_tests,
+risky_paths, and reasoning.
+"""
+
+fn render_review_prompt(diff) {
+  return render_string(
+    REVIEW_PROMPT,
+    {
+      pr: diff.pr_number,
+      file_count: len(diff.files),
+      files: diff.files,
+      total_added: total_added(diff.files),
+    },
+  )
+}
+
+fn render_clarification_prompt(pr, answer) {
+  return render_string(CLARIFICATION_PROMPT, {pr: pr, answer: answer})
 }
 
 pipeline default(_task) {
   let diff = diff_summary()
+  let system = "You are review_captain, a thorough code reviewer."
   let review_prompt = render_review_prompt(diff)
-  let initial_envelope = llm_call(review_prompt, "You are review_captain, a thorough code reviewer.")
-  let initial_response = initial_envelope.text
+  let initial_envelope = llm_call(review_prompt, system)
   __io_println("=== review_captain · stage 1 (initial scan) ===")
-  __io_println(initial_response)
+  __io_println(initial_envelope.text)
   __io_println("")
   let author_answer = "Yes, the retry middleware is intended to wrap idempotent requests only; non-idempotent calls bypass it via the `safe: false` opt-out."
-  let clarification_prompt = render_clarification_prompt(author_answer)
-  let final_envelope = llm_call(clarification_prompt, "You are review_captain, a thorough code reviewer.")
-  let final_response = final_envelope.text
+  let clarification_prompt = render_clarification_prompt(diff.pr_number, author_answer)
+  let final_envelope = llm_call(clarification_prompt, system)
   let receipt = {
     persona: "review_captain",
     execution_mode: "advisory",
@@ -54,7 +93,7 @@ pipeline default(_task) {
     files_reviewed: len(diff.files),
     clarifying_question_asked: true,
     clarifying_question_answer: author_answer,
-    final_verdict: final_response,
+    final_verdict: final_envelope.text,
     receipt_kind: "review_receipt",
   }
   __io_println("=== review_captain · stage 2 (final verdict) ===")


### PR DESCRIPTION
The `review-captain` and `merge-captain` demo scenarios built their model prompts as single giant inline strings, which wrapped into an unreadable block in the homepage example gallery (the gallery renders these exact files via a `?raw` import).

## Change
Rewrite the prompts as multi-line templates filled with `render_string(template, bindings)` — the same template engine that backs `.harn.prompt` files — kept inline because the demo bundle is embedded in the binary. Bonus cleanups:
- The review prompt's file list is now data-driven from `diff.files` (was duplicated hardcoded text that could drift from `diff_summary()`).
- Dropped an em dash from the clarification prompt.

## Why it's safe
The offline tapes match by glob on the `[review_captain][pr=502][stage=…]` and `[merge_captain][pr=N][tag=X]` markers, which the templates preserve, so both demos replay byte-for-byte. The receipts (what `demo_cli.rs` asserts and what prints) don't include prompt text or token counts.

## Verification
Built the binary and ran both demos against their bundled tapes:
- `harn demo review-captain` → unchanged `review_receipt` with `clarifying_question_asked: true`, `files_reviewed: 5`, identical verdict.
- `harn demo merge-captain` → all three PRs triaged ([#421] merge, [#422] handoff, [#423] block), unchanged `merge_supervision_receipt`.

`harn check` + `harn fmt` clean.

Follow-up (separate PR): lift the demo runner's single-file embedding so demos can use real `.harn.prompt` files and modules. `stage_scenario` already materializes to a tempdir and `include_dir` is already a dependency, so it's a small, low-risk change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)