### PR TITLE
Fix Harmony text tool-call leakage

### DIFF
--- a/changelog.d/openai-harmony-salvage.fixed.md
+++ b/changelog.d/openai-harmony-salvage.fixed.md
@@ -1,0 +1,2 @@
+Recover leaked Harmony `tool_call to=... code<|message|>{...}` text-format tool calls instead of
+rejecting the response as stray text.

--- a/crates/harn-vm/src/llm/tools/parse/bare.rs
+++ b/crates/harn-vm/src/llm/tools/parse/bare.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 
 use super::native_json::parse_native_json_tool_calls;
@@ -44,12 +45,6 @@ pub(crate) fn parse_bare_calls_in_body(
     let unwrapped = strip_tool_call_wrappers(cleaned.as_ref());
     let text = unwrapped.as_ref();
 
-    if let Some(unwrapped) = unwrap_exact_code_wrapper(text) {
-        let result = parse_bare_calls_in_body(unwrapped, tools_val);
-        if !result.calls.is_empty() || !result.errors.is_empty() {
-            return result;
-        }
-    }
     let mut known: BTreeSet<String> = collect_tool_schemas(tools_val, None)
         .into_iter()
         .map(|schema| schema.name)
@@ -58,6 +53,15 @@ pub(crate) fn parse_bare_calls_in_body(
     // the user-declared tool registry).
     known.insert("ledger".to_string());
     known.insert("load_skill".to_string());
+    let harmony_normalized = normalize_harmony_tool_call_lines(text, &known);
+    let text = harmony_normalized.as_ref();
+
+    if let Some(unwrapped) = unwrap_exact_code_wrapper(text) {
+        let result = parse_bare_calls_in_body(unwrapped, tools_val);
+        if !result.calls.is_empty() || !result.errors.is_empty() {
+            return result;
+        }
+    }
     let mut calls = Vec::new();
     let mut errors = Vec::new();
     // Byte ranges excised from the original text to form `prose`.
@@ -387,4 +391,56 @@ pub(crate) fn parse_bare_calls_in_body(
         done_marker: None,
         canonical: String::new(),
     }
+}
+
+fn normalize_harmony_tool_call_lines<'a>(text: &'a str, known: &BTreeSet<String>) -> Cow<'a, str> {
+    if !text.contains("tool_call to=") || !text.contains("<|message|>") {
+        return Cow::Borrowed(text);
+    }
+
+    let mut changed = false;
+    let mut normalized = String::with_capacity(text.len());
+    for segment in text.split_inclusive('\n') {
+        let (line, newline) = segment
+            .strip_suffix('\n')
+            .map_or((segment, ""), |line| (line, "\n"));
+        if let Some(rewritten) = rewrite_harmony_tool_call_line(line, known) {
+            normalized.push_str(&rewritten);
+            normalized.push_str(newline);
+            changed = true;
+        } else {
+            normalized.push_str(segment);
+        }
+    }
+
+    if changed {
+        Cow::Owned(normalized)
+    } else {
+        Cow::Borrowed(text)
+    }
+}
+
+fn rewrite_harmony_tool_call_line(line: &str, known: &BTreeSet<String>) -> Option<String> {
+    let call_start = line.find("tool_call to=")?;
+    let prefix = line[..call_start].trim();
+    if !prefix.is_empty() && !prefix.contains("<|") {
+        return None;
+    }
+
+    let after_to = &line[call_start + "tool_call to=".len()..];
+    let raw_name_end = after_to
+        .find(|ch: char| ch.is_whitespace() || ch == '<' || ch == ',' || ch == '(')
+        .unwrap_or(after_to.len());
+    let raw_name = after_to[..raw_name_end].trim_matches(['"', '\'', '`']);
+    let name = raw_name.split("<|").next().unwrap_or("").trim();
+    if name.is_empty() || !known.contains(name) {
+        return None;
+    }
+
+    let after_name = &after_to[raw_name_end..];
+    let marker_pos = after_name.find("<|message|>")?;
+    let payload = after_name[marker_pos + "<|message|>".len()..].trim_start();
+    let (_arguments, consumed) = parse_object_literal_from(payload, name).ok()?;
+    let object_literal = payload[..consumed].trim_end();
+    Some(format!("{name}({object_literal})"))
 }

--- a/crates/harn-vm/src/llm/tools/parse/tagged.rs
+++ b/crates/harn-vm/src/llm/tools/parse/tagged.rs
@@ -109,6 +109,21 @@ pub(crate) fn parse_text_tool_calls_with_tools(
             continue;
         }
 
+        if src[cursor..].starts_with("<|") {
+            let start = cursor;
+            while cursor < bytes.len() && bytes[cursor] != b'\n' {
+                cursor += 1;
+            }
+            report_stray(
+                &src[start..cursor],
+                &mut violations,
+                tools_val,
+                &mut calls,
+                &mut canonical_parts,
+            );
+            continue;
+        }
+
         if let Some((body, after)) = match_tool_call_block(src, cursor, TEXT_TOOL_CALL_TAG)
             .or_else(|| match_tool_call_block(src, cursor, TEXT_TOOL_CALL_TAG_COMPACT))
         {

--- a/crates/harn-vm/src/llm/tools/tests/core_parser.rs
+++ b/crates/harn-vm/src/llm/tools/tests/core_parser.rs
@@ -349,6 +349,100 @@ fn strips_gemma_tool_code_prefix_so_native_format_parses() {
 }
 
 #[test]
+fn recovers_fireworks_harmony_tool_call_to_message() {
+    let tools = sample_tool_registry();
+    let text = r#"<|start|>assistant<|channel|>commentary<|message|>tool_call to=edit code<|message|>{"action":"create","path":"src/schema.zig","content":"pub const ok = true;"}"#;
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert!(
+        result.errors.is_empty(),
+        "harmony leak should parse without hard errors: {:?}",
+        result.errors
+    );
+    assert_eq!(result.calls.len(), 1);
+    assert_eq!(result.calls[0]["name"], json!("edit"));
+    assert_eq!(result.calls[0]["arguments"]["action"], json!("create"));
+    assert_eq!(
+        result.calls[0]["arguments"]["path"],
+        json!("src/schema.zig")
+    );
+    assert_eq!(
+        result.calls[0]["arguments"]["content"],
+        json!("pub const ok = true;")
+    );
+    assert!(
+        !result.prose.contains("tool_call to=edit"),
+        "recovered harmony line should not remain in prose: {:?}",
+        result.prose
+    );
+}
+
+#[test]
+fn tagged_parser_salvages_harmony_leak_as_soft_wrapper_violation() {
+    let tools = sample_tool_registry();
+    let text =
+        r#"<|message|>tool_call to=run code<|message|>{"command":"zig test src/schema.zig"}"#;
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert!(
+        result.errors.is_empty(),
+        "tagged parser should salvage the leaked call instead of rejecting stray text: {:?}",
+        result.errors
+    );
+    assert_eq!(result.calls.len(), 1);
+    assert_eq!(result.calls[0]["name"], json!("run"));
+    assert_eq!(
+        result.calls[0]["arguments"]["command"],
+        json!("zig test src/schema.zig")
+    );
+    assert!(
+        result
+            .violations
+            .iter()
+            .all(|violation| !violation.contains("Stray text outside response tags")),
+        "harmony leak should not produce the terminal stray-text diagnostic: {:?}",
+        result.violations
+    );
+}
+
+#[test]
+fn tagged_parser_preserves_canonical_blocks_around_harmony_leak() {
+    let tools = sample_tool_registry();
+    let text = r#"<assistant_prose>
+Checking the Zig parser.
+</assistant_prose>
+<|message|>tool_call to=run code<|message|>{"command":"zig test src/schema.zig"}"#;
+    let result = parse_text_tool_calls_with_tools(text, Some(&tools));
+    assert!(
+        result.errors.is_empty(),
+        "mixed canonical/harmony response should recover cleanly: {:?}",
+        result.errors
+    );
+    assert_eq!(result.calls.len(), 1);
+    assert_eq!(result.prose, "Checking the Zig parser.");
+    assert_eq!(
+        result.calls[0]["arguments"]["command"],
+        json!("zig test src/schema.zig")
+    );
+    assert!(
+        result.canonical.contains("<assistant_prose>"),
+        "canonical replay should retain the normal prose block: {:?}",
+        result.canonical
+    );
+}
+
+#[test]
+fn harmony_tool_call_requires_known_tool_name() {
+    let tools = sample_tool_registry();
+    let text = r#"<|message|>tool_call to=unknown code<|message|>{"command":"zig test"}"#;
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert!(result.calls.is_empty());
+    assert!(
+        result.errors.is_empty(),
+        "unknown harmony tool leaks should remain prose, not become parser errors: {:?}",
+        result.errors
+    );
+}
+
+#[test]
 fn parses_qwen_call_colon_object_literal_tool_marker() {
     // Some Qwen/Gemma local templates emit `call:name{...}` instead of
     // `name({...})`. The name is still registry-checked; this only relaxes


### PR DESCRIPTION
## Summary

- recover Fireworks/OpenAI-compatible GPT-OSS Harmony text leaks shaped like `tool_call to=<name> code<|message|>{...}` into normal text tool calls
- keep recovery registry-guarded so unknown Harmony-shaped names remain prose instead of executable actions
- teach the strict tagged parser to pass top-level `<|...|>` Harmony lines intact into the existing stray-call salvage path

## Root Cause

Fireworks text-format GPT-OSS can leak Harmony chat-template markers into the assistant text. The strict tagged scanner previously split those lines on `<|message|>` markers before the bare-call parser saw the complete tool-call payload, producing `Stray text outside response tags` guidance and dropping the call for a turn.

## Validation

- `cargo test -p harn-vm harmony -- --nocapture` (17/17 relevant tests passed)
- `cargo test -p harn-vm llm::tools::tests -- --nocapture` (199/199 parser/tool tests passed)
- `git diff --check`
- signed commit pre-commit hook: markdown, rustfmt, `cargo clippy` on changed `harn-vm` package
- pre-push hook: markdown and targeted local checks

Full local `cargo test -p harn-vm` was intentionally not run because an active local eval loop was running under a Claude worktree; PR CI/merge queue should carry the broader matrix without contending with that eval.
