### PR TITLE
feat(agent): add agent_session_inject_reminder builtin (bridge-free ttl reminders)

### DIFF
--- a/changelog.d/agent-session-inject-reminder.added.md
+++ b/changelog.d/agent-session-inject-reminder.added.md
@@ -1,0 +1,9 @@
+Added `agent_session_inject_reminder(session_id, options)` — inject a single typed
+system reminder directly into a live session's transcript event stream,
+bridge-free. The in-process sibling of the
+`push_bridge_injection`/`drain_bridge_injections` reminder path, for hosts that
+drive the agent loop without an ACP `HostBridge`. `options` mirrors
+`transcript.inject_reminder` (`body` required; optional `tags`, `dedupe_key`,
+`ttl_turns`, `preserve_on_compact`, `propagate`, `role_hint`); the loop's
+existing `apply_reminder_post_turn` pass evicts the reminder once its `ttl_turns`
+reaches zero.

--- a/changelog.d/openai-message-key-allowlist.fixed.md
+++ b/changelog.d/openai-message-key-allowlist.fixed.md
@@ -1,1 +1,3 @@
-OpenAI-compatible providers now strip transcript-only and provider-private message fields before sending chat completions requests, avoiding strict-provider rejections of stored reasoning or cache metadata.
+OpenAI-compatible providers now strip transcript-only and provider-private
+message fields before sending chat completions requests, avoiding strict-provider
+rejections of stored reasoning or cache metadata.

--- a/conformance/tests/agents/agent_session_inject_reminder.expected
+++ b/conformance/tests/agents/agent_session_inject_reminder.expected
@@ -1,0 +1,1 @@
+[harn] agent_session_inject_reminder ephemeral ttl=1 tests passed

--- a/conformance/tests/agents/agent_session_inject_reminder.harn
+++ b/conformance/tests/agents/agent_session_inject_reminder.harn
@@ -1,0 +1,47 @@
+// agent_session_inject_reminder: a bridge-free, single-turn ephemeral system
+// reminder. This is the in-process seam Burin #3183 L4 uses to make
+// runtime_feedback ephemeral (rendered once into the next prompt, then evicted,
+// never re-billed as a durable transcript message).
+import {
+  agent_session_apply_reminder_post_turn,
+  agent_session_inject_reminder,
+} from "std/agent/state"
+
+pipeline main(task) {
+  let s = agent_session_open()
+  agent_session_reset(s)
+  let id = agent_session_inject_reminder(
+    s,
+    {
+      body: "re-read auth.go",
+      ttl_turns: 1,
+      role_hint: "user_block",
+      dedupe_key: "runtime-feedback/grounding",
+    },
+  )
+  require id != nil && id != "", "inject_reminder returns a reminder id"
+  // Lands in the EVENT stream (renders into the next prompt), never in
+  // `messages` (so it is not re-sent / re-billed on every later turn).
+  require agent_session_length(s) == 0, "reminder is not a transcript message"
+  let before = transcript_events_by_kind(agent_session_snapshot(s), "system_reminder")
+  require len(before) == 1, "exactly one reminder is pending in the event stream"
+  require before[0].reminder.body == "re-read auth.go", "reminder carries the body"
+  // One turn boundary later the ttl=1 reminder expires and is removed — so a note
+  // injected at turn N is absent from the turn N+2 payload.
+  let report = agent_session_apply_reminder_post_turn(s, 1)
+  require report.expired_count == 1, "the ttl=1 reminder expires after exactly one turn"
+  require report.remaining_count == 0, "nothing is carried to the next turn"
+  let after = transcript_events_by_kind(agent_session_snapshot(s), "system_reminder")
+  require len(after) == 0, "the reminder is dropped from carried history"
+  // Idempotent: a later post-turn pass finds nothing to evict.
+  let second = agent_session_apply_reminder_post_turn(s, 2)
+  require second.expired_count == 0, "no double-eviction"
+  // dedupe_key collapses a re-injected same-kind reminder to one pending entry.
+  agent_session_inject_reminder(s, {body: "first", ttl_turns: 1, dedupe_key: "k"})
+  agent_session_inject_reminder(s, {body: "second", ttl_turns: 1, dedupe_key: "k"})
+  let deduped = transcript_events_by_kind(agent_session_snapshot(s), "system_reminder")
+  require len(deduped) == 1, "same dedupe_key replaces the prior reminder"
+  require deduped[0].reminder.body == "second", "the latest reminder wins"
+  agent_session_close(s)
+  log("agent_session_inject_reminder ephemeral ttl=1 tests passed")
+}

--- a/crates/harn-stdlib/src/stdlib/agent/state.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/state.harn
@@ -251,6 +251,24 @@ pub fn agent_session_inject_feedback(session_id, kind, content) {
 }
 
 /**
+ * agent_session_inject_reminder. Inject a single typed system reminder
+ * directly into a live session's transcript event stream, bridge-free —
+ * the in-process sibling of the `push_bridge_injection`/`drain` reminder
+ * path for hosts that drive the loop without an ACP HostBridge. `options`
+ * mirrors `transcript.inject_reminder` (`body` required; optional `tags`,
+ * `dedupe_key`, `ttl_turns`, `preserve_on_compact`, `propagate`,
+ * `role_hint`). Returns the reminder id.
+ *
+ * @effects: [host]
+ * @errors: [runtime]
+ * @api_stability: experimental
+ * @example: agent_session_inject_reminder(session_id, {body: "re-read auth.go", ttl_turns: 1})
+ */
+pub fn agent_session_inject_reminder(session_id, options) {
+  return __host_agent_session_inject_reminder(session_id, options)
+}
+
+/**
  * agent_session_pop_last_assistant. Discard the trailing assistant
  * turn from a session transcript. Used by `agent_step_judge` in
  * `replace` (pop-and-regen) mode to remove a vetoed assistant

--- a/crates/harn-vm/src/llm/agent_session_host.rs
+++ b/crates/harn-vm/src/llm/agent_session_host.rs
@@ -35,6 +35,7 @@ const HOST_SESSION_PUSH_BRIDGE_INJECTION: &str = "__host_agent_session_push_brid
 const HOST_SESSION_PUSH_USER_MESSAGE: &str = "__host_agent_session_push_user_message";
 const HOST_SESSION_PENDING_INJECTIONS: &str = "__host_agent_session_pending_injections";
 const HOST_SESSION_REVOKE_REMINDER: &str = "__host_agent_session_revoke_reminder";
+const HOST_SESSION_INJECT_REMINDER: &str = "__host_agent_session_inject_reminder";
 const HOST_SESSION_TOTALS: &str = "__host_agent_session_totals";
 const HOST_SESSION_POST_EVENT: &str = "__host_agent_session_post_event";
 const HOST_SESSION_APPLY_REMINDER_POST_TURN: &str = "__host_agent_session_apply_reminder_post_turn";
@@ -1481,6 +1482,51 @@ fn host_agent_session_inject_feedback_builtin(
     )
     .map_err(VmError::Runtime)?;
     Ok(VmValue::Nil)
+}
+
+/// Inject a single typed system reminder directly into a live session's
+/// transcript event stream, bridge-free. The in-process sibling of the
+/// `push_bridge_injection` -> `drain_bridge_injections` reminder path: a host
+/// that drives the agent loop in-process (no ACP `HostBridge` attached, e.g.
+/// Burin's headless/TUI surfaces) can queue a single-turn ephemeral reminder
+/// synchronously, the same way `transcript.inject_reminder` does for a
+/// transcript value. `options` mirrors that shape — `body` required; optional
+/// `tags`, `dedupe_key`, `ttl_turns`, `preserve_on_compact`, `propagate`,
+/// `role_hint`. Same-`dedupe_key` reminders are replaced. The reminder renders
+/// into the next model prompt and the loop's existing `apply_reminder_post_turn`
+/// pass evicts it once its `ttl_turns` reaches zero. Returns the reminder id.
+#[harn_builtin(
+    sig = "__host_agent_session_inject_reminder(session_id: string, options: dict) -> string",
+    category = "agent.host",
+    runtime_only = true
+)]
+fn host_agent_session_inject_reminder_builtin(
+    args: &[VmValue],
+    _out: &mut String,
+) -> Result<VmValue, VmError> {
+    let session_id = match args.first() {
+        Some(VmValue::String(value)) if !value.is_empty() => value.to_string(),
+        _ => {
+            return Err(VmError::Runtime(format!(
+                "{HOST_SESSION_INJECT_REMINDER}: session_id must be a non-empty string"
+            )))
+        }
+    };
+    let Some(options) = args.get(1).and_then(|value| value.as_dict()) else {
+        return Err(VmError::Runtime(format!(
+            "{HOST_SESSION_INJECT_REMINDER}: options must be a dict with a string `body`"
+        )));
+    };
+    super::conversation::ensure_known_reminder_keys(
+        HOST_SESSION_INJECT_REMINDER,
+        options,
+        super::conversation::INJECT_REMINDER_KEYS,
+    )?;
+    let reminder =
+        super::conversation::parse_inject_reminder_options(options, HOST_SESSION_INJECT_REMINDER)?;
+    let report =
+        crate::agent_sessions::inject_reminder(&session_id, reminder).map_err(VmError::Runtime)?;
+    Ok(VmValue::String(arcstr::ArcStr::from(report.reminder_id)))
 }
 
 /// Post an event into a running session's `agent_inbox`. Surface for
@@ -3406,6 +3452,7 @@ const HOST_SESSION_BUILTINS: &[&VmBuiltinDef] = &[
     &HOST_AGENT_SESSION_TOTALS_BUILTIN_DEF,
     &HOST_AGENT_TRUNCATED_TOOL_CALL_BUILTIN_DEF,
     &HOST_AGENT_SESSION_INJECT_FEEDBACK_BUILTIN_DEF,
+    &HOST_AGENT_SESSION_INJECT_REMINDER_BUILTIN_DEF,
     &HOST_AGENT_SESSION_POST_EVENT_BUILTIN_DEF,
     &HOST_AGENT_SESSION_APPLY_REMINDER_POST_TURN_BUILTIN_DEF,
     &HOST_AGENT_SESSION_SET_ACTIVE_SKILLS_BUILTIN_DEF,

--- a/crates/harn-vm/src/llm/conversation.rs
+++ b/crates/harn-vm/src/llm/conversation.rs
@@ -16,7 +16,7 @@ use super::helpers::{
     REMINDER_INJECTED_EVENT_KIND, SYSTEM_REMINDER_EVENT_KIND,
 };
 
-const INJECT_REMINDER_KEYS: &[&str] = &[
+pub(crate) const INJECT_REMINDER_KEYS: &[&str] = &[
     "body",
     "tags",
     "dedupe_key",
@@ -764,7 +764,7 @@ fn require_reminder_options<'a>(
     }
 }
 
-fn ensure_known_reminder_keys(
+pub(crate) fn ensure_known_reminder_keys(
     context: &str,
     options: &crate::value::DictMap,
     allowed: &[&str],
@@ -785,7 +785,7 @@ fn ensure_known_reminder_keys(
     }
 }
 
-fn parse_inject_reminder_options(
+pub(crate) fn parse_inject_reminder_options(
     options: &crate::value::DictMap,
     context: &str,
 ) -> Result<SystemReminder, VmError> {

--- a/crates/harn-vm/tests/builtin_registry_alignment.rs
+++ b/crates/harn-vm/tests/builtin_registry_alignment.rs
@@ -115,6 +115,7 @@ const RUNTIME_ONLY_EXCEPTIONS: &[&str] = &[
     "__host_agent_session_finalize",
     "__host_agent_session_init",
     "__host_agent_session_inject_feedback",
+    "__host_agent_session_inject_reminder",
     "__host_agent_session_messages",
     "__host_agent_session_pop_last_assistant",
     "__host_agent_session_post_event",


### PR DESCRIPTION
## What

Adds `agent_session_inject_reminder(session_id, options)` — inject a single typed system reminder **directly into a live session's transcript event stream, bridge-free**. The in-process sibling of the `push_bridge_injection` → `drain_bridge_injections` reminder path: a host that drives the agent loop in-process **without an ACP `HostBridge`** (e.g. Burin's headless/TUI surfaces) can queue a single-turn ephemeral reminder synchronously, the same way `transcript.inject_reminder` does for a transcript value.

`options` mirrors `transcript.inject_reminder` (`body` required; optional `tags`, `dedupe_key`, `ttl_turns`, `preserve_on_compact`, `propagate`, `role_hint`) and reuses its `parse_inject_reminder_options` / `ensure_known_reminder_keys` parsing (now `pub(crate)`). Same-`dedupe_key` reminders are replaced. The reminder renders into the next model prompt and the loop's existing `apply_reminder_post_turn` pass evicts it once `ttl_turns` reaches zero. Returns the reminder id.

## Why

Unblocks **Burin #3183 L4** (ephemeral `runtime_feedback`). Burin re-bills every harness nudge forever because `agent_inject_feedback` appends a durable `transcript.messages` turn. The ephemeral fix wants a `ttl_turns: 1` reminder, but `agent_session_push_bridge_injection` **hard-errors without a `HostBridge`**, which Burin's in-process loop never attaches. This builtin is the missing in-process injection seam.

## Tests

- 6/6 `builtin_registry_alignment` (added to `RUNTIME_ONLY_EXCEPTIONS` + the `HOST_SESSION_BUILTINS` def list).
- 60 reminder lib tests pass (incl. `ttl_one_reminder_expires_during_lifecycle`, `anthropic_user_block_renders_as_xml_user_content_block`).
- rustfmt clean. Proven end-to-end: a Burin fixture injecting via this builtin shows the ttl=1 reminder evicting after one turn and never entering `messages`.

## Notes

- Second commit is a **formatting-only** line-wrap of the pre-existing `#3675` changelog fragment that was failing the shared `markdownlint` (MD013) pre-push/CI gate for every branch. No content change.
- Intended to batch into the next harn release, after which Burin repins and un-holds its L4 scaffold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)