### PR TITLE
Harden flake detection filter workflow

### DIFF
--- a/.github/workflows/flake-detection.yml
+++ b/.github/workflows/flake-detection.yml
@@ -20,6 +20,7 @@ jobs:
   flake-rerun:
     name: 50x flake rerun (touched tests)
     runs-on: ubuntu-latest
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -53,7 +54,7 @@ jobs:
           FILTER=""
           if [[ -n "${TOUCHED// }" ]]; then
             read -ra PATHS <<< "$TOUCHED"
-            FILTER=$(./scripts/nextest_filters_from_paths.sh "${PATHS[@]}" 2>/dev/null || true)
+            FILTER=$(./scripts/nextest_filters_from_paths.sh "${PATHS[@]}")
           fi
           if [[ -n "$FILTER" ]]; then
             echo "has_tests=true" >> "$GITHUB_OUTPUT"

--- a/Makefile
+++ b/Makefile
@@ -327,6 +327,7 @@ test-agent-scripts:
 
 test-pr-gate-scripts:
 	./scripts/tests/changelog_fragment_check_test.sh
+	./scripts/tests/nextest_filters_from_paths_test.sh
 	./scripts/tests/release_gate_harn_bin_test.sh
 	./scripts/tests/release_prepare_env_test.sh
 	./scripts/tests/publish_script_test.sh

--- a/changelog.d/3699.fixed.md
+++ b/changelog.d/3699.fixed.md
@@ -1,0 +1,3 @@
+- **Flake detection CI now fails loudly on broken nextest filter discovery
+  (#3699).** The touched-path mapper is portable to Bash 3, ignores non-Rust
+  paths itself, and scheduled reruns are bounded by a 180-minute job timeout.

--- a/scripts/nextest_filters_from_paths.sh
+++ b/scripts/nextest_filters_from_paths.sh
@@ -7,7 +7,7 @@
 #
 # Outputs a nextest -E filter expression on stdout (e.g.
 # "binary(orchestrator_http) or package(harn-vm)"), or nothing if no
-# Rust test-relevant paths are given.  Exit code is always 0.
+# Rust test-relevant paths are given.
 #
 # Mapping rules (first match wins):
 #
@@ -38,19 +38,20 @@ fi
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-declare -A seen
-declare -A workspace_packages
+workspace_members=()
+workspace_package_names=()
+seen_filters=()
 filters=()
 
 load_workspace_packages() {
     if ! command -v python3 >/dev/null 2>&1; then
-        return 0
+        echo "python3 is required to discover Cargo workspace packages" >&2
+        return 1
     fi
 
-    while IFS=$'\t' read -r member package; do
-        [[ -z "$member" || -z "$package" ]] && continue
-        workspace_packages["$member"]="$package"
-    done < <(python3 - "$repo_root" <<'PY'
+    local package_map
+    package_map=$(mktemp "${TMPDIR:-/tmp}/harn-nextest-filter-packages.XXXXXX")
+    if ! python3 - "$repo_root" > "$package_map" <<'PY'
 import fnmatch
 import pathlib
 import sys
@@ -58,7 +59,8 @@ import sys
 try:
     import tomllib
 except ModuleNotFoundError:
-    sys.exit(0)
+    print("tomllib is required to read Cargo.toml", file=sys.stderr)
+    sys.exit(1)
 
 root = pathlib.Path(sys.argv[1])
 with (root / "Cargo.toml").open("rb") as handle:
@@ -87,20 +89,39 @@ for pattern in members:
         if name:
             print(f"{relative}\t{name}")
 PY
-    )
+    then
+        rm -f "$package_map"
+        echo "failed to discover Cargo workspace packages" >&2
+        return 1
+    fi
+
+    while IFS=$'\t' read -r member package; do
+        [[ -z "$member" || -z "$package" ]] && continue
+        workspace_members+=("$member")
+        workspace_package_names+=("$package")
+    done < "$package_map"
+    rm -f "$package_map"
 }
 
 workspace_package_for_crate_dir() {
     local crate_dir="$1"
-    printf '%s' "${workspace_packages[$crate_dir]-}"
+    local index
+    for ((index = 0; index < ${#workspace_members[@]}; index++)); do
+        if [[ "${workspace_members[$index]}" == "$crate_dir" ]]; then
+            printf '%s' "${workspace_package_names[$index]}"
+            return 0
+        fi
+    done
 }
 
 add_filter() {
     local f="$1"
-    if [[ -z "${seen[$f]+_}" ]]; then
-        seen["$f"]=1
-        filters+=("$f")
-    fi
+    local seen_filter
+    for seen_filter in "${seen_filters[@]}"; do
+        [[ "$seen_filter" == "$f" ]] && return 0
+    done
+    seen_filters+=("$f")
+    filters+=("$f")
 }
 
 load_workspace_packages
@@ -109,6 +130,7 @@ for path in "$@"; do
     # Strip leading ./ and skip blank entries.
     path="${path#./}"
     [[ -z "$path" ]] && continue
+    [[ "$path" != *.rs ]] && continue
 
     # crates/<pkg>/tests/<name>.rs — top-level integration test binary.
     if [[ "$path" =~ ^crates/([^/]+)/tests/([^/]+)\.rs$ ]]; then

--- a/scripts/tests/nextest_filters_from_paths_test.sh
+++ b/scripts/tests/nextest_filters_from_paths_test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+filter_script="$repo_root/scripts/nextest_filters_from_paths.sh"
+
+tmp_root=$(mktemp -d)
+trap 'rm -rf "$tmp_root"' EXIT
+
+assert_filter() {
+  local expected="$1"
+  shift
+
+  local actual
+  actual=$("$filter_script" "$@")
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'expected filter:\n%s\nactual:\n%s\npaths:\n' "$expected" "$actual" >&2
+    printf '  %s\n' "$@" >&2
+    exit 1
+  fi
+}
+
+assert_empty_filter() {
+  local actual
+  actual=$("$filter_script" "$@")
+  if [[ -n "$actual" ]]; then
+    printf 'expected empty filter, got:\n%s\npaths:\n' "$actual" >&2
+    printf '  %s\n' "$@" >&2
+    exit 1
+  fi
+}
+
+assert_filter \
+  "binary(orchestrator_http)" \
+  "crates/harn-cli/tests/orchestrator_http/admin.rs"
+
+assert_filter \
+  "package(harn-cli)" \
+  "crates/harn-cli/tests/test_util/process.rs"
+
+assert_filter \
+  "package(harn-vm)" \
+  "crates/harn-vm/src/flow/slice.rs"
+
+assert_filter \
+  "package(harn-vm)" \
+  "crates/harn-vm/src/flow/slice.rs" \
+  "./crates/harn-vm/src/lib.rs"
+
+assert_filter \
+  "binary(orchestrator_http) or package(harn-cli) or package(harn-vm)" \
+  "crates/harn-cli/tests/orchestrator_http/admin.rs" \
+  "crates/harn-cli/tests/test_util/process.rs" \
+  "crates/harn-vm/src/flow/slice.rs"
+
+assert_empty_filter \
+  "README.md" \
+  "crates/harn-cli/tests/dispatch_fixtures/README.md" \
+  ""
+
+fake_bin="$tmp_root/bin"
+mkdir -p "$fake_bin"
+cat > "$fake_bin/python3" <<'SH'
+#!/usr/bin/env bash
+echo "fake python failure" >&2
+exit 42
+SH
+chmod +x "$fake_bin/python3"
+
+if PATH="$fake_bin:$PATH" \
+  "$filter_script" "crates/harn-vm/src/flow/slice.rs" \
+  > "$tmp_root/stdout.txt" \
+  2> "$tmp_root/stderr.txt"
+then
+  echo "expected workspace discovery failure to fail the helper" >&2
+  exit 1
+fi
+
+if [[ -s "$tmp_root/stdout.txt" ]]; then
+  echo "expected no stdout on workspace discovery failure" >&2
+  cat "$tmp_root/stdout.txt" >&2
+  exit 1
+fi
+
+grep -q "failed to discover Cargo workspace packages" "$tmp_root/stderr.txt"


### PR DESCRIPTION
## Summary
- make `nextest_filters_from_paths.sh` portable to macOS Bash 3 by removing associative arrays
- fail loudly when workspace package discovery fails, and stop suppressing mapper errors in the flake workflow
- bound scheduled flake detection with a 180-minute timeout and add deterministic PR-gate coverage for filter mapping/dedupe/failure cases

## Verification
- `./scripts/tests/nextest_filters_from_paths_test.sh`
- `make test-pr-gate-scripts`
- `actionlint .github/workflows/flake-detection.yml`
- `git diff --check`
- pre-commit hook: full-workspace clippy passed
- pre-push hook: targeted local checks passed
- follow-up correction: observed scheduled flake run `28364179716` completed green in 157 minutes, so timeout was raised from 150 to 180 before landing