### PR TITLE
refactor(cli)!: fold model-info into models info

### DIFF
--- a/changelog.d/cli-models-info.breaking.md
+++ b/changelog.d/cli-models-info.breaking.md
@@ -1,0 +1,4 @@
+- **`harn model-info` is folded into `harn models info`.** The standalone
+  top-level `model-info` command is removed; the same model-metadata lookup now
+  lives under the `models` noun (`harn models info <model> [--verify] [--warm]`),
+  matching the `provider`/`skill` consolidations. No alias is kept.

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -135,8 +135,8 @@ pub(crate) use merge_captain::{
     MergeCaptainMockStatusArgs, MergeCaptainMockStepArgs, MergeCaptainRunArgs,
 };
 pub(crate) use models::{
-    ModelRecommendArgs, ModelsArgs, ModelsCommand, ModelsInstallArgs, ModelsListArgs,
-    ModelsTestArgs,
+    ModelInfoArgs, ModelRecommendArgs, ModelsArgs, ModelsCommand, ModelsInstallArgs,
+    ModelsListArgs, ModelsTestArgs,
 };
 pub(crate) use orchestrator::{
     OrchestratorArgs, OrchestratorCommand, OrchestratorDeployArgs, OrchestratorDeployProvider,
@@ -168,7 +168,7 @@ pub(crate) use portal::PortalArgs;
 pub use precompile::PrecompileArgs;
 pub(crate) use profile::ProfileArgs;
 pub(crate) use provider::{
-    refresh_provider_catalog_if_requested, ModelInfoArgs, ProviderArgs, ProviderCapabilitiesArgs,
+    refresh_provider_catalog_if_requested, ProviderArgs, ProviderCapabilitiesArgs,
     ProviderCapabilitiesCommand, ProviderCapabilitiesPromoteFromEvalArgs, ProviderCommand,
     ProviderProbeArgs, ProviderToolProbeArgs, ProviderToolProbeModeArg,
 };
@@ -462,8 +462,6 @@ SCRIPTING
     /// Merge Captain transcript oracle and audit (#1013).
     #[command(name = "merge-captain")]
     MergeCaptain(MergeCaptainArgs),
-    /// Print resolved metadata for a model alias or model id as JSON.
-    ModelInfo(ModelInfoArgs),
     /// List, install, recommend, and test configured LLM models.
     Models(ModelsArgs),
     /// Manage local LLM runtime lifecycle: enumerate, switch, and stop

--- a/crates/harn-cli/src/cli/models.rs
+++ b/crates/harn-cli/src/cli/models.rs
@@ -1,5 +1,7 @@
 use clap::{Args, Subcommand};
 
+use super::util::llm_model_completion_parser;
+
 #[derive(Debug, Args)]
 pub(crate) struct ModelsArgs {
     #[command(subcommand)]
@@ -8,6 +10,8 @@ pub(crate) struct ModelsArgs {
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum ModelsCommand {
+    /// Print resolved metadata for a model alias or model id as JSON.
+    Info(ModelInfoArgs),
     /// List models grouped by provider.
     List(ModelsListArgs),
     /// Pull an Ollama model or print setup steps for a known local runtime.
@@ -16,6 +20,25 @@ pub(crate) enum ModelsCommand {
     Recommend(ModelRecommendArgs),
     /// Round-trip a small prompt through a model and report timing, tokens, and cost.
     Test(ModelsTestArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct ModelInfoArgs {
+    /// Verify provider-local readiness for the resolved model when supported.
+    #[arg(long)]
+    pub verify: bool,
+    /// Warm/preload the resolved model when supported. Implies --verify.
+    #[arg(long)]
+    pub warm: bool,
+    /// Ollama keep_alive value to use with --warm (for example 30m, forever, or -1).
+    #[arg(long = "keep-alive", value_name = "VALUE")]
+    pub keep_alive: Option<String>,
+    /// Model alias or provider-native model id.
+    #[arg(
+        value_parser = llm_model_completion_parser(),
+        hide_possible_values = true
+    )]
+    pub model: String,
 }
 
 #[derive(Debug, Args)]

--- a/crates/harn-cli/src/cli/provider.rs
+++ b/crates/harn-cli/src/cli/provider.rs
@@ -58,25 +58,6 @@ pub(crate) struct ProviderCapabilitiesPromoteFromEvalArgs {
 }
 
 #[derive(Debug, Args)]
-pub(crate) struct ModelInfoArgs {
-    /// Verify provider-local readiness for the resolved model when supported.
-    #[arg(long)]
-    pub verify: bool,
-    /// Warm/preload the resolved model when supported. Implies --verify.
-    #[arg(long)]
-    pub warm: bool,
-    /// Ollama keep_alive value to use with --warm (for example 30m, forever, or -1).
-    #[arg(long = "keep-alive", value_name = "VALUE")]
-    pub keep_alive: Option<String>,
-    /// Model alias or provider-native model id.
-    #[arg(
-        value_parser = llm_model_completion_parser(),
-        hide_possible_values = true
-    )]
-    pub model: String,
-}
-
-#[derive(Debug, Args)]
 pub(crate) struct ProviderCatalogShowArgs {
     /// Only include providers that are usable in the current environment.
     #[arg(long)]

--- a/crates/harn-cli/src/cli/tests/parse_providers.rs
+++ b/crates/harn-cli/src/cli/tests/parse_providers.rs
@@ -285,10 +285,11 @@ fn test_parses_viz_args() {
 }
 
 #[test]
-fn test_parses_model_info_args() {
+fn test_parses_models_info_args() {
     let cli = Cli::parse_from([
         "harn",
-        "model-info",
+        "models",
+        "info",
         "--verify",
         "--warm",
         "--keep-alive",
@@ -296,8 +297,11 @@ fn test_parses_model_info_args() {
         "tog-gemma4-31b",
     ]);
 
-    let Command::ModelInfo(args) = cli.command.unwrap() else {
-        panic!("expected model-info command");
+    let Command::Models(args) = cli.command.unwrap() else {
+        panic!("expected models command");
+    };
+    let ModelsCommand::Info(args) = args.command else {
+        panic!("expected models info");
     };
     assert_eq!(args.model, "tog-gemma4-31b");
     assert!(args.verify);

--- a/crates/harn-cli/src/commands/models/mod.rs
+++ b/crates/harn-cli/src/commands/models/mod.rs
@@ -9,6 +9,11 @@ use crate::cli::{ModelsArgs, ModelsCommand};
 
 pub(crate) async fn run(args: ModelsArgs) {
     match args.command {
+        ModelsCommand::Info(args) => {
+            if !crate::print_model_info(&args).await {
+                std::process::exit(1);
+            }
+        }
         ModelsCommand::List(args) => list::run(args).await,
         ModelsCommand::Install(args) => install::run(args).await,
         ModelsCommand::Recommend(args) => recommend::run(&args).await,

--- a/crates/harn-cli/src/lib.rs
+++ b/crates/harn-cli/src/lib.rs
@@ -1386,11 +1386,6 @@ async fn async_main(raw_args: Vec<String>, runtime_mode: CliRuntimeMode) {
                 }
             },
         },
-        Command::ModelInfo(args) => {
-            if !print_model_info(&args).await {
-                process::exit(1);
-            }
-        }
         Command::Tool(args) => match args.command {
             ToolCommand::New(new_args) => {
                 if let Err(error) = commands::tool::run_new(&new_args).await {
@@ -1490,7 +1485,7 @@ async fn run_version(args: cli::VersionArgs) -> i32 {
     dispatch::dispatch_to_embedded_script("version", argv, args.json).await
 }
 
-async fn print_model_info(args: &ModelInfoArgs) -> bool {
+pub(crate) async fn print_model_info(args: &ModelInfoArgs) -> bool {
     let resolved = harn_vm::llm_config::resolve_model_info(&args.model);
     let api_key_result = harn_vm::llm::resolve_api_key(&resolved.provider);
     let api_key_set = api_key_result.is_ok();
@@ -1576,7 +1571,7 @@ async fn print_model_info(args: &ModelInfoArgs) -> bool {
                 "valid": false,
                 "status": "unsupported_provider",
                 "message": format!(
-                    "model-info --verify is only supported for Ollama models; resolved provider is '{}'",
+                    "models info --verify is only supported for Ollama models; resolved provider is '{}'",
                     resolved.provider
                 ),
                 "provider": resolved.provider,

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1308,16 +1308,16 @@ harn models test qwen3:30b --provider ollama --json
 uses the configured provider client path, so it also respects provider
 credentials, base URL overrides, and `HARN_LLM_CALLS_DISABLED`.
 
-## harn model-info
+## harn models info
 
 Print resolved model metadata as JSON. For Ollama models, `--verify` probes
 `/api/tags` and checks the selected tag. `--warm` implies `--verify` and sends
 an empty `/api/generate` request to preload the matched tag.
 
 ```bash
-harn model-info llama3.2:latest
-harn model-info --verify llama3.2
-harn model-info --warm --keep-alive 30m llama3.2
+harn models info llama3.2:latest
+harn models info --verify llama3.2
+harn models info --warm --keep-alive 30m llama3.2
 ```
 
 Ollama readiness failures use stable `readiness.status` values, including

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -280,7 +280,7 @@ OpenAI Responses-capable rows also expose `responses_api`, `hosted_tools`,
 
 The same matrix is the source of truth for Harn's default tool-calling
 mode. Alias-level `tool_format` still wins when set explicitly, but
-otherwise `preferred_tool_format` chooses `agent_loop()` and `model-info`
+otherwise `preferred_tool_format` chooses `agent_loop()` and `models info`
 tool mode for that provider/model route. Rows that do not set it infer
 `native` when `native_tools = true` and `text` otherwise. Rows can set
 `text_tool_wire_format_supported = true` for runtimes where Harn's text-tool
@@ -536,7 +536,7 @@ runner.
 Inspect what is actually loaded vs. what Harn would request:
 
 ```bash
-harn model-info devstral-small-2 --verify --warm
+harn models info devstral-small-2 --verify --warm
 ```
 
 The JSON output includes:
@@ -551,7 +551,7 @@ If `context_drift` is set, force a reload with:
 
 ```bash
 ollama stop devstral-small-2:24b
-harn model-info devstral-small-2 --verify --warm
+harn models info devstral-small-2 --verify --warm
 ```
 
 The new warmup correctly passes `options.num_ctx`, so the next load


### PR DESCRIPTION
## Fold `model-info` into `models info`

Removes the standalone top-level `harn model-info` command; the same model-metadata lookup now lives under the `models` noun as **`harn models info <model> [--verify] [--warm] [--keep-alive]`**, matching the `provider`/`skill` consolidations. No alias kept (pre-1.0, direct cutover).

### Changes
- `ModelInfoArgs` moves from the provider module to the models module; `ModelsCommand` gains an `Info` variant.
- `print_model_info` (kept in lib.rs alongside the other `print_*` dispatch helpers) is reused by the `models info` dispatch.
- Top-level `Command::ModelInfo` + its dispatch removed; parse test + docs (`cli-reference`, `llm/providers`) updated; user-facing error message updated.

### Verification
- `harn-cli --lib`: 915 passed · `clippy -D warnings` (all targets) clean · build + smoke (`harn models info --help` works; `harn model-info` correctly errors as unknown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
