### PR TITLE
fix(catalog): provider catalog §4 corrections from cross-provider footgun pre-mortem (#3645)

### DIFF
--- a/changelog.d/3645-catalog-corrections.fixed.md
+++ b/changelog.d/3645-catalog-corrections.fixed.md
@@ -1,0 +1,12 @@
+- **Provider catalog corrections from the cross-provider footgun pre-mortem (harn#3645 §4).**
+  Added two reliable Together serverless sample routes
+  (`Qwen/Qwen2.5-7B-Instruct-Turbo`, `meta-llama/Llama-3.3-70B-Instruct-Turbo`)
+  to replace representative routes that were unusable as one-click samples
+  (`Qwen/Qwen3-Coder-Next-FP8` is dedicated-only; the Together Gemma route is a
+  reasoning model with an empty-content footgun). Marked the dead
+  `MiniMax-Text-01` route deprecated (HTTP 500 / absent from
+  `GET /v1/models`; use `MiniMax-M2`). Added three live-catalog contract tests
+  that guard the wire-id conventions the audit relied on: no `wire_model` retains
+  its own `<provider>/` route prefix, no DeepInfra wire id regains the
+  `deepinfra/` prefix, and `nvidia/minimax-m2.7` still dispatches the NIM wire id
+  `minimaxai/minimax-m2.7` (#3645).

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -3717,6 +3717,19 @@ prefers_xml_tools = false
 thinking_block_style = "reasoning_summary"
 
 [[provider.together]]
+model_match = "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+native_tools = true
+preferred_tool_format = "native"
+tool_mode_parity = "unknown"
+tool_mode_parity_notes = "Together documents native tool calls for this serverless sample route; add live parity probes before broadening to all Together-hosted Llama variants."
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "none"
+
+[[provider.together]]
 model_match = "deepseek-ai/deepseek-v4*"
 native_tools = true
 preferred_tool_format = "native"

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/60-together.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/60-together.toml
@@ -44,6 +44,19 @@ prefers_xml_tools = false
 thinking_block_style = "reasoning_summary"
 
 [[provider.together]]
+model_match = "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+native_tools = true
+preferred_tool_format = "native"
+tool_mode_parity = "unknown"
+tool_mode_parity_notes = "Together documents native tool calls for this serverless sample route; add live parity probes before broadening to all Together-hosted Llama variants."
+prefers_xml_scaffolding = false
+prefers_markdown_scaffolding = true
+supports_assistant_prefill = false
+prefers_role_developer = false
+prefers_xml_tools = false
+thinking_block_style = "none"
+
+[[provider.together]]
 model_match = "deepseek-ai/deepseek-v4*"
 native_tools = true
 preferred_tool_format = "native"

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/26-together-frontier-agents.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/26-together-frontier-agents.toml
@@ -57,3 +57,37 @@ pricing = { input_per_mtok = 0.30, output_per_mtok = 1.20, cache_read_per_mtok =
 tier = "frontier"
 open_weight = true
 strengths = ["speed", "coding", "agentic", "tool_use", "reasoning", "long_context"]
+
+# Reliable Together serverless sample routes (harn#3645 §4). The prior
+# representative serverless rows were unusable as one-click samples:
+# `Qwen/Qwen3-Coder-Next-FP8` returns `model_not_available` on serverless
+# chat-completions (needs a dedicated endpoint; carried as
+# `availability = "dedicated"` in 20-open-weight-openrouter.toml), and the
+# Together `google/gemma-4-31B-it` route is a reasoning model with an
+# empty-content footgun. These two non-reasoning Turbo routes are live on
+# Together's serverless `/v1/chat/completions` with native tool calls and
+# serve as dependable cheap executor samples. Verified live ids on
+# together.ai/models (Qwen2.5 7B Instruct Turbo, Llama 3.3 70B Instruct
+# Turbo).
+[models."Qwen/Qwen2.5-7B-Instruct-Turbo"]
+name = "Qwen2.5 7B Instruct Turbo (Together)"
+provider = "together"
+context_window = 32768
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 0.30, output_per_mtok = 0.30 }
+tier = "small"
+open_weight = true
+strengths = ["speed", "cheap", "tool_use"]
+[models."meta-llama/Llama-3.3-70B-Instruct-Turbo"]
+name = "Llama 3.3 70B Instruct Turbo (Together)"
+provider = "together"
+context_window = 131072
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 0.88, output_per_mtok = 0.88 }
+logical_model = "llama-3.3-70b-instruct"
+equivalence_group = "llama-3.3-70b-instruct"
+served_variant = "together"
+api_dialect = "openai_chat"
+tier = "mid"
+open_weight = true
+strengths = ["tool_use", "cheap"]

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/40-minimax.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/40-minimax.toml
@@ -81,6 +81,9 @@ provider = "minimax"
 context_window = 1000000
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.20, output_per_mtok = 1.10 }
+deprecated = true
+deprecation_note = "Dead on api.minimax.io 2026-06-28 (harn#3645 §4): HTTP 500 'token plan not support model (2061)' and absent from GET /v1/models. Use MiniMax-M2 (or M2.5/M2.7)."
+superseded_by = "MiniMax-M2"
 
 # MiniMax mirror on OpenRouter — same family, OpenRouter adds margin and
 # bundles native-tools passthrough so the openai_chat_completions wire

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -2144,6 +2144,40 @@ tier = "frontier"
 open_weight = true
 strengths = ["speed", "coding", "agentic", "tool_use", "reasoning", "long_context"]
 
+# Reliable Together serverless sample routes (harn#3645 §4). The prior
+# representative serverless rows were unusable as one-click samples:
+# `Qwen/Qwen3-Coder-Next-FP8` returns `model_not_available` on serverless
+# chat-completions (needs a dedicated endpoint; carried as
+# `availability = "dedicated"` in 20-open-weight-openrouter.toml), and the
+# Together `google/gemma-4-31B-it` route is a reasoning model with an
+# empty-content footgun. These two non-reasoning Turbo routes are live on
+# Together's serverless `/v1/chat/completions` with native tool calls and
+# serve as dependable cheap executor samples. Verified live ids on
+# together.ai/models (Qwen2.5 7B Instruct Turbo, Llama 3.3 70B Instruct
+# Turbo).
+[models."Qwen/Qwen2.5-7B-Instruct-Turbo"]
+name = "Qwen2.5 7B Instruct Turbo (Together)"
+provider = "together"
+context_window = 32768
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 0.30, output_per_mtok = 0.30 }
+tier = "small"
+open_weight = true
+strengths = ["speed", "cheap", "tool_use"]
+[models."meta-llama/Llama-3.3-70B-Instruct-Turbo"]
+name = "Llama 3.3 70B Instruct Turbo (Together)"
+provider = "together"
+context_window = 131072
+capabilities = ["tools", "streaming"]
+pricing = { input_per_mtok = 0.88, output_per_mtok = 0.88 }
+logical_model = "llama-3.3-70b-instruct"
+equivalence_group = "llama-3.3-70b-instruct"
+served_variant = "together"
+api_dialect = "openai_chat"
+tier = "mid"
+open_weight = true
+strengths = ["tool_use", "cheap"]
+
 # --- source: 60-models/30-cerebras.toml ---
 # Cerebras-hosted open-weight models. Serverless rows mirror
 # https://api.cerebras.ai/public/v1/models; dedicated-endpoint families are
@@ -2279,6 +2313,9 @@ provider = "minimax"
 context_window = 1000000
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.20, output_per_mtok = 1.10 }
+deprecated = true
+deprecation_note = "Dead on api.minimax.io 2026-06-28 (harn#3645 §4): HTTP 500 'token plan not support model (2061)' and absent from GET /v1/models. Use MiniMax-M2 (or M2.5/M2.7)."
+superseded_by = "MiniMax-M2"
 
 # MiniMax mirror on OpenRouter — same family, OpenRouter adds margin and
 # bundles native-tools passthrough so the openai_chat_completions wire

--- a/crates/harn-vm/src/provider_catalog/tests.rs
+++ b/crates/harn-vm/src/provider_catalog/tests.rs
@@ -1132,3 +1132,72 @@ routes = ["private:img:tag-a", "not-a-route"]
         "sibling routes are unaffected"
     );
 }
+
+#[test]
+fn live_catalog_wire_models_strip_provider_route_prefix() {
+    // harn#3645 §4 regression guard. Hosted rows are keyed by a
+    // `provider/<wire-id>` selector so the same weights stay collision-free
+    // across hosts (e.g. `groq/openai/gpt-oss-20b`,
+    // `deepinfra/Qwen/Qwen3.6-35B-A3B`), but the value sent on the wire must
+    // be the bare provider-native id with no `<provider>/` route prefix.
+    // A wire_model that still carries its own provider prefix 404s at request
+    // time. Assert every catalog row whose wire_model is set does NOT prefix
+    // the wire id with that row's provider segment.
+    let catalog = artifact();
+    let offenders: Vec<String> = catalog
+        .models
+        .iter()
+        .filter_map(|model| {
+            let wire = model.wire_model.as_deref()?;
+            let bad_prefix = format!("{}/", model.provider);
+            if wire.starts_with(&bad_prefix) {
+                Some(format!("{} -> wire_model {}", model.id, wire))
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert!(
+        offenders.is_empty(),
+        "wire_model values must not retain their own `<provider>/` route prefix: {offenders:?}"
+    );
+}
+
+#[test]
+fn live_catalog_deepinfra_wire_models_have_no_deepinfra_prefix() {
+    // harn#3645 §4 (deepinfra). The DeepInfra rows are keyed
+    // `deepinfra/<hf-id>` but dispatch the bare Hugging Face id (carried in
+    // wire_model). Lock that no DeepInfra wire id ever regains the
+    // `deepinfra/` prefix, e.g. the di-qwen3.6 route must send
+    // `Qwen/Qwen3.6-35B-A3B`, never `deepinfra/Qwen/Qwen3.6-35B-A3B`.
+    let catalog = artifact();
+    for model in catalog.models.iter().filter(|m| m.provider == "deepinfra") {
+        if let Some(wire) = model.wire_model.as_deref() {
+            assert!(
+                !wire.starts_with("deepinfra/"),
+                "deepinfra row {} has a wire_model still prefixed with `deepinfra/`: {wire}",
+                model.id
+            );
+        }
+    }
+}
+
+#[test]
+fn live_catalog_nvidia_minimax_m2_7_id_vs_wire_parity() {
+    // harn#3645 §4 (nvidia). The NVIDIA NIM catalog id `nvidia/minimax-m2.7`
+    // differs from the live NIM wire id `minimaxai/minimax-m2.7`. Dispatch is
+    // correct because wire_model carries the NIM id, but any path that uses the
+    // catalog `id` as the wire id 404s. Guard the wire_model so a future
+    // refresh cannot silently drop or wrong-case it.
+    let catalog = artifact();
+    let row = catalog
+        .models
+        .iter()
+        .find(|model| model.id == "nvidia/minimax-m2.7")
+        .expect("catalog has the nvidia/minimax-m2.7 row");
+    assert_eq!(
+        row.wire_model.as_deref(),
+        Some("minimaxai/minimax-m2.7"),
+        "nvidia/minimax-m2.7 must dispatch the NIM wire id minimaxai/minimax-m2.7"
+    );
+}

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -207,6 +207,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `together` | `qwen/*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `together` | `deepseek-ai/deepseek-v3*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `together` | `openai/gpt-oss-*` | `any` | `effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | no |
+| `together` | `meta-llama/Llama-3.3-70B-Instruct-Turbo` | `any` | no | no | no | no | no | yes | no | no | `markdown` | `none` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `together` | `deepseek-ai/deepseek-v4*` | `any` | `enabled,effort` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `reasoning_summary` | `native` | yes | yes | `unknown` | yes | yes |
 | `together` | `moonshotai/kimi-k2*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
 | `together` | `zai-org/glm-5*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `text` | yes | yes | `native_unreliable` | yes | yes |
@@ -377,7 +378,7 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `together` | `Qwen/Qwen3.7-Max` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `together` | `deepseek-ai/DeepSeek-V4-Pro` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `together` | `google/gemma-4-31B-it` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
-| `together` | `meta-llama/Llama-3.3-70B-Instruct-Turbo` | `text` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `together` | `meta-llama/Llama-3.3-70B-Instruct-Turbo` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `together` | `zai-org/GLM-5.1` | `text` | `native_unreliable` | - | - | - | - | - | `data not yet collected` |
 | `together` | `zai-org/GLM-5.2` | `text` | `native_unreliable` | - | - | - | - | - | `data not yet collected` |
 | `xai` | `grok-4.3` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -372,10 +372,12 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `sambanova` | `sambanova/gemma-4-31B-it` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `sambanova` | `sambanova/gpt-oss-120b` | `text` | `native_unreliable` | - | - | - | - | - | `data not yet collected` |
 | `together` | `MiniMaxAI/MiniMax-M2.7` | `text` | `native_unreliable` | - | - | - | - | - | `data not yet collected` |
+| `together` | `Qwen/Qwen2.5-7B-Instruct-Turbo` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `together` | `Qwen/Qwen3-Coder-Next-FP8` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `together` | `Qwen/Qwen3.7-Max` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `together` | `deepseek-ai/DeepSeek-V4-Pro` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `together` | `google/gemma-4-31B-it` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `together` | `meta-llama/Llama-3.3-70B-Instruct-Turbo` | `text` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `together` | `zai-org/GLM-5.1` | `text` | `native_unreliable` | - | - | - | - | - | `data not yet collected` |
 | `together` | `zai-org/GLM-5.2` | `text` | `native_unreliable` | - | - | - | - | - | `data not yet collected` |
 | `xai` | `grok-4.3` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -13130,14 +13130,17 @@
         ]
       },
       "tool_support": {
-        "native": false,
+        "native": true,
         "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "parity_notes": "Together documents native tool calls for this serverless sample route; add live parity probes before broadening to all Together-hosted Llama variants.",
         "tool_search": []
       },
       "structured_output": "none",
       "format_preferences": {
         "prefers_xml_scaffolding": false,
-        "prefers_markdown_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
         "structured_output_mode": "none",
         "supports_assistant_prefill": false,
         "prefers_role_developer": false,

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -6915,7 +6915,9 @@
         "cache_write_per_mtok": null
       },
       "deprecation": {
-        "status": "active"
+        "status": "deprecated",
+        "note": "Dead on api.minimax.io 2026-06-28 (harn#3645 §4): HTTP 500 'token plan not support model (2061)' and absent from GET /v1/models. Use MiniMax-M2 (or M2.5/M2.7).",
+        "superseded_by": "MiniMax-M2"
       },
       "availability": "serverless",
       "quality_tags": [],
@@ -12736,6 +12738,74 @@
       ]
     },
     {
+      "id": "Qwen/Qwen2.5-7B-Instruct-Turbo",
+      "name": "Qwen2.5 7B Instruct Turbo (Together)",
+      "provider": "together",
+      "aliases": [],
+      "context_window": 32768,
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": true,
+        "text": true,
+        "preferred_format": "native",
+        "parity": "unknown",
+        "tool_search": []
+      },
+      "structured_output": "native",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": true,
+        "structured_output_mode": "delimited",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "inline"
+      },
+      "reasoning": {
+        "modes": [
+          "enabled"
+        ],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.3,
+        "output_per_mtok": 0.3,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools",
+        "thinking",
+        "structured_output"
+      ],
+      "family": "qwen",
+      "lineage": "qwen",
+      "tier": "small",
+      "open_weight": true,
+      "strengths": [
+        "speed",
+        "cheap",
+        "tool_use"
+      ]
+    },
+    {
       "id": "Qwen/Qwen3-Coder-Next-FP8",
       "name": "Qwen3 Coder Next FP8 (Together, dedicated)",
       "provider": "together",
@@ -13039,6 +13109,71 @@
         "vision",
         "reasoning",
         "coding"
+      ]
+    },
+    {
+      "id": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+      "name": "Llama 3.3 70B Instruct Turbo (Together)",
+      "provider": "together",
+      "aliases": [],
+      "context_window": 131072,
+      "logical_model": "llama-3.3-70b-instruct",
+      "equivalence_group": "llama-3.3-70b-instruct",
+      "served_variant": "together",
+      "api_dialect": "openai_chat",
+      "modalities": {
+        "input": [
+          "text"
+        ],
+        "output": [
+          "text"
+        ]
+      },
+      "tool_support": {
+        "native": false,
+        "text": true,
+        "tool_search": []
+      },
+      "structured_output": "none",
+      "format_preferences": {
+        "prefers_xml_scaffolding": false,
+        "prefers_markdown_scaffolding": false,
+        "structured_output_mode": "none",
+        "supports_assistant_prefill": false,
+        "prefers_role_developer": false,
+        "prefers_xml_tools": false,
+        "thinking_block_style": "none"
+      },
+      "reasoning": {
+        "modes": [],
+        "effort_supported": false,
+        "none_supported": false,
+        "interleaved_supported": false,
+        "preserve_thinking": false
+      },
+      "prompt_cache": false,
+      "pricing": {
+        "input_per_mtok": 0.88,
+        "output_per_mtok": 0.88,
+        "cache_read_per_mtok": null,
+        "cache_write_per_mtok": null
+      },
+      "deprecation": {
+        "status": "active"
+      },
+      "availability": "serverless",
+      "quality_tags": [],
+      "capability_tags": [
+        "streaming",
+        "tools"
+      ],
+      "family": "llama",
+      "lineage": "llama",
+      "tier": "mid",
+      "open_weight": true,
+      "strengths": [
+        "tool_use",
+        "cheap"
       ]
     },
     {


### PR DESCRIPTION
Pure-config catalog corrections from the §4 "Catalog / tool-format corrections" checklist of harn#3645 (cross-provider footgun pre-mortem). Edits are in the sharded `catalog_sources/` fragments; `providers.toml`, `spec/provider-catalog/provider-catalog.json`, and `docs/src/provider-matrix.md` are regenerated from them with a freshly-built binary.

Refs #3645.

## §4 items closed

- **together** — added two reliable serverless sample routes (`Qwen/Qwen2.5-7B-Instruct-Turbo`, `meta-llama/Llama-3.3-70B-Instruct-Turbo`). The prior representative routes were unusable as one-click samples: `Qwen/Qwen3-Coder-Next-FP8` is dedicated-only (already `availability = "dedicated"`) and the Together Gemma route is a reasoning model with an empty-content footgun. Both new ids verified live/serverless on together.ai.
- **minimax** — deprecated the dead `MiniMax-Text-01` route (HTTP 500 `token plan not support model (2061)`; absent from `GET /v1/models`) with `superseded_by = "MiniMax-M2"`, using the existing deprecation convention.
- **deepinfra (#7)** — added a live-catalog contract test asserting no DeepInfra wire id retains the `deepinfra/` prefix (keeps the di-qwen3.6 `tool_format=text` pin untouched; the `Qwen/Qwen3.6-35B-A3B` wire_model already lives on the model row). Chose the contract-test option over duplicating `wire_model` onto the alias (aliases reference a model id; `wire_model` is a model-row field).
- **nvidia (#8)** — added a contract test asserting `nvidia/minimax-m2.7` dispatches the NIM wire id `minimaxai/minimax-m2.7` (wire_model already correct; this guards against regression).
- **groq (#4)** — covered by a third, general contract test asserting no `wire_model` retains its own `<provider>/` route prefix. The `groq/openai/gpt-oss-20b` row is already correct (wire_model `openai/gpt-oss-20b`, matching the established `provider/<wire-id>` keying used by every hosted gpt-oss row); `llama-3.3-70b-versatile` already exists as a cheap tool sample, so no row rename was warranted.

## Already correct (verified, no-op)

- **cerebras (#3)** — `gpt-oss-120b` + `zai-glm-4.7` are already the active samples; `llama-3.3-70b` is already `deprecated = true`.
- **anthropic (#9)** — `claude-3-5-haiku-20241022` is already `deprecated = true` + `superseded_by = "claude-haiku-4-5-20251001"`; the shipped haiku mapping is intact.

## Skipped (cannot be done as pure config — need a Rust consumer, out of scope)

- **huggingface (#1)** — the sharded catalog has **no huggingface gemma route**. The lowercase `gemma-4-26b-a4b-it` strings that exist are openrouter/gemini/local routes, and those are the **correct** wire ids for those providers (verified: OpenRouter + Gemini publish the fully-lowercase slug; only the HuggingFace/Google-direct id uses `gemma-4-26B-A4B-it`). The spec's target no longer exists; changing the lowercase rows would break OpenRouter/Gemini.
- **moonshot (#6)** — there is no `model_defaults`/`temperature` mechanism in the catalog schema at all (and no existing `moonshotai/*` default). Adding a temperature default would require a Rust schema field + consumer, which belongs to the openai_compat "Fix 3" and is excluded.
- **minimax reasoning_wire_format** — there is no `reasoning_wire_format`/`reasoning_split` field in the schema; inline-`<think>` extraction is response-decode behavior (Fix 4), not catalog config.

## Verification

Built and tested on a remote 24-core box (avoiding Mac CPU contention with the in-flight v0.8.152 release):
- `cargo build -p harn-vm` — OK
- `cargo test -p harn-vm --lib provider_catalog` — 38 passed (incl. 3 new contract tests)
- `cargo test -p harn-vm --lib llm_config` — 63 passed (no regression from the new `llama-3.3-70b-instruct` equivalence-group row)
- `cargo clippy -p harn-vm --all-targets -- -D warnings` — clean
- `harn providers build-config/export/matrix/support --check` + `validate --check-artifacts` — all up to date / OK with a freshly-built binary

Changelog fragment added: `changelog.d/3645-catalog-corrections.fixed.md`.