### PR TITLE
fix(agent): make argument allow-list denials recoverable, not terminal

### DIFF
--- a/changelog.d/arg-constraint-recoverable.fixed.md
+++ b/changelog.d/arg-constraint-recoverable.fixed.md
@@ -1,0 +1,8 @@
+- Coach a retry instead of a give-up when a tool call is refused by the argument
+  allow-list. A path/command outside an agent's scoped `tool_arg_constraints`
+  (e.g. a fan-out child scoped to `test/users.*` that tried to edit the shared
+  reference file) is now a SOFT, retryable denial: the model is told its allowed
+  pattern(s) and to re-issue with a matching argument — and to read reference
+  files with `look` rather than editing them — rather than reading the terminal
+  "permission denied / do not retry" body and abandoning the turn. Hard
+  capability/side-effect/tool ceilings stay terminal.

--- a/conformance/errors/semantic/tool_arg_constraint_rejection.harn
+++ b/conformance/errors/semantic/tool_arg_constraint_rejection.harn
@@ -5,7 +5,7 @@ fn list_tools() {
     "list_directory",
     "List directory contents",
     {
-      handler: { args -> "" },
+      handler: { _args -> "" },
       parameters: {path: {type: "string", description: "Directory path"}},
       returns: {type: "string"},
     },
@@ -27,6 +27,6 @@ pipeline test(task) {
   )
   log(result?.tools?.rejected[0])
   log(
-    json_stringify(transcript_messages(result?.transcript)).contains("does not match allowed patterns"),
+    json_stringify(transcript_messages(result?.transcript)).contains("is outside your allowed scope"),
   )
 }

--- a/crates/harn-vm/src/agent_events/tool.rs
+++ b/crates/harn-vm/src/agent_events/tool.rs
@@ -263,6 +263,27 @@ impl ToolDenial {
         }
     }
 
+    /// Build a SOFT denial (`retryable: true`): the call was refused for *this*
+    /// argument, but re-issuing it with a corrected argument can succeed — so
+    /// the model should be coached to retry with the correction rather than told
+    /// to give up. Used for the argument allow-list gate (`ArgConstraint`),
+    /// where a path/command outside the allowed scope is a fixable slip, not a
+    /// hard capability ceiling. The dispatch boundary routes a retryable denial
+    /// through the recoverable (retry-positive) tool-result body.
+    pub fn retryable(
+        gate: DenialGate,
+        capability: Option<String>,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            gate,
+            capability,
+            denied_paths: Vec::new(),
+            retryable: true,
+            reason: reason.into(),
+        }
+    }
+
     pub fn to_json(&self) -> serde_json::Value {
         serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
     }

--- a/crates/harn-vm/src/llm/agent_host_primitives.rs
+++ b/crates/harn-vm/src/llm/agent_host_primitives.rs
@@ -214,7 +214,12 @@ fn agent_primitive_denied_tool(
     // "permission_denied / Do not retry the same call" after one fixable arg
     // mistake and gave up (false FAIL across ~26 recent eval transcripts). True
     // policy/permission denials keep the don't-retry `denied_tool_result` body.
-    let mut result = if category.is_recoverable() {
+    // A denial the gate marked `retryable` (an argument allow-list miss — the
+    // tool is permitted, only this argument value is out of scope) is coached
+    // like a fixable-argument slip: retry with a corrected argument, not "give
+    // up". Hard ceilings and true permission denials keep the don't-retry body.
+    let retryable_denial = denial.is_some_and(|denial| denial.retryable);
+    let mut result = if category.is_recoverable() || retryable_denial {
         agent_tools::recoverable_tool_result(tool_name, reason.clone())
     } else {
         agent_tools::denied_tool_result(tool_name, reason.clone())
@@ -889,11 +894,24 @@ async fn host_agent_dispatch_tool_call(
             )
         })
     {
-        let denial = crate::agent_events::ToolDenial::terminal(
-            policy_denial.gate,
-            policy_denial.capability,
-            policy_denial.reason,
-        );
+        // An argument allow-list miss (e.g. a sub-agent scoped to `test/users.*`
+        // that tried to edit the shared reference file) is RECOVERABLE: the tool
+        // is permitted, only this path is out of scope, so coach a retry with an
+        // allowed path instead of a terminal "do not retry". Hard ceilings
+        // (tool/capability/side-effect) stay terminal.
+        let denial = if policy_denial.gate == crate::agent_events::DenialGate::ArgConstraint {
+            crate::agent_events::ToolDenial::retryable(
+                policy_denial.gate,
+                policy_denial.capability,
+                policy_denial.reason,
+            )
+        } else {
+            crate::agent_events::ToolDenial::terminal(
+                policy_denial.gate,
+                policy_denial.capability,
+                policy_denial.reason,
+            )
+        };
         return Ok(deny_tool_call_value(
             &session_id,
             &tool_name,
@@ -2055,6 +2073,65 @@ mod denied_tool_routing_tests {
         assert!(
             !next.contains("Do not retry"),
             "empty-name slip must be retry-positive: {next}"
+        );
+    }
+
+    #[test]
+    fn retryable_arg_constraint_denial_is_coached_as_recoverable() {
+        use crate::agent_events::{DenialGate, ToolDenial};
+        // A sub-agent scoped to `test/users.*` that tried to edit the shared
+        // reference file: the tool is permitted, only this path is out of scope.
+        let denial = ToolDenial::retryable(
+            DenialGate::ArgConstraint,
+            None,
+            "tool 'edit' path 'test/accounts.integration.test.ts' is outside your allowed \
+             scope. Allowed path pattern(s): [\"test/users.*\"]. This is fixable: re-issue \
+             the call with a path that matches one of those patterns.",
+        );
+        let envelope = agent_primitive_denied_tool(
+            "edit",
+            "call_3",
+            &serde_json::json!({ "path": "test/accounts.integration.test.ts" }),
+            denial.reason.clone(),
+            ToolCallErrorCategory::PermissionDenied,
+            Some(&denial),
+        );
+        let result = &envelope["result"];
+        // Retry-positive body, NOT a hard permission denial.
+        assert_eq!(result["error"], serde_json::json!("invalid_arguments"));
+        assert_ne!(result["error"], serde_json::json!("permission_denied"));
+        let next = result["next_step"].as_str().expect("next_step");
+        assert!(
+            !next.contains("Do not retry"),
+            "retryable arg-scope denial must coach a correction, not give-up: {next}"
+        );
+        // The structured denial still records the precise gate + retryable flag.
+        assert_eq!(envelope["denial"]["gate"], "arg_constraint");
+        assert_eq!(envelope["denial"]["retryable"], true);
+    }
+
+    #[test]
+    fn hard_capability_denial_stays_terminal() {
+        use crate::agent_events::{DenialGate, ToolDenial};
+        let denial = ToolDenial::terminal(
+            DenialGate::CapabilityCeiling,
+            Some("workspace.write_text".to_string()),
+            "tool 'edit' exceeds capability ceiling: workspace.write_text",
+        );
+        let envelope = agent_primitive_denied_tool(
+            "edit",
+            "call_4",
+            &serde_json::json!({ "path": "x" }),
+            denial.reason.clone(),
+            ToolCallErrorCategory::PermissionDenied,
+            Some(&denial),
+        );
+        let result = &envelope["result"];
+        assert_eq!(result["error"], serde_json::json!("permission_denied"));
+        let next = result["next_step"].as_str().expect("next_step");
+        assert!(
+            next.contains("Do not retry"),
+            "a hard capability ceiling must stay terminal: {next}"
         );
     }
 

--- a/crates/harn-vm/src/orchestration/policy/types.rs
+++ b/crates/harn-vm/src/orchestration/policy/types.rs
@@ -106,9 +106,11 @@ pub fn enforce_tool_arg_constraints(
                 DenialGate::ArgConstraint,
                 None,
                 format!(
-                    "tool '{tool_name}' {arg_key} '{candidate}' does not match allowed patterns: {:?}. \
-                     Only the {arg_key} argument is checked against this allow-list — other argument \
-                     values are not.",
+                    "tool '{tool_name}' {arg_key} '{candidate}' is outside your allowed scope. \
+                     Allowed {arg_key} pattern(s): {:?}. This is fixable: re-issue the call with a \
+                     {arg_key} that matches one of those patterns. If '{candidate}' is a \
+                     reference/example you only need to consult, read it with `look` instead — never \
+                     write to a path outside your scope.",
                     constraint.arg_patterns
                 ),
             );


### PR DESCRIPTION
## Why

A tool call refused by the per-agent argument allow-list (`tool_arg_constraints`) was routed through the **terminal** "permission_denied / do not retry" feedback body — the same body as a hard capability ceiling. But an argument outside the allowed scope is a **fixable slip**: the tool is permitted, only this argument value is wrong, and re-issuing with a matching argument succeeds.

Found dogfooding parallel fan-out: a cheap sub-agent scoped to `test/users.*`, after reading the shared **reference** file `test/accounts.integration.test.ts` to learn the pattern, sometimes wrote to that just-read path (a known salience slip). The scope correctly denied it — but the "do not retry" body told the child to give up the turn instead of redirecting it back to its own file.

## What

- `ToolDenial::retryable` marks the `ArgConstraint` gate as a **soft** denial. The dispatch boundary routes a retryable denial through the recoverable (retry-positive, `error: "invalid_arguments"`) body; hard tool / capability / side-effect ceilings stay terminal.
- The arg-constraint reason now **names the allowed pattern(s)** and tells the model to read reference files with `look` rather than editing them, so the coached retry targets the right path.

Generalizes to every scoped agent, not just fan-out: any path/command-scoped tool now coaches a correction instead of a dead end.

## Tests

Two routing tests (`retryable_arg_constraint_denial_is_coached_as_recoverable`, `hard_capability_denial_stays_terminal`) plus the existing `permission_denied_keeps_do_not_retry_body` regression guard. `cargo test -p harn-vm` green across the touched suites (123 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)