### PR TITLE
feat(agents): per-child files_written + usage on sub-agent/fanout envelopes

### DIFF
--- a/changelog.d/fanout-child-files-written.added.md
+++ b/changelog.d/fanout-child-files-written.added.md
@@ -1,0 +1,11 @@
+Sub-agent result envelopes (and therefore `agent_fanout` per-child results) now
+carry `files_written` — the authoritative set of workspace paths the child
+actually mutated through the deterministic hostlib write surface, collected at
+the single `fs_snapshot::auto_capture_for_write` chokepoint so capability-denied
+out-of-scope writes are excluded — plus a `usage` object
+(`input_tokens`/`output_tokens`/`total_tokens`). This lets a fan-out parent
+attribute writes to each child and detect a child that claimed completion but
+wrote nothing or wrote outside its scope, without re-parsing transcripts, and
+works headless. Exposed via new
+`harn_vm::agent_sessions::{record,session,take,clear}_session_changed_path(s)`
+helpers fed from the hostlib write chokepoint.

--- a/crates/harn-hostlib/src/fs_snapshot.rs
+++ b/crates/harn-hostlib/src/fs_snapshot.rs
@@ -447,6 +447,15 @@ pub(crate) fn auto_capture_for_write(builtin: &'static str, path: &Path) {
     let Some(session_id) = active_session_id() else {
         return;
     };
+    // Record the mutated path against the session BEFORE the snapshot/tool-call
+    // gate below: this is the single chokepoint every hostlib write reaches, so
+    // it is the authoritative source for a session's `files_written` (consumed by
+    // the sub-agent receipt). Recorded unconditionally — even when no restore
+    // snapshot is open (no active tool call) — because the write still happened.
+    harn_vm::agent_sessions::record_session_changed_path(
+        &session_id,
+        normalize_logical(path).to_string_lossy().as_ref(),
+    );
     let Some(snapshot_id) = harn_vm::agent_sessions::current_tool_call_id() else {
         return;
     };
@@ -1090,6 +1099,44 @@ mod tests {
         let restored = restore(&session, &scope, &[]).unwrap();
         assert_eq!(restored.restored_paths.len(), 1);
         assert_eq!(stdfs::read(&file).unwrap(), b"pre");
+    }
+
+    #[test]
+    fn auto_capture_records_session_changed_path_for_files_written_receipt() {
+        let dir = TempDir::new().unwrap();
+        let one = dir.path().join("a.txt");
+        let two = dir.path().join("b.txt");
+        let session = unique_session("snap-changed");
+        harn_vm::agent_sessions::clear_session_changed_paths(&session);
+        let _session_guard = enter_session(&session);
+
+        // No active tool call / open snapshot: the write still happened, so the
+        // path must be recorded for the receipt regardless.
+        auto_capture_for_write("hostlib_tools_write_file", &one);
+        auto_capture_for_write("hostlib_tools_write_file", &two);
+        // A duplicate write of the same path must dedupe.
+        auto_capture_for_write("hostlib_tools_write_file", &one);
+
+        let changed = harn_vm::agent_sessions::session_changed_paths(&session);
+        assert_eq!(changed.len(), 2, "two distinct paths recorded (deduped)");
+        let expect_one = normalize_logical(&one).to_string_lossy().into_owned();
+        let expect_two = normalize_logical(&two).to_string_lossy().into_owned();
+        assert!(
+            changed.contains(&expect_one),
+            "path a recorded: {changed:?}"
+        );
+        assert!(
+            changed.contains(&expect_two),
+            "path b recorded: {changed:?}"
+        );
+
+        // `take` drains so the receipt captures the set exactly once.
+        let drained = harn_vm::agent_sessions::take_session_changed_paths(&session);
+        assert_eq!(drained.len(), 2);
+        assert!(
+            harn_vm::agent_sessions::session_changed_paths(&session).is_empty(),
+            "take drains the session's recorded paths"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/src/agent_sessions.rs
+++ b/crates/harn-vm/src/agent_sessions.rs
@@ -18,9 +18,10 @@
 
 use crate::value::VmDictExt;
 use std::cell::{Cell, RefCell};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 
 use crate::actor_chain::ActorChain;
@@ -329,6 +330,68 @@ thread_local! {
 
 tokio::task_local! {
     static CURRENT_TOOL_CALL_TASK: String;
+}
+
+/// Per-session set of filesystem paths a session has mutated (written or
+/// deleted) via the deterministic hostlib write surface. Keyed by session id
+/// and process-global (not thread-local like [`SESSIONS`]) so a background
+/// fan-out child's writes are attributed correctly regardless of which runtime
+/// thread serviced them. Fed by the single hostlib write chokepoint
+/// (`harn-hostlib`'s `fs_snapshot::auto_capture_for_write`), which is reached
+/// only AFTER a write is policy-approved and about to touch disk — so this
+/// reflects ACTUAL committed mutations, not denied/aborted attempts. The
+/// authoritative source for a sub-agent's `files_written` receipt field.
+static SESSION_CHANGED_PATHS: OnceLock<Mutex<BTreeMap<String, BTreeSet<String>>>> = OnceLock::new();
+
+fn session_changed_paths_store() -> &'static Mutex<BTreeMap<String, BTreeSet<String>>> {
+    SESSION_CHANGED_PATHS.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+/// Record that `path` was mutated (written/deleted) by `session_id`. Called from
+/// the hostlib write chokepoint; a no-op when either argument is empty.
+pub fn record_session_changed_path(session_id: &str, path: &str) {
+    if session_id.is_empty() || path.is_empty() {
+        return;
+    }
+    if let Ok(mut store) = session_changed_paths_store().lock() {
+        store
+            .entry(session_id.to_string())
+            .or_default()
+            .insert(path.to_string());
+    }
+}
+
+/// The sorted set of paths `session_id` has mutated so far (empty when none).
+/// Non-draining: safe to call for introspection without disturbing the record.
+pub fn session_changed_paths(session_id: &str) -> Vec<String> {
+    session_changed_paths_store()
+        .lock()
+        .ok()
+        .and_then(|store| {
+            store
+                .get(session_id)
+                .map(|set| set.iter().cloned().collect())
+        })
+        .unwrap_or_default()
+}
+
+/// Read AND remove a session's mutated-path set. Used at sub-agent teardown so
+/// the receipt captures the child's writes exactly once and the global map does
+/// not grow unbounded across a long-lived daemon's many fan-outs.
+pub fn take_session_changed_paths(session_id: &str) -> Vec<String> {
+    session_changed_paths_store()
+        .lock()
+        .ok()
+        .and_then(|mut store| store.remove(session_id))
+        .map(|set| set.into_iter().collect())
+        .unwrap_or_default()
+}
+
+/// Drop a session's recorded mutated paths (explicit teardown / test reset).
+pub fn clear_session_changed_paths(session_id: &str) {
+    if let Ok(mut store) = session_changed_paths_store().lock() {
+        store.remove(session_id);
+    }
 }
 
 pub struct CurrentSessionGuard {

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -332,7 +332,60 @@ fn sub_agent_base_envelope(
     envelope.insert(crate::value::intern_key("data"), VmValue::Nil);
     envelope.insert(crate::value::intern_key("error"), VmValue::Nil);
     envelope.put_str("session_id", session_id);
+    // Per-child receipt fields (#29): the files this child actually mutated and
+    // its token usage. `files_written` is DRAINED from the session's authoritative
+    // hostlib write record (denied writes never reach it), so a failed child that
+    // still wrote files is visible and a "claimed-done, zero writes" child is
+    // detectable downstream. Present on BOTH the success and error envelope so the
+    // parent fan-out report can reason about every child uniformly.
+    envelope.insert(
+        crate::value::intern_key("files_written"),
+        crate::stdlib::json_to_vm_value(&serde_json::json!(
+            crate::agent_sessions::take_session_changed_paths(session_id)
+        )),
+    );
+    envelope.insert(
+        crate::value::intern_key("usage"),
+        crate::stdlib::json_to_vm_value(&serde_json::json!({ "total_tokens": tokens_used })),
+    );
     envelope
+}
+
+/// Split a child transcript's token usage into (input, output). Mirrors
+/// [`transcript_tokens_used`] (whose total is `input + output`) but keeps the two
+/// halves so the receipt can report `tokens_in` / `tokens_out` separately.
+fn transcript_usage(transcript: &VmValue) -> (i64, i64) {
+    let Some(events) = transcript
+        .as_dict()
+        .and_then(|dict| dict.get("events"))
+        .and_then(|value| match value {
+            VmValue::List(list) => Some(list),
+            _ => None,
+        })
+    else {
+        return (0, 0);
+    };
+    let mut input = 0i64;
+    let mut output = 0i64;
+    for metadata in events
+        .iter()
+        .filter_map(|event| event.as_dict())
+        .filter_map(|dict| dict.get("metadata").and_then(|value| value.as_dict()))
+    {
+        input = input.saturating_add(
+            metadata
+                .get("input_tokens")
+                .and_then(VmValue::as_int)
+                .unwrap_or(0),
+        );
+        output = output.saturating_add(
+            metadata
+                .get("output_tokens")
+                .and_then(VmValue::as_int)
+                .unwrap_or(0),
+        );
+    }
+    (input, output)
 }
 
 fn wrap_sub_agent_error(
@@ -879,6 +932,17 @@ pub(super) async fn execute_sub_agent(
         &spec.session_id,
     );
     envelope.insert(crate::value::intern_key("transcript"), transcript.clone());
+    // Enrich the receipt's `usage` with the input/output split now that a full
+    // transcript is in hand (the base envelope carries total-only).
+    let (input_tokens, output_tokens) = transcript_usage(&transcript);
+    envelope.insert(
+        crate::value::intern_key("usage"),
+        crate::stdlib::json_to_vm_value(&serde_json::json!({
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": tokens_used,
+        })),
+    );
 
     if spec.returns_schema.is_none() && option_requests_structured_output(&spec.options) {
         if let Some(candidate) = synthesized.structured_json.as_ref() {
@@ -1001,6 +1065,74 @@ mod tests {
             ..CapabilityPolicy::default()
         });
         ExecutionPolicyGuard
+    }
+
+    #[test]
+    fn base_envelope_carries_files_written_and_usage_then_drains() {
+        let session = format!("test-files-written-{}", uuid::Uuid::now_v7());
+        crate::agent_sessions::clear_session_changed_paths(&session);
+        crate::agent_sessions::record_session_changed_path(&session, "src/alpha.rs");
+        crate::agent_sessions::record_session_changed_path(&session, "src/beta.rs");
+
+        let envelope = sub_agent_base_envelope(
+            "did the work".to_string(),
+            VmValue::List(std::sync::Arc::new(Vec::new())),
+            0,
+            1234,
+            false,
+            &session,
+        );
+
+        let files = envelope
+            .get("files_written")
+            .and_then(|value| match value {
+                VmValue::List(list) => Some(list.clone()),
+                _ => None,
+            })
+            .expect("files_written is a list");
+        let paths: Vec<String> = files
+            .iter()
+            .filter_map(|value| match value {
+                VmValue::String(text) => Some(text.to_string()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            paths.contains(&"src/alpha.rs".to_string()),
+            "alpha written: {paths:?}"
+        );
+        assert!(
+            paths.contains(&"src/beta.rs".to_string()),
+            "beta written: {paths:?}"
+        );
+
+        let total = envelope
+            .get("usage")
+            .and_then(VmValue::as_dict)
+            .and_then(|usage| usage.get("total_tokens"))
+            .and_then(VmValue::as_int)
+            .expect("usage.total_tokens present");
+        assert_eq!(total, 1234, "usage carries the child's total tokens");
+
+        // The base envelope DRAINS the session record, so a second build sees no
+        // double-counted writes.
+        let again = sub_agent_base_envelope(
+            "again".to_string(),
+            VmValue::List(std::sync::Arc::new(Vec::new())),
+            0,
+            0,
+            false,
+            &session,
+        );
+        let again_files = again.get("files_written").and_then(|value| match value {
+            VmValue::List(list) => Some(list.len()),
+            _ => None,
+        });
+        assert_eq!(
+            again_files,
+            Some(0),
+            "files_written drains after the first build"
+        );
     }
 
     fn assistant_message(text: &str) -> VmValue {


### PR DESCRIPTION
## What

A sub-agent's result envelope — and therefore every `agent_fanout` per-child result and the worker summary — now carries two receipt fields so a parallel-dispatch parent can reason about each child **without re-parsing transcripts**:

- **`files_written`**: the authoritative set of workspace paths the child actually mutated. Collected at the single hostlib write chokepoint `fs_snapshot::auto_capture_for_write` (covers `write_file`, `delete_file`, `safe_text_patch`, AST edit/apply, `code_index` rename), which is reached only **after** a write is policy-approved and about to touch disk — so a capability-**denied** out-of-scope write never appears. This is the deterministic, **headless-safe** signal (no Swift/IDE dependency; `session.changed_paths` is IDE-only and returns `[]` in `burin-headless`/meter).
- **`usage`**: `{input_tokens, output_tokens, total_tokens}` on the success path (`{total_tokens}` on the error path), for per-child cost attribution.

This is the harn half of the per-child write-integrity + dispatch-receipt work (Burin #28/#29). It lets a dispatch parent detect a child that **claimed completion but wrote nothing**, or **wrote outside its declared targets**, and attribute cost per child.

## How

- New process-global per-session changed-paths accumulator in `harn_vm::agent_sessions` (`record_session_changed_path` / `session_changed_paths` / `take_session_changed_paths` / `clear_session_changed_paths`), keyed by session id so a background child's writes are attributed correctly regardless of runtime thread (mirrors `fs_snapshot`'s global pattern).
- `harn-hostlib`'s `auto_capture_for_write` records each mutated path into it — **before** the snapshot/tool-call gate, so the write is recorded even when no restore snapshot is open.
- `sub_agent_base_envelope` **drains** the session's set into `files_written` at child teardown (read-once → bounded growth) and emits `usage`. The child session id is the post-#3662 `audit.session_id`, so attribution lines up with existing fan-out lineage. Fields flow automatically to `__fanout_result.result.{files_written,usage}` and the worker summary.

## Scope / sequencing

- **No `execution.rs` / `WorkerState` change** — the fields ride the existing sub-agent envelope. This deliberately avoids a 3-way conflict with the in-flight ambient-scope (SEV-1) and spawn-resilience fan-out work.
- The separate **UUID-as-timestamp** bug at `execution.rs:588-590` (worker `created_at`/`started_at`/`finished_at` stored as `uuid::now_v7()` strings, not ms) is **not** in this PR; it's sequenced to land with/after the WorkerState restructure to avoid the conflict. Recommended fix there is to **add** `*_ms: i64` fields rather than replace the opaque time-sortable strings (they're used by the snapshot serialize/restore round-trip).

## Tests

- `harn-vm`: accumulator record/dedupe + envelope `files_written`/`usage` presence and **drain** semantics (`base_envelope_carries_files_written_and_usage_then_drains`).
- `harn-hostlib`: the write chokepoint records a session's mutated paths **unconditionally** (no open snapshot) and `take` drains (`auto_capture_records_session_changed_path_for_files_written_receipt`).
- Regression green: `agent_sessions` (38), `agents_sub_agent` (10), `fs_snapshot` (9); `clippy` clean; changelog fragment added.

Validated end-to-end against a real fan-out bundle is the follow-up dogfood (closes the P2 introspection residual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)