### PR TITLE
chore(hooks): catch session bundle schema drift

### DIFF
--- a/.githooks/lib.sh
+++ b/.githooks/lib.sh
@@ -9,6 +9,7 @@ HOOK_PORTAL_PATTERN='(^crates/harn-cli/portal/|^package(-lock)?\.json$)'
 HOOK_HIGHLIGHT_PATTERN='(^crates/harn-lexer/|^crates/harn-stdlib/src/stdlib/|^crates/harn-vm/src/(stdlib|lib\.rs)|^crates/harn-modules/|^docs/theme/harn-keywords\.js$)'
 HOOK_LANGSPEC_PATTERN='(^spec/chapters/.*\.md$|^spec/HARN_SPEC\.md$|^docs/src/language-spec\.md$|^docs/src/spec/language/.*\.md$|^docs/src/SUMMARY\.md$)'
 HOOK_DIAGCATALOG_PATTERN='(^crates/harn-parser/src/diagnostic_codes(\.rs|/)|^docs/src/diagnostics\.md$|^docs/diagnostics-catalog\.json$)'
+HOOK_SESSION_BUNDLE_SCHEMA_PATTERN='(^crates/harn-vm/src/session_bundle\.rs$|^crates/harn-vm/src/session_bundle/|^crates/harn-cli/src/commands/session\.rs$|^spec/schemas/session-bundle\.v1\.schema\.json$)'
 HOOK_RATCHET_PATTERN='(^crates/harn-vm/src/(llm/|orchestration/(workflow|artifacts|compaction)\.rs$)|^conformance/|^scripts/(allowed_long_strings\.txt|check_no_rust_prompt_prose\.sh|check_rust_prompt_prose\.py|check_xfail_count\.harn|xfail_threshold\.txt)$|^Makefile$)'
 # Lexer KEYWORDS const <-> tree-sitter keyword mirror.
 HOOK_TREESITTER_PATTERN='(^crates/harn-lexer/src/token\.rs$|^tree-sitter-harn/grammar/keywords\.js$)'

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -215,6 +215,14 @@ else
   echo "=== Pre-push: skipping portal lint (no portal changes) ==="
 fi
 
+if hook_paths_match "$changed" "$HOOK_SESSION_BUNDLE_SCHEMA_PATTERN"; then
+  echo "=== Pre-push: checking session bundle schema ==="
+  make -s check-session-bundle-schema
+  echo "    Session bundle schema OK."
+else
+  echo "=== Pre-push: skipping session bundle schema check (no session-bundle schema changes) ==="
+fi
+
 # Generated-mirror drift guard. The `harn-generated` merge driver
 # silently keeps the current side during merge/rebase (see
 # scripts/configure_merge_drivers.sh) and the post-rewrite hook

--- a/changelog.d/3721.fixed.md
+++ b/changelog.d/3721.fixed.md
@@ -1,0 +1,1 @@
+Fixed local pre-push coverage for session-bundle schema drift.

--- a/scripts/generated_artifacts.toml
+++ b/scripts/generated_artifacts.toml
@@ -150,11 +150,15 @@ description = "JSON Schema for the session-bundle DTO, generated from the Rust S
 gen = "gen-session-bundle-schema"
 check = "check-session-bundle-schema"
 outputs = ["spec/schemas/session-bundle.v1.schema.json"]
-sources = ["crates/harn-vm/src/sessions/", "crates/harn-cli/src/commands/session.rs"]
+sources = [
+  "crates/harn-vm/src/session_bundle.rs",
+  "crates/harn-vm/src/session_bundle/",
+  "crates/harn-cli/src/commands/session.rs",
+]
 ci = true
 make_all = true
 pre_commit = false
-pre_push = false
+pre_push = true
 
 [[artifact]]
 id = "run-session-view-fixtures"


### PR DESCRIPTION
## Summary
- add a scoped pre-push check for session-bundle schema drift when the DTO, schema command, or generated schema changes
- correct the generated-artifact registry sources for the session-bundle schema so they point at the real Rust DTO paths
- mark the artifact as covered by pre-push metadata

## Why
Harn #3720 initially missed the regenerated JSON schema locally and only failed in CI. This keeps the local hook aligned with the generated artifact that CI already enforces.

## Validation
- `sh -n .githooks/pre-push .githooks/lib.sh`
- `git diff --check`
- shell regex smoke test for `HOOK_SESSION_BUNDLE_SCHEMA_PATTERN`
- tornadough: `make check-generated-registry`
- tornadough: `make check-session-bundle-schema`
- local pre-push hook during `git push`