### PR TITLE
fix(agents): expose worker timing milliseconds

### DIFF
--- a/changelog.d/worker-timing-ms.fixed.md
+++ b/changelog.d/worker-timing-ms.fixed.md
@@ -1,0 +1,4 @@
+- **Worker lifecycle metadata now exposes millisecond timing fields.** Worker
+  summaries and `worker_update` bridge events include decoded `created_at_ms`,
+  `started_at_ms`, `finished_at_ms`, and `wall_ms` values instead of forcing
+  clients to parse UUIDv7 timestamp IDs themselves.

--- a/crates/harn-vm/src/stdlib/agents_workers/bridge.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/bridge.rs
@@ -33,6 +33,13 @@ fn worker_bridge_metadata(state: &WorkerState) -> serde_json::Value {
         "created_at": state.created_at,
         "started_at": state.started_at,
         "finished_at": state.finished_at,
+        // Real wall-clock ms decoded from the UUIDv7 ids above, so a worker_update
+        // consumer (TUI pane, ACP, dispatch receipt) gets a usable timestamp/
+        // duration instead of an opaque id. See `worker_timestamp_unix_ms`.
+        "created_at_ms": super::worker_timestamp_unix_ms(&state.created_at),
+        "started_at_ms": super::worker_timestamp_unix_ms(&state.started_at),
+        "finished_at_ms": state.finished_at.as_deref().and_then(super::worker_timestamp_unix_ms),
+        "wall_ms": super::worker_wall_ms(&state.started_at, state.finished_at.as_deref()),
         "awaiting_started_at": state.awaiting_started_at,
         "artifact_count": state.artifacts.len(),
         "has_transcript": state.transcript.is_some(),

--- a/crates/harn-vm/src/stdlib/agents_workers/mod.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/mod.rs
@@ -445,6 +445,29 @@ pub(super) fn worker_provenance(state: &WorkerState) -> WorkerProvenanceRecord {
     }
 }
 
+/// Decode the millisecond Unix timestamp embedded in a UUIDv7 string. Worker
+/// `created_at` / `started_at` / `finished_at` are stored as the time-ordered
+/// `uuid::Uuid::now_v7()` ids those points stamp in — which carry a real 48-bit
+/// wall-clock-ms prefix. Consumers (the TUI subagent pane, ACP worker updates,
+/// the dispatch receipt) want that millisecond value, not the opaque id; reading
+/// it back here fixes the long-standing "timestamp is a UUID string, not ms" bug
+/// without changing how the ids are stored (so persisted workers decode too).
+/// Returns None for a non-UUIDv7 string.
+pub(super) fn worker_timestamp_unix_ms(value: &str) -> Option<i64> {
+    let uuid = uuid::Uuid::parse_str(value).ok()?;
+    let (secs, nanos) = uuid.get_timestamp()?.to_unix();
+    Some(secs as i64 * 1000 + i64::from(nanos / 1_000_000))
+}
+
+/// Wall-clock milliseconds between two UUIDv7 worker timestamps, when both decode
+/// and are ordered. None when either is missing/undecodable or finished precedes
+/// started (a clock skew we decline to report as a negative duration).
+pub(super) fn worker_wall_ms(started_at: &str, finished_at: Option<&str>) -> Option<i64> {
+    let start = worker_timestamp_unix_ms(started_at)?;
+    let end = worker_timestamp_unix_ms(finished_at?)?;
+    (end >= start).then_some(end - start)
+}
+
 pub(super) fn clone_worker_state(state: &WorkerState) -> serde_json::Value {
     serde_json::json!({
         "_type": "agent_handle",
@@ -456,6 +479,10 @@ pub(super) fn clone_worker_state(state: &WorkerState) -> serde_json::Value {
         "created_at": state.created_at,
         "started_at": state.started_at,
         "finished_at": state.finished_at,
+        "created_at_ms": worker_timestamp_unix_ms(&state.created_at),
+        "started_at_ms": worker_timestamp_unix_ms(&state.started_at),
+        "finished_at_ms": state.finished_at.as_deref().and_then(worker_timestamp_unix_ms),
+        "wall_ms": worker_wall_ms(&state.started_at, state.finished_at.as_deref()),
         "awaiting_started_at": state.awaiting_started_at,
         "history": state.history,
         "request": state.request,

--- a/crates/harn-vm/src/stdlib/agents_workers/tests.rs
+++ b/crates/harn-vm/src/stdlib/agents_workers/tests.rs
@@ -20,6 +20,27 @@ fn vm_dict(pairs: Vec<(&str, VmValue)>) -> VmValue {
     )
 }
 
+fn uuid_v7_at_ms(ms: u64) -> String {
+    format!(
+        "{:08x}-{:04x}-7000-8000-000000000000",
+        (ms >> 16) as u32,
+        (ms & 0xffff) as u16
+    )
+}
+
+#[test]
+fn worker_timestamp_helpers_decode_uuid_v7_without_wall_clock() {
+    let start = uuid_v7_at_ms(1_700_000_010_000);
+    let finish = uuid_v7_at_ms(1_700_000_010_321);
+    let earlier = uuid_v7_at_ms(1_700_000_009_999);
+
+    assert_eq!(worker_timestamp_unix_ms(&start), Some(1_700_000_010_000));
+    assert_eq!(worker_wall_ms(&start, Some(&finish)), Some(321));
+    assert_eq!(worker_wall_ms(&start, Some(&earlier)), None);
+    assert_eq!(worker_timestamp_unix_ms("not-a-uuid"), None);
+    assert_eq!(worker_wall_ms(&start, None), None);
+}
+
 #[test]
 fn worker_snapshot_round_trip_preserves_resume_fields() {
     // Use an explicit per-test snapshot path inside a unique temp dir instead of
@@ -208,14 +229,17 @@ fn parse_worker_config_rejects_unknown_carry_options() {
 
 #[test]
 fn worker_summary_exposes_request_and_provenance() {
+    let created_at = uuid_v7_at_ms(1_700_000_000_000);
+    let started_at = uuid_v7_at_ms(1_700_000_000_250);
+    let finished_at = uuid_v7_at_ms(1_700_000_001_750);
     let mut state = WorkerState {
         id: "worker_123".to_string(),
         name: "worker".to_string(),
         task: "latest task".to_string(),
         status: "completed".to_string(),
-        created_at: "created".to_string(),
-        started_at: "started".to_string(),
-        finished_at: Some("finished".to_string()),
+        created_at: created_at.clone(),
+        started_at: started_at.clone(),
+        finished_at: Some(finished_at.clone()),
         awaiting_started_at: None,
         awaiting_since: None,
         mode: "sub_agent".to_string(),
@@ -285,6 +309,22 @@ fn worker_summary_exposes_request_and_provenance() {
         serde_json::json!("session_parent")
     );
     assert_eq!(summary["task"], serde_json::json!("latest task"));
+    assert_eq!(summary["created_at"], serde_json::json!(created_at));
+    assert_eq!(summary["started_at"], serde_json::json!(started_at));
+    assert_eq!(summary["finished_at"], serde_json::json!(finished_at));
+    assert_eq!(
+        summary["created_at_ms"],
+        serde_json::json!(1_700_000_000_000i64)
+    );
+    assert_eq!(
+        summary["started_at_ms"],
+        serde_json::json!(1_700_000_000_250i64)
+    );
+    assert_eq!(
+        summary["finished_at_ms"],
+        serde_json::json!(1_700_000_001_750i64)
+    );
+    assert_eq!(summary["wall_ms"], serde_json::json!(1_500i64));
 
     state.status = "suspended".to_string();
     state.suspension = Some(WorkerSuspension {
@@ -300,6 +340,22 @@ fn worker_summary_exposes_request_and_provenance() {
     });
 
     let event_snapshot = super::bridge::worker_event_snapshot(&state);
+    assert_eq!(
+        event_snapshot.metadata["created_at_ms"],
+        serde_json::json!(1_700_000_000_000i64)
+    );
+    assert_eq!(
+        event_snapshot.metadata["started_at_ms"],
+        serde_json::json!(1_700_000_000_250i64)
+    );
+    assert_eq!(
+        event_snapshot.metadata["finished_at_ms"],
+        serde_json::json!(1_700_000_001_750i64)
+    );
+    assert_eq!(
+        event_snapshot.metadata["wall_ms"],
+        serde_json::json!(1_500i64)
+    );
     let suspension = &event_snapshot.metadata["suspension"];
     assert_eq!(suspension["handle"], serde_json::json!("worker_123"));
     assert_eq!(suspension["reason"], serde_json::json!("waiting on review"));


### PR DESCRIPTION
## Summary
- decode the UUIDv7 timestamps already stored on worker lifecycle state into millisecond fields
- expose `created_at_ms`, `started_at_ms`, `finished_at_ms`, and `wall_ms` on worker summaries and `worker_update` bridge metadata
- keep persisted worker state backward-compatible by deriving the new fields instead of changing stored IDs

## Verification
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `CARGO_TARGET_DIR=/Users/ksinder/projects/harn/harn-worktrees/worker-timing-ms/target/codex-worker-timing cargo test -p harn-vm stdlib::agents::agents_workers::tests --lib`
- pre-commit hook: markdownlint, Rust formatting, rust prompt prose ratchet, changed-package clippy, highlight keyword sync
- pre-push hook: markdownlint, targeted local checks, highlight keyword check
