### PR TITLE
refactor(cli)!: remove trust-graph alias, rename completions→completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ Shell completions:
 
 ```bash
 mkdir -p ~/.local/share/bash-completion/completions
-harn completions bash > ~/.local/share/bash-completion/completions/harn
+harn completion bash > ~/.local/share/bash-completion/completions/harn
 
 mkdir -p ~/.zfunc
-harn completions zsh > ~/.zfunc/_harn
+harn completion zsh > ~/.zfunc/_harn
 # Add to ~/.zshrc if needed: fpath=(~/.zfunc $fpath); autoload -Uz compinit; compinit
 
 mkdir -p ~/.config/fish/completions
-harn completions fish > ~/.config/fish/completions/harn.fish
+harn completion fish > ~/.config/fish/completions/harn.fish
 ```
 
 Container image:

--- a/changelog.d/cli-naming-cleanup.breaking.md
+++ b/changelog.d/cli-naming-cleanup.breaking.md
@@ -1,0 +1,4 @@
+- **CLI naming cleanup.** The `harn trust-graph` alias is removed — use
+  `harn trust` (its canonical name). The shell-completion command is renamed
+  from `harn completions <shell>` to `harn completion <shell>` for consistency
+  with the rest of the CLI. No aliases are kept; both are direct cutovers.

--- a/crates/harn-cli/src/cli/completion.rs
+++ b/crates/harn-cli/src/cli/completion.rs
@@ -1,7 +1,7 @@
 use clap::{Args, ValueEnum};
 
 #[derive(Debug, Args)]
-pub(crate) struct CompletionsArgs {
+pub(crate) struct CompletionArgs {
     /// Shell to generate completions for.
     #[arg(value_enum)]
     pub shell: CompletionShell,

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -13,7 +13,7 @@
 mod bench;
 mod check;
 mod codemod;
-mod completions;
+mod completion;
 mod config_cmd;
 mod connect;
 mod connector;
@@ -77,7 +77,7 @@ mod workflow;
 pub(crate) use bench::{BenchArgs, BenchCommand, BenchReplayArgs};
 pub(crate) use check::{CheckArgs, CheckOutputFormat};
 pub(crate) use codemod::CodemodArgs;
-pub(crate) use completions::{CompletionShell, CompletionsArgs};
+pub(crate) use completion::{CompletionArgs, CompletionShell};
 pub(crate) use config_cmd::{ConfigArgs, ConfigCommand, ConfigInspectArgs, ConfigValidateArgs};
 pub(crate) use connect::{
     ConnectApiKeyArgs, ConnectArgs, ConnectCommand, ConnectGenericArgs, ConnectGithubArgs,
@@ -391,13 +391,10 @@ SCRIPTING
     Crystallize(CrystallizeArgs),
     /// Query and manage trust-graph autonomy state.
     Trust(TrustArgs),
-    /// Alias for `harn trust`. Query and verify trust-graph autonomy state.
-    #[command(name = "trust-graph")]
-    TrustGraph(TrustArgs),
     /// Verify a signed Harn provenance receipt.
     Verify(VerifyArgs),
     /// Print shell completion script to stdout.
-    Completions(CompletionsArgs),
+    Completion(CompletionArgs),
     /// Start the orchestrator process that hosts triggers and connector dispatch.
     Orchestrator(OrchestratorArgs),
     /// Run a pipeline against a Harn-native host module for fast iteration.

--- a/crates/harn-cli/src/cli/tests/parse_core.rs
+++ b/crates/harn-cli/src/cli/tests/parse_core.rs
@@ -240,11 +240,11 @@ fn test_parses_add_registry_override() {
 }
 
 #[test]
-fn test_parses_completions_args() {
-    let cli = Cli::parse_from(["harn", "completions", "zsh"]);
+fn test_parses_completion_args() {
+    let cli = Cli::parse_from(["harn", "completion", "zsh"]);
 
-    let Command::Completions(args) = cli.command.unwrap() else {
-        panic!("expected completions command");
+    let Command::Completion(args) = cli.command.unwrap() else {
+        panic!("expected completion command");
     };
     assert_eq!(args.shell, CompletionShell::Zsh);
 }
@@ -261,7 +261,7 @@ fn test_completion_scripts_include_subcommands() {
     );
     let script = String::from_utf8(output).expect("completion script should be utf-8");
 
-    assert!(script.contains("completions"));
+    assert!(script.contains("completion"));
     assert!(script.contains("tool-probe"));
 }
 

--- a/crates/harn-cli/src/cli/tests/parse_packaging.rs
+++ b/crates/harn-cli/src/cli/tests/parse_packaging.rs
@@ -160,14 +160,14 @@ fn test_parses_trust_demote_flags() {
 }
 
 #[test]
-fn test_parses_trust_graph_verify_chain() {
-    let cli = Cli::parse_from(["harn", "trust-graph", "verify-chain", "--json"]);
+fn test_parses_trust_verify_chain() {
+    let cli = Cli::parse_from(["harn", "trust", "verify-chain", "--json"]);
 
-    let Command::TrustGraph(args) = cli.command.unwrap() else {
-        panic!("expected trust-graph command");
+    let Command::Trust(args) = cli.command.unwrap() else {
+        panic!("expected trust command");
     };
     let TrustCommand::VerifyChain(verify) = args.command else {
-        panic!("expected trust-graph verify-chain");
+        panic!("expected trust verify-chain");
     };
     assert!(verify.json);
 }

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -988,7 +988,7 @@ async fn async_main(raw_args: Vec<String>, runtime_mode: CliRuntimeMode) {
                 process::exit(1);
             }
         }
-        Command::Trust(args) | Command::TrustGraph(args) => {
+        Command::Trust(args) => {
             if let Err(error) = commands::trust::handle(args).await {
                 eprintln!("error: {error}");
                 process::exit(1);
@@ -1000,7 +1000,7 @@ async fn async_main(raw_args: Vec<String>, runtime_mode: CliRuntimeMode) {
                 process::exit(1);
             }
         }
-        Command::Completions(args) => print_completions(args.shell),
+        Command::Completion(args) => print_completions(args.shell),
         Command::Orchestrator(args) => {
             if let Err(error) = commands::orchestrator::handle(args).await {
                 eprintln!("error: {error}");

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -312,14 +312,14 @@ harn session schema --check
 safety. `import` and `validate` accept
 `--allow-unsafe-secret-markers` only for trusted local bundles.
 
-## harn completions
+## harn completion
 
 Print shell completion scripts.
 
 ```bash
-harn completions bash
-harn completions zsh
-harn completions fish
+harn completion bash
+harn completion zsh
+harn completion fish
 ```
 
 Generated completions include subcommands plus static candidates for known
@@ -2032,13 +2032,13 @@ Supported filters:
 `--summary` groups records by agent and reports success rate, mean recorded
 cost, tier distribution, and outcome distribution.
 
-## harn trust-graph verify-chain
+## harn trust verify-chain
 
 Verify the workspace trust graph's hash chain.
 
 ```bash
-harn trust-graph verify-chain
-harn trust-graph verify-chain --json
+harn trust verify-chain
+harn trust verify-chain --json
 ```
 
 The command reads `trust_graph` and falls back to legacy `trust.graph` logs,

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -107,14 +107,14 @@ portal.
 
 ```bash
 mkdir -p ~/.local/share/bash-completion/completions
-harn completions bash > ~/.local/share/bash-completion/completions/harn
+harn completion bash > ~/.local/share/bash-completion/completions/harn
 
 mkdir -p ~/.zfunc
-harn completions zsh > ~/.zfunc/_harn
+harn completion zsh > ~/.zfunc/_harn
 # Add to ~/.zshrc if needed: fpath=(~/.zfunc $fpath); autoload -Uz compinit; compinit
 
 mkdir -p ~/.config/fish/completions
-harn completions fish > ~/.config/fish/completions/harn.fish
+harn completion fish > ~/.config/fish/completions/harn.fish
 ```
 
 ## Your first program

--- a/docs/src/spec/open-trust-graph/v0.md
+++ b/docs/src/spec/open-trust-graph/v0.md
@@ -60,8 +60,8 @@ Strategic positioning aside, the practical reasons:
 Inside Harn, emit the canonical envelope with:
 
 ```bash
-harn trust-graph export --output chain.json
-harn trust-graph export | python3 opentrustgraph-spec/examples/python/verify_chain.py
+harn trust export --output chain.json
+harn trust export | python3 opentrustgraph-spec/examples/python/verify_chain.py
 ```
 
 The export envelope has its `chain.verified` flag set from the

--- a/docs/src/trust-graph.md
+++ b/docs/src/trust-graph.md
@@ -81,17 +81,17 @@ Query the trust graph:
 harn trust query --agent github-triage-bot
 harn trust query --agent github-triage-bot --outcome denied --json
 harn trust query --summary
-harn trust-graph verify-chain
-harn trust-graph export --output chain.json
+harn trust verify-chain
+harn trust export --output chain.json
 ```
 
-`harn trust-graph export` writes the canonical
+`harn trust export` writes the canonical
 [`opentrustgraph-chain/v0`](spec/open-trust-graph/v0.md) envelope. With no
 `--output`, it prints the JSON to stdout. Pipe it through any conformant
 verifier — e.g. the reference Python verifier:
 
 ```bash
-harn trust-graph export | python3 opentrustgraph-spec/examples/python/verify_chain.py
+harn trust export | python3 opentrustgraph-spec/examples/python/verify_chain.py
 ```
 
 Promote or demote an agent:

--- a/opentrustgraph-spec/CONFORMANCE.md
+++ b/opentrustgraph-spec/CONFORMANCE.md
@@ -103,7 +103,7 @@ supervision UIs, and third-party verifiers.
    `records = []`.
 
 The Harn reference impl emits this envelope via
-`harn trust-graph export --output chain.json` (or stdout). External
+`harn trust export --output chain.json` (or stdout). External
 consumers can also project the portal `GET /api/trust-graph` response
 into the envelope shape.
 

--- a/opentrustgraph-spec/README.md
+++ b/opentrustgraph-spec/README.md
@@ -63,7 +63,7 @@ chain extends the parent's `actor_chain` by exactly one hop.
   required but omits the approver/signature evidence.
 - `examples/python/verify_chain.py`: reference, stdlib-only verifier in pure
   Python. Validates every fixture and any chain emitted by
-  `harn trust-graph export`.
+  `harn trust export`.
 
 ## Verification contract
 
@@ -88,7 +88,7 @@ one signature receipt in `metadata.approval.signatures`.
 ## Harn integration points
 
 - Runtime events are emitted to `trust_graph` plus `trust_graph.<agent_id>`.
-- `harn trust-graph verify-chain --json` exposes verification metadata that can
+- `harn trust verify-chain --json` exposes verification metadata that can
   be projected into the chain export shape.
 - The portal `GET /api/trust-graph` endpoint returns records, summaries, and
   verification status for local supervision surfaces.

--- a/opentrustgraph-spec/examples/python/README.md
+++ b/opentrustgraph-spec/examples/python/README.md
@@ -17,7 +17,7 @@ python3 verify_chain.py ../../fixtures/invalid/missing-approval.json
 python3 verify_chain.py ../../fixtures/invalid/actor-chain-parentage.json
 
 # Read from stdin (for piping out of a producer):
-harn trust-graph export | python3 verify_chain.py
+harn trust export | python3 verify_chain.py
 ```
 
 The script implements the canonicalization rule documented in

--- a/spec/opentrustgraph.md
+++ b/spec/opentrustgraph.md
@@ -186,13 +186,13 @@ checks Harn runs internally.
 
 ## Producing a chain export
 
-Harn ships `harn trust-graph export` (alias of `harn trust export`),
+Harn ships `harn trust export`,
 which writes a verified `opentrustgraph-chain/v0` envelope to stdout or
 to a file:
 
 ```bash
-harn trust-graph export --output chain.json
-harn trust-graph export | python3 opentrustgraph-spec/examples/python/verify_chain.py
+harn trust export --output chain.json
+harn trust export | python3 opentrustgraph-spec/examples/python/verify_chain.py
 ```
 
 The export uses `verify_trust_chain` internally so `chain.verified` is


### PR DESCRIPTION
## CLI naming cleanup (no aliases)

Two consistency fixes, both direct cutovers:

- **Remove the `harn trust-graph` alias** — it was a pure alias for `harn trust` (identical handler). The OpenTrustGraph spec, conformance docs, examples, and CLI reference now use `harn trust export` / `harn trust verify-chain`.
- **Rename `harn completions <shell>` → `harn completion <shell>`** for noun/verb consistency with the rest of the CLI.

Part of the pre-public CLI cutover (after the provider #3661 and skill #3664 consolidations).

### Scope notes (deliberate non-changes)
- `harn scan` is **kept** (not renamed to `search`): it runs rules/lint over files (analysis, not find-only), and `harn package search` already owns "search" for the registry.
- Package commands are **already cargo-aligned** (`add`/`install`/`remove`/`update`/`publish`/`pack` top-level; `harn package` holds cache/audit/docs/etc) — no grouping needed.

### Verification
- `harn-cli --lib`: 915 passed · `clippy -D warnings` (all targets) clean · build + smoke (`harn completion zsh` works; `harn completions` and `harn trust-graph` correctly error as unknown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
