### PR TITLE
feat(session-bundle): expose replay observability

### DIFF
--- a/changelog.d/3684.added.md
+++ b/changelog.d/3684.added.md
@@ -1,0 +1,3 @@
+- **Session bundles now carry run observability records explicitly (#3684).**
+  Verification outcomes and transcript pointers travel in the replay envelope
+  even when consumers import from bundle-level replay data.

--- a/crates/harn-vm/src/session_bundle.rs
+++ b/crates/harn-vm/src/session_bundle.rs
@@ -18,7 +18,8 @@ use crate::agent_events::AgentEvent;
 use crate::event_log::sanitize_topic_component;
 use crate::orchestration::{
     new_id, now_rfc3339, AgentSessionReplayEvent, ReplayFixture, RunCheckpointRecord,
-    RunHitlQuestionRecord, RunRecord, RunTraceSpanRecord, RunTransitionRecord, ToolCallRecord,
+    RunHitlQuestionRecord, RunObservabilityRecord, RunRecord, RunTraceSpanRecord,
+    RunTransitionRecord, ToolCallRecord,
 };
 use crate::redact::{RedactionPolicy, REDACTED_PLACEHOLDER};
 use crate::workspace_anchor::{anchor_from_transcript_metadata_json, MountedRoot, WorkspaceAnchor};
@@ -285,6 +286,8 @@ pub struct BundlePermission {
 pub struct BundleReplay {
     pub replay_fixture: Option<ReplayFixture>,
     pub run_record: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observability: Option<RunObservabilityRecord>,
     pub event_log_pointers: Vec<BundleEventLogPointer>,
     pub transitions: Vec<RunTransitionRecord>,
     pub checkpoints: Vec<RunCheckpointRecord>,
@@ -508,7 +511,22 @@ pub fn validate_session_bundle_str(
 }
 
 pub fn import_run_record_value(bundle: &SessionBundle) -> Result<JsonValue, SessionBundleError> {
-    if let Some(run_record) = bundle.replay.run_record.clone() {
+    if let Some(mut run_record) = bundle.replay.run_record.clone() {
+        let should_fill_observability = match run_record.get("observability") {
+            Some(value) => value.is_null(),
+            None => true,
+        };
+        if should_fill_observability {
+            if let (JsonValue::Object(map), Some(observability)) =
+                (&mut run_record, &bundle.replay.observability)
+            {
+                map.insert(
+                    "observability".to_string(),
+                    serde_json::to_value(observability)
+                        .map_err(|error| SessionBundleError::Encode(error.to_string()))?,
+                );
+            }
+        }
         return Ok(run_record);
     }
     if let Some(fixture) = &bundle.replay.replay_fixture {
@@ -549,6 +567,7 @@ pub fn import_run_record_value(bundle: &SessionBundle) -> Result<JsonValue, Sess
             "transcript": transcript,
             "usage": bundle.runtime.usage.clone(),
             "replay_fixture": fixture,
+            "observability": bundle.replay.observability.clone(),
             "trace_spans": bundle.replay.trace_spans.clone(),
             "tool_recordings": bundle.tools.calls.clone(),
             "hitl_questions": hitl_questions,
@@ -848,6 +867,7 @@ fn raw_bundle_from_run(
         replay: BundleReplay {
             replay_fixture: run.replay_fixture.clone(),
             run_record: Some(run_record_value),
+            observability: run.observability.clone(),
             event_log_pointers: event_log_pointers_from_run(run),
             transitions: run.transitions.clone(),
             checkpoints: run.checkpoints.clone(),

--- a/crates/harn-vm/src/session_bundle/schema.rs
+++ b/crates/harn-vm/src/session_bundle/schema.rs
@@ -101,6 +101,7 @@ pub fn session_bundle_schema() -> JsonValue {
                 "properties": {
                     "replay_fixture": {"type": ["object", "null"]},
                     "run_record": {"type": ["object", "null"]},
+                    "observability": {"type": ["object", "null"]},
                     "event_log_pointers": {"type": "array", "items": {"type": "object"}},
                     "transitions": {"type": "array", "items": {"type": "object"}},
                     "checkpoints": {"type": "array", "items": {"type": "object"}},

--- a/crates/harn-vm/src/session_bundle/tests.rs
+++ b/crates/harn-vm/src/session_bundle/tests.rs
@@ -3,7 +3,10 @@ use std::fs;
 use serde_json::json;
 
 use super::*;
-use crate::orchestration::{LlmUsageRecord, RunStageRecord};
+use crate::orchestration::{
+    LlmUsageRecord, RunObservabilityRecord, RunStageRecord, RunTranscriptPointerRecord,
+    RunVerificationOutcomeRecord,
+};
 
 fn repo_fixture_path(name: &str) -> String {
     format!(
@@ -76,6 +79,42 @@ fn fixture_run() -> RunRecord {
     }
 }
 
+fn fixture_observability() -> RunObservabilityRecord {
+    RunObservabilityRecord {
+        schema_version: 4,
+        verification_outcomes: vec![RunVerificationOutcomeRecord {
+            stage_id: "stage_1".to_string(),
+            node_id: "answer".to_string(),
+            status: "completed".to_string(),
+            passed: Some(true),
+            summary: Some("verification passed with private details".to_string()),
+        }],
+        transcript_pointers: vec![RunTranscriptPointerRecord {
+            id: "transcript_1".to_string(),
+            label: "LLM transcript".to_string(),
+            kind: "llm_jsonl".to_string(),
+            location: "run-llm/llm_transcript.jsonl".to_string(),
+            path: Some("/private/harn/run_123/run-llm/llm_transcript.jsonl".to_string()),
+            available: true,
+        }],
+        ..RunObservabilityRecord::default()
+    }
+}
+
+fn fixture_replay_fixture(run: &RunRecord) -> ReplayFixture {
+    ReplayFixture {
+        type_name: "replay_fixture".to_string(),
+        id: "fixture_run_123".to_string(),
+        source_run_id: run.id.clone(),
+        workflow_id: run.workflow_id.clone(),
+        workflow_name: run.workflow_name.clone(),
+        created_at: "2026-05-01T00:00:30Z".to_string(),
+        eval_kind: Some("replay".to_string()),
+        expected_status: run.status.clone(),
+        ..ReplayFixture::default()
+    }
+}
+
 #[test]
 fn sanitized_export_redacts_secrets_and_records_manifest() {
     let bundle =
@@ -110,6 +149,114 @@ fn replay_only_export_withholds_prompt_and_tool_payloads() {
         .entries
         .iter()
         .any(|entry| entry.action == "withheld"));
+}
+
+#[test]
+fn observability_exports_in_replay_envelope_and_imports_without_embedded_run_record() {
+    let mut run = fixture_run();
+    run.replay_fixture = Some(fixture_replay_fixture(&run));
+    run.observability = Some(fixture_observability());
+
+    let mut bundle = export_run_record_bundle(
+        &run,
+        &SessionBundleExportOptions {
+            mode: SessionBundleExportMode::Local,
+            ..SessionBundleExportOptions::default()
+        },
+    )
+    .unwrap();
+
+    let observability = bundle
+        .replay
+        .observability
+        .as_ref()
+        .expect("bundle replay observability");
+    assert_eq!(observability.schema_version, 4);
+    assert_eq!(observability.verification_outcomes.len(), 1);
+    assert_eq!(
+        observability.verification_outcomes[0].node_id.as_str(),
+        "answer"
+    );
+    assert_eq!(observability.transcript_pointers.len(), 1);
+
+    bundle.replay.run_record = None;
+    let imported = import_run_record_value(&bundle).unwrap();
+    assert_eq!(
+        imported["observability"]["verification_outcomes"][0]["passed"],
+        json!(true)
+    );
+    assert_eq!(
+        imported["observability"]["transcript_pointers"][0]["path"],
+        json!("/private/harn/run_123/run-llm/llm_transcript.jsonl")
+    );
+}
+
+#[test]
+fn import_backfills_observability_from_replay_envelope_when_run_record_lacks_it() {
+    let mut run = fixture_run();
+    run.observability = Some(fixture_observability());
+
+    let mut bundle = export_run_record_bundle(
+        &run,
+        &SessionBundleExportOptions {
+            mode: SessionBundleExportMode::Local,
+            ..SessionBundleExportOptions::default()
+        },
+    )
+    .unwrap();
+    bundle.replay.run_record.as_mut().unwrap()["observability"] = JsonValue::Null;
+
+    let imported = import_run_record_value(&bundle).unwrap();
+    assert_eq!(
+        imported["observability"]["verification_outcomes"][0]["summary"],
+        json!("verification passed with private details")
+    );
+}
+
+#[test]
+fn sanitized_export_redacts_replay_observability_pointer_paths() {
+    let mut run = fixture_run();
+    run.observability = Some(fixture_observability());
+
+    let bundle = export_run_record_bundle(&run, &SessionBundleExportOptions::default()).unwrap();
+    let observability = bundle
+        .replay
+        .observability
+        .as_ref()
+        .expect("bundle replay observability");
+    assert_eq!(
+        observability.transcript_pointers[0].path.as_deref(),
+        Some(REDACTED_PLACEHOLDER)
+    );
+    assert!(bundle.redaction.entries.iter().any(|entry| {
+        entry.path == "$.replay.observability.transcript_pointers[0].path"
+            && entry.class == "local_pointer_path"
+    }));
+}
+
+#[test]
+fn replay_only_export_withholds_observability_verification_summaries() {
+    let mut run = fixture_run();
+    run.observability = Some(fixture_observability());
+    let options = SessionBundleExportOptions {
+        mode: SessionBundleExportMode::ReplayOnly,
+        ..SessionBundleExportOptions::default()
+    };
+
+    let bundle = export_run_record_bundle(&run, &options).unwrap();
+    let rendered = serde_json::to_string(&bundle).unwrap();
+    assert!(!rendered.contains("private details"));
+    assert_eq!(
+        bundle
+            .replay
+            .observability
+            .as_ref()
+            .unwrap()
+            .verification_outcomes[0]
+            .summary
+            .as_deref(),
+        Some(REPLAY_ONLY_PLACEHOLDER)
+    );
 }
 
 #[test]

--- a/spec/schemas/session-bundle.v1.schema.json
+++ b/spec/schemas/session-bundle.v1.schema.json
@@ -175,6 +175,12 @@
           },
           "type": "array"
         },
+        "observability": {
+          "type": [
+            "object",
+            "null"
+          ]
+        },
         "replay_fixture": {
           "type": [
             "object",


### PR DESCRIPTION
## Summary
- add optional `replay.observability` to session bundles so typed `RunObservabilityRecord` data travels alongside replay metadata
- backfill imported run records from the replay observability mirror when the embedded run record is absent or lacks observability
- cover export/import, sanitized pointer-path redaction, replay-only summary withholding, schema declaration, and fixture compatibility

## Validation
- `cargo fmt --check -p harn-vm`
- `git diff --check`
- `npx markdownlint-cli2 changelog.d/3684.added.md`
- remote/tornadough: `cargo test -p harn-vm session_bundle::tests -- --nocapture`
- pre-commit: markdownlint, Rust formatting, rust prompt-prose ratchet, `cargo clippy -p harn-vm -- -D warnings`

Refs #3684, #3682