### PR TITLE
Avoid strict OpenAI-compatible request conflicts

### DIFF
--- a/changelog.d/cerebras-tools-response-format.fixed.md
+++ b/changelog.d/cerebras-tools-response-format.fixed.md
@@ -1,0 +1,1 @@
+OpenAI-compatible chat-completions requests now avoid strict-provider 400s by omitting `response_format` for Cerebras native-tool calls, omitting `tool_choice` whenever no native `tools` array is sent, and dropping orphaned native tool-result messages before send.

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -418,6 +418,11 @@ pub struct ProviderRule {
     /// one-call assistant turns for those routes.
     #[serde(default)]
     pub supports_parallel_tool_calls: Option<bool>,
+    /// Whether the route rejects `response_format` when native `tools` are
+    /// present. Strict OpenAI-compatible servers such as Cerebras accept each
+    /// feature alone but reject the pair together.
+    #[serde(default)]
+    pub tools_exclude_response_format: Option<bool>,
     /// Preferred endpoint family for this provider/model route. Values
     /// are descriptive labels consumed by providers, e.g.
     /// `/api/generate-raw` for Ollama raw prompt bypass.
@@ -581,6 +586,7 @@ pub struct Capabilities {
     pub allowed_tool_choice_modes: Vec<String>,
     pub requires_tool_result_adjacency: bool,
     pub supports_parallel_tool_calls: bool,
+    pub tools_exclude_response_format: bool,
     pub recommended_endpoint: Option<String>,
     pub text_tool_wire_format_supported: bool,
     pub preferred_tool_format: Option<String>,
@@ -665,6 +671,7 @@ impl Default for Capabilities {
             allowed_tool_choice_modes: Vec::new(),
             requires_tool_result_adjacency: false,
             supports_parallel_tool_calls: true,
+            tools_exclude_response_format: false,
             recommended_endpoint: None,
             text_tool_wire_format_supported: true,
             preferred_tool_format: None,
@@ -1587,6 +1594,7 @@ fn defaults_to_caps(defaults: &ProviderDefaults) -> Capabilities {
         allowed_tool_choice_modes: None,
         requires_tool_result_adjacency: None,
         supports_parallel_tool_calls: None,
+        tools_exclude_response_format: None,
         recommended_endpoint: None,
         text_tool_wire_format_supported: None,
         preferred_tool_format: None,
@@ -1710,6 +1718,7 @@ fn rule_to_caps(rule: &ProviderRule, defaults: &ProviderDefaults) -> Capabilitie
         allowed_tool_choice_modes: rule.allowed_tool_choice_modes.clone().unwrap_or_default(),
         requires_tool_result_adjacency: rule.requires_tool_result_adjacency.unwrap_or(false),
         supports_parallel_tool_calls: rule.supports_parallel_tool_calls.unwrap_or(true),
+        tools_exclude_response_format: rule.tools_exclude_response_format.unwrap_or(false),
         recommended_endpoint: rule.recommended_endpoint.clone(),
         text_tool_wire_format_supported: rule.text_tool_wire_format_supported.unwrap_or(true),
         preferred_tool_format: Some(rule_preferred_tool_format(rule)),
@@ -2084,6 +2093,14 @@ preferred_tool_format = "native"
                 .supports_parallel_tool_calls
         );
         assert!(lookup("openai", "gpt-4o").supports_parallel_tool_calls);
+    }
+
+    #[test]
+    fn cerebras_tools_exclude_response_format() {
+        reset();
+        assert!(lookup("cerebras", "gpt-oss-120b").tools_exclude_response_format);
+        assert!(lookup("cerebras", "zai-glm-4.7").tools_exclude_response_format);
+        assert!(!lookup("openai", "gpt-4o").tools_exclude_response_format);
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -187,6 +187,10 @@
 #                     `tool_calls[]` entries; strict OpenAI-compatible servers
 #                     can reject replayed history with more than one tool call
 #                     even when Harn originally parsed text-tool calls.
+#   tools_exclude_response_format:
+#                     whether the route rejects `response_format` when native
+#                     `tools` are present. Harn drops response_format for these
+#                     routes only when tools are actually being sent.
 #
 # OPINIONATED PROVIDER/MODEL/CONFIG POLICY (enforced by the footgun gate in
 # crate::llm::capability_audit, wired into `providers build-capabilities
@@ -4015,11 +4019,17 @@ thinking_block_style = "none"
 # with reasoning_effort_levels above, reasoning_policy floors an auto "off" to
 # the lowest accepted effort ("low") for tool tasks instead of disabling
 # reasoning. Must NOT carry a Qwen-style `auto_reasoning_overrides = "off"`.
+#
+# Cerebras accepts native tools and structured output independently, but rejects
+# `tools` + `response_format` in the same chat-completions request. Prefer the
+# interactive tool loop when both are requested, and drop response_format at the
+# OpenAI-compatible wire boundary.
 [[provider.cerebras]]
 model_match = "gpt-oss-*"
 native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"
+tools_exclude_response_format = true
 thinking_modes = ["effort"]
 reasoning_effort_supported = true
 reasoning_effort_levels = ["low", "medium", "high"]
@@ -4046,6 +4056,7 @@ model_match = "zai-glm-*"
 native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"
+tools_exclude_response_format = true
 thinking_modes = ["effort"]
 reasoning_effort_supported = true
 reasoning_none_supported = true
@@ -4062,6 +4073,7 @@ model_match = "llama-*"
 native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"
+tools_exclude_response_format = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
 structured_output_mode = "native_json"
@@ -4075,6 +4087,7 @@ model_match = "qwen-*"
 native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"
+tools_exclude_response_format = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
 structured_output_mode = "native_json"

--- a/crates/harn-vm/src/llm/capability_sources/00-base.toml
+++ b/crates/harn-vm/src/llm/capability_sources/00-base.toml
@@ -183,6 +183,10 @@
 #                     `tool_calls[]` entries; strict OpenAI-compatible servers
 #                     can reject replayed history with more than one tool call
 #                     even when Harn originally parsed text-tool calls.
+#   tools_exclude_response_format:
+#                     whether the route rejects `response_format` when native
+#                     `tools` are present. Harn drops response_format for these
+#                     routes only when tools are actually being sent.
 #
 # OPINIONATED PROVIDER/MODEL/CONFIG POLICY (enforced by the footgun gate in
 # crate::llm::capability_audit, wired into `providers build-capabilities

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/80-cerebras.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/80-cerebras.toml
@@ -27,11 +27,17 @@
 # with reasoning_effort_levels above, reasoning_policy floors an auto "off" to
 # the lowest accepted effort ("low") for tool tasks instead of disabling
 # reasoning. Must NOT carry a Qwen-style `auto_reasoning_overrides = "off"`.
+#
+# Cerebras accepts native tools and structured output independently, but rejects
+# `tools` + `response_format` in the same chat-completions request. Prefer the
+# interactive tool loop when both are requested, and drop response_format at the
+# OpenAI-compatible wire boundary.
 [[provider.cerebras]]
 model_match = "gpt-oss-*"
 native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"
+tools_exclude_response_format = true
 thinking_modes = ["effort"]
 reasoning_effort_supported = true
 reasoning_effort_levels = ["low", "medium", "high"]
@@ -58,6 +64,7 @@ model_match = "zai-glm-*"
 native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"
+tools_exclude_response_format = true
 thinking_modes = ["effort"]
 reasoning_effort_supported = true
 reasoning_none_supported = true
@@ -74,6 +81,7 @@ model_match = "llama-*"
 native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"
+tools_exclude_response_format = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
 structured_output_mode = "native_json"
@@ -87,6 +95,7 @@ model_match = "qwen-*"
 native_tools = true
 preferred_tool_format = "native"
 structured_output = "native"
+tools_exclude_response_format = true
 prefers_xml_scaffolding = false
 prefers_markdown_scaffolding = true
 structured_output_mode = "native_json"
@@ -94,4 +103,3 @@ supports_assistant_prefill = false
 prefers_role_developer = false
 prefers_xml_tools = false
 thinking_block_style = "none"
-

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -147,6 +147,9 @@ impl OpenAiCompatibleProvider {
             }));
         }
         msgs = crate::llm::api::normalize_openai_style_messages(msgs, force_string_content);
+        if has_native_tools {
+            msgs = drop_orphan_tool_result_messages(msgs);
+        }
         if caps.requires_tool_result_adjacency {
             msgs = enforce_tool_result_adjacency(msgs);
         }
@@ -261,6 +264,11 @@ impl OpenAiCompatibleProvider {
                     }
                 });
             }
+        }
+        if has_native_tools && caps.tools_exclude_response_format {
+            body.as_object_mut()
+                .expect("request body is object")
+                .remove("response_format");
         }
         if opts.provider == "openrouter"
             && (body.get("response_format").is_some() || body.get("top_k").is_some())
@@ -408,6 +416,27 @@ fn enforce_tool_result_adjacency(messages: Vec<serde_json::Value>) -> Vec<serde_
 
         normalized.extend(results);
         normalized.extend(deferred);
+    }
+    normalized
+}
+
+fn drop_orphan_tool_result_messages(messages: Vec<serde_json::Value>) -> Vec<serde_json::Value> {
+    let mut live_tool_call_ids = HashSet::new();
+    let mut normalized = Vec::with_capacity(messages.len());
+    for message in messages {
+        match message.get("role").and_then(|role| role.as_str()) {
+            Some("assistant") => {
+                if let Some(ids) = assistant_tool_call_ids(&message) {
+                    live_tool_call_ids.extend(ids);
+                }
+                normalized.push(message);
+            }
+            Some("tool") => match message.get("tool_call_id").and_then(|value| value.as_str()) {
+                Some(id) if live_tool_call_ids.remove(id) => normalized.push(message),
+                _ => {}
+            },
+            _ => normalized.push(message),
+        }
     }
     normalized
 }
@@ -826,7 +855,13 @@ fn normalize_tool_choice_for_capabilities(
     caps: &crate::llm::capabilities::Capabilities,
     has_native_tools: bool,
 ) -> Option<serde_json::Value> {
-    let tool_choice = normalize_openai_compat_tool_choice(tool_choice, has_native_tools)?;
+    // OpenAI-compatible providers interpret `tool_choice` as a selector over the
+    // native `tools` array. Text-tool routes deliberately omit that array, and
+    // stricter providers reject any `tool_choice` without tools.
+    if !has_native_tools {
+        return None;
+    }
+    let tool_choice = normalize_openai_compat_tool_choice(tool_choice)?;
     if caps.allowed_tool_choice_modes.is_empty() {
         return Some(tool_choice);
     }
@@ -859,7 +894,6 @@ fn normalize_tool_choice_for_capabilities(
 
 fn normalize_openai_compat_tool_choice(
     tool_choice: &serde_json::Value,
-    has_native_tools: bool,
 ) -> Option<serde_json::Value> {
     match tool_choice {
         serde_json::Value::String(raw) => {
@@ -871,26 +905,12 @@ fn normalize_openai_compat_tool_choice(
             if matches!(mode.as_str(), "auto" | "none" | "any" | "required") {
                 return Some(serde_json::Value::String(mode));
             }
-            if !has_native_tools {
-                return Some(serde_json::Value::String("required".to_string()));
-            }
             Some(serde_json::json!({
                 "type": "function",
                 "function": {"name": trimmed},
             }))
         }
-        serde_json::Value::Object(object) => {
-            if !has_native_tools {
-                let is_specific_tool = matches!(
-                    object.get("type").and_then(|value| value.as_str()),
-                    Some("function" | "tool")
-                );
-                if is_specific_tool {
-                    return Some(serde_json::Value::String("required".to_string()));
-                }
-            }
-            Some(tool_choice.clone())
-        }
+        serde_json::Value::Object(_) => Some(tool_choice.clone()),
         serde_json::Value::Null => None,
         _ => Some(tool_choice.clone()),
     }
@@ -1464,11 +1484,27 @@ mod tests {
         let mut payload = base_request_payload();
         payload.provider = "openrouter".to_string();
         payload.model = "moonshotai/kimi-k2.7-code".to_string();
+        payload.native_tools = Some(vec![json!({
+            "type": "function",
+            "function": {
+                "name": "add_two",
+                "description": "Add two integers.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "integer"},
+                        "b": {"type": "integer"}
+                    },
+                    "required": ["a", "b"]
+                }
+            }
+        })]);
         payload.tool_choice = Some(json!("none"));
 
         let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
 
         assert_eq!(body["tool_choice"], "none");
+        assert_eq!(body["tools"][0]["function"]["name"], "add_two");
     }
 
     #[test]
@@ -1503,7 +1539,7 @@ mod tests {
     }
 
     #[test]
-    fn openai_compat_specific_tool_choice_degrades_for_text_tool_routes() {
+    fn openai_compat_omits_tool_choice_for_text_tool_routes() {
         let mut payload = base_request_payload();
         payload.provider = "fireworks".to_string();
         payload.model = "accounts/fireworks/models/gpt-oss-120b".to_string();
@@ -1511,7 +1547,20 @@ mod tests {
 
         let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
 
-        assert_eq!(body["tool_choice"], "required");
+        assert!(body.get("tool_choice").is_none());
+        assert!(body.get("tools").is_none());
+    }
+
+    #[test]
+    fn openai_compat_omits_required_tool_choice_without_native_tools() {
+        let mut payload = base_request_payload();
+        payload.provider = "together".to_string();
+        payload.model = "zai-org/glm-5.2".to_string();
+        payload.tool_choice = Some(json!("required"));
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+
+        assert!(body.get("tool_choice").is_none());
         assert!(body.get("tools").is_none());
     }
 
@@ -2024,6 +2073,47 @@ thinking_modes = ["enabled"]
     }
 
     #[test]
+    fn cerebras_tools_drop_response_format() {
+        let mut payload = base_request_payload();
+        payload.provider = "cerebras".to_string();
+        payload.model = "gpt-oss-120b".to_string();
+        payload.output_format = crate::llm::api::OutputFormat::JsonObject;
+        payload.native_tools = Some(vec![json!({
+            "type": "function",
+            "function": {
+                "name": "read",
+                "description": "Read a file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"]
+                }
+            }
+        })]);
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+
+        assert!(body.get("tools").is_some());
+        assert!(
+            body.get("response_format").is_none(),
+            "Cerebras rejects tools + response_format together: {body}"
+        );
+    }
+
+    #[test]
+    fn cerebras_keeps_response_format_without_tools() {
+        let mut payload = base_request_payload();
+        payload.provider = "cerebras".to_string();
+        payload.model = "gpt-oss-120b".to_string();
+        payload.output_format = crate::llm::api::OutputFormat::JsonObject;
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+
+        assert_eq!(body["response_format"]["type"], "json_object");
+        assert!(body.get("tools").is_none());
+    }
+
+    #[test]
     fn openrouter_structured_output_requires_supported_parameters() {
         let mut payload = base_request_payload();
         payload.output_format = crate::llm::api::OutputFormat::JsonSchema {
@@ -2310,6 +2400,59 @@ thinking_modes = ["enabled"]
         assert_eq!(messages[2]["tool_call_id"], "call_002");
         assert_eq!(messages[3]["tool_call_id"], "call_001");
         assert_eq!(messages[4]["content"], "[runtime_feedback] keep going");
+    }
+
+    #[test]
+    fn native_route_drops_orphan_tool_result_messages() {
+        let mut payload = base_request_payload();
+        payload.provider = "groq".to_string();
+        payload.model = "openai/gpt-oss-120b".to_string();
+        payload.native_tools = Some(vec![json!({
+            "type": "function",
+            "function": {
+                "name": "read",
+                "description": "Read a file.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"]
+                }
+            }
+        })]);
+        payload.messages = vec![
+            json!({"role": "user", "content": "inspect"}),
+            json!({"role": "tool", "tool_call_id": "stale_call", "content": "stale compacted result"}),
+            json!({
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": "call_001",
+                    "type": "function",
+                    "function": {"name": "read", "arguments": "{\"path\":\"a.rs\"}"},
+                }],
+            }),
+            json!({"role": "tool", "tool_call_id": "call_001", "content": "fresh result"}),
+            json!({"role": "tool", "tool_call_id": "call_001", "content": "duplicate result"}),
+            json!({"role": "user", "content": "continue"}),
+        ];
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        let messages = body["messages"].as_array().expect("messages array");
+        let roles = messages
+            .iter()
+            .map(|message| message["role"].as_str().unwrap_or("?"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(roles, vec!["user", "assistant", "tool", "user"]);
+        assert_eq!(messages[2]["tool_call_id"], "call_001");
+        assert_eq!(messages[2]["content"], "fresh result");
+        assert!(
+            messages
+                .iter()
+                .all(|message| message["content"] != "stale compacted result"
+                    && message["content"] != "duplicate result"),
+            "orphaned or duplicate tool results must not reach native tool providers: {messages:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a provider capability for strict APIs where native tools cannot be combined with response_format
- mark Cerebras OpenAI-compatible rows with the new capability
- drop response_format only when native tools are present, preserving structured-output calls without tools
- omit tool_choice whenever the request has no native tools array, avoiding strict-provider 400s on text-tool routes such as Together GLM
- drop orphaned or duplicate native tool-result messages before sending OpenAI-compatible requests

Fixes part of #3645.

## Verification
- CARGO_BUILD_JOBS=2 CARGO_TARGET_DIR=/tmp/harn-target-cerebras-tools cargo test -p harn-vm openai_compat -- --nocapture
- CARGO_BUILD_JOBS=2 CARGO_TARGET_DIR=/tmp/harn-target-cerebras-tools cargo test -p harn-vm tool_choice -- --nocapture
- CARGO_BUILD_JOBS=2 CARGO_TARGET_DIR=/tmp/harn-target-cerebras-tools cargo test -p harn-vm cerebras_ -- --nocapture
- CARGO_BUILD_JOBS=2 CARGO_TARGET_DIR=/tmp/harn-target-cerebras-tools make check-provider-capabilities
- cargo fmt --check --package harn-vm
- git diff --check