### PR TITLE
feat(website): surface multi-file demos in the example gallery

### DIFF
--- a/website/src/components/ExampleGallery.tsx
+++ b/website/src/components/ExampleGallery.tsx
@@ -1,31 +1,45 @@
 import { useState } from "react"
-import { exampleScenarios } from "../examples/gallery"
-import { highlightHarnSource } from "../lib/harn-highlight"
+import { exampleScenarios, type ExampleFile } from "../examples/gallery"
+import { highlightHarnSource, highlightPromptTemplate } from "../lib/harn-highlight"
 import { useMessages } from "../i18n"
 
 export { exampleScenarios }
+
+function highlightFile(file: ExampleFile) {
+  return file.lang === "prompt" ? highlightPromptTemplate(file.source) : highlightHarnSource(file.source)
+}
 
 export function ExampleGallery() {
   const t = useMessages()
   const ex = t.landing.examples
   const [activeSlug, setActiveSlug] = useState(exampleScenarios[0]?.slug ?? "review-captain")
-  const [copiedSlug, setCopiedSlug] = useState<string | null>(null)
+  const [activeFileName, setActiveFileName] = useState(exampleScenarios[0]?.files[0]?.name ?? "")
+  const [copiedKey, setCopiedKey] = useState<string | null>(null)
   const active = exampleScenarios.find((scenario) => scenario.slug === activeSlug) ?? exampleScenarios[0]
 
-  async function copyActiveSource() {
-    if (!active) return
-    if (typeof navigator === "undefined" || !navigator.clipboard) return
-    try {
-      await navigator.clipboard.writeText(active.source)
-      setCopiedSlug(active.slug)
-      window.setTimeout(() => setCopiedSlug(null), 1600)
-    } catch {
-      setCopiedSlug(null)
-    }
+  function selectScenario(slug: typeof activeSlug) {
+    const scenario = exampleScenarios.find((s) => s.slug === slug)
+    setActiveSlug(slug)
+    setActiveFileName(scenario?.files[0]?.name ?? "")
   }
 
   if (!active) return null
+  const activeFile = active.files.find((file) => file.name === activeFileName) ?? active.files[0]
+  if (!activeFile) return null
+  const copyKey = `${active.slug}:${activeFile.name}`
   const copy = ex.scenarios[active.slug]
+  const isMultiFile = active.files.length > 1
+
+  async function copyActiveSource() {
+    if (typeof navigator === "undefined" || !navigator.clipboard) return
+    try {
+      await navigator.clipboard.writeText(activeFile.source)
+      setCopiedKey(copyKey)
+      window.setTimeout(() => setCopiedKey(null), 1600)
+    } catch {
+      setCopiedKey(null)
+    }
+  }
 
   return (
     <div className="overflow-hidden rounded-xl border border-card-border bg-card-bg">
@@ -38,10 +52,11 @@ export function ExampleGallery() {
                 key={scenario.slug}
                 type="button"
                 role="tab"
+                data-scenario-tab="true"
                 aria-selected={isActive}
                 aria-controls={`example-panel-${scenario.slug}`}
                 id={`example-tab-${scenario.slug}`}
-                onClick={() => setActiveSlug(scenario.slug)}
+                onClick={() => selectScenario(scenario.slug)}
                 className={`h-9 shrink-0 rounded-lg border px-3 text-sm font-semibold transition-colors ${
                   isActive
                     ? "border-accent-500 bg-accent-600 text-white dark:bg-accent-500 dark:text-accent-950"
@@ -74,7 +89,7 @@ export function ExampleGallery() {
 
           <div className="mt-5 flex flex-wrap gap-3">
             <a
-              href={active.sourceHref}
+              href={activeFile.href}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex h-9 items-center justify-center rounded-lg bg-accent-600 px-4 text-sm font-semibold text-white transition-colors hover:bg-accent-700 dark:bg-accent-500 dark:text-accent-950 dark:hover:bg-accent-400"
@@ -88,29 +103,53 @@ export function ExampleGallery() {
               {ex.readDocs}
             </a>
           </div>
+          {isMultiFile && <p className="mt-5 text-xs leading-relaxed text-foreground-muted">{ex.multiFileNote}</p>}
           <div className="mt-6 rounded-lg border border-border bg-surface-tertiary px-3 py-2 font-mono text-xs break-all text-foreground-secondary">
-            {active.sourcePath}
+            {activeFile.path}
           </div>
         </div>
         <div className="min-w-0 bg-[#07100f]">
-          <div className="flex items-center justify-between gap-3 border-b border-white/10 bg-[#0c1413] px-4 py-3">
-            <span className="font-mono text-xs font-medium text-white/55">{ex.fileLabel}</span>
+          <div className="flex items-center justify-between gap-3 border-b border-white/10 bg-[#0c1413] px-2 py-2 pl-3">
+            {isMultiFile ? (
+              <div role="tablist" aria-label={ex.filesAria} className="flex min-w-0 gap-1 overflow-x-auto">
+                {active.files.map((file) => {
+                  const isActive = file.name === activeFile.name
+                  return (
+                    <button
+                      key={file.name}
+                      type="button"
+                      role="tab"
+                      data-file-tab="true"
+                      aria-selected={isActive}
+                      onClick={() => setActiveFileName(file.name)}
+                      className={`h-7 shrink-0 rounded-md px-2.5 font-mono text-xs font-medium transition-colors ${
+                        isActive ? "bg-white/[0.12] text-white" : "text-white/45 hover:bg-white/[0.06] hover:text-white/80"
+                      }`}
+                    >
+                      {file.name}
+                    </button>
+                  )
+                })}
+              </div>
+            ) : (
+              <span className="px-1 font-mono text-xs font-medium text-white/55">{activeFile.name}</span>
+            )}
             <button
               type="button"
               onClick={copyActiveSource}
               aria-label={ex.copyAria}
-              className="inline-flex h-8 items-center gap-2 rounded-lg border border-white/10 bg-white/[0.04] px-3 text-xs font-semibold text-white/75 transition-colors hover:bg-white/[0.08] hover:text-white"
+              className="inline-flex h-8 shrink-0 items-center gap-2 rounded-lg border border-white/10 bg-white/[0.04] px-3 text-xs font-semibold text-white/75 transition-colors hover:bg-white/[0.08] hover:text-white"
             >
               <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
                 <path d="M8 8h10v12H8z" />
                 <path d="M6 16H4V4h12v2" />
               </svg>
-              {copiedSlug === active.slug ? ex.copied : ex.copy}
+              {copiedKey === copyKey ? ex.copied : ex.copy}
             </button>
           </div>
           <pre className="m-0 max-h-[30rem] overflow-auto p-4 text-[12px] leading-relaxed whitespace-pre-wrap break-words text-white/80">
-            <code data-example-gallery-code="true" className="language-harn">
-              {highlightHarnSource(active.source)}
+            <code data-example-gallery-code="true" className={`language-${activeFile.lang === "prompt" ? "prompt" : "harn"}`}>
+              {highlightFile(activeFile)}
             </code>
           </pre>
         </div>

--- a/website/src/examples/gallery.ts
+++ b/website/src/examples/gallery.ts
@@ -1,4 +1,6 @@
 import reviewCaptainSource from "../../../crates/harn-cli/assets/demo/review-captain/scenario.harn?raw"
+import reviewCaptainReviewPrompt from "../../../crates/harn-cli/assets/demo/review-captain/review.harn.prompt?raw"
+import reviewCaptainClarifyPrompt from "../../../crates/harn-cli/assets/demo/review-captain/clarification.harn.prompt?raw"
 import mergeCaptainSource from "../../../crates/harn-cli/assets/demo/merge-captain/scenario.harn?raw"
 import mcpHostSource from "../../../crates/harn-cli/assets/demo/mcp-host/scenario.harn?raw"
 import stdlibToolkitSource from "../../../crates/harn-cli/assets/demo/stdlib-toolkit/scenario.harn?raw"
@@ -14,51 +16,75 @@ function leadWithCode(src: string): string {
   return body.trimEnd()
 }
 
+// `.harn.prompt` templates carry no design-note header, so they display as-is.
+function trimmed(src: string): string {
+  return src.replace(/^﻿/, "").trimEnd()
+}
+
+// `harn` gets full syntax highlighting; `prompt` files are render_prompt
+// templates, highlighted only for their `{{ … }}` interpolation markers.
+export type ExampleFileLang = "harn" | "prompt"
+
+// One file in a scenario's bundle. Most scenarios are a single scenario.harn;
+// multi-file scenarios (review-captain) add sibling `.harn.prompt` templates,
+// which the demo runner materializes and resolves via `render_prompt`.
+export type ExampleFile = {
+  name: string
+  path: string
+  href: string
+  lang: ExampleFileLang
+  source: string
+}
+
 // Structural data only. Display copy (tab, title, outcome) lives in the i18n
 // catalog under `landing.examples.scenarios`, keyed by `slug`. The `command` is
 // a literal CLI invocation, not translatable prose, so it stays here.
 export type ExampleScenario = {
   slug: keyof typeof import("../i18n/en").en.landing.examples.scenarios
   command: string
-  sourcePath: string
-  sourceHref: string
   docsHref: string
-  source: string
+  files: ExampleFile[]
 }
 
 const DEMO_DOCS_HREF = "/cli-reference.html#harn-demo"
+
+// Build a file entry from a scenario-relative path, wiring up its GitHub href.
+function demoFile(slug: string, name: string, lang: ExampleFileLang, source: string): ExampleFile {
+  const path = `crates/harn-cli/assets/demo/${slug}/${name}`
+  return { name, path, href: `${GITHUB_DEMO_ROOT}/${slug}/${name}`, lang, source }
+}
+
+function scenarioFile(slug: string, source: string): ExampleFile {
+  return demoFile(slug, "scenario.harn", "harn", leadWithCode(source))
+}
 
 export const exampleScenarios: ExampleScenario[] = [
   {
     slug: "review-captain",
     command: "harn demo review-captain",
-    sourcePath: "crates/harn-cli/assets/demo/review-captain/scenario.harn",
-    sourceHref: `${GITHUB_DEMO_ROOT}/review-captain/scenario.harn`,
     docsHref: DEMO_DOCS_HREF,
-    source: leadWithCode(reviewCaptainSource),
+    files: [
+      scenarioFile("review-captain", reviewCaptainSource),
+      demoFile("review-captain", "review.harn.prompt", "prompt", trimmed(reviewCaptainReviewPrompt)),
+      demoFile("review-captain", "clarification.harn.prompt", "prompt", trimmed(reviewCaptainClarifyPrompt)),
+    ],
   },
   {
     slug: "merge-captain",
     command: "harn demo merge-captain",
-    sourcePath: "crates/harn-cli/assets/demo/merge-captain/scenario.harn",
-    sourceHref: `${GITHUB_DEMO_ROOT}/merge-captain/scenario.harn`,
     docsHref: DEMO_DOCS_HREF,
-    source: leadWithCode(mergeCaptainSource),
+    files: [scenarioFile("merge-captain", mergeCaptainSource)],
   },
   {
     slug: "mcp-host",
     command: "harn demo mcp-host",
-    sourcePath: "crates/harn-cli/assets/demo/mcp-host/scenario.harn",
-    sourceHref: `${GITHUB_DEMO_ROOT}/mcp-host/scenario.harn`,
     docsHref: DEMO_DOCS_HREF,
-    source: leadWithCode(mcpHostSource),
+    files: [scenarioFile("mcp-host", mcpHostSource)],
   },
   {
     slug: "stdlib-toolkit",
     command: "harn demo stdlib-toolkit",
-    sourcePath: "crates/harn-cli/assets/demo/stdlib-toolkit/scenario.harn",
-    sourceHref: `${GITHUB_DEMO_ROOT}/stdlib-toolkit/scenario.harn`,
     docsHref: DEMO_DOCS_HREF,
-    source: leadWithCode(stdlibToolkitSource),
+    files: [scenarioFile("stdlib-toolkit", stdlibToolkitSource)],
   },
 ]

--- a/website/src/i18n/en.ts
+++ b/website/src/i18n/en.ts
@@ -106,10 +106,12 @@ export const en = {
       sectionBody:
         "The same checked scenario files ship in the CLI demo bundle and run locally with deterministic fixtures.",
       tablistAria: "Runnable Harn examples",
-      fileLabel: "scenario.harn",
+      filesAria: "Scenario files",
+      multiFileNote:
+        "This scenario ships more than one file. The prompts live in sibling .harn.prompt templates and load with render_prompt, the way a real Harn project is laid out.",
       copy: "Copy",
       copied: "Copied",
-      copyAria: "Copy scenario source",
+      copyAria: "Copy file source",
       viewSource: "View source",
       readDocs: "Read the docs",
       // Keyed by scenario slug (see examples/gallery.ts).

--- a/website/src/lib/harn-highlight.tsx
+++ b/website/src/lib/harn-highlight.tsx
@@ -97,3 +97,29 @@ function renderHighlightNode(node: HighlightNode, index: number): ReactNode {
 export function highlightHarnSource(source: string) {
   return harnLowlight.highlight("harn", source).children.map(renderHighlightNode)
 }
+
+// `.harn.prompt` files are plain text with `{{ … }}` interpolation. Rather than
+// pretend they are Harn code, we highlight only the template markers so the
+// shape of `render_prompt` substitution reads at a glance. No lowlight grammar
+// needed: split on the marker pattern and wrap the matches.
+const TEMPLATE_MARKER = /\{\{[\s\S]*?\}\}/g
+
+export function highlightPromptTemplate(source: string): ReactNode[] {
+  const nodes: ReactNode[] = []
+  let lastIndex = 0
+  let key = 0
+  for (const match of source.matchAll(TEMPLATE_MARKER)) {
+    const start = match.index ?? 0
+    if (start > lastIndex) nodes.push(source.slice(lastIndex, start))
+    // Bright teal so the substitution slots stand out against the dark panel.
+    // (The hljs theme's own token colors are too low-contrast here.)
+    nodes.push(
+      <span key={key++} className="font-semibold text-[#5eead4]">
+        {match[0]}
+      </span>,
+    )
+    lastIndex = start + match[0].length
+  }
+  if (lastIndex < source.length) nodes.push(source.slice(lastIndex))
+  return nodes
+}

--- a/website/tests/ExampleGallery.test.tsx
+++ b/website/tests/ExampleGallery.test.tsx
@@ -5,9 +5,9 @@ import { ExampleGallery, exampleScenarios } from "../src/components/ExampleGalle
 describe("ExampleGallery", () => {
   it("renders the curated runnable example tabs, leading with a coding agent", () => {
     const markup = renderToStaticMarkup(<ExampleGallery />)
-    const tabCount = (markup.match(/role="tab"/g) ?? []).length
+    const scenarioTabs = (markup.match(/data-scenario-tab="true"/g) ?? []).length
 
-    expect(tabCount).toBe(4)
+    expect(scenarioTabs).toBe(4)
     expect(exampleScenarios.map((scenario) => scenario.slug)).toMatchInlineSnapshot(`
       [
         "review-captain",
@@ -18,9 +18,33 @@ describe("ExampleGallery", () => {
     `)
   })
 
-  it("leads each scenario with code, not the design-note header comment", () => {
+  it("leads each scenario's primary file with code, not the design-note header comment", () => {
     for (const scenario of exampleScenarios) {
-      expect(scenario.source.startsWith("/*")).toBe(false)
+      const primary = scenario.files[0]
+      expect(primary.name).toBe("scenario.harn")
+      expect(primary.source.startsWith("/*")).toBe(false)
     }
+  })
+
+  it("surfaces review-captain's sibling .harn.prompt templates as switchable files", () => {
+    const reviewCaptain = exampleScenarios.find((s) => s.slug === "review-captain")
+    expect(reviewCaptain?.files.map((f) => f.name)).toEqual([
+      "scenario.harn",
+      "review.harn.prompt",
+      "clarification.harn.prompt",
+    ])
+    const promptFiles = reviewCaptain?.files.filter((f) => f.lang === "prompt") ?? []
+    expect(promptFiles).toHaveLength(2)
+    // The prompt templates carry the render_prompt interpolation markers.
+    for (const file of promptFiles) {
+      expect(file.source).toMatch(/\{\{.*\}\}/)
+    }
+  })
+
+  it("renders the file switcher only for multi-file scenarios", () => {
+    const markup = renderToStaticMarkup(<ExampleGallery />)
+    // review-captain is first and is multi-file, so file tabs render initially.
+    const fileTabs = (markup.match(/data-file-tab="true"/g) ?? []).length
+    expect(fileTabs).toBe(3)
   })
 })


### PR DESCRIPTION
## What

The `review-captain` demo now ships sibling `.harn.prompt` templates (landed in #3650). This surfaces them on harnlang.com: the example gallery's code panel gains an in-panel **file switcher** so visitors can flip between `scenario.harn` and its `review.harn.prompt` / `clarification.harn.prompt` templates, the way a real Harn project is laid out.

Single-file scenarios keep the plain filename label, so only multi-file demos grow the switcher.

## Changes

- **`gallery.ts`**: each scenario now carries a `files[]` list (`name`, `path`, `href`, `lang`, `source`) instead of a single source string; prompt files import via `?raw` alongside `scenario.harn`.
- **`harn-highlight.tsx`**: new `highlightPromptTemplate` renders `.harn.prompt` files as plain text with the `{{ … }}` interpolation markers in high-contrast teal (the hljs theme tokens were near-invisible on the dark panel).
- **`ExampleGallery.tsx`**: the View source link, path chip, copy button, and a short multi-file note all follow the active file.
- **i18n**: replaced the now-unused `fileLabel` with `filesAria` + `multiFileNote`.
- **Tests**: assert the switcher only appears for multi-file scenarios and that review-captain exposes both prompt templates.

## Verification

- `npm test` (6/6) and `npm run build` (tsc + client + SSR + 263-page prerender) pass.
- Rendering checked on **desktop and mobile** (default + both prompt tabs) via headless Chrome screenshots: no overflow, overlap, or padding issues. The file-switcher row scrolls horizontally on narrow viewports as intended, with the Copy button pinned and the active tab fully visible. Confirmed `documentElement.scrollWidth == clientWidth` (no page-level horizontal overflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)