### PR TITLE
fix(agent_fanout): isolate spawn-time throws so one bad child can't nuke a wave

### DIFF
--- a/changelog.d/fanout-spawn-resilience.fixed.md
+++ b/changelog.d/fanout-spawn-resilience.fixed.md
@@ -1,0 +1,10 @@
+- **`agent_fanout` no longer loses a whole batch when one child fails to spawn.**
+  A background `sub_agent_run` validates and builds its request synchronously
+  (e.g. parsing `allowed_tools`) and can also hit a host worker-spawn fault, so
+  it can `throw` before any handle exists. The per-wave spawn loop had no
+  per-child guard, so a single malformed unit aborted the entire wave *and*
+  every later wave — silently dropping every sibling result. Each spawn is now
+  caught individually: a spawn-time throw becomes that unit's own `ok: false`
+  result (`status: "failed"`, the fault in `error`) at its correct offset, the
+  surviving children are still joined, and results stay 1:1 and positionally
+  aligned with `requests`. One bad unit can no longer nuke a parallel fan-out.

--- a/crates/harn-stdlib/src/stdlib/agent/workers.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/workers.harn
@@ -823,6 +823,24 @@ fn __fanout_result(request, index, summary) {
 }
 
 /**
+ * __fanout_spawn_error_summary turns a spawn-time throw into a synthetic worker
+ * summary shaped exactly like a terminal failure: `__fanout_envelope` reads the
+ * `ok: false` envelope, `__fanout_ok` returns false, and `__fanout_error`
+ * surfaces the spawn fault — so a child that never launched still produces a
+ * 1:1 ok:false result at its own offset instead of aborting the wave.
+ *
+ * @effects: []
+ * @errors: []
+ * @api_stability: experimental
+ */
+fn __fanout_spawn_error_summary(error) {
+  return {
+    status: "failed",
+    result: {ok: false, error: __sub_agent_string(error, "sub_agent_run: spawn failed")},
+  }
+}
+
+/**
  * agent_fanout runs many sub-agent requests CONCURRENTLY in bounded waves and
  * joins them, returning one normalized result per request in input order.
  *
@@ -876,18 +894,42 @@ pub fn agent_fanout(requests, options = nil) {
     // Spawn the whole wave as background workers BEFORE joining: each
     // background `sub_agent_run` returns its handle immediately, so the
     // children's turns overlap while `wait_agent` awaits them.
-    var handles = []
+    //
+    // A spawn can throw SYNCHRONOUSLY (bad request `options`, e.g. a malformed
+    // `allowed_tools`, or a host worker-spawn fault) before any handle exists.
+    // We catch each spawn so one failing unit becomes that unit's ok:false
+    // result instead of aborting the whole wave and every later wave. The
+    // outcome list stays positionally aligned with `wave`; only the units that
+    // actually spawned are joined via `wait_agent`.
+    var outcomes = []
     for request in wave {
-      let summary = sub_agent_run(request.task, request.options + {background: true, name: request.label})
-      handles = handles.push(summary)
+      let outcome = try {
+        let handle = sub_agent_run(request.task, request.options + {background: true, name: request.label})
+        {spawned: true, handle: handle}
+      } catch (spawn_error) {
+        {spawned: false, error: spawn_error}
+      }
+      outcomes = outcomes.push(outcome)
     }
-    let waited = wait_agent(handles)
+    var live_handles = []
+    for outcome in outcomes {
+      if outcome.spawned {
+        live_handles = live_handles.push(outcome.handle)
+      }
+    }
+    let waited = wait_agent(live_handles)
     var offset = 0
+    var live_index = 0
     for request in wave {
-      let summary = if type_of(waited) == "list" {
-        waited[offset] ?? {}
+      let outcome = outcomes[offset]
+      var summary = {}
+      if outcome.spawned {
+        if type_of(waited) == "list" {
+          summary = waited[live_index] ?? {}
+        }
+        live_index = live_index + 1
       } else {
-        {}
+        summary = __fanout_spawn_error_summary(outcome.error)
       }
       results = results.push(__fanout_result(request, base + offset, summary))
       offset = offset + 1

--- a/crates/harn-vm/tests/agent_fanout.rs
+++ b/crates/harn-vm/tests/agent_fanout.rs
@@ -333,3 +333,167 @@ pipeline main(task) {{
     }
     eprintln!("WAVES CONFIRMED: 5 requests across waves of 2 all completed in input order with own markers");
 }
+
+#[test]
+fn fanout_isolates_a_spawn_time_throw() {
+    // A spawn can throw SYNCHRONOUSLY — before any worker handle exists —
+    // when a request's `options` are malformed. Here index 1 ("bravo") carries
+    // an `allowed_tools` list with a non-string entry, so `sub_agent_run` ->
+    // `sub_agent_request` -> `__sub_agent_string_list` throws inside the wave
+    // spawn loop. The fix must turn that into THAT unit's ok:false result
+    // (status "failed", error surfaced) without aborting the wave — the whole
+    // `agent_fanout` call must NOT throw, and the siblings must still return
+    // their own markers in input order.
+    let source = format!(
+        r#"{PRELUDE}
+pipeline main(task) {{
+  let labels = ["alpha", "bravo", "charlie"]
+  var reqs = []
+  var i = 0
+  for label in labels {{
+    let marker = "MARK-" + to_string(i)
+    let opts = if i == 1 {{
+      base_opts(ok_caller(marker)) + {{allowed_tools: [123]}}
+    }} else {{
+      base_opts(ok_caller(marker))
+    }}
+    reqs = reqs.push({{task: "do " + marker, options: opts, label: label}})
+    i = i + 1
+  }}
+  let results = agent_fanout(reqs, {{max_parallel: 8}})
+  log("COUNT=" + to_string(len(results)))
+  emit_rows(results)
+}}
+"#
+    );
+
+    // The whole call must NOT throw — `.expect` here is itself the regression
+    // guard: before the fix, the spawn throw propagated out of `agent_fanout`.
+    let raw = run_with_bridge(&source).expect("a spawn-time throw must not abort agent_fanout");
+    let lines = out_lines(&raw);
+    eprintln!("--- harn output ---\n{}", lines.join("\n"));
+
+    let rows = parse_rows(&lines);
+    let labels = ["alpha", "bravo", "charlie"];
+    assert_eq!(
+        rows.len(),
+        labels.len(),
+        "spawn throw dropped sibling results; lines: {lines:?}"
+    );
+
+    for (i, expected_label) in labels.iter().enumerate() {
+        let row = &rows[i];
+        assert_eq!(row.index, i, "lines: {lines:?}");
+        assert_eq!(&row.label, expected_label, "lines: {lines:?}");
+        if i == 1 {
+            // The unit whose spawn threw: synthetic failure result, error
+            // surfaced, never ran an LLM turn (no marker summary).
+            assert!(
+                !row.ok,
+                "spawn-failed unit (index 1) must have ok == false; lines: {lines:?}"
+            );
+            assert!(
+                row.error_present,
+                "spawn-failed unit (index 1) must surface the spawn fault; lines: {lines:?}"
+            );
+            assert_eq!(
+                row.status, "failed",
+                "spawn-failed unit (index 1) status should be 'failed'; lines: {lines:?}"
+            );
+            assert_eq!(
+                row.summary, "",
+                "spawn-failed unit (index 1) never produced an envelope summary; lines: {lines:?}"
+            );
+        } else {
+            // Siblings unaffected: still ok, still carry their own marker.
+            assert!(row.ok, "sibling {i} should still be ok; lines: {lines:?}");
+            assert!(
+                !row.error_present,
+                "sibling {i} should have no error; lines: {lines:?}"
+            );
+            assert_eq!(
+                row.summary,
+                format!("MARK-{i}"),
+                "sibling {i} cross-talk / drop under a spawn throw; lines: {lines:?}"
+            );
+        }
+    }
+    eprintln!(
+        "SPAWN-THROW ISOLATION CONFIRMED: index 1 spawn fault -> ok=false+error, siblings ok+own-marker, no wave abort"
+    );
+}
+
+#[test]
+fn fanout_spawn_throw_in_first_wave_does_not_drop_later_waves() {
+    // Four requests with max_parallel: 2 -> waves [0,1], [2,3]. Index 0's spawn
+    // throws (malformed allowed_tools) in the FIRST wave. Before the fix that
+    // throw aborted the wave AND every later wave, silently dropping waves 2.
+    // The fix must let later waves run: all four results come back, in order,
+    // with only index 0 marked failed.
+    let source = format!(
+        r#"{PRELUDE}
+pipeline main(task) {{
+  let labels = ["w0", "w1", "w2", "w3"]
+  var reqs = []
+  var i = 0
+  for label in labels {{
+    let marker = "WAVE-" + to_string(i)
+    let opts = if i == 0 {{
+      base_opts(ok_caller(marker)) + {{allowed_tools: [123]}}
+    }} else {{
+      base_opts(ok_caller(marker))
+    }}
+    reqs = reqs.push({{task: "do " + marker, options: opts, label: label}})
+    i = i + 1
+  }}
+  let results = agent_fanout(reqs, {{max_parallel: 2}})
+  log("COUNT=" + to_string(len(results)))
+  emit_rows(results)
+}}
+"#
+    );
+
+    let raw =
+        run_with_bridge(&source).expect("a first-wave spawn throw must not abort later waves");
+    let lines = out_lines(&raw);
+    eprintln!("--- harn output ---\n{}", lines.join("\n"));
+
+    let rows = parse_rows(&lines);
+    let labels = ["w0", "w1", "w2", "w3"];
+    assert_eq!(
+        rows.len(),
+        labels.len(),
+        "a first-wave spawn throw dropped later waves; lines: {lines:?}"
+    );
+
+    for (i, expected_label) in labels.iter().enumerate() {
+        let row = &rows[i];
+        assert_eq!(row.index, i, "wave reordering at {i}; lines: {lines:?}");
+        assert_eq!(&row.label, expected_label, "lines: {lines:?}");
+        if i == 0 {
+            assert!(
+                !row.ok,
+                "spawn-failed wave child 0 must be ok=false; lines: {lines:?}"
+            );
+            assert!(
+                row.error_present,
+                "spawn-failed wave child 0 must surface an error; lines: {lines:?}"
+            );
+            assert_eq!(row.status, "failed", "lines: {lines:?}");
+        } else {
+            // The crucial assertion: wave-2 children (index 2,3) still ran.
+            assert!(
+                row.ok,
+                "later-wave child {i} should be ok; lines: {lines:?}"
+            );
+            assert_eq!(
+                row.summary,
+                format!("WAVE-{i}"),
+                "later-wave child {i} returned the wrong marker / was dropped; lines: {lines:?}"
+            );
+        }
+    }
+    eprintln!(
+        "LATER-WAVES-SURVIVE CONFIRMED: wave-1 spawn throw at index 0 did not drop wave-2 children"
+    );
+}


### PR DESCRIPTION
## Summary
A synchronous spawn-time throw in `agent_fanout` aborts the ENTIRE wave + all later waves. The per-wave spawn loop (`crates/harn-stdlib/src/stdlib/agent/workers.harn`) called `sub_agent_run(...)` with NO per-child try/catch, but `sub_agent_request` validates `allowed_tools`/session and `__host_sub_agent_run` can fault BEFORE any background handle exists — so one malformed unit's throw propagates straight out of `agent_fanout`, losing every sibling result. Distinct from wait-time error propagation (already covered by `fanout_isolates_a_single_child_failure`).

Confirmed real against committed `origin/main` (bare spawn loop, try/catch=0). Fix wraps each spawn: a spawn fault becomes that unit's `{spawned:false}` → positional `ok:false` result, results stay 1:1 with requests, the wave + later waves continue.

## Tests
- 2 non-vacuous tests injecting a deterministic synchronous throw (`allowed_tools: [123]`): against the unfixed loop the throw propagates out of `agent_fanout`; with the fix all 5 fanout tests pass. fmt/check/clippy clean.

Rides the next harn release (not cutting one here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)