### PR TITLE
refactor(serve): de-slop / typed-struct pass on harn-serve

### DIFF
--- a/crates/harn-serve/src/adapters/a2a/events.rs
+++ b/crates/harn-serve/src/adapters/a2a/events.rs
@@ -110,20 +110,18 @@ impl harn_vm::agent_events::AgentEventSink for A2aWorkerSink {
             }
             _ => return,
         };
-        let task_for_push = {
+        {
             let mut tasks = self.tasks.lock().expect("tasks poisoned");
             let Some(task) = tasks.get_mut(&self.task_id) else {
                 return;
             };
             publish_locked(task, payload);
-            task_to_json(task)
-        };
+        }
         // No `deliver_push` here: worker_update events stream live to
         // active subscribers but don't fire push-config webhooks. Push
         // delivery is reserved for the canonical task lifecycle
         // transitions so high-volume worker traffic doesn't flood
         // outbound HTTP endpoints.
-        let _ = task_for_push;
     }
 }
 

--- a/crates/harn-serve/src/adapters/acp/core.rs
+++ b/crates/harn-serve/src/adapters/acp/core.rs
@@ -225,7 +225,6 @@ impl AcpServer {
     }
 
     /// Send a JSON-RPC notification (no id, no response expected).
-    #[allow(dead_code)]
     pub(super) fn send_notification(&self, method: &str, params: serde_json::Value) {
         let notification = harn_vm::jsonrpc::notification(method, params);
         if let Ok(line) = serde_json::to_string(&notification) {
@@ -234,7 +233,6 @@ impl AcpServer {
     }
 
     /// Send a `session/update` notification with an agent message chunk.
-    #[allow(dead_code)]
     pub(super) fn send_update(&self, session_id: &str, text: &str) {
         let visible_text = sanitize_visible_assistant_text(text, true);
         let mut content = serde_json::json!({

--- a/crates/harn-serve/src/adapters/acp/inject.rs
+++ b/crates/harn-serve/src/adapters/acp/inject.rs
@@ -212,7 +212,6 @@ impl AcpServer {
                 message_id.clone(),
                 InjectControlRecord {
                     owner: actor.clone(),
-                    status: "pending".to_string(),
                 },
             );
         self.emit_control_outcome(
@@ -296,13 +295,6 @@ impl AcpServer {
         }
         match inject_state.revoke_pending_user_message(message_id).await {
             harn_vm::bridge::PendingUserMessageMutationResult::Mutated => {
-                if let Some(record) = self
-                    .inject_controls
-                    .get_mut(&session_id)
-                    .and_then(|records| records.get_mut(message_id))
-                {
-                    record.status = "revoked".to_string();
-                }
                 self.emit_control_outcome(
                     &session_id,
                     "session/revoke_inject",
@@ -333,13 +325,6 @@ impl AcpServer {
                 );
             }
             harn_vm::bridge::PendingUserMessageMutationResult::AlreadyDelivered => {
-                if let Some(record) = self
-                    .inject_controls
-                    .get_mut(&session_id)
-                    .and_then(|records| records.get_mut(message_id))
-                {
-                    record.status = "delivered".to_string();
-                }
                 self.emit_control_outcome(
                     &session_id,
                     "session/revoke_inject",
@@ -479,13 +464,6 @@ impl AcpServer {
                 );
             }
             harn_vm::bridge::PendingUserMessageMutationResult::AlreadyDelivered => {
-                if let Some(record) = self
-                    .inject_controls
-                    .get_mut(&session_id)
-                    .and_then(|records| records.get_mut(message_id))
-                {
-                    record.status = "delivered".to_string();
-                }
                 self.emit_control_outcome(
                     &session_id,
                     "session/replace_inject",

--- a/crates/harn-serve/src/adapters/acp/mod.rs
+++ b/crates/harn-serve/src/adapters/acp/mod.rs
@@ -153,10 +153,11 @@ fn parse_oauth_redirect_url(
     Ok((state, code, query("iss")))
 }
 
+/// Tracks the ACP actor that owns a pending injected message so that
+/// revoke/replace requests can enforce ownership.
 #[derive(Clone)]
 struct InjectControlRecord {
     owner: serde_json::Value,
-    status: String,
 }
 
 struct TimelineSubscription {

--- a/crates/harn-serve/src/adapters/api.rs
+++ b/crates/harn-serve/src/adapters/api.rs
@@ -374,9 +374,6 @@ impl ApiState {
         };
         match method.as_str() {
             "session/update" => self.register_session_update(message),
-            "_harn/agentEvent" | "harn.hitl.requested" => {
-                self.append_event(None, None, &method, message);
-            }
             _ => {
                 self.append_event(None, None, &method, message);
             }


### PR DESCRIPTION
Behavior-preserving code-quality (\"de-slop\") pass on `crates/harn-serve`, part of the pre-public productionization push. No public API removed; all changes are internal and verified.

## Changes
- **api.rs** — `handle_acp_notification`: collapsed two identical match arms (the `"_harn/agentEvent" | "harn.hitl.requested"` arm and the catch-all `_` arm did the exact same thing) into a single `_` arm.
- **acp `InjectControlRecord`** — removed the `status` field. It was written (`"pending"`/`"revoked"`/`"delivered"`) at four sites but **never read anywhere** in the crate — pure write-only dead state. Removing it also deleted three now-empty `get_mut` blocks. Added a doc comment on the remaining `owner` field.
- **a2a/events.rs** — `worker_update` handler computed `task_to_json(task)` into a `task_for_push` binding that was immediately discarded via `let _ = task_for_push;`. Dropped the needless serialization/allocation; kept the explanatory comment about why push isn't fired here.
- **acp/core.rs** — removed two stale `#[allow(dead_code)]` attributes on `send_notification` / `send_update`, which are in fact used (the attributes were lying about the code).

## What I deliberately did NOT do
The larger "stringly-typed → typed struct" candidates (the core `BTreeMap<String, serde_json::Value>` session/task/workspace state in api.rs; JSON-RPC method-dispatch enums) were evaluated and left alone: they are sprawling (100+ access sites) and risk subtly changing wire format / field ordering / null-vs-omit behavior, which would violate the behavior-preserving + tight-reviewable-diff constraints. harn-serve is otherwise well-structured (core.rs, site.rs, modes.rs already use proper enums/types).

## Verification
- `cargo test -p harn-serve` — all pass (478 + integration/doc suites, 0 failed)
- `cargo clippy -p harn-serve --all-targets -- -D warnings` — clean
- `cargo fmt -p harn-serve` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)