### PR TITLE
Harden agent loop: string `.slice`, pinpointed errors, no tail-truncation of failures

### DIFF
--- a/changelog.d/error-pinpoint-and-no-tail-truncation.fixed.md
+++ b/changelog.d/error-pinpoint-and-no-tail-truncation.fixed.md
@@ -1,0 +1,13 @@
+- **Runtime errors now name the source file, not just the line.** Error
+  enrichment appended a bare `(line N)` drawn from the innermost stack frame,
+  which is ambiguous across 100+ stdlib `.harn` files and forced a manual hunt
+  to locate a crash. When the frame carries a source path the suffix is now
+  `(<file>:N)` (e.g. `(stall.harn:497)`); the bare `(line N)` form is kept
+  as the fallback when no path is known.
+- **Failure-evidence snippets no longer amputate the tail.** `agent/stall`'s
+  diagnostic snippet and `agent/sitrep`'s message truncation both did a
+  head-only clip, silently dropping the end of the text — which for tool and
+  command output is usually where the decisive error lives (failing assertion,
+  last compiler error). Both now preserve a generous head **and** tail with an
+  explicit `…[N chars elided]…` marker, so the model never loses the part of a
+  tool-call error that pinpoints the fix.

--- a/changelog.d/string-slice-method.fixed.md
+++ b/changelog.d/string-slice-method.fixed.md
@@ -1,0 +1,9 @@
+- **Strings now support `.slice(start, end?)` as an alias for `.substring`.**
+  `slice` was a list-only method, so calling it on a string raised a runtime
+  `string has no method \`slice\`` that aborted the whole agent loop. Harness
+  authors (and JS/Python muscle memory) reach for `.slice` on strings
+  constantly; it is now char-based and negative-index aware, mirroring
+  `list.slice` exactly, which structurally removes the crash class rather than
+  chasing individual call sites. This was crashing `agent/stall`'s failure-
+  snippet path whenever a failing tool result carried a >240-char error body
+  (e.g. a long compiler error), terminating the loop mid-fix.

--- a/crates/harn-stdlib/src/stdlib/agent/sitrep.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/sitrep.harn
@@ -100,7 +100,19 @@ fn __sitrep_truncate(text, max_chars) {
   if max_chars == nil || max_chars <= 0 || len(text) <= max_chars {
     return text
   }
-  return substring(text, 0, max_chars) + " …[truncated]"
+  // Keep both ends: a head-only clip drops the tail, which for tool/command
+  // output is usually where the error lives. Preserve a head + tail with an
+  // explicit elision marker so the cut is visible and the failing detail
+  // survives.
+  let total = len(text)
+  let tail_chars = max_chars / 3
+  let head_chars = max_chars - tail_chars
+  let omitted = total - head_chars - tail_chars
+  return substring(text, 0, head_chars)
+    + " …["
+    + to_string(omitted)
+    + " chars elided]… "
+    + substring(text, total - tail_chars, total)
 }
 
 fn __sitrep_format_messages(messages, max_chars_per_message) {

--- a/crates/harn-stdlib/src/stdlib/agent/stall.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/stall.harn
@@ -491,10 +491,29 @@ fn __agent_stall_result_snippet(result) -> string {
   }
   let text = to_string(result?.error ?? result?.message ?? result?.result ?? "")
   let normalized = trim(text)
-  if len(normalized) <= 240 {
-    return normalized
+  return __agent_clip_head_tail(normalized, 4000)
+}
+
+/**
+ * Clip an evidence string to `cap` chars WITHOUT amputating the tail. The root
+ * cause of a failure is often split across both ends — the exception/class up
+ * top, the decisive line (failing assertion, last compiler error) at the
+ * bottom. A blind head-only clip silently hid that tail from the model. Keep a
+ * generous head + tail with an explicit elision marker so nothing is dropped
+ * invisibly. `cap` is intentionally large; we are NOT trying to save tokens,
+ * only to bound a pathological multi-megabyte blob.
+ */
+fn __agent_clip_head_tail(text, cap) {
+  let total = len(text)
+  if total <= cap {
+    return text
   }
-  return normalized.slice(0, 240)
+  let tail_len = cap / 3
+  let head_len = cap - tail_len
+  let omitted = total - head_len - tail_len
+  let head = text.substring(0, head_len)
+  let tail = text.substring(total - tail_len, total)
+  return head + "\n…[" + to_string(omitted) + " chars elided — middle of output]…\n" + tail
 }
 
 /**

--- a/crates/harn-vm/src/vm/execution.rs
+++ b/crates/harn-vm/src/vm/execution.rs
@@ -816,16 +816,28 @@ impl crate::vm::Vm {
     /// trace. Appends ` (line N)` to error variants whose messages don't
     /// already carry location context.
     pub(crate) fn enrich_error_with_line(&self, error: VmError) -> VmError {
-        // Determine the line from the captured stack trace (innermost frame).
-        let line = self
+        // Determine the line AND source file from the captured stack trace
+        // (innermost frame) so the error names the exact `.harn` it crashed in.
+        // A bare `(line N)` is ambiguous across 100+ stdlib files and forces a
+        // manual hunt; `(stall.harn:497)` pinpoints it immediately.
+        let (line, file) = self
             .error_stack_trace
             .last()
-            .map(|(_, l, _, _)| *l)
-            .unwrap_or_else(|| self.current_line());
+            .map(|(_, l, _, f)| (*l, f.clone()))
+            .unwrap_or_else(|| (self.current_line(), None));
         if line == 0 {
             return error;
         }
-        let suffix = format!(" (line {line})");
+        let suffix = match file.as_deref() {
+            Some(path) => {
+                let name = std::path::Path::new(path)
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(path);
+                format!(" ({name}:{line})")
+            }
+            None => format!(" (line {line})"),
+        };
         match error {
             VmError::Runtime(msg) => VmError::Runtime(format!("{msg}{suffix}")),
             VmError::TypeError(msg) => VmError::TypeError(format!("{msg}{suffix}")),

--- a/crates/harn-vm/src/vm/methods/string.rs
+++ b/crates/harn-vm/src/vm/methods/string.rs
@@ -42,6 +42,36 @@ impl crate::vm::Vm {
                     args.get(1).and_then(|a| a.as_int()),
                 ),
             ))),
+            // `slice` is a list method, but harness authors (and JS/Python
+            // muscle memory) routinely call it on strings. Aliasing it to a
+            // char-based, negative-index-aware substring — mirroring
+            // `list.slice` semantics exactly — structurally removes the entire
+            // "string has no method `slice`" crash class instead of chasing
+            // each call site. End index defaults to the char length.
+            "slice" => {
+                let chars: Vec<char> = s.chars().collect();
+                let len = chars.len() as i64;
+                let start_raw = args.first().and_then(|a| a.as_int()).unwrap_or(0);
+                let start = if start_raw < 0 {
+                    (len + start_raw).max(0) as usize
+                } else {
+                    start_raw.min(len) as usize
+                };
+                let end = if args.len() > 1 {
+                    let end_raw = args[1].as_int().unwrap_or(len);
+                    if end_raw < 0 {
+                        (len + end_raw).max(0) as usize
+                    } else {
+                        end_raw.min(len) as usize
+                    }
+                } else {
+                    len as usize
+                };
+                let end = end.max(start);
+                Ok(VmValue::String(arcstr::ArcStr::from(
+                    chars[start..end].iter().collect::<String>(),
+                )))
+            }
             "index_of" => {
                 let needle = args.first().map(|a| a.as_str_cow()).unwrap_or_default();
                 let idx = s

--- a/crates/harn-vm/tests/builtin_call_dispatch.rs
+++ b/crates/harn-vm/tests/builtin_call_dispatch.rs
@@ -86,3 +86,30 @@ fn builtin_argument_validation_still_fires_on_fast_path() {
         "expected a validation error for abs(string), got {result:?}"
     );
 }
+
+#[test]
+fn string_slice_aliases_substring_with_list_semantics() {
+    // `slice` is historically a list method; harness authors routinely call it
+    // on strings (JS/Python muscle memory). It must now work on strings —
+    // char-based, negative-index aware, clamped — mirroring `list.slice`,
+    // so "string has no method `slice`" can never crash an agent loop again.
+    assert!(matches!(
+        eval(r#"pipeline t(task) { return "hello world".slice(0, 5) }"#),
+        Ok(VmValue::String(ref s)) if s == "hello"
+    ));
+    // Negative indices count from the end (like list.slice).
+    assert!(matches!(
+        eval(r#"pipeline t(task) { return "hello".slice(-3) }"#),
+        Ok(VmValue::String(ref s)) if s == "llo"
+    ));
+    // Out-of-range end clamps instead of panicking.
+    assert!(matches!(
+        eval(r#"pipeline t(task) { return "hi".slice(0, 999) }"#),
+        Ok(VmValue::String(ref s)) if s == "hi"
+    ));
+    // start > end yields empty, never a slice-index panic.
+    assert!(matches!(
+        eval(r#"pipeline t(task) { return "hello".slice(4, 1) }"#),
+        Ok(VmValue::String(ref s)) if s.is_empty()
+    ));
+}


### PR DESCRIPTION
## Why

Driving cheap-solo eval convergence surfaced a crash that aborted the agent
loop mid-fix: `agent/stall`'s failure-snippet called `normalized.slice(0, 240)`
on a **string**, but `slice` was a list-only method → `string has no method
slice` runtime error every time a failing tool result carried a >240-char error
body (e.g. a long compiler error). The model never got to iterate on its own
fix. The stack trace also only said `(line 497)` with no filename, so locating
it across 100+ stdlib `.harn` files cost real time.

## What

Three root-cause hardenings so this class **structurally cannot bite harness
authors again**:

1. **`slice` on strings** (`crates/harn-vm/src/vm/methods/string.rs`) — aliased
   to a char-based, negative-index-aware substring mirroring `list.slice`. Kills
   the entire "string has no method `slice`" crash class instead of chasing
   call sites.
2. **`(file:line)` in runtime errors** (`crates/harn-vm/src/vm/execution.rs`) —
   error enrichment already had the source path on the innermost frame; we were
   discarding it. Now `(stall.harn:497)` instead of `(line 497)`; bare
   `(line N)` kept as fallback.
3. **No more head-only truncation of failure evidence**
   (`agent/stall`, `agent/sitrep`) — the **tail** of tool/command output is
   where the decisive error lives. Both now keep a generous head **and** tail
   with an explicit `…[N chars elided]…` marker, so a char-length cap can never
   silently hide the part of an error that pinpoints the fix.

## Tests

- New `string_slice_aliases_substring_with_list_semantics` (positive/negative
  indices, clamping, start>end).
- `agent_loop_steering_seams` + `agent_loop_final_wrapup` green (they compile
  the edited `stall`/`sitrep` modules).
- `harn-vm` runtime unit tests (144) green. Pre-commit clippy + harn lint green.

No public API removed; `slice` was already a known method name (lists), so no
linter/LSP/registry desync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)