### PR TITLE
fix(catalog): correct DeepInfra GLM-5.2 pricing to its published rate

### DIFF
--- a/changelog.d/deepinfra-glm52-pricing.fixed.md
+++ b/changelog.d/deepinfra-glm52-pricing.fixed.md
@@ -1,0 +1,8 @@
+- **Corrected the DeepInfra GLM-5.2 catalog pricing to its published rate.**
+  The `deepinfra/zai-org/GLM-5.2` row carried `1.40/4.40/0.26` — the
+  together/baseten placeholder copied onto the sibling DeepInfra row, not
+  DeepInfra's own rate. DeepInfra's published GLM-5.2 pricing, verified against
+  their pricing API and reconciled exactly against a live `chat/completions`
+  `estimated_cost` (and corroborated by OpenRouter's `z-ai/glm-5.2` listing),
+  is `$0.95` in / `$3.00` out / `$0.18` cached read per MTok. Catalog data only,
+  no behavior change; this fixes cost accounting for the DeepInfra GLM-5.2 route.

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/95-moonshot-deepinfra-sambanova.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/95-moonshot-deepinfra-sambanova.toml
@@ -120,7 +120,13 @@ served_variant = "deepinfra"
 api_dialect = "openai_chat"
 context_window = 1048576
 capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
-pricing = { input_per_mtok = 1.40, output_per_mtok = 4.40, cache_read_per_mtok = 0.26 }
+# DeepInfra's published GLM-5.2 rate, verified 2026-06-28 against their pricing
+# API (cents_per_input_token 9.5e-05 -> $0.95/MTok; cents_per_output_token
+# 3e-04 -> $3.00/MTok; cached-read ratio -> $0.18/MTok) and reconciled against a
+# live chat-completion `estimated_cost` (175 in + 36 out billed $0.00027425,
+# exact). OpenRouter's z-ai/glm-5.2 listing agrees ($0.95/$3.00/$0.18). The prior
+# 1.40/4.40/0.26 was the together/baseten placeholder, not DeepInfra's rate.
+pricing = { input_per_mtok = 0.95, output_per_mtok = 3.00, cache_read_per_mtok = 0.18 }
 tier = "frontier"
 open_weight = true
 strengths = ["coding", "agentic", "tool_use", "reasoning", "long_context"]

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -3073,7 +3073,13 @@ served_variant = "deepinfra"
 api_dialect = "openai_chat"
 context_window = 1048576
 capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
-pricing = { input_per_mtok = 1.40, output_per_mtok = 4.40, cache_read_per_mtok = 0.26 }
+# DeepInfra's published GLM-5.2 rate, verified 2026-06-28 against their pricing
+# API (cents_per_input_token 9.5e-05 -> $0.95/MTok; cents_per_output_token
+# 3e-04 -> $3.00/MTok; cached-read ratio -> $0.18/MTok) and reconciled against a
+# live chat-completion `estimated_cost` (175 in + 36 out billed $0.00027425,
+# exact). OpenRouter's z-ai/glm-5.2 listing agrees ($0.95/$3.00/$0.18). The prior
+# 1.40/4.40/0.26 was the together/baseten placeholder, not DeepInfra's rate.
+pricing = { input_per_mtok = 0.95, output_per_mtok = 3.00, cache_read_per_mtok = 0.18 }
 tier = "frontier"
 open_weight = true
 strengths = ["coding", "agentic", "tool_use", "reasoning", "long_context"]

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -4488,9 +4488,9 @@
       },
       "prompt_cache": true,
       "pricing": {
-        "input_per_mtok": 1.4,
-        "output_per_mtok": 4.4,
-        "cache_read_per_mtok": 0.26,
+        "input_per_mtok": 0.95,
+        "output_per_mtok": 3.0,
+        "cache_read_per_mtok": 0.18,
         "cache_write_per_mtok": null
       },
       "deprecation": {


### PR DESCRIPTION
## Summary
- The `deepinfra/zai-org/GLM-5.2` catalog row carried `1.40/4.40/0.26` — the together/baseten placeholder, not DeepInfra's rate.
- Corrected to DeepInfra's published rate: **$0.95 in / $3.00 out / $0.18 cached read**.
- Regenerated the embedded provider snapshot (`provider catalog build-config`) and the spec catalog artifact (`provider catalog export`); the generated diff is pricing-only.

## Verification of the rate (3 independent sources, 2026-06-28)
- DeepInfra pricing API for `zai-org/GLM-5.2`: `cents_per_input_token 9.5e-05` → $0.95/MTok; `cents_per_output_token 3e-04` → $3.00/MTok; cached-read ratio → $0.18/MTok.
- Reconciled exactly against a live `chat/completions` response: 175 input + 36 output tokens billed `estimated_cost = 0.00027425`, which equals `175*9.5e-7 + 36*3e-6` to the cent.
- OpenRouter's `z-ai/glm-5.2` listing independently agrees ($0.95 / $3.00 / $0.18).

## Test plan
- [x] `provider catalog build-config --check` — snapshot up to date
- [x] `provider catalog validate --check-artifacts` — validation OK
- [x] No test hardcodes the GLM-5.2 deepinfra pricing (grep-verified)

## Release note
Catalog-data only; no behavior change. Burin picks this up on the next `.harn-version` repin. I am **not** cutting a release for this — leaving the version bump to the release owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)