### PR TITLE
docs: slopwash + Diataxis pass on onboarding prose

### DIFF
--- a/docs/src/concepts/cross-session-pattern-knowledge.md
+++ b/docs/src/concepts/cross-session-pattern-knowledge.md
@@ -1,4 +1,4 @@
-# Cross-Session Pattern Knowledge
+# Cross-session pattern knowledge
 
 Harn owns cross-session pattern recall as a typed `harness.knowledge` layer over
 `std/memory`. The concrete stdlib entrypoint is `std/agent/pattern_knowledge`,
@@ -9,7 +9,7 @@ This is not an A.5 session-store cross-session API. Session storage is useful
 for transcript and run-event audit trails; pattern recall is long-lived agent
 knowledge with its own retention, recall, and promotion policy.
 
-## Decision Criteria
+## Decision criteria
 
 | Criterion | Decision |
 |---|---|
@@ -18,7 +18,7 @@ knowledge with its own retention, recall, and promotion policy.
 | Multi-tenant shape | Namespace and memory root isolate local projects today. Cloud agents can map the same namespace to tenant, organization, and project scopes without adding a Burin-specific host API. |
 | Embedding versus keyword | The default clustering is deterministic lexical matching so tests and replay are stable. Hosts that need semantic recall can open the same memory namespace in vector or hybrid mode through `std/memory`. |
 
-## Primitive Shape
+## Primitive shape
 
 `std/agent/pattern_knowledge` stores `harn.pattern_learning.v1` records under the
 `project/pattern-learning` namespace:

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -69,7 +69,7 @@ harn version
 The one-line installer and `cargo install harn-cli` do not require a
 Rust toolchain on the user's machine.
 
-### See Harn in action in 30 seconds
+## See Harn in action in 30 seconds
 
 Before configuring anything, run a bundled offline demo. No API keys,
 no project setup, no network — every demo replays from a JSONL tape
@@ -84,7 +84,7 @@ harn demo --list           # one-line summary of every scenario
 See [`harn demo` in the CLI reference](cli-reference.md#harn-demo) for
 the full surface and `--live` opt-in.
 
-### Run this first
+## Run this first
 
 `harn doctor` is the one-command environment readiness check. It probes the
 toolchain, optional dev tools, portal dependencies, platform capabilities,
@@ -103,7 +103,7 @@ releases — IDE hosts and cloud platforms read the `summary.blocked_flows` arra
 decide whether a host can build, test, release, run scripts, or work on the
 portal.
 
-### Optional shell completions
+## Optional shell completions
 
 ```bash
 mkdir -p ~/.local/share/bash-completion/completions


### PR DESCRIPTION
## What

A prose-quality and Diataxis-structure pass on the high-traffic onboarding
docs ahead of the public launch. I ran the slopwash rubric against the prose
of `README.md`, `docs/src/getting-started.md`, `CONTRIBUTING.md`, and every
`docs/src/concepts/*` page.

## Finding: the prose is already clean

Every prose section scored 97-99/100 on the slopwash rubric, with zero
high-severity vocabulary, tone, or formatting hits. The only flagged
"violations" were rule-of-three comma lists that are factual feature
enumerations (e.g. "transcripts, context assembly, retries") — rewriting
those to dodge the heuristic would have hurt accuracy, so I left them. A
grep for the banned-vocabulary list across all in-scope files came back
empty. These docs have clearly had prior editorial passes.

## Changes (structure only)

- **`docs/src/getting-started.md`** — promoted "See Harn in action in 30
  seconds", "Run this first" (`harn doctor`), and "Optional shell
  completions" from `###` to `##`. They were mis-nested as children of
  "Prerequisites for building from source" despite being top-level
  onboarding steps unrelated to building from source. Fixes the page
  outline / sidebar nesting.
- **`docs/src/concepts/cross-session-pattern-knowledge.md`** — converted
  Title Case headings ("Cross-Session Pattern Knowledge", "Decision
  Criteria", "Primitive Shape") to sentence case, matching the house style
  every other docs page uses and the casing the concepts index card already
  uses to link this page.

## Safety

No commands, code blocks, flags, or file paths were touched. Markdown
anchors lowercase heading text, and the H-level changes leave anchor text
intact, so no internal links break. `markdownlint-cli2` passes clean.