### PR TITLE
test(portal): harden frontend tests against runner timing

### DIFF
--- a/crates/harn-cli/portal/src/App.test.tsx
+++ b/crates/harn-cli/portal/src/App.test.tsx
@@ -179,7 +179,7 @@ describe("App", () => {
     render(
       <MemoryRouter initialEntries={["/runs?page=1.5&page_size=37&status=bogus&sort=weird"]}>
         <IntlProvider locale="en">
-          <RunsPage />
+          <RunsPage poll={false} />
         </IntlProvider>
       </MemoryRouter>,
     )

--- a/crates/harn-cli/portal/src/components/LaunchPanel.test.tsx
+++ b/crates/harn-cli/portal/src/components/LaunchPanel.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { IntlProvider } from "react-intl"
 import { afterEach, describe, expect, it, vi } from "vitest"
@@ -44,20 +44,23 @@ describe("LaunchPanel", () => {
       </IntlProvider>,
     )
 
-    await userEvent.clear(screen.getByLabelText("Task"))
-    await userEvent.type(screen.getByLabelText("Task"), "Draft a release note")
+    fireEvent.change(screen.getByLabelText("Task"), {
+      target: { value: "Draft a release note" },
+    })
     fireEvent.change(screen.getByLabelText("Env JSON overrides"), {
       target: { value: '{"OPENAI_API_KEY":"test-key"}' },
     })
-    await userEvent.click(screen.getAllByRole("button", { name: "Run now" }).at(-1)!)
+    fireEvent.click(screen.getAllByRole("button", { name: "Run now" }).at(-1)!)
 
-    expect(onLaunch).toHaveBeenCalledWith({
-      env: { OPENAI_API_KEY: "test-key" },
-      file_path: undefined,
-      model: "gpt-4.1-mini",
-      provider: "openai",
-      source: undefined,
-      task: "Draft a release note",
+    await waitFor(() => {
+      expect(onLaunch).toHaveBeenCalledWith({
+        env: { OPENAI_API_KEY: "test-key" },
+        file_path: undefined,
+        model: "gpt-4.1-mini",
+        provider: "openai",
+        source: undefined,
+        task: "Draft a release note",
+      })
     })
   })
 

--- a/crates/harn-cli/portal/src/components/RunActivityItem.test.tsx
+++ b/crates/harn-cli/portal/src/components/RunActivityItem.test.tsx
@@ -1,28 +1,12 @@
 import { render, screen, within } from "@testing-library/react"
-import { IntlProvider } from "react-intl"
 import { describe, expect, it } from "vitest"
 
-import type { PortalActivity, PortalRunDetail, RunSummary } from "../types"
-import { RunDetail } from "./RunDetail"
+import type { PortalActivity } from "../types"
+import { RunActivityItem } from "./RunActivityItem"
 
-const baseSummary: RunSummary = {
-  path: "run.json",
-  id: "run-1",
-  workflow_name: "demo",
-  status: "completed",
-  last_stage_node_id: "finalize",
-  failure_summary: null,
-  started_at: "2026-05-16T10:00:00Z",
-  finished_at: "2026-05-16T10:00:05Z",
-  duration_ms: 5000,
-  stage_count: 1,
-  child_run_count: 0,
-  call_count: 2,
-  input_tokens: 10,
-  output_tokens: 5,
-  models: ["gpt-5"],
-  updated_at_ms: 1,
-  skills: [],
+const labels = {
+  auditLayersTooltip: "Middleware layers (outer -> inner)",
+  auditReceiptLink: "View receipt",
 }
 
 const auditedActivity: PortalActivity = {
@@ -56,63 +40,8 @@ const plainActivity: PortalActivity = {
   summary: "tool call summary",
 }
 
-function buildDetail(activities: PortalActivity[]): PortalRunDetail {
-  return {
-    summary: baseSummary,
-    task: "Demo audit chip rendering",
-    workflow_id: "wf",
-    parent_run_id: null,
-    root_run_id: null,
-    policy_summary: {
-      tools: [],
-      capabilities: [],
-      workspace_roots: [],
-      side_effect_level: null,
-      recursion_limit: null,
-      tool_arg_constraints: [],
-      validation_valid: true,
-      validation_errors: [],
-      validation_warnings: [],
-      reachable_nodes: [],
-    },
-    replay_summary: null,
-    execution: null,
-    insights: [],
-    stages: [],
-    spans: [],
-    activities,
-    transitions: [],
-    checkpoints: [],
-    artifacts: [],
-    execution_summary: null,
-    transcript_steps: [],
-    template_renders: [],
-    story: [],
-    child_runs: [],
-    observability: {
-      schema_version: 4,
-      planner_rounds: [],
-      research_fact_count: 0,
-      action_graph_nodes: [],
-      action_graph_edges: [],
-      worker_lineage: [],
-      verification_outcomes: [],
-      transcript_pointers: [],
-      daemon_events: [],
-    },
-    skill_timeline: [],
-    skill_match_events: [],
-    tool_load_events: [],
-    active_skills: [],
-  }
-}
-
-function renderRunDetail(detail: PortalRunDetail) {
-  return render(
-    <IntlProvider locale="en">
-      <RunDetail detail={detail} runs={[baseSummary]} onSelectRun={() => {}} />
-    </IntlProvider>,
-  )
+function renderActivity(item: PortalActivity) {
+  return render(<RunActivityItem item={item} labels={labels} />)
 }
 
 function findActivityRow(label: string) {
@@ -122,9 +51,9 @@ function findActivityRow(label: string) {
     .find((node): node is HTMLElement => node instanceof HTMLElement)
 }
 
-describe("RunDetail audit chip", () => {
+describe("RunActivityItem audit chip", () => {
   it("renders the rationale chip, layer tooltip, and receipt link when audit is present", () => {
-    renderRunDetail(buildDetail([auditedActivity]))
+    renderActivity(auditedActivity)
 
     const row = findActivityRow("search_files")
     expect(row).toBeTruthy()
@@ -152,7 +81,7 @@ describe("RunDetail audit chip", () => {
   })
 
   it("renders no audit container when audit is absent", () => {
-    const { container } = renderRunDetail(buildDetail([plainActivity]))
+    const { container } = renderActivity(plainActivity)
 
     const row = findActivityRow("read_file")
     expect(row).toBeTruthy()

--- a/crates/harn-cli/portal/src/components/RunActivityItem.tsx
+++ b/crates/harn-cli/portal/src/components/RunActivityItem.tsx
@@ -1,0 +1,56 @@
+import { formatDuration } from "../lib/format"
+import type { PortalActivity } from "../types"
+
+export type RunActivityItemLabels = {
+  auditLayersTooltip: string
+  auditReceiptLink: string
+}
+
+type RunActivityItemProps = {
+  item: PortalActivity
+  labels: RunActivityItemLabels
+}
+
+export function RunActivityItem({ item, labels }: RunActivityItemProps) {
+  const audit = item.audit
+  const layerChain = audit?.layers.length ? audit.layers.map((layer) => layer.name).join(" → ") : null
+  const tooltipId = audit ? `activity-audit-${item.call_id ?? item.label}-${item.started_offset_ms}` : undefined
+
+  return (
+    <div className="activity-item">
+      <div className="row">
+        <strong>{item.label}</strong>
+        <span>{formatDuration(item.duration_ms)}</span>
+      </div>
+      {audit ? (
+        <div className="activity-audit">
+          {audit.reason ? (
+            <span className="turn-chip activity-audit-reason" title={audit.reason}>
+              {audit.reason}
+            </span>
+          ) : null}
+          {layerChain ? (
+            <span className="turn-chip activity-audit-layers" aria-describedby={tooltipId} title={layerChain}>
+              {audit.layers.length} layer
+              {audit.layers.length === 1 ? "" : "s"}
+              <span id={tooltipId} role="tooltip" className="activity-audit-tooltip">
+                <span className="activity-audit-tooltip-title">{labels.auditLayersTooltip}</span>
+                <span className="activity-audit-tooltip-chain">{layerChain}</span>
+              </span>
+            </span>
+          ) : null}
+          {audit.receipt_uri ? (
+            <a className="turn-chip activity-audit-receipt" href={audit.receipt_uri} target="_blank" rel="noreferrer">
+              {labels.auditReceiptLink}
+            </a>
+          ) : null}
+        </div>
+      ) : null}
+      <div className="meta">
+        {item.kind} • +{formatDuration(item.started_offset_ms)}
+        {item.stage_node_id ? ` • ${item.stage_node_id}` : ""}
+      </div>
+      <div className="meta">{item.summary}</div>
+    </div>
+  )
+}

--- a/crates/harn-cli/portal/src/components/RunDetail.tsx
+++ b/crates/harn-cli/portal/src/components/RunDetail.tsx
@@ -4,6 +4,7 @@ import { defineMessages, useIntl } from "react-intl"
 import { fetchRunCompare, replayTriggerEvent } from "../lib/api"
 import { formatDuration, formatNumber, pct, statusClass } from "../lib/format"
 import type { PortalRunDetail, PortalRunDiff, RunSummary } from "../types"
+import { RunActivityItem } from "./RunActivityItem"
 import { SkillObservability } from "./SkillObservability"
 
 const messages = defineMessages({
@@ -621,6 +622,10 @@ export function RunDetail({ detail, runs, onSelectRun }: RunDetailProps) {
       : detail.policy_summary.validation_valid
         ? intl.formatMessage(messages.validationPassed)
         : intl.formatMessage(messages.validationFailed)
+  const activityItemLabels = {
+    auditLayersTooltip: intl.formatMessage(messages.auditLayersTooltip),
+    auditReceiptLink: intl.formatMessage(messages.auditReceiptLink),
+  }
   const graphNodeLabels = new Map(detail.observability.action_graph_nodes.map((node) => [node.id, node.label]))
   const actionGraphNodes = [...detail.observability.action_graph_nodes].sort((left, right) => {
     const order = ["trigger", "predicate", "trigger_predicate", "approval", "dispatch", "a2a_hop", "worker_enqueue", "retry", "dlq"]
@@ -1302,72 +1307,12 @@ export function RunDetail({ detail, runs, onSelectRun }: RunDetailProps) {
           <div className="activity-list">
             {detail.activities.length ? (
               detail.activities.slice(0, 40).map((item) => {
-                const audit = item.audit
-                const layerChain = audit?.layers.length
-                  ? audit.layers.map((layer) => layer.name).join(" → ")
-                  : null
-                const tooltipId = audit
-                  ? `activity-audit-${item.call_id ?? item.label}-${item.started_offset_ms}`
-                  : undefined
                 return (
-                  <div
-                    className="activity-item"
+                  <RunActivityItem
                     key={`${item.label}-${item.started_offset_ms}`}
-                  >
-                    <div className="row">
-                      <strong>{item.label}</strong>
-                      <span>{formatDuration(item.duration_ms)}</span>
-                    </div>
-                    {audit ? (
-                      <div className="activity-audit">
-                        {audit.reason ? (
-                          <span
-                            className="turn-chip activity-audit-reason"
-                            title={audit.reason}
-                          >
-                            {audit.reason}
-                          </span>
-                        ) : null}
-                        {layerChain ? (
-                          <span
-                            className="turn-chip activity-audit-layers"
-                            aria-describedby={tooltipId}
-                            title={layerChain}
-                          >
-                            {audit.layers.length} layer
-                            {audit.layers.length === 1 ? "" : "s"}
-                            <span
-                              id={tooltipId}
-                              role="tooltip"
-                              className="activity-audit-tooltip"
-                            >
-                              <span className="activity-audit-tooltip-title">
-                                {intl.formatMessage(messages.auditLayersTooltip)}
-                              </span>
-                              <span className="activity-audit-tooltip-chain">
-                                {layerChain}
-                              </span>
-                            </span>
-                          </span>
-                        ) : null}
-                        {audit.receipt_uri ? (
-                          <a
-                            className="turn-chip activity-audit-receipt"
-                            href={audit.receipt_uri}
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            {intl.formatMessage(messages.auditReceiptLink)}
-                          </a>
-                        ) : null}
-                      </div>
-                    ) : null}
-                    <div className="meta">
-                      {item.kind} • +{formatDuration(item.started_offset_ms)}
-                      {item.stage_node_id ? ` • ${item.stage_node_id}` : ""}
-                    </div>
-                    <div className="meta">{item.summary}</div>
-                  </div>
+                    item={item}
+                    labels={activityItemLabels}
+                  />
                 )
               })
             ) : (

--- a/crates/harn-cli/portal/src/pages/RunsPage.tsx
+++ b/crates/harn-cli/portal/src/pages/RunsPage.tsx
@@ -66,7 +66,11 @@ function readPageSize(value: string | null) {
   return (RUN_PAGE_SIZES as readonly number[]).includes(parsed) ? parsed : 25
 }
 
-export function RunsPage() {
+type RunsPageProps = {
+  poll?: boolean
+}
+
+export function RunsPage({ poll = true }: RunsPageProps = {}) {
   const intl = useIntl()
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -83,7 +87,7 @@ export function RunsPage() {
     page,
     pageSize,
     skill: skill || undefined,
-    poll: true,
+    poll,
   })
 
   function updateParams(next: Record<string, string | number | null>) {


### PR DESCRIPTION
## Summary
- extract runtime activity audit-chip rendering into a focused `RunActivityItem` component/test instead of mounting the full run detail page
- add a `RunsPage` polling seam so query-normalization tests do not install the production refresh interval
- avoid per-keystroke simulation in the LaunchPanel submit-payload test; the test asserts payload construction, not typing mechanics

## Verification
- `cd crates/harn-cli/portal && npm run lint`
- `cd crates/harn-cli/portal && npm run test`
- `cd crates/harn-cli/portal && npm run build`
- pre-push targeted Rust check + portal lint
