### PR TITLE
test: stabilize watch-mode admin reload coverage

### DIFF
--- a/changelog.d/watch-reload-paused-clock.fixed.md
+++ b/changelog.d/watch-reload-paused-clock.fixed.md
@@ -1,0 +1,2 @@
+- **Orchestrator watch-mode reload coverage is now deterministic.** The admin
+  reload test no longer races the manifest file-watch debounce.

--- a/crates/harn-cli/tests/orchestrator_http/admin.rs
+++ b/crates/harn-cli/tests/orchestrator_http/admin.rs
@@ -136,9 +136,12 @@ async fn watch_mode_reload_handle_applies_manifest_changes() {
         ("HARN_ORCHESTRATOR_HMAC_SECRET", "shared-secret"),
     ])
     .await;
+    let clock = harn_vm::clock::PausedClock::new(OffsetDateTime::UNIX_EPOCH);
     let harness = start_harness_with(&temp, |mut config| {
         config.watch_manifest = true;
-        config
+        // Keep the file-watch debounce pending so the explicit admin reload
+        // deterministically owns the manifest diff in this test.
+        config.with_clock(clock)
     })
     .await;
     let base_url = harness.listener_url().to_string();


### PR DESCRIPTION
## Summary\n- run the watch-mode admin reload test with a paused Harn clock\n- prevent the manifest file-watch debounce from racing the explicit /admin/reload assertion\n- add a changelog fragment for the release-tail reliability fix\n\n## Verification\n- cargo fmt -p harn-cli --check\n- git diff --check\n- remote CI will run the full Harn gate; no local cargo test was started because Claude's serialized rust-feat N=5 eval is active on this Mac