### PR TITLE
feat(session-bundle): embed worker snapshots

### DIFF
--- a/changelog.d/3724.added.md
+++ b/changelog.d/3724.added.md
@@ -1,0 +1,3 @@
+Session bundles now carry embedded suspended worker snapshots and materialize them
+on import, so portable checkpoint bundles no longer depend on source-host snapshot
+paths.

--- a/crates/harn-cli/src/cli/session.rs
+++ b/crates/harn-cli/src/cli/session.rs
@@ -43,6 +43,9 @@ pub(crate) struct SessionImportArgs {
     /// Write the imported run record to this path.
     #[arg(long, value_name = "PATH")]
     pub out: Option<String>,
+    /// Directory for worker snapshots embedded in the bundle.
+    #[arg(long, value_name = "PATH")]
+    pub worker_snapshot_dir: Option<String>,
     /// Allow bundles that still contain high-confidence secret markers.
     #[arg(long)]
     pub allow_unsafe_secret_markers: bool,

--- a/crates/harn-cli/src/cli/tests/parse_orchestration.rs
+++ b/crates/harn-cli/src/cli/tests/parse_orchestration.rs
@@ -163,6 +163,8 @@ fn test_parses_session_bundle_commands() {
         "bundle.json",
         "--out",
         "imported.json",
+        "--worker-snapshot-dir",
+        "workers",
         "--allow-unsafe-secret-markers",
     ]);
 
@@ -174,6 +176,7 @@ fn test_parses_session_bundle_commands() {
     };
     assert_eq!(import.bundle, "bundle.json");
     assert_eq!(import.out.as_deref(), Some("imported.json"));
+    assert_eq!(import.worker_snapshot_dir.as_deref(), Some("workers"));
     assert!(import.allow_unsafe_secret_markers);
 
     let cli = Cli::parse_from(["harn", "session", "validate", "bundle.json", "--json"]);

--- a/crates/harn-cli/src/commands/session.rs
+++ b/crates/harn-cli/src/commands/session.rs
@@ -70,13 +70,34 @@ fn run_import(args: SessionImportArgs) {
         args.allow_unsafe_secret_markers,
         "invalid session bundle",
     );
-    let run_record = match harn_vm::session_bundle::import_run_record_value(&bundle) {
-        Ok(run_record) => run_record,
-        Err(error) => {
-            eprintln!("error: failed to import session bundle: {error}");
-            process::exit(1);
-        }
-    };
+    let out = args.out.map(PathBuf::from).unwrap_or_else(|| {
+        harn_vm::runtime_paths::run_root(Path::new("."))
+            .join("imported")
+            .join(format!("{}.json", bundle.source.run_record_id))
+    });
+    let snapshot_dir = args
+        .worker_snapshot_dir
+        .map(PathBuf::from)
+        .unwrap_or_else(|| default_worker_snapshot_dir(&out, &bundle.source.run_record_id));
+    let materialized =
+        match harn_vm::session_bundle::materialize_worker_snapshots(&bundle, &snapshot_dir) {
+            Ok(materialized) => materialized,
+            Err(error) => {
+                eprintln!("error: failed to materialize worker snapshots: {error}");
+                process::exit(1);
+            }
+        };
+    let run_record =
+        match harn_vm::session_bundle::import_run_record_value_with_materialized_worker_snapshots(
+            &bundle,
+            &materialized,
+        ) {
+            Ok(run_record) => run_record,
+            Err(error) => {
+                eprintln!("error: failed to import session bundle: {error}");
+                process::exit(1);
+            }
+        };
     let rendered = match serde_json::to_string_pretty(&run_record) {
         Ok(json) => format!("{json}\n"),
         Err(error) => {
@@ -84,12 +105,14 @@ fn run_import(args: SessionImportArgs) {
             process::exit(1);
         }
     };
-    let out = args.out.map(PathBuf::from).unwrap_or_else(|| {
-        harn_vm::runtime_paths::run_root(Path::new("."))
-            .join("imported")
-            .join(format!("{}.json", bundle.source.run_record_id))
-    });
     write_text(&out, &rendered);
+    if !materialized.is_empty() {
+        eprintln!(
+            "materialized {} worker snapshot(s) under {}",
+            materialized.len(),
+            snapshot_dir.display()
+        );
+    }
     println!("{}", out.display());
 }
 
@@ -208,6 +231,18 @@ fn write_stdout(content: &str) {
         eprintln!("error: failed to write stdout: {error}");
         process::exit(1);
     }
+}
+
+fn default_worker_snapshot_dir(out: &Path, run_record_id: &str) -> PathBuf {
+    let name = out
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(run_record_id);
+    out.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+        .join(format!("{name}.worker-snapshots"))
 }
 
 fn normalize_line_endings(input: &str) -> String {

--- a/crates/harn-vm/src/session_bundle.rs
+++ b/crates/harn-vm/src/session_bundle.rs
@@ -7,8 +7,9 @@
 //! a second persistence model.
 
 use std::borrow::Cow;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
+use std::fs;
 use std::path::Path;
 
 use chrono::{DateTime, SecondsFormat, Utc};
@@ -290,11 +291,31 @@ pub struct BundleReplay {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub observability: Option<RunObservabilityRecord>,
     pub verification_outcomes: Vec<RunVerificationOutcomeRecord>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub worker_snapshots: Vec<BundleWorkerSnapshot>,
     pub event_log_pointers: Vec<BundleEventLogPointer>,
     pub transitions: Vec<RunTransitionRecord>,
     pub checkpoints: Vec<RunCheckpointRecord>,
     pub trace_spans: Vec<RunTraceSpanRecord>,
     pub deterministic_events: Vec<BundleJsonEntry>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct BundleWorkerSnapshot {
+    pub worker_id: String,
+    pub worker_name: String,
+    pub status: String,
+    pub snapshot_ref: String,
+    pub source_path: Option<String>,
+    pub value: JsonValue,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct MaterializedWorkerSnapshot {
+    pub worker_id: String,
+    pub path: String,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -578,10 +599,109 @@ pub fn import_run_record_value(bundle: &SessionBundle) -> Result<JsonValue, Sess
             "metadata": {
                 "imported_from_session_bundle": bundle.bundle_id.clone(),
                 "session_bundle_schema_version": bundle.schema_version,
+                "worker_snapshot_count": bundle.replay.worker_snapshots.len(),
             }
         }));
     }
     Err(SessionBundleError::MissingRunRecord)
+}
+
+pub fn import_run_record_value_with_materialized_worker_snapshots(
+    bundle: &SessionBundle,
+    materialized: &[MaterializedWorkerSnapshot],
+) -> Result<JsonValue, SessionBundleError> {
+    let mut run_record = import_run_record_value(bundle)?;
+    apply_materialized_worker_snapshot_paths(&mut run_record, materialized);
+    Ok(run_record)
+}
+
+pub fn materialize_worker_snapshots(
+    bundle: &SessionBundle,
+    out_dir: &Path,
+) -> Result<Vec<MaterializedWorkerSnapshot>, SessionBundleError> {
+    if bundle.replay.worker_snapshots.is_empty() {
+        return Ok(Vec::new());
+    }
+    fs::create_dir_all(out_dir).map_err(|error| {
+        SessionBundleError::Encode(format!(
+            "failed to create worker snapshot directory {}: {error}",
+            out_dir.display()
+        ))
+    })?;
+
+    let mut materialized = Vec::new();
+    for (index, snapshot) in bundle.replay.worker_snapshots.iter().enumerate() {
+        let worker_id = if snapshot.worker_id.trim().is_empty() {
+            format!("worker_{index}")
+        } else {
+            snapshot.worker_id.clone()
+        };
+        let path = out_dir.join(worker_snapshot_file_name(&worker_id, index));
+        let value = worker_snapshot_value_for_import(&snapshot.value, &path);
+        let rendered = serde_json::to_string_pretty(&value)
+            .map(|json| format!("{json}\n"))
+            .map_err(|error| SessionBundleError::Encode(error.to_string()))?;
+        fs::write(&path, rendered).map_err(|error| {
+            SessionBundleError::Encode(format!(
+                "failed to write worker snapshot {}: {error}",
+                path.display()
+            ))
+        })?;
+        materialized.push(MaterializedWorkerSnapshot {
+            worker_id,
+            path: path.to_string_lossy().into_owned(),
+        });
+    }
+    Ok(materialized)
+}
+
+fn apply_materialized_worker_snapshot_paths(
+    run_record: &mut JsonValue,
+    materialized: &[MaterializedWorkerSnapshot],
+) {
+    if materialized.is_empty() {
+        return;
+    }
+
+    let paths_by_worker_id = materialized
+        .iter()
+        .filter(|snapshot| !snapshot.worker_id.is_empty())
+        .map(|snapshot| (snapshot.worker_id.as_str(), snapshot.path.as_str()))
+        .collect::<BTreeMap<_, _>>();
+    if paths_by_worker_id.is_empty() {
+        return;
+    }
+
+    rewrite_worker_snapshot_paths(run_record.get_mut("child_runs"), &paths_by_worker_id);
+    rewrite_worker_snapshot_paths(
+        run_record
+            .get_mut("observability")
+            .and_then(|observability| observability.get_mut("worker_lineage")),
+        &paths_by_worker_id,
+    );
+}
+
+fn rewrite_worker_snapshot_paths(
+    records: Option<&mut JsonValue>,
+    paths_by_worker_id: &BTreeMap<&str, &str>,
+) {
+    let Some(records) = records.and_then(JsonValue::as_array_mut) else {
+        return;
+    };
+    for record in records {
+        let Some(worker_id) = record.get("worker_id").and_then(JsonValue::as_str) else {
+            continue;
+        };
+        let Some(path) = paths_by_worker_id.get(worker_id) else {
+            continue;
+        };
+        if let JsonValue::Object(map) = record {
+            map.insert(
+                "snapshot_path".to_string(),
+                JsonValue::String((*path).to_string()),
+            );
+        }
+    }
 }
 
 fn replay_observability_for_import(replay: &BundleReplay) -> Option<RunObservabilityRecord> {
@@ -888,6 +1008,7 @@ fn raw_bundle_from_run(
             run_record: Some(run_record_value),
             observability: run.observability.clone(),
             verification_outcomes: verification_outcomes_for_run(run),
+            worker_snapshots: worker_snapshots_from_run(run),
             event_log_pointers: event_log_pointers_from_run(run),
             transitions: run.transitions.clone(),
             checkpoints: run.checkpoints.clone(),
@@ -929,7 +1050,9 @@ fn bundle_redaction_policy(base: &RedactionPolicy) -> RedactionPolicy {
         .with_extra_field("persisted_path")
         .with_extra_field("primary")
         .with_extra_field("run_path")
+        .with_extra_field("snapshot_ref")
         .with_extra_field("snapshot_path")
+        .with_extra_field("source_path")
 }
 
 fn workspace_from_run(run: &RunRecord) -> Option<BundleWorkspace> {
@@ -1168,6 +1291,116 @@ fn event_log_pointers_from_run(run: &RunRecord) -> Vec<BundleEventLogPointer> {
         }
     }
     pointers
+}
+
+fn worker_snapshots_from_run(run: &RunRecord) -> Vec<BundleWorkerSnapshot> {
+    let mut snapshots = Vec::new();
+    let mut seen_paths = BTreeSet::new();
+    for child in &run.child_runs {
+        let Some(path) = child.snapshot_path.as_deref() else {
+            continue;
+        };
+        if !seen_paths.insert(path.to_string()) {
+            continue;
+        }
+        if let Some(snapshot) = worker_snapshot_from_path(
+            &child.worker_id,
+            &child.worker_name,
+            &child.status,
+            Path::new(path),
+        ) {
+            snapshots.push(snapshot);
+        }
+    }
+    if let Some(observability) = run.observability.as_ref() {
+        for worker in &observability.worker_lineage {
+            let Some(path) = worker.snapshot_path.as_deref() else {
+                continue;
+            };
+            if !seen_paths.insert(path.to_string()) {
+                continue;
+            }
+            if let Some(snapshot) = worker_snapshot_from_path(
+                &worker.worker_id,
+                &worker.worker_name,
+                &worker.status,
+                Path::new(path),
+            ) {
+                snapshots.push(snapshot);
+            }
+        }
+    }
+    snapshots
+}
+
+fn worker_snapshot_from_path(
+    worker_id: &str,
+    worker_name: &str,
+    status: &str,
+    path: &Path,
+) -> Option<BundleWorkerSnapshot> {
+    let content = fs::read_to_string(path).ok()?;
+    let value = serde_json::from_str::<JsonValue>(&content).ok()?;
+    Some(BundleWorkerSnapshot {
+        worker_id: if worker_id.is_empty() {
+            value
+                .get("id")
+                .and_then(JsonValue::as_str)
+                .unwrap_or_default()
+                .to_string()
+        } else {
+            worker_id.to_string()
+        },
+        worker_name: if worker_name.is_empty() {
+            value
+                .get("name")
+                .and_then(JsonValue::as_str)
+                .unwrap_or("worker")
+                .to_string()
+        } else {
+            worker_name.to_string()
+        },
+        status: if status.is_empty() {
+            value
+                .get("status")
+                .and_then(JsonValue::as_str)
+                .unwrap_or_default()
+                .to_string()
+        } else {
+            status.to_string()
+        },
+        snapshot_ref: value
+            .get("suspension")
+            .and_then(|value| value.get("snapshot_ref"))
+            .and_then(JsonValue::as_str)
+            .or_else(|| value.get("snapshot_path").and_then(JsonValue::as_str))
+            .unwrap_or_else(|| path.to_str().unwrap_or_default())
+            .to_string(),
+        source_path: Some(path.to_string_lossy().into_owned()),
+        value,
+    })
+}
+
+fn worker_snapshot_file_name(worker_id: &str, index: usize) -> String {
+    let component = sanitize_topic_component(worker_id);
+    let component = if component.is_empty() {
+        format!("worker_{index}")
+    } else {
+        component
+    };
+    format!("{component}.json")
+}
+
+fn worker_snapshot_value_for_import(value: &JsonValue, path: &Path) -> JsonValue {
+    let mut value = value.clone();
+    let path = path.to_string_lossy().into_owned();
+    if let JsonValue::Object(map) = &mut value {
+        map.insert("snapshot_path".to_string(), JsonValue::String(path.clone()));
+        if let Some(JsonValue::Object(suspension)) = map.get_mut("suspension") {
+            suspension.insert("snapshot_ref".to_string(), JsonValue::String(path));
+        }
+    }
+    value
 }
 
 fn deterministic_events_from_run(

--- a/crates/harn-vm/src/session_bundle/schema.rs
+++ b/crates/harn-vm/src/session_bundle/schema.rs
@@ -103,6 +103,7 @@ pub fn session_bundle_schema() -> JsonValue {
                     "run_record": {"type": ["object", "null"]},
                     "observability": {"type": ["object", "null"]},
                     "verification_outcomes": {"type": "array", "items": {"type": "object"}},
+                    "worker_snapshots": {"type": "array", "items": {"$ref": "#/$defs/worker_snapshot"}},
                     "event_log_pointers": {"type": "array", "items": {"type": "object"}},
                     "transitions": {"type": "array", "items": {"type": "object"}},
                     "checkpoints": {"type": "array", "items": {"type": "object"}},
@@ -150,6 +151,19 @@ pub fn session_bundle_schema() -> JsonValue {
                     "events": {"type": "array", "items": true},
                     "assets": {"type": "array", "items": true},
                     "metadata": {"type": "object"}
+                }
+            },
+            "worker_snapshot": {
+                "type": "object",
+                "required": ["worker_id", "worker_name", "status", "snapshot_ref", "value"],
+                "additionalProperties": true,
+                "properties": {
+                    "worker_id": {"type": "string"},
+                    "worker_name": {"type": "string"},
+                    "status": {"type": "string"},
+                    "snapshot_ref": {"type": "string"},
+                    "source_path": {"type": ["string", "null"]},
+                    "value": {"type": "object"}
                 }
             }
         }

--- a/crates/harn-vm/src/session_bundle/tests.rs
+++ b/crates/harn-vm/src/session_bundle/tests.rs
@@ -1,11 +1,12 @@
 use std::fs;
+use std::path::{Path, PathBuf};
 
 use serde_json::json;
 
 use super::*;
 use crate::orchestration::{
-    LlmUsageRecord, RunObservabilityRecord, RunStageRecord, RunTranscriptPointerRecord,
-    RunVerificationOutcomeRecord,
+    LlmUsageRecord, RunChildRecord, RunObservabilityRecord, RunStageRecord,
+    RunTranscriptPointerRecord, RunVerificationOutcomeRecord, RunWorkerLineageRecord,
 };
 
 fn repo_fixture_path(name: &str) -> String {
@@ -113,6 +114,65 @@ fn fixture_replay_fixture(run: &RunRecord) -> ReplayFixture {
         expected_status: run.status.clone(),
         ..ReplayFixture::default()
     }
+}
+
+fn fixture_run_with_worker_snapshot(root: &Path) -> (RunRecord, PathBuf) {
+    let mut run = fixture_run();
+    let snapshot_path = root.join("workers").join("worker_1.json");
+    fs::create_dir_all(snapshot_path.parent().unwrap()).unwrap();
+    fs::write(
+        &snapshot_path,
+        serde_json::to_string_pretty(&json!({
+            "_type": "worker_snapshot",
+            "id": "worker_1",
+            "name": "sub-agent",
+            "task": "continue portable work",
+            "status": "suspended",
+            "snapshot_path": snapshot_path.to_string_lossy(),
+            "config": {
+                "mode": "sub_agent",
+                "spec": {
+                    "name": "sub-agent",
+                    "task": "continue portable work",
+                    "session_id": "session-child",
+                    "parent_session_id": "session-parent"
+                }
+            },
+            "suspension": {
+                "reason": "operator",
+                "initiator": "operator",
+                "suspended_at": "2026-05-01T00:00:20Z",
+                "snapshot_ref": snapshot_path.to_string_lossy()
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    run.child_runs = vec![RunChildRecord {
+        worker_id: "worker_1".to_string(),
+        worker_name: "sub-agent".to_string(),
+        task: "continue portable work".to_string(),
+        status: "suspended".to_string(),
+        started_at: "2026-05-01T00:00:00Z".to_string(),
+        session_id: Some("session-child".to_string()),
+        parent_session_id: Some("session-parent".to_string()),
+        snapshot_path: Some(snapshot_path.to_string_lossy().into_owned()),
+        ..RunChildRecord::default()
+    }];
+    run.observability = Some(RunObservabilityRecord {
+        worker_lineage: vec![RunWorkerLineageRecord {
+            worker_id: "worker_1".to_string(),
+            worker_name: "sub-agent".to_string(),
+            task: "continue portable work".to_string(),
+            status: "suspended".to_string(),
+            session_id: Some("session-child".to_string()),
+            parent_session_id: Some("session-parent".to_string()),
+            snapshot_path: Some(snapshot_path.to_string_lossy().into_owned()),
+            ..RunWorkerLineageRecord::default()
+        }],
+        ..RunObservabilityRecord::default()
+    });
+    (run, snapshot_path)
 }
 
 #[test]
@@ -355,6 +415,86 @@ fn replay_only_export_withholds_observability_verification_summaries() {
         bundle.replay.verification_outcomes[0].summary.as_deref(),
         Some(REPLAY_ONLY_PLACEHOLDER)
     );
+}
+
+#[test]
+fn local_export_embeds_worker_snapshots_and_import_materializes_them() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (run, source_snapshot_path) = fixture_run_with_worker_snapshot(tmp.path());
+
+    let bundle = export_run_record_bundle(
+        &run,
+        &SessionBundleExportOptions {
+            mode: SessionBundleExportMode::Local,
+            ..SessionBundleExportOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(bundle.replay.worker_snapshots.len(), 1);
+    let snapshot = &bundle.replay.worker_snapshots[0];
+    assert_eq!(snapshot.worker_id, "worker_1");
+    assert_eq!(snapshot.status, "suspended");
+    assert_eq!(
+        snapshot.source_path.as_deref(),
+        Some(source_snapshot_path.to_string_lossy().as_ref())
+    );
+    assert_eq!(snapshot.value["config"]["mode"], json!("sub_agent"));
+
+    let imported_dir = tmp.path().join("imported-worker-snapshots");
+    let materialized = materialize_worker_snapshots(&bundle, &imported_dir).unwrap();
+    assert_eq!(materialized.len(), 1);
+    assert_eq!(materialized[0].worker_id, "worker_1");
+
+    let materialized_snapshot: JsonValue =
+        serde_json::from_str(&fs::read_to_string(&materialized[0].path).unwrap()).unwrap();
+    assert_eq!(
+        materialized_snapshot["snapshot_path"],
+        json!(materialized[0].path)
+    );
+    assert_eq!(
+        materialized_snapshot["suspension"]["snapshot_ref"],
+        json!(materialized[0].path)
+    );
+    assert_eq!(
+        materialized_snapshot["config"]["spec"]["session_id"],
+        json!("session-child")
+    );
+
+    let imported =
+        import_run_record_value_with_materialized_worker_snapshots(&bundle, &materialized).unwrap();
+    assert_eq!(
+        imported["child_runs"][0]["snapshot_path"],
+        json!(materialized[0].path)
+    );
+    assert_eq!(
+        imported["observability"]["worker_lineage"][0]["snapshot_path"],
+        json!(materialized[0].path)
+    );
+    assert_ne!(
+        imported["child_runs"][0]["snapshot_path"],
+        json!(source_snapshot_path.to_string_lossy())
+    );
+}
+
+#[test]
+fn sanitized_export_redacts_worker_snapshot_local_paths() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (run, source_snapshot_path) = fixture_run_with_worker_snapshot(tmp.path());
+
+    let bundle = export_run_record_bundle(&run, &SessionBundleExportOptions::default()).unwrap();
+    let snapshot = &bundle.replay.worker_snapshots[0];
+
+    assert_eq!(snapshot.source_path.as_deref(), Some(REDACTED_PLACEHOLDER));
+    assert_eq!(snapshot.snapshot_ref, REDACTED_PLACEHOLDER);
+    assert_eq!(snapshot.value["snapshot_path"], json!(REDACTED_PLACEHOLDER));
+    assert_eq!(
+        snapshot.value["suspension"]["snapshot_ref"],
+        json!(REDACTED_PLACEHOLDER)
+    );
+    assert!(!serde_json::to_string(&bundle)
+        .unwrap()
+        .contains(source_snapshot_path.to_string_lossy().as_ref()));
 }
 
 #[test]

--- a/spec/schemas/session-bundle.v1.schema.json
+++ b/spec/schemas/session-bundle.v1.schema.json
@@ -67,6 +67,40 @@
         "metadata"
       ],
       "type": "object"
+    },
+    "worker_snapshot": {
+      "additionalProperties": true,
+      "properties": {
+        "snapshot_ref": {
+          "type": "string"
+        },
+        "source_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "type": "string"
+        },
+        "value": {
+          "type": "object"
+        },
+        "worker_id": {
+          "type": "string"
+        },
+        "worker_name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "worker_id",
+        "worker_name",
+        "status",
+        "snapshot_ref",
+        "value"
+      ],
+      "type": "object"
     }
   },
   "$id": "https://harnlang.com/schemas/session-bundle.v1.json",
@@ -208,6 +242,12 @@
         "verification_outcomes": {
           "items": {
             "type": "object"
+          },
+          "type": "array"
+        },
+        "worker_snapshots": {
+          "items": {
+            "$ref": "#/$defs/worker_snapshot"
           },
           "type": "array"
         }


### PR DESCRIPTION
## Summary
- add replay.worker_snapshots for suspended worker snapshot JSON carried by local session bundles
- materialize embedded worker snapshots during session import, rewriting snapshot_path and suspension snapshot_ref to the destination host path
- add schema, CLI parsing, redaction, export, and import-materialization coverage

## Validation
- cargo fmt -p harn-vm -p harn-cli --check
- git diff --check
- npx markdownlint-cli2 changelog.d/3682.fixed.md
- remote-build.sh cargo test -p harn-vm session_bundle::tests -- --nocapture
- remote-build.sh make check-session-bundle-schema
- remote-build.sh cargo test -p harn-cli test_parses_session_bundle_commands -- --nocapture

Part of #3682.