### PR TITLE
feat(session-bundle): persist verification outcomes

### DIFF
--- a/changelog.d/3684.added.md
+++ b/changelog.d/3684.added.md
@@ -1,3 +1,6 @@
 - **Session bundles now carry run observability records explicitly (#3684).**
   Verification outcomes and transcript pointers travel in the replay envelope
   even when consumers import from bundle-level replay data.
+- Added direct session-bundle replay verification outcomes so verify results
+  survive portable replay/import without requiring the full observability
+  snapshot.

--- a/crates/harn-vm/src/session_bundle.rs
+++ b/crates/harn-vm/src/session_bundle.rs
@@ -9,6 +9,7 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt;
+use std::path::Path;
 
 use chrono::{DateTime, SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
@@ -17,9 +18,9 @@ use serde_json::{json, Value as JsonValue};
 use crate::agent_events::AgentEvent;
 use crate::event_log::sanitize_topic_component;
 use crate::orchestration::{
-    new_id, now_rfc3339, AgentSessionReplayEvent, ReplayFixture, RunCheckpointRecord,
-    RunHitlQuestionRecord, RunObservabilityRecord, RunRecord, RunTraceSpanRecord,
-    RunTransitionRecord, ToolCallRecord,
+    derive_run_observability, new_id, now_rfc3339, AgentSessionReplayEvent, ReplayFixture,
+    RunCheckpointRecord, RunHitlQuestionRecord, RunObservabilityRecord, RunRecord,
+    RunTraceSpanRecord, RunTransitionRecord, RunVerificationOutcomeRecord, ToolCallRecord,
 };
 use crate::redact::{RedactionPolicy, REDACTED_PLACEHOLDER};
 use crate::workspace_anchor::{anchor_from_transcript_metadata_json, MountedRoot, WorkspaceAnchor};
@@ -288,6 +289,7 @@ pub struct BundleReplay {
     pub run_record: Option<JsonValue>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub observability: Option<RunObservabilityRecord>,
+    pub verification_outcomes: Vec<RunVerificationOutcomeRecord>,
     pub event_log_pointers: Vec<BundleEventLogPointer>,
     pub transitions: Vec<RunTransitionRecord>,
     pub checkpoints: Vec<RunCheckpointRecord>,
@@ -511,6 +513,7 @@ pub fn validate_session_bundle_str(
 }
 
 pub fn import_run_record_value(bundle: &SessionBundle) -> Result<JsonValue, SessionBundleError> {
+    let replay_observability = replay_observability_for_import(&bundle.replay);
     if let Some(mut run_record) = bundle.replay.run_record.clone() {
         let should_fill_observability = match run_record.get("observability") {
             Some(value) => value.is_null(),
@@ -518,7 +521,7 @@ pub fn import_run_record_value(bundle: &SessionBundle) -> Result<JsonValue, Sess
         };
         if should_fill_observability {
             if let (JsonValue::Object(map), Some(observability)) =
-                (&mut run_record, &bundle.replay.observability)
+                (&mut run_record, replay_observability.as_ref())
             {
                 map.insert(
                     "observability".to_string(),
@@ -567,7 +570,7 @@ pub fn import_run_record_value(bundle: &SessionBundle) -> Result<JsonValue, Sess
             "transcript": transcript,
             "usage": bundle.runtime.usage.clone(),
             "replay_fixture": fixture,
-            "observability": bundle.replay.observability.clone(),
+            "observability": replay_observability,
             "trace_spans": bundle.replay.trace_spans.clone(),
             "tool_recordings": bundle.tools.calls.clone(),
             "hitl_questions": hitl_questions,
@@ -579,6 +582,22 @@ pub fn import_run_record_value(bundle: &SessionBundle) -> Result<JsonValue, Sess
         }));
     }
     Err(SessionBundleError::MissingRunRecord)
+}
+
+fn replay_observability_for_import(replay: &BundleReplay) -> Option<RunObservabilityRecord> {
+    let mut observability = replay.observability.clone().unwrap_or_default();
+    let has_observability = replay.observability.is_some();
+    let has_verification_outcomes = !replay.verification_outcomes.is_empty();
+    if !has_observability && !has_verification_outcomes {
+        return None;
+    }
+    if observability.schema_version == 0 {
+        observability.schema_version = 4;
+    }
+    if observability.verification_outcomes.is_empty() && has_verification_outcomes {
+        observability.verification_outcomes = replay.verification_outcomes.clone();
+    }
+    Some(observability)
 }
 
 pub fn session_bundle_from_agent_session_events(
@@ -868,6 +887,7 @@ fn raw_bundle_from_run(
             replay_fixture: run.replay_fixture.clone(),
             run_record: Some(run_record_value),
             observability: run.observability.clone(),
+            verification_outcomes: verification_outcomes_for_run(run),
             event_log_pointers: event_log_pointers_from_run(run),
             transitions: run.transitions.clone(),
             checkpoints: run.checkpoints.clone(),
@@ -894,6 +914,14 @@ fn raw_bundle_from_run(
         json!("Session bundles are portable JSON envelopes; hosted share links should reference sanitized bundles rather than raw run records."),
     );
     Ok(bundle)
+}
+
+fn verification_outcomes_for_run(run: &RunRecord) -> Vec<RunVerificationOutcomeRecord> {
+    if let Some(observability) = run.observability.as_ref() {
+        return observability.verification_outcomes.clone();
+    }
+    derive_run_observability(run, run.persisted_path.as_deref().map(Path::new))
+        .verification_outcomes
 }
 
 fn bundle_redaction_policy(base: &RedactionPolicy) -> RedactionPolicy {

--- a/crates/harn-vm/src/session_bundle/schema.rs
+++ b/crates/harn-vm/src/session_bundle/schema.rs
@@ -102,6 +102,7 @@ pub fn session_bundle_schema() -> JsonValue {
                     "replay_fixture": {"type": ["object", "null"]},
                     "run_record": {"type": ["object", "null"]},
                     "observability": {"type": ["object", "null"]},
+                    "verification_outcomes": {"type": "array", "items": {"type": "object"}},
                     "event_log_pointers": {"type": "array", "items": {"type": "object"}},
                     "transitions": {"type": "array", "items": {"type": "object"}},
                     "checkpoints": {"type": "array", "items": {"type": "object"}},

--- a/crates/harn-vm/src/session_bundle/tests.rs
+++ b/crates/harn-vm/src/session_bundle/tests.rs
@@ -177,6 +177,11 @@ fn observability_exports_in_replay_envelope_and_imports_without_embedded_run_rec
         observability.verification_outcomes[0].node_id.as_str(),
         "answer"
     );
+    assert_eq!(bundle.replay.verification_outcomes.len(), 1);
+    assert_eq!(
+        bundle.replay.verification_outcomes[0].node_id.as_str(),
+        "answer"
+    );
     assert_eq!(observability.transcript_pointers.len(), 1);
 
     bundle.replay.run_record = None;
@@ -188,6 +193,95 @@ fn observability_exports_in_replay_envelope_and_imports_without_embedded_run_rec
     assert_eq!(
         imported["observability"]["transcript_pointers"][0]["path"],
         json!("/private/harn/run_123/run-llm/llm_transcript.jsonl")
+    );
+}
+
+#[test]
+fn import_backfills_observability_from_first_class_verification_outcomes() {
+    let mut run = fixture_run();
+    run.observability = Some(fixture_observability());
+
+    let mut bundle = export_run_record_bundle(
+        &run,
+        &SessionBundleExportOptions {
+            mode: SessionBundleExportMode::Local,
+            ..SessionBundleExportOptions::default()
+        },
+    )
+    .unwrap();
+    bundle.replay.observability = None;
+    bundle
+        .replay
+        .run_record
+        .as_mut()
+        .unwrap()
+        .as_object_mut()
+        .unwrap()
+        .remove("observability");
+
+    let imported = import_run_record_value(&bundle).unwrap();
+    assert_eq!(
+        imported["observability"]["verification_outcomes"][0]["summary"],
+        json!("verification passed with private details")
+    );
+    assert_eq!(
+        imported["observability"]["verification_outcomes"][0]["passed"],
+        json!(true)
+    );
+}
+
+#[test]
+fn export_derives_first_class_verification_outcomes_when_observability_is_missing() {
+    let mut run = fixture_run();
+    run.stages[0].kind = "verify".to_string();
+    run.stages[0].status = "completed".to_string();
+    run.stages[0].outcome = "success".to_string();
+    run.stages[0].verification = Some(json!({"pass": true, "summary": "tests passed"}));
+
+    let mut bundle = export_run_record_bundle(
+        &run,
+        &SessionBundleExportOptions {
+            mode: SessionBundleExportMode::Local,
+            ..SessionBundleExportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert!(bundle.replay.observability.is_none());
+    assert_eq!(bundle.replay.verification_outcomes.len(), 1);
+    assert_eq!(bundle.replay.verification_outcomes[0].passed, Some(true));
+
+    bundle.replay.run_record = None;
+    bundle.replay.replay_fixture = Some(fixture_replay_fixture(&run));
+    let imported = import_run_record_value(&bundle).unwrap();
+    assert_eq!(
+        imported["observability"]["verification_outcomes"][0]["summary"],
+        json!("{\"pass\":true,\"summary\":\"tests passed\"}")
+    );
+}
+
+#[test]
+fn replay_fixture_import_preserves_first_class_verification_outcomes() {
+    let mut run = fixture_run();
+    run.replay_fixture = Some(fixture_replay_fixture(&run));
+    run.observability = Some(fixture_observability());
+
+    let mut bundle = export_run_record_bundle(
+        &run,
+        &SessionBundleExportOptions {
+            mode: SessionBundleExportMode::Local,
+            ..SessionBundleExportOptions::default()
+        },
+    )
+    .unwrap();
+    bundle.replay.run_record = None;
+    bundle.replay.observability = None;
+
+    let imported = import_run_record_value(&bundle).unwrap();
+    assert_eq!(imported["observability"]["schema_version"], json!(4));
+    assert_eq!(
+        imported["observability"]["verification_outcomes"][0]["node_id"],
+        json!("answer")
     );
 }
 
@@ -255,6 +349,10 @@ fn replay_only_export_withholds_observability_verification_summaries() {
             .verification_outcomes[0]
             .summary
             .as_deref(),
+        Some(REPLAY_ONLY_PLACEHOLDER)
+    );
+    assert_eq!(
+        bundle.replay.verification_outcomes[0].summary.as_deref(),
         Some(REPLAY_ONLY_PLACEHOLDER)
     );
 }

--- a/spec/schemas/session-bundle.v1.schema.json
+++ b/spec/schemas/session-bundle.v1.schema.json
@@ -204,6 +204,12 @@
             "type": "object"
           },
           "type": "array"
+        },
+        "verification_outcomes": {
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
         }
       },
       "required": [

--- a/spec/session-bundles/fixtures/sample-local.bundle.json
+++ b/spec/session-bundles/fixtures/sample-local.bundle.json
@@ -388,7 +388,8 @@
         "timestamp": "2026-05-01T00:00:01Z",
         "to_node_id": "answer"
       }
-    ]
+    ],
+    "verification_outcomes": []
   },
   "runtime": {
     "harn_version": "fixture",

--- a/spec/session-bundles/fixtures/sample-replay-only.bundle.json
+++ b/spec/session-bundles/fixtures/sample-replay-only.bundle.json
@@ -571,7 +571,8 @@
         "timestamp": "2026-05-01T00:00:01Z",
         "to_node_id": "answer"
       }
-    ]
+    ],
+    "verification_outcomes": []
   },
   "runtime": {
     "harn_version": "fixture",

--- a/spec/session-bundles/fixtures/sample-sanitized.bundle.json
+++ b/spec/session-bundles/fixtures/sample-sanitized.bundle.json
@@ -437,7 +437,8 @@
         "timestamp": "2026-05-01T00:00:01Z",
         "to_node_id": "answer"
       }
-    ]
+    ],
+    "verification_outcomes": []
   },
   "runtime": {
     "harn_version": "fixture",


### PR DESCRIPTION
## Summary
- add first-class `replay.verification_outcomes` to session bundles
- populate outcomes from materialized observability or derive them from verify stages when observability is absent
- import direct replay outcomes back into `RunObservabilityRecord` for embedded-run and replay-fixture paths
- regenerate the session-bundle schema and checked fixtures

## Why
This closes the #3684 gap where verify outcomes could travel only as part of a larger observability snapshot. The replay envelope now carries them as a typed portable artifact, so migrated or replay-only imports can preserve verifier receipts deterministically.

## Validation
- `cargo fmt --check -p harn-vm`
- `make check-session-bundle-schema`
- `git diff --check`
- `cargo test -p harn-vm session_bundle::tests -- --nocapture`
- pre-commit clippy on `harn-vm`

Refs #3684