### PR TITLE
Regenerate release protocol artifacts with post-bump binary

### DIFF
--- a/changelog.d/release-gate-protocol-bin.fixed.md
+++ b/changelog.d/release-gate-protocol-bin.fixed.md
@@ -1,0 +1,2 @@
+Regenerate protocol artifacts with a post-bump Harn binary during release
+prepare so their artifact version matches the new workspace version.

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -438,7 +438,10 @@ updated = re.sub(r'tag = "v\d+\.\d+\.\d+"', f'tag = "v{next_version}"', text)
 if updated != text:
     doc.write_text(updated)
 PY
-  make gen-protocol-artifacts
+  # HARN_BIN may still point at the pre-bump binary warmed during the audit
+  # phase. Protocol artifacts stamp the compiled crate version, so force this
+  # target through a fresh post-bump cargo-built binary.
+  HARN_BIN= make gen-protocol-artifacts
   cargo check --workspace --all-targets >/dev/null
   echo "Version updated: $current -> $next"
   echo "Next steps:"

--- a/scripts/tests/release_prepare_env_test.sh
+++ b/scripts/tests/release_prepare_env_test.sh
@@ -106,6 +106,17 @@ if ! grep -Fq "run scripts/sync_protocol_fixture_runtime_versions.harn -- --from
   exit 1
 fi
 
+if ! grep -Fxq "target=gen-protocol-artifacts" "$record_make"; then
+  echo "release_gate prepare did not regenerate protocol artifacts" >&2
+  cat "$record_make" >&2
+  exit 1
+fi
+if ! grep -Fxq "HARN_BIN=" "$record_make"; then
+  echo "release_gate prepare should force protocol artifact generation through a post-bump binary" >&2
+  cat "$record_make" >&2
+  exit 1
+fi
+
 for record in "$record_cargo" "$record_make"; do
   if ! grep -Fxq "CARGO_INCREMENTAL=0" "$record"; then
     echo "expected CARGO_INCREMENTAL=0 in $record" >&2


### PR DESCRIPTION
## Summary
- Force `release_gate.sh prepare` to regenerate protocol artifacts with a post-bump Harn binary instead of a warmed pre-bump `HARN_BIN`.
- Preserve warmed `HARN_BIN` for script helper calls that do not compile the workspace version into generated artifacts.
- Add a regression assertion to the release prepare env test.

## Why
The v0.8.156 release initially failed CI because `spec/protocol-artifacts/*` still stamped `0.8.155` after Cargo.toml moved to `0.8.156`. The release audit had warmed a pre-bump binary and `make gen-protocol-artifacts` reused it through `HARN_BIN`.

## Validation
- `bash scripts/tests/release_prepare_env_test.sh`
- `make lint-md`
- pre-commit/pre-push hooks passed on this branch
