### PR TITLE
chore: add fast-only pre-push mode

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -149,6 +149,12 @@ fi
 # expensive steps). Reached only once the fast validators above pass.
 # ---------------------------------------------------------------------------
 
+if [ "${HARN_PREPUSH_FAST_ONLY:-0}" = "1" ]; then
+  echo "=== Pre-push: skipping expensive local checks (HARN_PREPUSH_FAST_ONLY=1) ==="
+  echo "    Signature, merge-queue, and fast drift guards passed; remote CI remains required."
+  exit 0
+fi
+
 echo "=== Pre-push: running targeted local checks ==="
 if [ "${HARN_PREPUSH_FULL_TESTS:-0}" = "1" ] && hook_paths_match "$changed" "$HOOK_TEST_PATTERN"; then
   make test

--- a/changelog.d/prepush-fast-only.changed.md
+++ b/changelog.d/prepush-fast-only.changed.md
@@ -1,0 +1,3 @@
+- **Pre-push hooks can now run in fast-only mode.** Set
+  `HARN_PREPUSH_FAST_ONLY=1` to keep signature, merge-queue, and cheap drift
+  guards while deferring expensive local build checks to remote CI.


### PR DESCRIPTION
## Summary\n- add HARN_PREPUSH_FAST_ONLY=1 for pre-push hooks\n- keep signature, merge-queue, changelog, workflow, markdown, tree-sitter, and generated-registry guards\n- skip only the expensive local build/Harn/generated-mirror phase, leaving remote CI as the gate\n\n## Verification\n- sh -n .githooks/pre-push\n- git diff --check\n- remote CI will validate the full repo; no local build was started because Claude's serialized rust-feat N=5 eval is active on this Mac