### PR TITLE
[codex] fix Windows path handling in harn-cli

### DIFF
--- a/changelog.d/windows-path-cli.fixed.md
+++ b/changelog.d/windows-path-cli.fixed.md
@@ -1,0 +1,4 @@
+- **Harn CLI Windows paths.** Windows drive-letter paths are now treated as
+  filesystem paths instead of URL schemes in package registry, archive, and
+  connector/OpenAPI flows, and CLI JSON/TOML artifacts normalize path output
+  deterministically across platforms.

--- a/crates/harn-cli/src/commands/check/bundle.rs
+++ b/crates/harn-cli/src/commands/check/bundle.rs
@@ -48,7 +48,7 @@ struct BundleManifestBuilder {
 
 impl BundleManifestBuilder {
     fn add_module(&mut self, path: &Path, role: &'static str) {
-        let key = path.display().to_string();
+        let key = crate::format::slash_path(path);
         self.modules
             .entry(key.clone())
             .or_insert(BundleModuleRecord { path: key, role });
@@ -56,8 +56,8 @@ impl BundleManifestBuilder {
 
     fn add_import_edge(&mut self, from: &Path, to: &Path) {
         self.import_edges.insert(BundleImportEdge {
-            from: from.display().to_string(),
-            to: to.display().to_string(),
+            from: crate::format::slash_path(from),
+            to: crate::format::slash_path(to),
         });
     }
 
@@ -76,22 +76,31 @@ impl BundleManifestBuilder {
                 .iter()
                 .find(|path| path.exists())
                 .or_else(|| candidates.first())
-                .map(|path| path.display().to_string())
+                .map(|path| crate::format::slash_path(path))
                 .unwrap_or_else(|| target.to_string())
         });
         let candidate_strings = stdlib_asset
             .iter()
             .cloned()
-            .chain(candidates.iter().map(|path| path.display().to_string()))
+            .chain(
+                candidates
+                    .iter()
+                    .map(|path| crate::format::slash_path(path)),
+            )
             .collect::<Vec<_>>();
         let exists = if stdlib_asset.is_some() {
             harn_vm::stdlib_modules::get_stdlib_prompt_asset(target).is_some()
         } else {
             candidates.iter().any(|path| path.exists())
         };
-        let key = format!("{}\u{0}{}\u{0}{}", declared_in.display(), via, resolved);
+        let key = format!(
+            "{}\u{0}{}\u{0}{}",
+            crate::format::slash_path(declared_in),
+            via,
+            resolved
+        );
         self.assets.entry(key).or_insert(BundleAssetRecord {
-            declared_in: declared_in.display().to_string(),
+            declared_in: crate::format::slash_path(declared_in),
             via: via.to_string(),
             kind,
             target: target.to_string(),
@@ -171,7 +180,7 @@ impl BundleManifestBuilder {
             .collect::<BTreeMap<_, _>>();
         serde_json::json!({
             "version": 1,
-            "targets": targets.iter().map(|path| path.display().to_string()).collect::<Vec<_>>(),
+            "targets": targets.iter().map(|path| crate::format::slash_path(path)).collect::<Vec<_>>(),
             "bundle_root": config.bundle_root,
             "entry_modules": entry_modules,
             "import_modules": import_modules,
@@ -284,11 +293,9 @@ fn scan_node_bundle(
         }
         Node::FunctionCall { name, args, .. } if name == "exec_at" || name == "shell_at" => {
             if let Some(dir) = args.first().and_then(literal_string) {
-                manifest.execution_dirs.insert(
-                    resolve_source_relative(file_path, &dir)
-                        .display()
-                        .to_string(),
-                );
+                manifest.execution_dirs.insert(crate::format::slash_path(
+                    &resolve_source_relative(file_path, &dir),
+                ));
             }
             let children = args.iter().collect::<Vec<_>>();
             scan_children_bundle(&children, file_path, config, visited, manifest);
@@ -539,21 +546,21 @@ fn collect_spawn_agent_bundle(
         return;
     };
     if let Some(cwd) = dict_literal_field(execution, "cwd").and_then(literal_string) {
-        manifest.execution_dirs.insert(
-            resolve_source_relative(file_path, &cwd)
-                .display()
-                .to_string(),
-        );
+        manifest
+            .execution_dirs
+            .insert(crate::format::slash_path(&resolve_source_relative(
+                file_path, &cwd,
+            )));
     }
     let Some(worktree) = dict_literal_field(execution, "worktree") else {
         return;
     };
     if let Some(repo) = dict_literal_field(worktree, "repo").and_then(literal_string) {
-        manifest.worktree_repos.insert(
-            resolve_source_relative(file_path, &repo)
-                .display()
-                .to_string(),
-        );
+        manifest
+            .worktree_repos
+            .insert(crate::format::slash_path(&resolve_source_relative(
+                file_path, &repo,
+            )));
     }
 }
 

--- a/crates/harn-cli/src/commands/check/preflight.rs
+++ b/crates/harn-cli/src/commands/check/preflight.rs
@@ -2121,7 +2121,7 @@ pub(super) fn resolve_preflight_target(
 fn render_candidate_paths(candidates: &[PathBuf]) -> String {
     candidates
         .iter()
-        .map(|path| path.display().to_string())
+        .map(|path| crate::format::slash_path(path))
         .collect::<Vec<_>>()
         .join(" or ")
 }
@@ -2240,11 +2240,11 @@ fn render_target_miss_help(file_path: &Path, template_path: &str) -> String {
     }
     let display = near
         .strip_prefix(&project_root)
-        .map(|p| p.display().to_string())
-        .unwrap_or_else(|_| near.display().to_string());
+        .map(crate::format::slash_path)
+        .unwrap_or_else(|_| crate::format::slash_path(&near));
     format!(
         "did you mean '{display}'? (found at {}). Otherwise: {GENERIC}",
-        near.display()
+        crate::format::slash_path(&near)
     )
 }
 

--- a/crates/harn-cli/src/commands/check/tests.rs
+++ b/crates/harn-cli/src/commands/check/tests.rs
@@ -346,11 +346,9 @@ pipeline main() {
         .find(|d| d.message.contains("render_prompt target"))
         .expect("expected render_prompt target diagnostic for missing @/ asset");
     assert!(
-        render_diag.message.contains(
+        render_diag.message.contains(&crate::format::slash_path(
             &dir.join("prompts/missing.harn.prompt")
-                .display()
-                .to_string()
-        ),
+        )),
         "expected diagnostic to surface the resolved project-root path, got: {}",
         render_diag.message
     );
@@ -415,11 +413,9 @@ pipeline main() {
         .find(|d| d.message.contains("render_prompt target"))
         .expect("expected render_prompt target diagnostic for missing aliased asset");
     assert!(
-        render_diag.message.contains(
+        render_diag.message.contains(&crate::format::slash_path(
             &dir.join("src/prompts/missing.harn.prompt")
-                .display()
-                .to_string()
-        ),
+        )),
         "expected diagnostic to surface the alias-resolved path, got: {}",
         render_diag.message
     );

--- a/crates/harn-cli/src/commands/connector.rs
+++ b/crates/harn-cli/src/commands/connector.rs
@@ -814,9 +814,9 @@ fn run_install_import_smoke(package_dir: &Path, metadata_ok: bool) -> ConnectorG
     };
     let consumer = temp.path();
     let manifest = format!(
-        "[package]\nname = \"connector-smoke-consumer\"\nversion = \"0.0.0\"\n\n[dependencies]\n\"{}\" = {{ path = \"{}\" }}\n",
-        crate::format::escape_toml_basic_string(&package_name),
-        crate::format::escape_toml_basic_string(&package_dependency_path)
+        "[package]\nname = \"connector-smoke-consumer\"\nversion = \"0.0.0\"\n\n[dependencies]\n{} = {{ path = {} }}\n",
+        crate::format::toml_basic_string_literal(&package_name),
+        crate::format::toml_basic_string_literal(&package_dependency_path)
     );
     if let Err(error) = fs::write(consumer.join("harn.toml"), manifest) {
         return gate_check_from_findings(
@@ -1737,7 +1737,10 @@ transient_provider_outage = "Retry after the provider is reachable."
 
         let dependency_path = package_dependency_path(relative).unwrap();
 
-        assert_eq!(dependency_path, dir.path().display().to_string());
+        assert_eq!(
+            dependency_path,
+            dir.path().canonicalize().unwrap().display().to_string()
+        );
     }
 
     #[tokio::test]

--- a/crates/harn-cli/src/commands/merge_captain.rs
+++ b/crates/harn-cli/src/commands/merge_captain.rs
@@ -510,12 +510,12 @@ mod tests {
                 r#"
 version = 1
 id = "merge-captain-ladders"
-base_dir = "{}"
+base_dir = {}
 
 [[ladders]]
 id = "green-pr-value-model"
 persona = "merge_captain"
-artifact-root = "{}"
+artifact-root = {}
 
 [ladders.backend]
 kind = "replay"
@@ -529,8 +529,10 @@ route = "local/gemma-value"
 id = "balanced"
 max-tool-calls = 4
 "#,
-                repo_root().display(),
-                temp.path().join("artifacts").display()
+                crate::format::toml_basic_string_literal(&repo_root().display().to_string()),
+                crate::format::toml_basic_string_literal(
+                    &temp.path().join("artifacts").display().to_string()
+                )
             ),
         );
 

--- a/crates/harn-cli/src/commands/pack.rs
+++ b/crates/harn-cli/src/commands/pack.rs
@@ -1162,7 +1162,10 @@ fn collect_path(
             format!("failed to read contribution asset {}: {err}", abs.display()),
         )
     })?;
-    entries.push(HarnpackEntry::new(rel.to_path_buf(), bytes));
+    entries.push(HarnpackEntry::new(
+        PathBuf::from(logical_bundle_path(rel)),
+        bytes,
+    ));
     Ok(())
 }
 
@@ -1342,7 +1345,7 @@ path = "SKILL.md"
         let assets = carry_extension_metadata(temp.path(), &mut bundle).unwrap();
         let paths: std::collections::BTreeSet<String> = assets
             .iter()
-            .map(|e| e.path.to_string_lossy().to_string())
+            .map(|e| crate::format::slash_path(&e.path))
             .collect();
         assert!(paths.contains("assets/preview.html"), "{paths:?}");
         assert!(paths.contains("canon/latex/invariants.harn"), "{paths:?}");

--- a/crates/harn-cli/src/commands/package_scaffold.rs
+++ b/crates/harn-cli/src/commands/package_scaffold.rs
@@ -127,6 +127,9 @@ struct LoadedSpec {
 }
 
 async fn load_spec(spec: &str) -> Result<LoadedSpec, PackageError> {
+    if crate::format::looks_like_windows_drive_path(spec) {
+        return loaded_spec_from_bytes(read_spec_path(&expand_tilde(spec))?);
+    }
     let (source_label, bytes) = match Url::parse(spec) {
         Ok(url) => match url.scheme() {
             "http" | "https" => fetch_spec_url(&url).await?,
@@ -146,6 +149,12 @@ async fn load_spec(spec: &str) -> Result<LoadedSpec, PackageError> {
         Err(_) => read_spec_path(&expand_tilde(spec))?,
     };
 
+    loaded_spec_from_bytes((source_label, bytes))
+}
+
+fn loaded_spec_from_bytes(
+    (source_label, bytes): (String, Vec<u8>),
+) -> Result<LoadedSpec, PackageError> {
     if bytes.len() as u64 > MAX_SPEC_BYTES {
         return Err(format!(
             "OpenAPI spec {} is {} bytes; maximum supported size is {} bytes",

--- a/crates/harn-cli/src/format.rs
+++ b/crates/harn-cli/src/format.rs
@@ -4,6 +4,7 @@
 //! timestamp / human-friendly duration formatters; consolidating them
 //! here keeps formatting consistent across the user-facing surface.
 
+use std::path::Path;
 use std::time::Duration as StdDuration;
 
 use time::format_description::well_known::Rfc3339;
@@ -113,6 +114,29 @@ pub(crate) fn escape_toml_basic_string(value: &str) -> String {
     out
 }
 
+/// Render a full TOML basic string literal.
+pub(crate) fn toml_basic_string_literal(value: &str) -> String {
+    format!("\"{}\"", escape_toml_basic_string(value))
+}
+
+/// Normalize path separators in machine-readable output. Harn package and
+/// bundle artifacts use slash-separated logical paths even on Windows.
+pub(crate) fn slash_separators(value: &str) -> String {
+    value.replace('\\', "/")
+}
+
+/// Render a path with slash separators for deterministic JSON/report output.
+pub(crate) fn slash_path(path: &Path) -> String {
+    slash_separators(&path.to_string_lossy())
+}
+
+/// True when a string starts with Windows drive syntax such as `C:\`, `C:/`,
+/// or drive-relative `C:foo`. URL parsers otherwise treat these as scheme `c`.
+pub(crate) fn looks_like_windows_drive_path(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -140,6 +164,33 @@ mod tests {
         // Other C0 controls (the case the old connector copy missed
         // entirely) become \uXXXX escapes.
         assert_eq!(escape_toml_basic_string("bell\u{7}"), "bell\\u0007");
+    }
+
+    #[test]
+    fn toml_basic_string_literal_round_trips_windows_paths() {
+        let raw = r"C:\Users\RUNNER~1\AppData\Local\Temp\.tmpJHS6sR\coding-pack";
+        let parsed: toml::Value =
+            toml::from_str(&format!("path = {}\n", toml_basic_string_literal(raw))).unwrap();
+        assert_eq!(parsed.get("path").and_then(toml::Value::as_str), Some(raw));
+    }
+
+    #[test]
+    fn slash_path_normalizes_windows_separators() {
+        assert_eq!(
+            slash_separators(r"C:\tmp\pkg\lib.harn"),
+            "C:/tmp/pkg/lib.harn"
+        );
+    }
+
+    #[test]
+    fn detects_windows_drive_paths_without_url_parser() {
+        assert!(looks_like_windows_drive_path(r"C:\tmp\registry.toml"));
+        assert!(looks_like_windows_drive_path("D:/tmp/registry.toml"));
+        assert!(looks_like_windows_drive_path("E:relative"));
+        assert!(!looks_like_windows_drive_path(
+            "https://example.com/index.toml"
+        ));
+        assert!(!looks_like_windows_drive_path("/tmp/index.toml"));
     }
 
     #[test]

--- a/crates/harn-cli/src/package/manifest.rs
+++ b/crates/harn-cli/src/package/manifest.rs
@@ -1906,11 +1906,11 @@ name = "workspace"
 version = "0.1.0"
 
 [dependencies]
-coding-pack = {{ path = "{}" }}
-helper-lib = {{ path = "{}" }}
+coding-pack = {{ path = {} }}
+helper-lib = {{ path = {} }}
 "#,
-                dependency.display(),
-                helper.display()
+                crate::format::toml_basic_string_literal(&dependency.display().to_string()),
+                crate::format::toml_basic_string_literal(&helper.display().to_string())
             ),
         )
         .unwrap();

--- a/crates/harn-cli/src/package/maturity.rs
+++ b/crates/harn-cli/src/package/maturity.rs
@@ -908,7 +908,7 @@ version = "0.1.0"
         let root = project_tmp.path();
         let workspace = TestWorkspace::new(root);
         fs::create_dir_all(root.join(".git")).unwrap();
-        let dep_path = dep_root.display().to_string();
+        let dep_path = crate::format::toml_basic_string_literal(&dep_root.display().to_string());
         fs::write(
             root.join(MANIFEST),
             format!(
@@ -918,7 +918,7 @@ name = "workspace"
 version = "0.1.0"
 
 [dependencies]
-openapi = {{ path = "{dep_path}" }}
+openapi = {{ path = {dep_path} }}
 "#
             ),
         )
@@ -1069,8 +1069,8 @@ acme-lib = {{ git = "{git}", rev = "v1.0.0" }}
         let project_tmp = tempfile::tempdir().unwrap();
         let root = project_tmp.path();
         let registry_path = root.join("index.toml");
-        let workspace =
-            TestWorkspace::new(root).with_registry_source(registry_path.display().to_string());
+        let workspace = TestWorkspace::new(root)
+            .with_registry_source(registry_path.to_string_lossy().to_string());
         let git = normalize_git_url(repo.to_string_lossy().as_ref()).unwrap();
         let harn_range = current_harn_range_example();
         fs::write(

--- a/crates/harn-cli/src/package/package_ops/validate.rs
+++ b/crates/harn-cli/src/package/package_ops/validate.rs
@@ -630,9 +630,7 @@ pub(crate) fn safe_package_relative_path(
 
 pub(super) fn has_windows_rooted_or_drive_relative_prefix(path: &str) -> bool {
     let normalized = path.replace('\\', "/");
-    let bytes = normalized.as_bytes();
-    normalized.starts_with('/')
-        || (bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':')
+    normalized.starts_with('/') || crate::format::looks_like_windows_drive_path(&normalized)
 }
 
 pub(super) fn has_windows_separator_escape(path: &str) -> bool {

--- a/crates/harn-cli/src/package/registry.rs
+++ b/crates/harn-cli/src/package/registry.rs
@@ -562,6 +562,9 @@ pub(crate) fn path_from_source_uri(source: &str) -> Result<PathBuf, PackageError
     let raw = source
         .strip_prefix("path+")
         .ok_or_else(|| format!("invalid path source: {source}"))?;
+    if crate::format::looks_like_windows_drive_path(raw) {
+        return Ok(PathBuf::from(raw));
+    }
     if let Ok(url) = Url::parse(raw) {
         return url
             .to_file_path()
@@ -581,6 +584,9 @@ pub(crate) fn archive_source_uri(raw: &str) -> Result<String, PackageError> {
 }
 
 pub(crate) fn registry_file_url_or_path(raw: &str) -> Result<Option<PathBuf>, PackageError> {
+    if crate::format::looks_like_windows_drive_path(raw) {
+        return Ok(Some(PathBuf::from(raw)));
+    }
     if let Ok(url) = Url::parse(raw) {
         if url.scheme() == "file" {
             return url.to_file_path().map(Some).map_err(|_| {
@@ -596,6 +602,9 @@ pub(crate) fn normalize_archive_url(raw: &str) -> Result<String, PackageError> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return Err("archive URL cannot be empty".to_string().into());
+    }
+    if crate::format::looks_like_windows_drive_path(trimmed) {
+        return normalize_archive_path(trimmed);
     }
     if let Ok(url) = Url::parse(trimmed) {
         return match url.scheme() {
@@ -621,7 +630,11 @@ pub(crate) fn normalize_archive_url(raw: &str) -> Result<String, PackageError> {
         };
     }
 
-    let path = PathBuf::from(trimmed);
+    normalize_archive_path(trimmed)
+}
+
+fn normalize_archive_path(raw: &str) -> Result<String, PackageError> {
+    let path = PathBuf::from(raw);
     if !path.exists() {
         return Err(format!("package archive not found: {}", path.display()).into());
     }
@@ -629,7 +642,7 @@ pub(crate) fn normalize_archive_url(raw: &str) -> Result<String, PackageError> {
         .canonicalize()
         .map_err(|error| format!("failed to canonicalize {}: {error}", path.display()))?;
     let url = Url::from_file_path(canonical)
-        .map_err(|_| format!("failed to convert {trimmed} to file:// URL"))?;
+        .map_err(|_| format!("failed to convert {raw} to file:// URL"))?;
     Ok(url.to_string())
 }
 
@@ -2526,6 +2539,21 @@ pub fn show_package_registry_info(spec: &str, registry: Option<&str>, json: bool
 mod tests {
     use super::*;
     use crate::package::test_support::*;
+
+    #[test]
+    fn windows_drive_registry_sources_are_file_paths_not_url_schemes() {
+        let source = r"C:\Users\RUNNER~1\AppData\Local\Temp\index.toml";
+        let path = registry_file_url_or_path(source).unwrap().unwrap();
+        assert_eq!(path, PathBuf::from(source));
+
+        let archive_error = normalize_archive_url(source).unwrap_err();
+        assert!(
+            archive_error
+                .to_string()
+                .contains("package archive not found"),
+            "expected missing Windows path to be treated as a file path, got: {archive_error}"
+        );
+    }
 
     #[test]
     fn pick_ls_remote_commit_prefers_peeled_tag_over_tag_object() {

--- a/crates/harn-cli/tests/pack_cli.rs
+++ b/crates/harn-cli/tests/pack_cli.rs
@@ -674,10 +674,11 @@ fn pack_verify_require_trusted_signer_rejects_signer_outside_policy_allowlist() 
         let policy = workdir.path().join("trust-policy.json");
         fs::write(
             &policy,
-            format!(
-                r#"{{"signer_registry_url":"{}","trusted_signers":["not-the-real-signer"]}}"#,
-                signers_dir.display()
-            ),
+            serde_json::to_string(&serde_json::json!({
+                "signer_registry_url": signers_dir.display().to_string(),
+                "trusted_signers": ["not-the-real-signer"],
+            }))
+            .unwrap(),
         )
         .unwrap();
 

--- a/crates/harn-cli/tests/trigger_replay_cli.rs
+++ b/crates/harn-cli/tests/trigger_replay_cli.rs
@@ -199,7 +199,7 @@ fn trigger_replay_diff_reports_structured_drift() {
     let workspace_root = temp.path().to_path_buf();
     write_manifest(&workspace_root);
     let child_replay_expr = if cfg!(windows) {
-        r#"shell("echo|set /p=%HARN_REPLAY%").stdout"#
+        r#"shell("[Console]::Out.Write($env:HARN_REPLAY)").stdout"#
     } else {
         r#"shell("printf '%s' \"$HARN_REPLAY\"").stdout"#
     };


### PR DESCRIPTION
## Summary

- Fix Windows drive-letter paths being interpreted as URL schemes in package registry, archive, and OpenAPI/connector flows.
- Emit deterministic slash-separated paths in harn-cli bundle/preflight/pack artifacts so Windows CI does not diverge from Unix expectations.
- Escape TOML/JSON fixtures through structured serializers instead of interpolating raw Windows paths.

## Root cause

The scheduled Windows nightly was failing because several harn-cli paths flowed through URL/TOML/JSON logic as raw display strings. On Windows that meant `C:\...` could become a `c:` URL scheme or an invalid TOML/JSON escape sequence, and a few machine-readable assertions still depended on platform path separators.

## Validation

- `cargo fmt --package harn-cli`
- `git diff --check`
- `cargo test -p harn-cli commands::connector::tests::package_dependency_path_canonicalizes_relative_package_dir`
- `cargo clippy -p harn-cli --all-targets -- -D warnings`
- `cargo test -p harn-cli`
- pre-commit hooks: markdown, Rust formatting, prompt-prose ratchet, changed-package clippy
- pre-push hooks: markdown and targeted local Rust checks

Refs: scheduled Windows nightly run 28359636497.
