### PR TITLE
Harden OpenAI-compatible provider boundaries

### DIFF
--- a/changelog.d/openai-sampling-clamp.fixed.md
+++ b/changelog.d/openai-sampling-clamp.fixed.md
@@ -1,0 +1,2 @@
+OpenAI-compatible requests now clamp emitted temperature and top_p values to
+provider-safe ranges before send.

--- a/changelog.d/provider-error-decoder.fixed.md
+++ b/changelog.d/provider-error-decoder.fixed.md
@@ -1,0 +1,2 @@
+OpenAI-compatible provider errors now surface numeric codes, request ids, and
+upstream failure tails from varied provider error envelopes.

--- a/crates/harn-vm/src/llm/api/errors.rs
+++ b/crates/harn-vm/src/llm/api/errors.rs
@@ -129,15 +129,12 @@ fn sanitize_provider_error_body(body: &str) -> String {
 fn structured_provider_error_summary(body: &str) -> Option<String> {
     let json: serde_json::Value = serde_json::from_str(body).ok()?;
     let error = json.get("error").unwrap_or(&json);
-    if let Some(message) = error.get("message").and_then(serde_json::Value::as_str) {
+    if let Some(message) = provider_error_message(error).or_else(|| provider_error_message(&json)) {
         let message = truncate_chars(message, MAX_PROVIDER_ERROR_BODY_CHARS.saturating_sub(256));
         let mut details = Vec::new();
-        for key in ["type", "code", "status"] {
-            if let Some(value) = error.get(key).and_then(serde_json::Value::as_str) {
-                if !value.is_empty() {
-                    details.push(format!("{key}: {value}"));
-                }
-            }
+        collect_error_details(error, &mut details);
+        if !std::ptr::eq(error, &json) {
+            collect_error_details(&json, &mut details);
         }
         if details.is_empty() {
             Some(message)
@@ -146,6 +143,100 @@ fn structured_provider_error_summary(body: &str) -> Option<String> {
         }
     } else {
         error.as_str().map(str::to_string)
+    }
+}
+
+fn provider_error_message(value: &serde_json::Value) -> Option<&str> {
+    match value {
+        serde_json::Value::String(message) => non_empty_str(message),
+        serde_json::Value::Object(object) => ["message", "detail", "error_description"]
+            .into_iter()
+            .find_map(|key| object.get(key).and_then(provider_error_message)),
+        _ => None,
+    }
+}
+
+fn collect_error_details(value: &serde_json::Value, details: &mut Vec<String>) {
+    let Some(object) = value.as_object() else {
+        return;
+    };
+    for key in [
+        "type",
+        "code",
+        "status",
+        "http_code",
+        "request_id",
+        "requestId",
+    ] {
+        if let Some(value) = object.get(key).and_then(provider_error_detail_value) {
+            push_unique_detail(details, key, &value);
+        }
+    }
+    if let Some(metadata) = object.get("metadata") {
+        collect_error_details(metadata, details);
+        if let Some(previous) = metadata
+            .get("previous_errors")
+            .and_then(serde_json::Value::as_array)
+        {
+            if let Some(summary) = previous_errors_summary(previous) {
+                push_unique_detail(details, "previous_errors", &summary);
+            }
+        }
+    }
+}
+
+fn provider_error_detail_value(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(text) => non_empty_str(text).map(str::to_string),
+        serde_json::Value::Number(number) => Some(number.to_string()),
+        serde_json::Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn previous_errors_summary(errors: &[serde_json::Value]) -> Option<String> {
+    let mut parts = Vec::new();
+    for error in errors.iter().rev().take(3).rev() {
+        let provider = error
+            .get("provider_name")
+            .or_else(|| error.get("provider"))
+            .and_then(provider_error_detail_value);
+        let message = error
+            .get("error")
+            .and_then(provider_error_message)
+            .or_else(|| provider_error_message(error));
+        if let Some(message) = message {
+            let message = truncate_chars(message, 180);
+            if let Some(provider) = provider {
+                parts.push(format!("{provider}: {message}"));
+            } else {
+                parts.push(message);
+            }
+        }
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" | "))
+    }
+}
+
+fn push_unique_detail(details: &mut Vec<String>, key: &str, value: &str) {
+    if value.is_empty() {
+        return;
+    }
+    let detail = format!("{key}: {value}");
+    if !details.iter().any(|existing| existing == &detail) {
+        details.push(detail);
+    }
+}
+
+fn non_empty_str(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
     }
 }
 
@@ -464,6 +555,10 @@ fn is_model_unavailable(lower: &str) -> bool {
         // so caller fallback logic routes around it instead of surfacing a
         // generic invalid_request to the agent.
         || lower.contains("non-serverless model")
+        // MiniMax returns HTTP 500 with a provider-specific numeric code for
+        // account/model-plan mismatches; retries cannot change the route.
+        || lower.contains("token plan not support model")
+        || lower.contains("(2061)")
         // OpenRouter's HTTP-400 wording for an unknown model ID
         // ("<id> is not a valid model ID"). Mirror the `not_found` mapping in
         // `value::error::classify_error_message` so the reason taxonomy agrees
@@ -717,6 +812,76 @@ mod tests {
         assert!(!message.contains("secret-material"));
         assert!(message.contains("<redacted:jwt:"));
         assert!(message.contains("<redacted:private_key_block:"));
+    }
+
+    #[test]
+    fn provider_http_errors_surface_numeric_codes_and_request_ids() {
+        let info = classify_provider_http_error(
+            "minimax",
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            None,
+            r#"{"type":"error","error":{"message":"token plan not support model","http_code":"500","code":2061,"request_id":"req_123"}}"#,
+        );
+
+        assert_eq!(info.kind, LlmErrorKind::Terminal);
+        assert_eq!(info.reason, LlmErrorReason::ModelUnavailable);
+        assert!(info.message.contains("token plan not support model"));
+        assert!(info.message.contains("http_code: 500"));
+        assert!(info.message.contains("code: 2061"));
+        assert!(info.message.contains("request_id: req_123"));
+    }
+
+    #[test]
+    fn provider_http_errors_surface_openrouter_previous_errors_tail() {
+        let info = classify_provider_http_error(
+            "openrouter",
+            reqwest::StatusCode::BAD_GATEWAY,
+            None,
+            r#"{
+                "error": {
+                    "message": "No endpoints could satisfy the request",
+                    "code": 502,
+                    "metadata": {
+                        "request_id": "or_req_456",
+                        "previous_errors": [
+                            {
+                                "provider_name": "Cerebras",
+                                "error": {"message": "tools is incompatible with response_format"}
+                            },
+                            {
+                                "provider_name": "Groq",
+                                "message": "Request too large"
+                            }
+                        ]
+                    }
+                }
+            }"#,
+        );
+
+        assert_eq!(info.kind, LlmErrorKind::Transient);
+        assert_eq!(info.reason, LlmErrorReason::ServerError);
+        assert!(info
+            .message
+            .contains("No endpoints could satisfy the request"));
+        assert!(info.message.contains("code: 502"));
+        assert!(info.message.contains("request_id: or_req_456"));
+        assert!(info.message.contains(
+            "previous_errors: Cerebras: tools is incompatible with response_format | Groq: Request too large"
+        ));
+    }
+
+    #[test]
+    fn provider_http_errors_accept_top_level_json_string() {
+        let info = classify_provider_http_error(
+            "nvidia",
+            reqwest::StatusCode::NOT_FOUND,
+            None,
+            r#""404 page not found""#,
+        );
+
+        assert_eq!(info.kind, LlmErrorKind::Terminal);
+        assert_eq!(info.reason, LlmErrorReason::ModelUnavailable);
+        assert!(info.message.contains("404 page not found"));
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/api/errors.rs
+++ b/crates/harn-vm/src/llm/api/errors.rs
@@ -133,7 +133,7 @@ fn structured_provider_error_summary(body: &str) -> Option<String> {
         let message = truncate_chars(message, MAX_PROVIDER_ERROR_BODY_CHARS.saturating_sub(256));
         let mut details = Vec::new();
         collect_error_details(error, &mut details);
-        if !std::ptr::eq(error, &json) {
+        if !std::ptr::eq(std::ptr::from_ref(error), std::ptr::addr_of!(json)) {
             collect_error_details(&json, &mut details);
         }
         if details.is_empty() {

--- a/crates/harn-vm/src/llm/api/errors.rs
+++ b/crates/harn-vm/src/llm/api/errors.rs
@@ -833,29 +833,17 @@ mod tests {
 
     #[test]
     fn provider_http_errors_surface_openrouter_previous_errors_tail() {
+        let body = concat!(
+            r#"{"error":{"message":"No endpoints could satisfy the request","code":502,"metadata":{"#,
+            r#""request_id":"or_req_456","previous_errors":["#,
+            r#"{"provider_name":"Cerebras","error":{"message":"tools is incompatible with response_format"}},"#,
+            r#"{"provider_name":"Groq","message":"Request too large"}]}}}"#,
+        );
         let info = classify_provider_http_error(
             "openrouter",
             reqwest::StatusCode::BAD_GATEWAY,
             None,
-            r#"{
-                "error": {
-                    "message": "No endpoints could satisfy the request",
-                    "code": 502,
-                    "metadata": {
-                        "request_id": "or_req_456",
-                        "previous_errors": [
-                            {
-                                "provider_name": "Cerebras",
-                                "error": {"message": "tools is incompatible with response_format"}
-                            },
-                            {
-                                "provider_name": "Groq",
-                                "message": "Request too large"
-                            }
-                        ]
-                    }
-                }
-            }"#,
+            body,
         );
 
         assert_eq!(info.kind, LlmErrorKind::Transient);

--- a/crates/harn-vm/src/llm/api/response.rs
+++ b/crates/harn-vm/src/llm/api/response.rs
@@ -211,6 +211,53 @@ fn parse_tool_arguments(arguments: Option<&serde_json::Value>) -> serde_json::Va
     }
 }
 
+fn parse_openai_tool_argument_values(args_str: &str) -> Vec<serde_json::Value> {
+    match serde_json::from_str::<serde_json::Value>(args_str) {
+        Ok(value) => return vec![value],
+        Err(first_error) => {
+            let mut values = Vec::new();
+            for parsed in
+                serde_json::Deserializer::from_str(args_str).into_iter::<serde_json::Value>()
+            {
+                match parsed {
+                    Ok(value) => values.push(value),
+                    Err(_) => {
+                        return vec![tool_argument_parse_error(args_str, first_error)];
+                    }
+                }
+            }
+            if values.len() > 1
+                && values
+                    .iter()
+                    .all(|value| matches!(value, serde_json::Value::Object(_)))
+            {
+                return values;
+            }
+            vec![tool_argument_parse_error(args_str, first_error)]
+        }
+    }
+}
+
+fn tool_argument_parse_error(args_str: &str, error: serde_json::Error) -> serde_json::Value {
+    serde_json::json!({
+        "__parse_error": format!(
+            "Could not parse tool arguments as JSON: {}. Raw input: {}",
+            error,
+            preview_chars(args_str, 200)
+        )
+    })
+}
+
+fn openai_synthetic_tool_call_id(base_id: &str, call_index: usize, arg_index: usize) -> String {
+    if base_id.is_empty() {
+        format!("call_{call_index}_{}", arg_index + 1)
+    } else if arg_index == 0 {
+        base_id.to_string()
+    } else {
+        format!("{base_id}_{}", arg_index + 1)
+    }
+}
+
 fn openai_responses_tool_kind(item_type: &str) -> &'static str {
     match item_type {
         "web_search_call" => "web_search",
@@ -779,7 +826,7 @@ pub(crate) fn parse_llm_response(
 
         let mut tool_calls = Vec::new();
         if let Some(calls) = message["tool_calls"].as_array() {
-            for call in calls {
+            for (call_index, call) in calls.iter().enumerate() {
                 // OpenAI Responses-API tool_search (harn#71) emits
                 // `tool_search_call` blocks when the server-hosted
                 // search runs. These are NOT dispatchable tools — the
@@ -825,33 +872,27 @@ pub(crate) fn parse_llm_response(
                 }
                 let raw_name = call["function"]["name"].as_str().unwrap_or("").to_string();
                 let args_str = call["function"]["arguments"].as_str().unwrap_or("{}");
-                let arguments: serde_json::Value = match serde_json::from_str(args_str) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        serde_json::json!({
-                            "__parse_error": format!(
-                                "Could not parse tool arguments as JSON: {}. Raw input: {}",
-                                e,
-                                preview_chars(args_str, 200)
-                            )
-                        })
-                    }
-                };
-                let (name, arguments) =
-                    crate::llm::tools::normalize_tool_call_shape(&raw_name, arguments);
-                let id = call["id"].as_str().unwrap_or("").to_string();
-                tool_calls.push(serde_json::json!({
-                    "id": id,
-                    "name": name,
-                    "arguments": arguments,
-                }));
-                blocks.push(serde_json::json!({
-                    "type": "tool_call",
-                    "id": call["id"].clone(),
-                    "name": name,
-                    "arguments": arguments.clone(),
-                    "visibility": "internal",
-                }));
+                let base_id = call["id"].as_str().unwrap_or("");
+                for (arg_index, arguments) in parse_openai_tool_argument_values(args_str)
+                    .into_iter()
+                    .enumerate()
+                {
+                    let (name, arguments) =
+                        crate::llm::tools::normalize_tool_call_shape(&raw_name, arguments);
+                    let id = openai_synthetic_tool_call_id(base_id, call_index, arg_index);
+                    tool_calls.push(serde_json::json!({
+                        "id": id.clone(),
+                        "name": name,
+                        "arguments": arguments,
+                    }));
+                    blocks.push(serde_json::json!({
+                        "type": "tool_call",
+                        "id": id,
+                        "name": name,
+                        "arguments": arguments.clone(),
+                        "visibility": "internal",
+                    }));
+                }
             }
         }
 
@@ -1550,6 +1591,76 @@ mod tests {
             assert_eq!(result.tool_calls[0]["name"], "edit");
             assert_eq!(result.tool_calls[0]["arguments"], serde_json::json!({}));
         }
+    }
+
+    #[test]
+    fn openai_parser_splits_concatenated_tool_argument_objects() {
+        let response = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "chatcmpl-tool-1",
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": "{\"path\":\"a.rs\"}{\"path\":\"b.rs\"}"
+                            }
+                        }
+                    ]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 20}
+        });
+
+        let result = parse_llm_response(&response, "openrouter", "google/gemma-4", false, false)
+            .expect("parser succeeds");
+
+        assert_eq!(result.tool_calls.len(), 2);
+        assert_eq!(result.tool_calls[0]["id"], "chatcmpl-tool-1");
+        assert_eq!(result.tool_calls[0]["name"], "read");
+        assert_eq!(result.tool_calls[0]["arguments"]["path"], "a.rs");
+        assert_eq!(result.tool_calls[1]["id"], "chatcmpl-tool-1_2");
+        assert_eq!(result.tool_calls[1]["name"], "read");
+        assert_eq!(result.tool_calls[1]["arguments"]["path"], "b.rs");
+        let tool_blocks = result
+            .blocks
+            .iter()
+            .filter(|block| block["type"] == "tool_call")
+            .collect::<Vec<_>>();
+        assert_eq!(tool_blocks.len(), 2);
+        assert_eq!(tool_blocks[1]["id"], "chatcmpl-tool-1_2");
+    }
+
+    #[test]
+    fn openai_parser_splits_concatenated_tool_arguments_without_source_id() {
+        let response = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": "{\"path\":\"a.rs\"}{\"path\":\"b.rs\"}"
+                            }
+                        }
+                    ]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 20}
+        });
+
+        let result = parse_llm_response(&response, "openrouter", "google/gemma-4", false, false)
+            .expect("parser succeeds");
+
+        assert_eq!(result.tool_calls.len(), 2);
+        assert_eq!(result.tool_calls[0]["id"], "call_0_1");
+        assert_eq!(result.tool_calls[1]["id"], "call_0_2");
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/api/response.rs
+++ b/crates/harn-vm/src/llm/api/response.rs
@@ -213,7 +213,7 @@ fn parse_tool_arguments(arguments: Option<&serde_json::Value>) -> serde_json::Va
 
 fn parse_openai_tool_argument_values(args_str: &str) -> Vec<serde_json::Value> {
     match serde_json::from_str::<serde_json::Value>(args_str) {
-        Ok(value) => return vec![value],
+        Ok(value) => vec![value],
         Err(first_error) => {
             let mut values = Vec::new();
             for parsed in

--- a/crates/harn-vm/src/llm/providers/openai_compat.rs
+++ b/crates/harn-vm/src/llm/providers/openai_compat.rs
@@ -171,10 +171,10 @@ impl OpenAiCompatibleProvider {
             body[token_limit_field] = serde_json::json!(opts.max_tokens);
         }
         if let Some(temp) = opts.temperature.filter(|_| caps.temperature_supported) {
-            body["temperature"] = serde_json::json!(temp);
+            body["temperature"] = serde_json::json!(clamp_temperature(temp));
         }
         if let Some(top_p) = opts.top_p.filter(|_| caps.top_p_supported) {
-            body["top_p"] = serde_json::json!(top_p);
+            body["top_p"] = serde_json::json!(clamp_probability(top_p));
         }
         if let Some(top_k) = opts.top_k.filter(|_| caps.top_k_supported) {
             body["top_k"] = serde_json::json!(top_k);
@@ -555,6 +555,20 @@ fn split_parallel_native_tool_call_history(
         normalized.extend(deferred);
     }
     normalized
+}
+
+fn clamp_temperature(value: f64) -> f64 {
+    if !value.is_finite() {
+        return 1.0;
+    }
+    value.clamp(0.0, 2.0)
+}
+
+fn clamp_probability(value: f64) -> f64 {
+    if !value.is_finite() {
+        return 1.0;
+    }
+    value.clamp(0.0, 1.0)
 }
 
 fn assistant_tool_calls(message: &serde_json::Value) -> Option<Vec<serde_json::Value>> {
@@ -1185,6 +1199,26 @@ mod tests {
         payload.fast = false;
         let body_off = OpenAiCompatibleProvider::build_request_body(&payload, false);
         assert!(body_off.get("service_tier").is_none());
+    }
+
+    #[test]
+    fn build_request_body_clamps_sampling_ranges_before_send() {
+        let mut payload = base_request_payload();
+        payload.provider = "openai".to_string();
+        payload.model = "gpt-4o".to_string();
+        payload.temperature = Some(99.0);
+        payload.top_p = Some(5000.0);
+
+        let body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+
+        assert_eq!(body["temperature"], json!(2.0));
+        assert_eq!(body["top_p"], json!(1.0));
+
+        payload.temperature = Some(f64::NEG_INFINITY);
+        payload.top_p = Some(f64::NAN);
+        let non_finite_body = OpenAiCompatibleProvider::build_request_body(&payload, false);
+        assert_eq!(non_finite_body["temperature"], json!(1.0));
+        assert_eq!(non_finite_body["top_p"], json!(1.0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- split concatenated top-level JSON object tool arguments from OpenAI-compatible chat completions into separate dispatchable tool calls
- synthesize stable tool-call ids when providers omit ids, while preserving the original id for the first split call when present
- surface useful details from varied provider error envelopes: numeric/string code and status, request ids, MiniMax http_code, and OpenRouter metadata.previous_errors tails
- classify MiniMax account/model-plan code 2061 as terminal model_unavailable so retry/fallback behavior treats it like a config/route issue
- clamp emitted OpenAI-compatible `temperature` and `top_p` values to provider-safe ranges before send
- add changelog fragments for the response decoder, error decoder, and sampling clamp fixes

Closes part of #3645 (R4 / footgun #7, R7 / footgun #15, and R8 / footgun #20).

## Verification

- `CARGO_BUILD_JOBS=2 CARGO_TARGET_DIR=/tmp/harn-target-cerebras-tools cargo test -p harn-vm openai_parser -- --nocapture`
- `CARGO_BUILD_JOBS=2 CARGO_TARGET_DIR=/tmp/harn-target-cerebras-tools cargo test -p harn-vm provider_http_errors -- --nocapture`
- `CARGO_BUILD_JOBS=2 CARGO_TARGET_DIR=/tmp/harn-target-cerebras-tools cargo test -p harn-vm build_request_body_clamps_sampling_ranges_before_send -- --nocapture`
- `CARGO_BUILD_JOBS=2 CARGO_TARGET_DIR=/tmp/harn-target-cerebras-tools cargo test -p harn-vm openai_compat::tests -- --nocapture`
- `cargo fmt --check --package harn-vm`
- `git diff --check`
- `npx markdownlint-cli2 changelog.d/openai-sampling-clamp.fixed.md changelog.d/provider-error-decoder.fixed.md changelog.d/cerebras-tools-response-format.fixed.md`