### PR TITLE
Speed up release prepare cargo reuse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,6 +328,7 @@ test-agent-scripts:
 test-pr-gate-scripts:
 	./scripts/tests/changelog_fragment_check_test.sh
 	./scripts/tests/release_gate_harn_bin_test.sh
+	./scripts/tests/release_prepare_env_test.sh
 	./scripts/tests/publish_script_test.sh
 
 # Format check (no changes, for CI)

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -409,6 +409,18 @@ cmd_prepare() {
   current="$(current_version)"
   next="$(next_version "$bump")"
   bump_version "$next"
+  # The audit lanes that ran before prepare populate cache state keyed to the
+  # old workspace crate hashes. Once `bump_version` rewrites Cargo.toml, the
+  # prepare-time cargo calls are one-shot rebuilds of generated-artifact
+  # helpers; caching them has little value and has failed under macOS sccache
+  # file-descriptor pressure. Use direct rustc and skip incremental state for
+  # this post-bump phase. `CARGO_BUILD_RUSTC_WRAPPER=` is required because
+  # Harn's checked-in `.cargo/config.toml` otherwise still applies sccache.
+  export CARGO_INCREMENTAL=0
+  export RUSTC_WRAPPER=
+  export CARGO_BUILD_RUSTC_WRAPPER=
+  export SCCACHE_DISABLE=1
+
   harn_cmd run scripts/sync_protocol_fixture_runtime_versions.harn -- --from "$current" --to "$next"
   # Keep the embedding guide's `tag = "vX.Y.Z"` pins on the released version
   # line. Nothing owned these before and they silently drifted ~46 versions
@@ -426,15 +438,6 @@ updated = re.sub(r'tag = "v\d+\.\d+\.\d+"', f'tag = "v{next_version}"', text)
 if updated != text:
     doc.write_text(updated)
 PY
-  # The audit lanes that ran before prepare populate cache state keyed to the
-  # old workspace crate hashes. Once `bump_version` rewrites Cargo.toml, the
-  # prepare-time cargo calls are one-shot rebuilds of generated-artifact
-  # helpers; caching them has little value and has failed under macOS sccache
-  # file-descriptor pressure. Use direct rustc and skip incremental state for
-  # this post-bump phase.
-  export CARGO_INCREMENTAL=0
-  export RUSTC_WRAPPER=
-  export SCCACHE_DISABLE=1
   make gen-protocol-artifacts
   cargo check --workspace --all-targets >/dev/null
   echo "Version updated: $current -> $next"

--- a/scripts/release_ship.sh
+++ b/scripts/release_ship.sh
@@ -236,6 +236,38 @@ print(f"{major}.{minor}.{patch}")
 PY
 }
 
+debug_harn_binary() {
+  local target_dir="${CARGO_TARGET_DIR:-}"
+  if [[ -z "$target_dir" ]]; then
+    target_dir="$(cargo metadata --format-version=1 --no-deps \
+      | python3 -c 'import json, sys; print(json.load(sys.stdin)["target_directory"])')"
+  fi
+  local suffix=""
+  case "${OS:-$(uname -s)}" in
+    Windows_NT|MINGW*|MSYS*|CYGWIN*) suffix=".exe" ;;
+  esac
+  printf '%s/debug/harn%s\n' "$target_dir" "$suffix"
+}
+
+export_warmed_harn_bin() {
+  if [[ -n "${HARN_BIN:-}" ]]; then
+    return 0
+  fi
+  local harn_bin
+  harn_bin="$(debug_harn_binary)"
+  if [[ -x "$harn_bin" ]]; then
+    export HARN_BIN="$harn_bin"
+    printf 'Reusing warmed HARN_BIN: %s\n' "$HARN_BIN"
+  fi
+}
+
+disable_prepare_cargo_cache_wrappers() {
+  export CARGO_INCREMENTAL=0
+  export RUSTC_WRAPPER=
+  export CARGO_BUILD_RUSTC_WRAPPER=
+  export SCCACHE_DISABLE=1
+}
+
 require_base_branch() {
   local base="$1"
   local branch
@@ -459,6 +491,7 @@ open_bump_pr() {
   log_step "Create bump branch"
   git switch -c "$branch"
 
+  export_warmed_harn_bin
   log_step "Version bump"
   "$RELEASE_GATE_SCRIPT" prepare --bump "$BUMP"
   local actual_next
@@ -539,6 +572,7 @@ prepare_here() {
   # --allow-dirty (see scripts/publish.sh).
   run_common_gates
 
+  export_warmed_harn_bin
   log_step "Version bump (in place)"
   "$RELEASE_GATE_SCRIPT" prepare --bump "$BUMP" --allow-dirty
   local actual_next
@@ -552,9 +586,7 @@ prepare_here() {
   # one-shot rebuilds. That export does not survive the subprocess boundary,
   # so re-apply it for the cargo invocations `regenerate_derived_files` runs in
   # this shell.
-  export CARGO_INCREMENTAL=0
-  export RUSTC_WRAPPER=
-  export SCCACHE_DISABLE=1
+  disable_prepare_cargo_cache_wrappers
   regenerate_derived_files
 
   log_step "Stage release content"

--- a/scripts/tests/release_prepare_env_test.sh
+++ b/scripts/tests/release_prepare_env_test.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+
+tmp_root=$(mktemp -d)
+trap 'rm -rf "$tmp_root"' EXIT
+
+release_root="$tmp_root/release-root"
+mkdir -p "$release_root/crates/example" "$release_root/docs/src/spec/language" "$release_root/docs/theme"
+cat > "$release_root/Cargo.toml" <<'EOF'
+[workspace]
+version = "1.2.3"
+members = ["crates/example"]
+resolver = "2"
+EOF
+cat > "$release_root/Cargo.lock" <<'EOF'
+# fake lock
+EOF
+cat > "$release_root/crates/example/Cargo.toml" <<'EOF'
+[package]
+name = "example"
+version = "1.2.3"
+edition = "2021"
+EOF
+cat > "$release_root/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## v1.2.4
+
+- release notes
+EOF
+cat > "$release_root/docs/src/embedding-rust.md" <<'EOF'
+tag = "v1.2.3"
+EOF
+touch \
+  "$release_root/docs/src/language-spec.md" \
+  "$release_root/docs/src/SUMMARY.md" \
+  "$release_root/docs/theme/harn-keywords.js"
+
+git -C "$release_root" init --quiet
+git -C "$release_root" config user.name "Release Test"
+git -C "$release_root" config user.email "release-test@example.com"
+git -C "$release_root" add .
+git -C "$release_root" commit --quiet -m "initial"
+git -C "$release_root" checkout --quiet -b release/v1.2.4
+
+fake_bin="$tmp_root/bin"
+mkdir -p "$fake_bin"
+
+cat > "$fake_bin/harn" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_HARN_RECORD"
+exit 0
+SH
+chmod +x "$fake_bin/harn"
+
+cat > "$fake_bin/cargo" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "check" ]]; then
+  {
+    printf 'CARGO_INCREMENTAL=%s\n' "${CARGO_INCREMENTAL-__unset__}"
+    printf 'RUSTC_WRAPPER=%s\n' "${RUSTC_WRAPPER-__unset__}"
+    printf 'CARGO_BUILD_RUSTC_WRAPPER=%s\n' "${CARGO_BUILD_RUSTC_WRAPPER-__unset__}"
+    printf 'SCCACHE_DISABLE=%s\n' "${SCCACHE_DISABLE-__unset__}"
+  } >> "$FAKE_CARGO_RECORD"
+  exit 0
+fi
+echo "unexpected cargo invocation: $*" >&2
+exit 2
+SH
+chmod +x "$fake_bin/cargo"
+
+cat > "$fake_bin/make" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+{
+  printf 'target=%s\n' "$*"
+  printf 'HARN_BIN=%s\n' "${HARN_BIN-__unset__}"
+  printf 'CARGO_INCREMENTAL=%s\n' "${CARGO_INCREMENTAL-__unset__}"
+  printf 'RUSTC_WRAPPER=%s\n' "${RUSTC_WRAPPER-__unset__}"
+  printf 'CARGO_BUILD_RUSTC_WRAPPER=%s\n' "${CARGO_BUILD_RUSTC_WRAPPER-__unset__}"
+  printf 'SCCACHE_DISABLE=%s\n' "${SCCACHE_DISABLE-__unset__}"
+} >> "$FAKE_MAKE_RECORD"
+exit 0
+SH
+chmod +x "$fake_bin/make"
+
+record_harn="$tmp_root/harn-record.txt"
+record_cargo="$tmp_root/cargo-record.txt"
+record_make="$tmp_root/make-record.txt"
+
+HARN_RELEASE_ROOT="$release_root" \
+HARN_BIN="$fake_bin/harn" \
+FAKE_HARN_RECORD="$record_harn" \
+FAKE_CARGO_RECORD="$record_cargo" \
+FAKE_MAKE_RECORD="$record_make" \
+PATH="$fake_bin:$PATH" \
+  "$repo_root/scripts/release_gate.sh" prepare --bump patch
+
+if ! grep -Fq "run scripts/sync_protocol_fixture_runtime_versions.harn -- --from 1.2.3 --to 1.2.4" "$record_harn"; then
+  echo "release_gate prepare did not route fixture sync through HARN_BIN" >&2
+  cat "$record_harn" >&2
+  exit 1
+fi
+
+for record in "$record_cargo" "$record_make"; do
+  if ! grep -Fxq "CARGO_INCREMENTAL=0" "$record"; then
+    echo "expected CARGO_INCREMENTAL=0 in $record" >&2
+    cat "$record" >&2
+    exit 1
+  fi
+  if ! grep -Fxq "RUSTC_WRAPPER=" "$record"; then
+    echo "expected empty RUSTC_WRAPPER in $record" >&2
+    cat "$record" >&2
+    exit 1
+  fi
+  if ! grep -Fxq "CARGO_BUILD_RUSTC_WRAPPER=" "$record"; then
+    echo "expected empty CARGO_BUILD_RUSTC_WRAPPER in $record" >&2
+    cat "$record" >&2
+    exit 1
+  fi
+  if ! grep -Fxq "SCCACHE_DISABLE=1" "$record"; then
+    echo "expected SCCACHE_DISABLE=1 in $record" >&2
+    cat "$record" >&2
+    exit 1
+  fi
+done
+
+git -C "$release_root" reset --hard --quiet HEAD
+>"$record_make"
+
+ship_gate="$tmp_root/fake-release-gate.sh"
+cat > "$ship_gate" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  audit)
+    mkdir -p "${CARGO_TARGET_DIR:?}/debug"
+    cat > "$CARGO_TARGET_DIR/debug/harn" <<'BIN'
+#!/usr/bin/env bash
+exit 0
+BIN
+    chmod +x "$CARGO_TARGET_DIR/debug/harn"
+    ;;
+  publish)
+    ;;
+  prepare)
+    printf 'prepare HARN_BIN=%s\n' "${HARN_BIN-__unset__}" >> "$SHIP_GATE_RECORD"
+    python3 - <<'PY'
+from pathlib import Path
+p = Path("Cargo.toml")
+p.write_text(p.read_text().replace('version = "1.2.3"', 'version = "1.2.4"'))
+lock = Path("Cargo.lock")
+lock.write_text(lock.read_text() + "# touched\n")
+PY
+    ;;
+  *)
+    echo "unexpected release gate invocation: $*" >&2
+    exit 2
+    ;;
+esac
+SH
+chmod +x "$ship_gate"
+
+record_ship="$tmp_root/ship-gate-record.txt"
+target_dir="$tmp_root/target"
+
+HARN_RELEASE_ROOT="$release_root" \
+HARN_RELEASE_HARNESS=1 \
+HARN_RELEASE_GATE_SCRIPT="$ship_gate" \
+CARGO_TARGET_DIR="$target_dir" \
+SHIP_GATE_RECORD="$record_ship" \
+FAKE_MAKE_RECORD="$record_make" \
+PATH="$fake_bin:$PATH" \
+  "$repo_root/scripts/release_ship.sh" --prepare --bump patch --skip-dry-run
+
+expected_harn="$target_dir/debug/harn"
+if ! grep -Fxq "prepare HARN_BIN=$expected_harn" "$record_ship"; then
+  echo "release_ship did not pass warmed HARN_BIN into release_gate prepare" >&2
+  cat "$record_ship" >&2
+  exit 1
+fi
+
+echo "release_prepare_env_test: ok"


### PR DESCRIPTION
## Summary
- reuse the debug harn binary warmed by release audit when running the prepare phase
- disable sccache/incremental cargo wrappers for post-bump generated-artifact cargo work, including CARGO_BUILD_RUSTC_WRAPPER from checked-in cargo config
- add a hermetic release_prepare_env_test and wire it into test-pr-gate-scripts

## Why
The release prepare step rewrites Cargo.toml after audit caches are populated, so its cargo work is a one-shot post-bump path. Reusing the warmed harn binary and bypassing fragile cache wrappers reduces release wall time and avoids macOS sccache file-descriptor pressure in the release tail.

## Validation
- ./scripts/tests/release_prepare_env_test.sh
- git diff --check origin/main...HEAD
- make test-pr-gate-scripts
- pre-push hook, including generated-artifact registry check and targeted cargo check