### PR TITLE
fix(stdlib): allow command policy approval verdicts

### DIFF
--- a/changelog.d/3685.fixed.md
+++ b/changelog.d/3685.fixed.md
@@ -1,0 +1,2 @@
+- `std/agent/host_tools` command policies now accept `require_approval` verdicts
+  and return structured approval requests instead of throwing or executing.

--- a/crates/harn-cli/tests/agent_run_command_argv_coercion.rs
+++ b/crates/harn-cli/tests/agent_run_command_argv_coercion.rs
@@ -102,6 +102,52 @@ pipeline main(_) {
     );
 }
 
+/// A command policy can require host approval without throwing or running the command.
+#[test]
+fn command_policy_can_return_require_approval_verdict() {
+    let body = r#"
+import { agent_command_tools } from "std/agent/host_tools"
+
+fn require_approval(request, args) {
+  return {require_approval: true, reason: "needs human approval", approval_id: "approval-123"}
+}
+
+pipeline main(_) {
+  let opts = {root: "/workspace", command_policy: require_approval, output_format: "value"}
+  let h = tool_find(agent_command_tools(tool_registry(), opts), "run_command").handler
+  let r = h({argv: ["definitely-not-run-command-policy-sentinel"]})
+  __io_println("STATUS=" + to_string(r.status))
+  __io_println("REQUIRES=" + to_string(r.requires_approval))
+  __io_println("REASON=" + r.reason)
+  __io_println("APPROVAL_ID=" + r.approval_id)
+  __io_println("MODE=" + to_string(r.request?.mode))
+  __io_println("ARGV=" + json_stringify(r.request?.argv))
+}
+"#;
+    let stdout = run_script(body);
+    assert!(
+        stdout.contains("STATUS=requires_approval"),
+        "require_approval verdict should return a structured approval request; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("REQUIRES=true"),
+        "approval result should carry requires_approval=true; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("REASON=needs human approval"),
+        "approval result should preserve the policy reason; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("APPROVAL_ID=approval-123"),
+        "approval result should preserve the optional approval id; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("MODE=argv")
+            && stdout.contains(r#"ARGV=["definitely-not-run-command-policy-sentinel"]"#),
+        "approval result should include the shaped command request; got:\n{stdout}"
+    );
+}
+
 /// A non-empty `command` LIST routes to argv mode even when shell is disabled
 /// (argv mode never needs a shell), instead of being rejected.
 #[test]

--- a/crates/harn-stdlib/src/stdlib/agent/host_tools.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/host_tools.harn
@@ -295,6 +295,21 @@ fn __agent_host_policy_blocked(reason, request, args, options) {
   }
 }
 
+fn __agent_host_policy_requires_approval(verdict, request, args) {
+  let approval_request = verdict?.request ?? verdict?.rewrite ?? request
+  var out = {
+    requires_approval: true,
+    status: "requires_approval",
+    reason: verdict?.reason ?? "command_policy requires approval",
+    request: approval_request,
+    args: args,
+  }
+  if verdict?.approval_id != nil {
+    out = out + {approval_id: verdict.approval_id}
+  }
+  return out
+}
+
 fn __agent_host_apply_command_policy(request, args, options) {
   let opts = __agent_host_options(options)
   let policy = opts?.command_policy ?? opts?.allow_command
@@ -316,6 +331,10 @@ fn __agent_host_apply_command_policy(request, args, options) {
     return __agent_host_policy_blocked(verdict, request, args, opts)
   }
   if kind == "dict" {
+    let approval_value = verdict?.require_approval ?? verdict?.requires_approval
+    if type_of(approval_value) == "bool" && approval_value {
+      return __agent_host_policy_requires_approval(verdict, request, args)
+    }
     if verdict?.request != nil {
       return verdict.request
     }
@@ -777,7 +796,7 @@ pub fn agent_command_tools(registry = nil, options = nil) {
           ),
           handler: { args ->
             let req = __agent_host_command_request(args, opts)
-            if req?.blocked ?? false {
+            if (req?.blocked ?? false) || (req?.requires_approval ?? false) {
               return __agent_host_render(req, opts, key)
             }
             let planned = if opts?.preserve_filtered_output ?? true {


### PR DESCRIPTION
## Summary
- accept `require_approval` / `requires_approval` dict verdicts from `std/agent/host_tools` command policies
- return a structured approval request instead of throwing unsupported verdicts or executing the command
- add a regression test proving the sentinel command is not run and the shaped argv request is preserved

Fixes #3685.

## Verification
- harn fmt --check crates/harn-stdlib/src/stdlib/agent/host_tools.harn
- harn check crates/harn-stdlib/src/stdlib/agent/host_tools.harn
- cargo fmt --check
- git diff --check
- cargo test -p harn-cli --test agent_run_command_argv_coercion command_policy_can_return_require_approval_verdict -- --nocapture
- cargo test -p harn-cli --test agent_run_command_argv_coercion
- pre-commit hook
- pre-push hook before rebase
- rebase onto current origin/main after #3687, then pre-push hook again