### PR TITLE
docs(website): site-wide pre-release notice → release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ reserved `metadata` keys (`effects_grant`, `effects_used`,
 `effects_used` stayed inside the parent's `effects_grant`. The public
 schema and fixtures live in [`opentrustgraph-spec/`](./opentrustgraph-spec/).
 
+> **Pre-release.** Harn is pre-1.0 — the language, standard library, and
+> CLI may change between releases. Track what moved in the
+> [release notes](https://github.com/burin-labs/harn/releases) and
+> [`CHANGELOG.md`](./CHANGELOG.md).
+
 ## Install
 
 One-line installer (recommended; no Rust toolchain required):

--- a/changelog.d/3727.added.md
+++ b/changelog.d/3727.added.md
@@ -1,0 +1,1 @@
+Added a site-wide pre-release notice (banner above the navbar on every page, plus a README callout) that links to the GitHub release notes so readers know the language, standard library, and CLI may change between releases.

--- a/website/src/components/PrereleaseBanner.tsx
+++ b/website/src/components/PrereleaseBanner.tsx
@@ -1,0 +1,28 @@
+import { useMessages } from "../i18n"
+
+const RELEASES = "https://github.com/burin-labs/harn/releases"
+
+// A thin site-wide notice that Harn is pre-1.0. Rendered above the navbar on
+// every page (landing + docs) so the "subject to change" caveat travels with
+// the content and points readers at the release notes for what moved.
+export function PrereleaseBanner() {
+  const t = useMessages()
+  return (
+    <div className="border-b border-accent-500/20 bg-accent-500/10">
+      <p className="mx-auto max-w-6xl px-4 py-1.5 text-center text-xs text-foreground-secondary sm:px-6 lg:px-8">
+        <span className="font-semibold text-accent-700 dark:text-accent-300">
+          {t.banner.label}
+        </span>{" "}
+        {t.banner.prerelease}{" "}
+        <a
+          href={RELEASES}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-accent-700 underline decoration-accent-500/40 underline-offset-2 transition-colors hover:text-accent-600 dark:text-accent-300 dark:hover:text-accent-200"
+        >
+          {t.banner.changelogLink}
+        </a>
+      </p>
+    </div>
+  )
+}

--- a/website/src/i18n/en.ts
+++ b/website/src/i18n/en.ts
@@ -13,6 +13,12 @@ export const en = {
     github: "GitHub",
   },
 
+  banner: {
+    label: "Pre-release",
+    prerelease: "Harn is pre-1.0 — the language, standard library, and CLI may change between releases.",
+    changelogLink: "See the release notes",
+  },
+
   nav: {
     brandHomeAria: "Harn home",
     docs: "Docs",

--- a/website/src/layouts/RootLayout.tsx
+++ b/website/src/layouts/RootLayout.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react"
 import { Outlet, useLocation } from "react-router"
 import { Navbar } from "../components/Navbar"
+import { PrereleaseBanner } from "../components/PrereleaseBanner"
 import { Footer } from "../components/Footer"
 import { SearchModal } from "../components/SearchModal"
 import { KeywordTooltip } from "../components/KeywordTooltip"
@@ -37,6 +38,7 @@ export function RootLayout() {
 
   return (
     <div className="flex min-h-screen flex-col">
+      <PrereleaseBanner />
       <Navbar onOpenSearch={openSearch} />
       <main className="flex-1">
         <Outlet />


### PR DESCRIPTION
## What

Adds a site-wide **pre-release notice** so visitors know Harn is pre-1.0 and the language/stdlib/CLI may change between releases, pointing them at the release notes for what moved:

- A thin banner above the navbar on **every** page (landing + all 263 doc pages), rendered server-side into the prerendered HTML — no client state, no dismissal — using the existing accent tokens and the i18n message catalog (`banner.*`), so it stays localizable.
- A matching `> **Pre-release.**` callout near the top of the README pointing at the release notes and `CHANGELOG.md`.

## SEO

The "flip the SEO flags" ask is already satisfied as of #3652 — verified during a full build of this branch:

- `robots.txt` → `User-agent: * / Allow: /` with a `Sitemap:` line.
- `prerender.mjs` emits `sitemap.xml` (**264 urls**) into `docs/dist` on every build, plus `canonical` + Open Graph + `twitter:card` + JSON-LD per page.

No SEO code change was needed; this PR is the disclaimer layer.

## Verification

- `npx tsc -b` → clean
- `npm run build` → client + SSR + prerender succeed; `sitemap.xml` (264 urls) regenerated; banner present in `docs/dist/index.html` ("Pre-release" / "See the release notes").
- `npm test` → 6 passed
- Style matches the project's no-semicolon convention (repo has no prettier config; its default would wrongly add semicolons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)