### PR TITLE
test(cli): remove manifest watch event race

### DIFF
--- a/crates/harn-cli/tests/orchestrator_http/admin.rs
+++ b/crates/harn-cli/tests/orchestrator_http/admin.rs
@@ -143,12 +143,6 @@ async fn watch_mode_reloads_manifest_changes() {
     .await;
     let base_url = harness.listener_url().to_string();
 
-    write_file(
-        temp.path(),
-        "harn.toml",
-        &a2a_manifest(None).replace("/a2a/review", "/a2a/review-watch"),
-    );
-
     let client = reqwest::Client::new();
     let mut auth_headers = json_headers();
     auth_headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer reload-key"));
@@ -157,16 +151,27 @@ async fn watch_mode_reloads_manifest_changes() {
     // event on `orchestrator.manifest` once the new route is live;
     // that is exactly the signal HTTP requests would otherwise have
     // to discover by retrying.
-    await_topic_event(&harness.event_log(), "orchestrator.manifest", |event| {
-        event.kind == "reload_succeeded"
-            && event.payload["summary"]["modified"]
-                .as_array()
-                .is_some_and(|modified| {
-                    modified
-                        .iter()
-                        .any(|item| item.as_str() == Some("incoming-review-task"))
-                })
-    })
+    await_topic_event_after(
+        &harness.event_log(),
+        "orchestrator.manifest",
+        || {
+            write_file(
+                temp.path(),
+                "harn.toml",
+                &a2a_manifest(None).replace("/a2a/review", "/a2a/review-watch"),
+            );
+        },
+        |event| {
+            event.kind == "reload_succeeded"
+                && event.payload["summary"]["modified"]
+                    .as_array()
+                    .is_some_and(|modified| {
+                        modified
+                            .iter()
+                            .any(|item| item.as_str() == Some("incoming-review-task"))
+                    })
+        },
+    )
     .await;
 
     let response = client

--- a/crates/harn-cli/tests/orchestrator_http/support.rs
+++ b/crates/harn-cli/tests/orchestrator_http/support.rs
@@ -674,6 +674,18 @@ pub(super) async fn await_topic_event(
     topic: &str,
     predicate: impl Fn(&LogEvent) -> bool,
 ) -> LogEvent {
+    await_topic_event_after(event_log, topic, || {}, predicate).await
+}
+
+/// Subscribe to a topic, run `trigger`, then wait for the first event matching
+/// `predicate`. Use this when `trigger` can emit quickly enough that subscribing
+/// afterward would race the broadcast delivery.
+pub(super) async fn await_topic_event_after(
+    event_log: &Arc<AnyEventLog>,
+    topic: &str,
+    trigger: impl FnOnce(),
+    predicate: impl Fn(&LogEvent) -> bool,
+) -> LogEvent {
     let topic_obj = Topic::new(topic).unwrap_or_else(|error| {
         panic!("invalid topic `{topic}`: {error}");
     });
@@ -682,6 +694,7 @@ pub(super) async fn await_topic_event(
         .subscribe(&topic_obj, None)
         .await
         .unwrap_or_else(|error| panic!("subscribe to {topic} failed: {error}"));
+    trigger();
     let result = tokio::time::timeout(EVENT_FAIL_FAST_TIMEOUT, async {
         loop {
             let next = stream


### PR DESCRIPTION
## Summary
- subscribe to orchestrator.manifest before mutating harn.toml in the watch-mode hot-reload test
- keep the real notify watcher path under test while removing the lost-broadcast race that blocked the v0.8.155 release audit

## Verification
- cargo fmt --check
- git diff --check
- cargo test -p harn-cli --test orchestrator_http watch_mode_reloads_manifest_changes -- --nocapture
- cargo test -p harn-cli --test orchestrator_http
- pre-commit hook
- pre-push hook

Release context: v0.8.155 run 019f1178 failed in release_gate audit because this test timed out after a fast file-watch reload event was missed.