### PR TITLE
fix(catalog): drop Opus 4.6 fast mode metadata

### DIFF
--- a/changelog.d/2620.removed.md
+++ b/changelog.d/2620.removed.md
@@ -1,0 +1,2 @@
+- Removed stale Anthropic Opus 4.6 fast-mode catalog metadata after Anthropic's June 29, 2026 removal date;
+  Harn no longer advertises `speed = "fast"` for `claude-opus-4-6`.

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/00-anthropic.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/00-anthropic.toml
@@ -211,8 +211,6 @@ tier = "frontier"
 open_weight = false
 strengths = ["reasoning", "coding", "long_context", "agentic"]
 benchmarks = { swe_bench_verified = 80.8, swe_bench_pro = 53.4 }
-# Fast mode DEPRECATED at the Opus 4.8 launch; removed ~30 days later.
-fast_mode = { param = "speed", value = "fast", beta_header = "fast-mode-2026-02-01", otps_speedup = 2.5, status = "deprecated", pricing = { input_per_mtok = 30.00, output_per_mtok = 150.00, cache_read_per_mtok = 3.00, cache_write_per_mtok = 37.50 }, note = "Deprecated at the Opus 4.8 launch; removed ~30 days later, after which speed=fast silently falls back to standard speed/pricing. Migrate to Opus 4.8 or 4.7 fast mode." }
 [models."claude-opus-4-7"]
 name = "Claude Opus 4.7"
 provider = "anthropic"

--- a/crates/harn-vm/src/llm/fast_mode.rs
+++ b/crates/harn-vm/src/llm/fast_mode.rs
@@ -115,11 +115,27 @@ mod tests {
     #[test]
     fn gate_rejects_unsupported_and_deprecated() {
         assert!(matches!(gate("gpt-4o"), FastModeGate::Unsupported));
-        // Opus 4.6's fast tier is deprecated in the catalog.
+        // Opus 4.6's fast tier has been removed from the catalog after
+        // Anthropic's June 29, 2026 removal date.
+        assert!(matches!(gate("claude-opus-4-6"), FastModeGate::Unsupported));
+
+        let overlay = crate::llm_config::parse_config_toml(
+            r#"
+[models."test-deprecated-fast"]
+name = "Deprecated Fast Test"
+provider = "test"
+context_window = 128000
+fast_mode = { param = "speed", value = "fast", status = "deprecated", note = "removed" }
+"#,
+        )
+        .expect("test catalog overlay");
+        crate::llm_config::set_user_overrides(Some(overlay));
         assert!(matches!(
-            gate("claude-opus-4-6"),
+            gate("test-deprecated-fast"),
             FastModeGate::Deprecated { .. }
         ));
+        crate::llm_config::clear_user_overrides();
+
         assert!(matches!(gate("gpt-5.5"), FastModeGate::Usable));
     }
 

--- a/crates/harn-vm/src/llm/helpers/options/routing_tests.rs
+++ b/crates/harn-vm/src/llm/helpers/options/routing_tests.rs
@@ -432,13 +432,38 @@ fn fast_opts_into_tier_for_supported_model_and_guards_others() {
         other => panic!("expected thrown error for gpt-4o, got {:?}", other.is_ok()),
     }
 
-    // Deprecated tier -> rejected.
+    // Opus 4.6's fast tier has been removed from the catalog after
+    // Anthropic's June 29, 2026 removal date.
     match extract_with_options(fast_options("claude-opus-4-6")) {
+        Err(VmError::Thrown(VmValue::String(message))) => {
+            assert!(message.contains("no accelerated-serving tier"), "{message}");
+        }
+        other => panic!(
+            "expected thrown error for opus 4.6, got {:?}",
+            other.is_ok()
+        ),
+    }
+
+    // Deprecated tier -> rejected. Keep this covered with a synthetic catalog
+    // row now that no built-in model has a deprecated fast tier.
+    let overlay = crate::llm_config::parse_config_toml(
+        r#"
+[models."test-deprecated-fast"]
+name = "Deprecated Fast Test"
+provider = "anthropic"
+context_window = 128000
+fast_mode = { param = "speed", value = "fast", status = "deprecated", note = "removed" }
+"#,
+    )
+    .expect("test catalog overlay");
+    crate::llm_config::set_user_overrides(Some(overlay));
+    super::super::reset_provider_key_cache();
+    match extract_with_options(fast_options("test-deprecated-fast")) {
         Err(VmError::Thrown(VmValue::String(message))) => {
             assert!(message.contains("deprecated"), "{message}");
         }
         other => panic!(
-            "expected thrown error for opus 4.6, got {:?}",
+            "expected thrown error for deprecated fast tier, got {:?}",
             other.is_ok()
         ),
     }

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -1606,8 +1606,6 @@ tier = "frontier"
 open_weight = false
 strengths = ["reasoning", "coding", "long_context", "agentic"]
 benchmarks = { swe_bench_verified = 80.8, swe_bench_pro = 53.4 }
-# Fast mode DEPRECATED at the Opus 4.8 launch; removed ~30 days later.
-fast_mode = { param = "speed", value = "fast", beta_header = "fast-mode-2026-02-01", otps_speedup = 2.5, status = "deprecated", pricing = { input_per_mtok = 30.00, output_per_mtok = 150.00, cache_read_per_mtok = 3.00, cache_write_per_mtok = 37.50 }, note = "Deprecated at the Opus 4.8 launch; removed ~30 days later, after which speed=fast silently falls back to standard speed/pricing. Migrate to Opus 4.8 or 4.7 fast mode." }
 [models."claude-opus-4-7"]
 name = "Claude Opus 4.7"
 provider = "anthropic"

--- a/crates/harn-vm/src/llm_config.rs
+++ b/crates/harn-vm/src/llm_config.rs
@@ -756,7 +756,7 @@ impl ModelArchitectureDef {
 /// `service_tier = "fast"` / `"priority"`. Premium pricing is stored as
 /// absolute per-MTok rates rather than a single multiplier because
 /// providers price the tier asymmetrically (Anthropic Opus 4.8 is 2x
-/// standard; Opus 4.6/4.7 fast mode is 6x).
+/// standard; Opus 4.7 fast mode is 6x).
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct FastModeDef {
     /// Request field that opts into the fast tier (e.g. "speed" for
@@ -4118,6 +4118,21 @@ mod tests {
                 "{model} should be superseded by claude-opus-4-8"
             );
         }
+    }
+
+    #[test]
+    fn opus_46_no_longer_advertises_fast_mode() {
+        let opus46 = model_catalog_entry("claude-opus-4-6").expect("opus 4.6 catalog entry");
+        assert!(
+            opus46.fast_mode.is_none(),
+            "Anthropic removed Opus 4.6 fast mode on 2026-06-29; Harn should not advertise it"
+        );
+
+        let opus47 = model_catalog_entry("claude-opus-4-7").expect("opus 4.7 catalog entry");
+        assert!(
+            opus47.fast_mode.is_some(),
+            "Opus 4.7 still advertises its own fast-mode tier"
+        );
     }
 
     #[test]

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -1951,20 +1951,6 @@
       "benchmarks": {
         "swe_bench_pro": 53.4,
         "swe_bench_verified": 80.8
-      },
-      "fast_mode": {
-        "param": "speed",
-        "value": "fast",
-        "beta_header": "fast-mode-2026-02-01",
-        "otps_speedup": 2.5,
-        "status": "deprecated",
-        "pricing": {
-          "input_per_mtok": 30.0,
-          "output_per_mtok": 150.0,
-          "cache_read_per_mtok": 3.0,
-          "cache_write_per_mtok": 37.5
-        },
-        "note": "Deprecated at the Opus 4.8 launch; removed ~30 days later, after which speed=fast silently falls back to standard speed/pricing. Migrate to Opus 4.8 or 4.7 fast mode."
       }
     },
     {


### PR DESCRIPTION
## Summary
- remove deprecated Anthropic Opus 4.6 fast-mode metadata from the source catalog and flattened provider snapshot
- regenerate the provider catalog JSON artifact
- add a regression test that Opus 4.6 no longer advertises fast mode while Opus 4.7 still does

## Why
Anthropic's fast-mode docs say Claude Opus 4.6 fast mode was deprecated on May 28, 2026 and removed on June 29, 2026. After that date, requests with speed=fast fall back to standard speed/pricing, so Harn should not advertise the stale tier.

Source: https://platform.claude.com/docs/en/build-with-claude/fast-mode

Closes #2620

## Validation
- cargo fmt --check -p harn-vm
- git diff --check
- jq confirms claude-opus-4-6 fast_mode is null in spec/provider-catalog/provider-catalog.json
- npx markdownlint-cli2 changelog.d/2620.removed.md
- HARN_PREPUSH_FAST_ONLY=1 git push fast guards
- tornadough: cargo run --quiet --bin harn -- provider catalog build-config --check
- tornadough: cargo run --quiet --bin harn -- provider catalog validate --check-artifacts
- tornadough: cargo test -p harn-vm opus_46_no_longer_advertises_fast_mode
- tornadough: cargo test -p harn-vm opus_alias_tracks_claude_opus_4_8_with_fast_mode
- tornadough: cargo test -p harn-vm superseded_opus_models_point_at_claude_opus_4_8