### PR TITLE
fix(policy,agents): let narrowed fan-out workers stat + carry real session id

### DIFF
--- a/changelog.d/3662.fixed.md
+++ b/changelog.d/3662.fixed.md
@@ -1,0 +1,5 @@
+- Let narrowed sub-agent fan-out workers stat paths and carry their real session
+  id: subsume `workspace.exists` under a `read_text`/`list` grant (so `look`,
+  `read_file`, and edit preflight stop hard-failing under a tool-derived child
+  policy), and stamp a sub-agent's audit with its real `sub_agent_session_*` id
+  instead of a fresh random one that joins to nothing.

--- a/crates/harn-vm/src/orchestration/policy/mod.rs
+++ b/crates/harn-vm/src/orchestration/policy/mod.rs
@@ -127,12 +127,37 @@ fn policy_allows_tool(policy: &CapabilityPolicy, tool: &str) -> bool {
     policy.tools.is_empty() || policy.tools.iter().any(|allowed| allowed == tool)
 }
 
+fn policy_grants_capability(policy: &CapabilityPolicy, capability: &str, op: &str) -> bool {
+    policy
+        .capabilities
+        .get(capability)
+        .is_some_and(|ops| ops.is_empty() || ops.iter().any(|allowed| allowed == op))
+}
+
 fn policy_allows_capability(policy: &CapabilityPolicy, capability: &str, op: &str) -> bool {
-    policy.capabilities.is_empty()
-        || policy
-            .capabilities
-            .get(capability)
-            .is_some_and(|ops| ops.is_empty() || ops.iter().any(|allowed| allowed == op))
+    if policy.capabilities.is_empty() {
+        // Empty capability map = allow-all (e.g. the root agent policy).
+        return true;
+    }
+    if policy_grants_capability(policy, capability, op) {
+        return true;
+    }
+    // Capability subsumption: a stronger read grant implies the weaker
+    // observations it already exposes. An existence/metadata probe
+    // (`workspace.exists`, used by `file_exists`/`stat`) reveals strictly less
+    // than reading file contents (`workspace.read_text`) or listing a directory
+    // (`workspace.list`) — both of which already disclose whether a path
+    // exists. A policy that grants read/list but withholds the existence probe
+    // is incoherent, and silently wedges any tool that stats a path before
+    // reading it (look, read_file, edit/scaffold preflight). Narrowed worker
+    // policies derived from tool annotations hit this constantly because no
+    // annotation declares `workspace.exists`. Encode the lattice once here so
+    // every narrowed policy benefits, not one dispatch surface at a time.
+    if capability == "workspace" && op == "exists" {
+        return policy_grants_capability(policy, "workspace", "read_text")
+            || policy_grants_capability(policy, "workspace", "list");
+    }
+    false
 }
 
 fn policy_allows_side_effect(policy: &CapabilityPolicy, requested: &str) -> bool {
@@ -843,6 +868,52 @@ mod approval_policy_tests {
     use super::*;
     use crate::orchestration::{pop_execution_policy, push_execution_policy, CapabilityPolicy};
     use crate::tool_annotations::{ToolAnnotations, ToolArgSchema, ToolKind};
+
+    fn workspace_caps(ops: &[&str]) -> CapabilityPolicy {
+        CapabilityPolicy {
+            capabilities: std::collections::BTreeMap::from([(
+                "workspace".to_string(),
+                ops.iter().map(|s| s.to_string()).collect(),
+            )]),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn read_text_subsumes_exists_probe() {
+        // A narrowed worker policy that grants read_text/list (the shape derived
+        // from look/edit/scaffold tool annotations) but never declares the
+        // weaker `workspace.exists` op must still permit `file_exists`/`stat`:
+        // existence is strictly less information than reading the file. Without
+        // subsumption this silently wedged every parallel sub-agent (look denied
+        // -> zero progress -> zero edits).
+        push_execution_policy(workspace_caps(&[
+            "read_text",
+            "list",
+            "write_text",
+            "apply_edit",
+        ]));
+        assert!(enforce_current_policy_for_builtin("file_exists", &[]).is_ok());
+        assert!(enforce_current_policy_for_builtin("stat", &[]).is_ok());
+        pop_execution_policy();
+    }
+
+    #[test]
+    fn list_alone_subsumes_exists_probe() {
+        // Listing a directory already reveals which entries exist.
+        push_execution_policy(workspace_caps(&["list"]));
+        assert!(enforce_current_policy_for_builtin("file_exists", &[]).is_ok());
+        pop_execution_policy();
+    }
+
+    #[test]
+    fn exists_probe_rejected_without_any_read_grant() {
+        // A write-only grant exposes no read surface, so the existence probe is
+        // genuinely above the ceiling and must still be rejected.
+        push_execution_policy(workspace_caps(&["write_text", "apply_edit"]));
+        assert!(enforce_current_policy_for_builtin("file_exists", &[]).is_err());
+        pop_execution_policy();
+    }
 
     #[test]
     fn auto_deny_takes_precedence_over_auto_approve() {

--- a/crates/harn-vm/src/stdlib/agents.rs
+++ b/crates/harn-vm/src/stdlib/agents.rs
@@ -149,6 +149,16 @@ fn fresh_worker_state(
     let mut audit = init.audit.normalize();
     audit.worker_id = Some(worker_id.clone());
     audit.execution_kind = Some(mode.clone());
+    // Receipts/lineage: a sub-agent's audit session_id must be its REAL session
+    // (`sub_agent_session_*`, the same id its event topic + transcript live
+    // under) so a fan-out is reconstructable from the audit alone. `normalize()`
+    // above otherwise minted a fresh random `session_*` that points at no topic,
+    // poisoning every downstream join (provenance, ACP wire, snapshot).
+    if let WorkerConfig::SubAgent { spec } = &init.config {
+        if !spec.session_id.is_empty() {
+            audit.session_id = spec.session_id.clone();
+        }
+    }
     let request = worker_request_for_config(&init.task, &init.config);
     Arc::new(parking_lot::Mutex::new(WorkerState {
         id: worker_id.clone(),


### PR DESCRIPTION
## Why

These are two correctness fixes for **sub-agent fan-out under a narrowed capability policy** (the shape `agent_fanout`/`dispatch` children run with). Both are invisible under the parent agent's allow-all policy and only bite a narrowed child.

Found by dogfooding a 10-file parallel `*.test.ts` → `*.integration.test.ts` migration through `burin-headless`: parallel children completed **zero** writes. Ground-truth from the run's `events.sqlite`: the children were denied on **`look`**, not `edit` — `"builtin 'file_exists' exceeds workspace.exists ceiling"`. A child that can't stat a path can't read it, can't make progress, and never edits.

## What

1. **Subsume `workspace.exists` under `read_text`/`list`** (`policy_allows_capability`). A worker policy derived from tool annotations grants `read_text`/`list` but never `exists` (no annotation declares it), yet `look`/`read_file`/edit-preflight call the `file_exists`/`stat` builtins. Existence is strictly weaker than reading contents or listing a directory — both already disclose whether a path exists — so granting either now permits the probe. A write-only grant still correctly rejects it.

   Deliberately **not** blanket-subsuming all read-only host_calls under workspace-read: `secrets.*` is classified `read_only` in the host_call gate and must stay gated. The subsumption is the single, safe `exists` edge.

2. **A sub-agent's `audit.session_id` must be its real `sub_agent_session_*` id.** `fresh_worker_state` ran `audit.normalize()`, minting a fresh random `session_*` that points at no event topic or transcript, so a fan-out could not be reconstructed from the audit alone (provenance, ACP wire view, snapshot joins all dereferenced a dead id).

## Tests

3 new `approval_policy_tests` unit tests: `read_text_subsumes_exists_probe`, `list_alone_subsumes_exists_probe`, `exists_probe_rejected_without_any_read_grant`. Full `orchestration::policy` + `agents_workers` + `stdlib::agents` suites green (135 passed).

## Proof it closes the delta

With this fix the same dogfood: judge **PASS / 52-of-52** checks, 22/22 tests green, all 10 files truly migrated (mockDb removed, real `db` imported, `db.reset()` in `beforeEach`), and **8 children running concurrently** for a **~5.2x wall-clock speedup** — children do the work, the parent does not redo it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)