### PR TITLE
chore(deps): refresh Cargo.lock within semver + security fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,7 +2287,7 @@ dependencies = [
  "grep-matcher",
  "log",
  "memchr",
- "memmap2 0.9.10",
+ "memmap2 0.9.11",
 ]
 
 [[package]]
@@ -3804,9 +3804,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -4634,7 +4634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4701,9 +4701,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4721,9 +4721,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
Conservative Dependabot-style `cargo update` within existing semver ranges across the 36-crate workspace. No `Cargo.toml` ranges changed — lockfile-only refresh.

## Security (cargo audit: 2 → 0)
- **quinn-proto** 0.11.14 → 0.11.15 — RUSTSEC-2026-0185 (**high, 7.5**): remote memory exhaustion via unbounded out-of-order stream reassembly.
- **wasmtime-wasi** 45.0.0 → 45.0.3 — RUSTSEC-2026-0182 (low, 2.3): WASIp1 `fd_renumber` leak. Whole wasmtime stack moved 45.0.0 → 45.0.3.

## Skipped
- 4 allowed unmaintained-crate advisories (`bincode`, `paste`, `memmap2`, `serde_yml`) — no in-range patched release; would need dependency-graph changes. Left for separate review.
- Major bumps left in place (e.g. wasmtime 46, tower-http 0.7).

## Local verification
- `cargo check --workspace` ✅
- `cargo fmt --all --check` ✅
- `cargo audit` 2 vulns → 0 ✅

CI is the final gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)