### PR TITLE
feat(session): report import resume commands

### DIFF
--- a/changelog.d/session-import-resume-report.added.md
+++ b/changelog.d/session-import-resume-report.added.md
@@ -1,0 +1,4 @@
+- **Session bundle import reports (#3682).** `harn session import --json` now
+  prints the imported run-record path, materialized worker snapshot paths, and
+  argv-form `harn run --resume` commands for portable checkpoint restore
+  workflows.

--- a/crates/harn-cli/src/cli/session.rs
+++ b/crates/harn-cli/src/cli/session.rs
@@ -49,6 +49,9 @@ pub(crate) struct SessionImportArgs {
     /// Allow bundles that still contain high-confidence secret markers.
     #[arg(long)]
     pub allow_unsafe_secret_markers: bool,
+    /// Print a JSON import report with materialized worker snapshot resume commands.
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/harn-cli/src/cli/tests/parse_orchestration.rs
+++ b/crates/harn-cli/src/cli/tests/parse_orchestration.rs
@@ -166,6 +166,7 @@ fn test_parses_session_bundle_commands() {
         "--worker-snapshot-dir",
         "workers",
         "--allow-unsafe-secret-markers",
+        "--json",
     ]);
 
     let Command::Session(args) = cli.command.unwrap() else {
@@ -178,6 +179,7 @@ fn test_parses_session_bundle_commands() {
     assert_eq!(import.out.as_deref(), Some("imported.json"));
     assert_eq!(import.worker_snapshot_dir.as_deref(), Some("workers"));
     assert!(import.allow_unsafe_secret_markers);
+    assert!(import.json);
 
     let cli = Cli::parse_from(["harn", "session", "validate", "bundle.json", "--json"]);
     let Command::Session(args) = cli.command.unwrap() else {

--- a/crates/harn-cli/src/commands/session.rs
+++ b/crates/harn-cli/src/commands/session.rs
@@ -106,14 +106,18 @@ fn run_import(args: SessionImportArgs) {
         }
     };
     write_text(&out, &rendered);
-    if !materialized.is_empty() {
-        eprintln!(
-            "materialized {} worker snapshot(s) under {}",
-            materialized.len(),
-            snapshot_dir.display()
-        );
+    if args.json {
+        write_json_stdout(&session_import_report(&out, &snapshot_dir, &materialized));
+    } else {
+        if !materialized.is_empty() {
+            eprintln!(
+                "materialized {} worker snapshot(s) under {}",
+                materialized.len(),
+                snapshot_dir.display()
+            );
+        }
+        println!("{}", out.display());
     }
-    println!("{}", out.display());
 }
 
 fn run_validate(args: SessionValidateArgs) {
@@ -233,6 +237,40 @@ fn write_stdout(content: &str) {
     }
 }
 
+fn write_json_stdout(value: &serde_json::Value) {
+    match serde_json::to_string_pretty(value) {
+        Ok(json) => println!("{json}"),
+        Err(error) => {
+            eprintln!("error: failed to render import report: {error}");
+            process::exit(1);
+        }
+    }
+}
+
+fn session_import_report(
+    out: &Path,
+    worker_snapshot_dir: &Path,
+    materialized: &[harn_vm::session_bundle::MaterializedWorkerSnapshot],
+) -> serde_json::Value {
+    let worker_snapshots = materialized
+        .iter()
+        .map(|snapshot| {
+            serde_json::json!({
+                "worker_id": snapshot.worker_id,
+                "path": snapshot.path,
+                "resume_command": ["harn", "run", "--resume", snapshot.path],
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::json!({
+        "ok": true,
+        "run_record_path": out.to_string_lossy(),
+        "worker_snapshot_dir": worker_snapshot_dir.to_string_lossy(),
+        "worker_snapshot_count": materialized.len(),
+        "worker_snapshots": worker_snapshots,
+    })
+}
+
 fn default_worker_snapshot_dir(out: &Path, run_record_id: &str) -> PathBuf {
     let name = out
         .file_stem()
@@ -247,4 +285,39 @@ fn default_worker_snapshot_dir(out: &Path, run_record_id: &str) -> PathBuf {
 
 fn normalize_line_endings(input: &str) -> String {
     input.replace("\r\n", "\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_import_report_includes_resume_commands() {
+        let materialized = vec![harn_vm::session_bundle::MaterializedWorkerSnapshot {
+            worker_id: "worker_1".to_string(),
+            path: "/tmp/imported.worker-snapshots/worker_1.json".to_string(),
+        }];
+
+        let report = session_import_report(
+            Path::new("/tmp/imported/run.json"),
+            Path::new("/tmp/imported.worker-snapshots"),
+            &materialized,
+        );
+
+        assert_eq!(report["ok"], serde_json::json!(true));
+        assert_eq!(
+            report["run_record_path"],
+            serde_json::json!("/tmp/imported/run.json")
+        );
+        assert_eq!(report["worker_snapshot_count"], serde_json::json!(1));
+        assert_eq!(
+            report["worker_snapshots"][0]["resume_command"],
+            serde_json::json!([
+                "harn",
+                "run",
+                "--resume",
+                "/tmp/imported.worker-snapshots/worker_1.json"
+            ])
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- add `harn session import --json` for machine-readable import reports
- include the imported run-record path, worker snapshot directory/count, materialized worker snapshot paths, and argv-form `harn run --resume` commands
- keep legacy non-JSON stdout/stderr behavior unchanged

## Why

This is a small #3682 follow-up to #3724. Session bundle import now materializes embedded worker snapshots, but operators and automation still had to discover the destination-local snapshot filenames before resuming a worker. The JSON report closes that gap without changing bundle schema or runtime resume semantics.

Refs #3682.

## Validation

- `cargo fmt -p harn-cli --check`
- `git diff --check origin/main..HEAD`
- `cargo test -p harn-cli session_import_report_includes_resume_commands -- --nocapture`
- `cargo test -p harn-cli test_parses_session_bundle_commands -- --nocapture`
- temp end-to-end smoke: augmented `sample-local.bundle.json` with one embedded worker snapshot, ran `target/debug/harn session import --json`, and asserted the JSON report, materialized snapshot self-reference rewrite, and imported run-record child/observability `snapshot_path` rewrites
- pre-push hook passed: markdownlint, targeted local checks, and `make check-session-bundle-schema`
