### PR TITLE
fix(agent): auto-continue hidden reasoning truncation

### DIFF
--- a/changelog.d/3645.fixed.md
+++ b/changelog.d/3645.fixed.md
@@ -1,0 +1,3 @@
+- **Agent loop truncation recovery.** Length-truncated turns that contain only
+  hidden reasoning now auto-continue with a raised output cap instead of
+  flowing into empty-turn parse or stall handling (#3645).

--- a/conformance/tests/agents/agent_loop_truncation_auto_continue.expected
+++ b/conformance/tests/agents/agent_loop_truncation_auto_continue.expected
@@ -7,3 +7,6 @@ true
 done
 3
 true
+done
+2
+true

--- a/conformance/tests/agents/agent_loop_truncation_auto_continue.harn
+++ b/conformance/tests/agents/agent_loop_truncation_auto_continue.harn
@@ -120,4 +120,29 @@ pipeline default() {
       __io_println(contains(json_stringify(calls[1].messages), "parse_guidance"))
     },
   )
+  // (d) Length truncation with billed hidden work but no visible text/tool
+  // calls is still budget exhaustion. Retry with a raised cap instead of
+  // feeding an empty turn into parse/stall accounting.
+  with_llm_script(
+    [{text: "", output_tokens: 342, stop_reason: "length"}, llm_text("<done>##DONE##</done>")],
+    { ->
+      let result = agent_loop(
+        "Think briefly, then finish.",
+        nil,
+        {
+          provider: "mock",
+          tool_format: "text",
+          loop_until_done: true,
+          max_iterations: 3,
+          max_nudges: 3,
+          max_tokens: 64,
+          tools: note_tools(),
+        },
+      )
+      let calls = llm_mock_calls()
+      __io_println(result.status)
+      __io_println(len(calls))
+      __io_println(!contains(json_stringify(calls[1].messages), "parse_guidance"))
+    },
+  )
 }

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -227,10 +227,12 @@ fn __invoke_llm(message, turn_system, llm_opts) {
 // Bounded to a small number of continuations; if still truncated after the cap
 // we return the last result and the existing parse-guidance path takes over.
 //
-// The gate (`__host_agent_truncated_tool_call`) fires ONLY on a real length
-// truncation with zero usable calls AND a partial-call signal, so it never
-// double-handles the clean-stop-but-malformed (#3137) or reasoning-leak (#3142)
-// cases — those stop with `end_turn`/`stop`, not `length`/`max_tokens`.
+// The tool-call gate (`__host_agent_truncated_tool_call`) fires ONLY on a real
+// length truncation with zero usable calls AND a partial-call signal. A second
+// gate covers hidden-reasoning-only truncation: strict providers can return no
+// visible text/tool calls, `stop_reason: length`, and non-empty reasoning. That
+// is still a budget exhaustion, so retry with a larger output cap instead of
+// handing an empty turn to the normal loop body.
 
 // -------------------------------------------------------------------------------------------------
 
@@ -272,6 +274,29 @@ fn __autocontinue_raised_cap(current, llm_opts) {
   return raised
 }
 
+fn __autocontinue_is_length_stop(stop_reason) {
+  let normalized = lowercase(trim(to_string(stop_reason ?? "")))
+  return normalized == "length" || normalized == "max_tokens"
+}
+
+fn __autocontinue_hidden_reasoning_truncated(llm_result, tool_call_count) {
+  if !__autocontinue_is_length_stop(llm_result?.stop_reason) {
+    return false
+  }
+  if tool_call_count > 0 {
+    return false
+  }
+  if trim(to_string(llm_result?.text ?? "")) != "" {
+    return false
+  }
+  let thinking = trim(to_string(llm_result?.thinking ?? ""))
+  let summary = trim(to_string(llm_result?.thinking_summary ?? ""))
+  if thinking != "" || summary != "" {
+    return true
+  }
+  return (to_int(llm_result?.output_tokens ?? 0) ?? 0) > 0
+}
+
 /**
  * Detect whether `call` is a length-truncated turn that resolved no usable
  * tool call but looks like it was mid-call — the one condition where
@@ -289,12 +314,15 @@ fn __autocontinue_should_continue(call, turn_opts) {
   let parsed = agent_parse_tool_calls(raw_text, turn_opts?.tools, turn_opts?.tool_format)
   let tool_calls = __resolve_tool_calls(llm_result, parsed)
   let has_parse_errors = len(parsed?.tool_parse_errors ?? []) > 0
-  return __host_agent_truncated_tool_call(
+  if __host_agent_truncated_tool_call(
     llm_result?.stop_reason,
     raw_text,
     len(tool_calls),
     has_parse_errors,
-  )
+  ) {
+    return true
+  }
+  return __autocontinue_hidden_reasoning_truncated(llm_result, len(tool_calls))
 }
 
 /**

--- a/crates/harn-vm/src/llm/api/response.rs
+++ b/crates/harn-vm/src/llm/api/response.rs
@@ -598,13 +598,19 @@ pub(crate) struct CompletionContractSignals<'a> {
 /// to `agent_loop`, which can accept it, nudge for more work, or fail required
 /// tool policy.
 pub(crate) fn is_billed_noncommittal_completion(signals: &CompletionContractSignals) -> bool {
-    let finished_clean = !matches!(signals.stop_reason, Some("length"));
+    let finished_clean = !is_length_stop_reason(signals.stop_reason);
     finished_clean
         && signals.output_tokens > 0
         && signals.tools_offered
         && signals.tool_call_count == 0
         && !signals.has_tool_search_block
         && signals.text.trim().is_empty()
+}
+
+fn is_length_stop_reason(stop_reason: Option<&str>) -> bool {
+    stop_reason.is_some_and(|reason| {
+        reason.eq_ignore_ascii_case("length") || reason.eq_ignore_ascii_case("max_tokens")
+    })
 }
 
 /// Build the loud, actionable error returned when
@@ -903,6 +909,8 @@ pub(crate) fn parse_llm_response(
         let stop_reason = finish_reason.map(|s| s.to_string());
         let request_id = json["id"].as_str().filter(|value| !value.is_empty());
         let telemetry = ProviderTelemetry::from_openai_usage(&json["usage"], request_id);
+        let billed_length_truncation =
+            is_length_stop_reason(stop_reason.as_deref()) && output_tokens > 0;
 
         // OpenAI Responses-API `tool_search_call` / `tool_search_output`
         // blocks (harn#71) are server-executed and get stripped from
@@ -910,7 +918,10 @@ pub(crate) fn parse_llm_response(
         // blocks. Count their presence as "did deliver something" so
         // the empty-response error below doesn't trip when the
         // server's response consisted entirely of a search
-        // query/result exchange.
+        // query/result exchange. Also let billed length-truncated turns
+        // through so the agent loop can raise max_tokens and continue them:
+        // hidden reasoning can consume the whole cap without leaving a
+        // provider-visible reasoning string to preserve here.
         let has_tool_search_block = blocks.iter().any(|b| {
             matches!(
                 b.get("type").and_then(|v| v.as_str()),
@@ -922,6 +933,7 @@ pub(crate) fn parse_llm_response(
             && reasoning_summary.is_empty()
             && tool_calls.is_empty()
             && !has_tool_search_block
+            && !billed_length_truncation
         {
             return Err(VmError::Thrown(VmValue::String(arcstr::ArcStr::from(
                 format!(
@@ -1171,6 +1183,19 @@ mod tests {
     }
 
     #[test]
+    fn contract_violation_silent_on_max_tokens_truncation() {
+        let signals = CompletionContractSignals {
+            stop_reason: Some("max_tokens"),
+            output_tokens: 4096,
+            tools_offered: true,
+            tool_call_count: 0,
+            has_tool_search_block: false,
+            text: "",
+        };
+        assert!(!is_billed_noncommittal_completion(&signals));
+    }
+
+    #[test]
     fn contract_violation_silent_when_no_tools_offered() {
         // A deliberately terse text reply to a tool-less prompt is fine.
         let signals = CompletionContractSignals {
@@ -1225,6 +1250,35 @@ mod tests {
             message.contains("upstream contract violation"),
             "error must name the contract violation: {message}"
         );
+    }
+
+    #[test]
+    fn parse_llm_response_allows_billed_empty_length_truncation() {
+        // Some reasoning routes consume the output cap in a hidden channel and
+        // return no visible content or reasoning string, only a length stop and
+        // billed completion tokens. The parser must hand this shape to the
+        // agent loop so it can auto-continue with a raised cap.
+        let response = serde_json::json!({
+            "id": "gen-hidden-truncated",
+            "choices": [{
+                "index": 0,
+                "finish_reason": "length",
+                "message": {
+                    "role": "assistant",
+                    "content": ""
+                }
+            }],
+            "usage": { "prompt_tokens": 321, "completion_tokens": 342 }
+        });
+        let result = parse_llm_response(&response, "openrouter", "hidden-reasoning", false, true)
+            .expect("billed length truncation is recoverable");
+
+        assert_eq!(result.text, "");
+        assert!(result.tool_calls.is_empty());
+        assert_eq!(result.output_tokens, 342);
+        assert_eq!(result.stop_reason.as_deref(), Some("length"));
+        assert_eq!(result.thinking, None);
+        assert_eq!(result.thinking_summary, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Completes the remaining #3645 R6/#14 budget-exhaustion gap after the earlier provider-hardening PRs landed.

This PR makes length-truncated turns with hidden/billed reasoning work recoverable instead of flowing into empty-turn parse/stall handling:

- lets OpenAI-compatible parser results through when the provider returns `finish_reason: "length"`/`"max_tokens"`, no visible text/tool calls, and billed output tokens
- extends the agent-loop truncation auto-continue gate to treat that usage-only hidden-work shape as budget exhaustion
- keeps clean billed no-op turns loud via the existing provider contract-violation path
- adds Rust parser coverage plus Harn conformance coverage for the usage-only shape

## #3645 burn-down

Already merged before this PR:

- #3643: Anthropic strict tool-result adjacency
- #3653: OpenAI-compatible strict tool-result adjacency
- #3659: provider catalog corrections
- #3665: Fireworks single-tool-call history
- #3675: OpenAI-compatible per-message allowlist
- #3676: capability-gated request conflict handling
- #3678: Anthropic whitespace-only text block drop
- #3680: remaining OpenAI-compatible boundary hardening, including orphan tool results, concatenated tool-argument splitting, reasoning fallback, tolerant errors, and sampling clamps

This PR closes the remaining hidden-reasoning length-truncation case.

Closes #3645.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/Users/ksinder/projects/harn-release-v0.8.155-codex/target/release-harn cargo test -p harn-vm llm::api::response::tests::` (38 passed)
- `CARGO_TARGET_DIR=/Users/ksinder/projects/harn-release-v0.8.155-codex/target/release-harn HARN_LLM_CALLS_DISABLED=1 cargo run --quiet --bin harn -- test conformance --filter agent_loop_truncation_auto_continue` (1 passed)
- local pre-commit and pre-push hooks passed
