### PR TITLE
fix(agent): make arg-scoped DynamicPermission denials recoverable (extends #3670)

### DIFF
--- a/changelog.d/3728.fixed.md
+++ b/changelog.d/3728.fixed.md
@@ -1,3 +1,6 @@
-- **Agent denial recovery.** Arg-scoped dynamic permission denials are now
-  classified as recoverable so an agent can retry with corrected arguments
-  instead of treating them as terminal failures (#3728).
+Arg/path-scoped dynamic-permission denials are now coached as recoverable
+instead of terminal: when a route is permitted but a specific argument value or
+path is out of policy, the agent is told to retry with an allowed value (the
+same treatment the argument allow-list gate already gets, harn#3670). Hard
+capability ceilings, approval-unavailable, and explicit user rejections stay
+terminal — a retry there yields the same answer.

--- a/changelog.d/3728.fixed.md
+++ b/changelog.d/3728.fixed.md
@@ -1,0 +1,3 @@
+- **Agent denial recovery.** Arg-scoped dynamic permission denials are now
+  classified as recoverable so an agent can retry with corrected arguments
+  instead of treating them as terminal failures (#3728).

--- a/crates/harn-vm/src/llm/agent_host_primitives.rs
+++ b/crates/harn-vm/src/llm/agent_host_primitives.rs
@@ -959,7 +959,11 @@ async fn host_agent_dispatch_tool_call(
                     escalated,
                 );
             }
-            permissions::PermissionCheck::Denied { reason, escalated } => {
+            permissions::PermissionCheck::Denied {
+                reason,
+                escalated,
+                recoverable,
+            } => {
                 if escalated {
                     emit_permission_event(
                         &session_id,
@@ -970,11 +974,25 @@ async fn host_agent_dispatch_tool_call(
                         true,
                     );
                 }
-                let denial = crate::agent_events::ToolDenial::terminal(
-                    crate::agent_events::DenialGate::DynamicPermission,
-                    None,
-                    reason,
-                );
+                // A dynamic-permission denial scoped to a specific argument
+                // value/path (the tool is otherwise permitted) is RECOVERABLE:
+                // coach a retry with an allowed value, mirroring the
+                // ArgConstraint allow-list gate (harn#3670). A hard
+                // dynamic-permission ceiling — the whole tool is denied, or an
+                // approval/escalation refusal — stays terminal.
+                let denial = if recoverable {
+                    crate::agent_events::ToolDenial::retryable(
+                        crate::agent_events::DenialGate::DynamicPermission,
+                        None,
+                        reason,
+                    )
+                } else {
+                    crate::agent_events::ToolDenial::terminal(
+                        crate::agent_events::DenialGate::DynamicPermission,
+                        None,
+                        reason,
+                    )
+                };
                 return Ok(deny_tool_call_value(
                     &session_id,
                     &tool_name,
@@ -2133,6 +2151,93 @@ mod denied_tool_routing_tests {
             next.contains("Do not retry"),
             "a hard capability ceiling must stay terminal: {next}"
         );
+    }
+
+    #[test]
+    fn arg_scoped_dynamic_permission_denial_is_coached_as_recoverable() {
+        use crate::agent_events::{DenialGate, ToolDenial};
+        // A dynamic permission rule denied a specific path while the tool itself
+        // is permitted (analogous to ArgConstraint): coach a retry with an
+        // allowed value rather than a terminal "do not retry".
+        let denial = ToolDenial::retryable(
+            DenialGate::DynamicPermission,
+            None,
+            "permission denied: path 'docs/secret.md' is outside custom path scope",
+        );
+        let envelope = agent_primitive_denied_tool(
+            "edit",
+            "call_5",
+            &serde_json::json!({ "path": "docs/secret.md" }),
+            denial.reason.clone(),
+            ToolCallErrorCategory::PermissionDenied,
+            Some(&denial),
+        );
+        let result = &envelope["result"];
+        // Retry-positive body, NOT a hard permission denial.
+        assert_eq!(result["error"], serde_json::json!("invalid_arguments"));
+        assert_ne!(result["error"], serde_json::json!("permission_denied"));
+        let next = result["next_step"].as_str().expect("next_step");
+        assert!(
+            !next.contains("Do not retry"),
+            "arg-scoped dynamic-permission denial must coach a correction: {next}"
+        );
+        assert_eq!(envelope["denial"]["gate"], "dynamic_permission");
+        assert_eq!(envelope["denial"]["retryable"], true);
+    }
+
+    #[test]
+    fn hard_dynamic_permission_ceiling_stays_terminal() {
+        use crate::agent_events::{DenialGate, ToolDenial};
+        // The whole tool is denied by the dynamic policy: a retry can't help.
+        let denial = ToolDenial::terminal(
+            DenialGate::DynamicPermission,
+            None,
+            "permission denied: tool 'exec' is not allowed by this agent's permissions",
+        );
+        let envelope = agent_primitive_denied_tool(
+            "exec",
+            "call_6",
+            &serde_json::json!({ "command": "rm -rf /" }),
+            denial.reason.clone(),
+            ToolCallErrorCategory::PermissionDenied,
+            Some(&denial),
+        );
+        let result = &envelope["result"];
+        assert_eq!(result["error"], serde_json::json!("permission_denied"));
+        let next = result["next_step"].as_str().expect("next_step");
+        assert!(
+            next.contains("Do not retry"),
+            "a hard dynamic-permission ceiling must stay terminal: {next}"
+        );
+        assert_eq!(envelope["denial"]["retryable"], false);
+    }
+
+    #[test]
+    fn approval_unavailable_and_host_rejected_stay_terminal() {
+        use crate::agent_events::{DenialGate, ToolDenial};
+        // ApprovalUnavailable means no approver exists; HostRejected means the
+        // user said no. A retry yields the same result, so both stay terminal
+        // and are never marked recoverable.
+        for gate in [DenialGate::ApprovalUnavailable, DenialGate::HostRejected] {
+            let denial = ToolDenial::terminal(gate, None, "approval refused");
+            assert!(!denial.retryable, "{} must stay terminal", gate.as_str());
+            let envelope = agent_primitive_denied_tool(
+                "exec",
+                "call_7",
+                &serde_json::json!({ "command": "ls" }),
+                denial.reason.clone(),
+                ToolCallErrorCategory::PermissionDenied,
+                Some(&denial),
+            );
+            let result = &envelope["result"];
+            assert_eq!(result["error"], serde_json::json!("permission_denied"));
+            let next = result["next_step"].as_str().expect("next_step");
+            assert!(
+                next.contains("Do not retry"),
+                "{} must stay terminal: {next}",
+                gate.as_str()
+            );
+        }
     }
 
     use super::empty_args_cause_named_feedback;

--- a/crates/harn-vm/src/llm/permissions.rs
+++ b/crates/harn-vm/src/llm/permissions.rs
@@ -38,6 +38,23 @@ enum PermissionMatcher {
     Predicate(VmValue),
 }
 
+impl PermissionMatcher {
+    /// Whether a denial this matcher produces is scoped to a specific argument
+    /// value/path (the tool is otherwise permitted) rather than a hard,
+    /// tool-wide ceiling. Arg/path-scoped denials are recoverable — coaching a
+    /// retry with an allowed value is correct, mirroring the `ArgConstraint`
+    /// allow-list gate (harn#3670). A bare/`Any`/`Bool` match denies the whole
+    /// tool, and a predicate can deny on any basis, so both stay hard ceilings.
+    fn denial_is_arg_scoped(&self) -> bool {
+        matches!(
+            self,
+            PermissionMatcher::Patterns(_)
+                | PermissionMatcher::KeyedPatterns { .. }
+                | PermissionMatcher::PathScope(_)
+        )
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 struct PathScopeMatcher {
@@ -79,8 +96,22 @@ enum PathScopeAction {
 }
 
 pub(crate) enum PermissionCheck {
-    Granted { reason: String, escalated: bool },
-    Denied { reason: String, escalated: bool },
+    Granted {
+        reason: String,
+        escalated: bool,
+    },
+    Denied {
+        reason: String,
+        escalated: bool,
+        /// Whether the denial is scoped to a specific argument value/path (the
+        /// tool is otherwise permitted) rather than a hard, tool-wide ceiling.
+        /// An arg/path-scoped denial is RECOVERABLE: the dispatch boundary
+        /// coaches a retry with an allowed value, mirroring the `ArgConstraint`
+        /// allow-list gate (harn#3670). A hard ceiling stays terminal. Hook
+        /// blocks and escalation rejections are approval-style refusals — a
+        /// retry yields the same answer — so they stay terminal (`false`).
+        recoverable: bool,
+    },
 }
 
 /// Build the transcript event that callers append to a session when a
@@ -470,8 +501,16 @@ pub(crate) async fn check_dynamic_permission(
         )
         .await?
         {
-            PermissionCheck::Denied { reason, escalated } => {
-                return Ok(Some(PermissionCheck::Denied { reason, escalated }));
+            PermissionCheck::Denied {
+                reason,
+                escalated,
+                recoverable,
+            } => {
+                return Ok(Some(PermissionCheck::Denied {
+                    reason,
+                    escalated,
+                    recoverable,
+                }));
             }
             grant @ PermissionCheck::Granted { .. } => {
                 grant_result = Some(grant);
@@ -510,19 +549,40 @@ async fn check_one_dynamic_permission(
         Some(first_matching_allow_rule(ctx, &policy.allow, tool_name, args, session_id).await?)
     };
 
-    let denial_reason = if let Some(reason) = denied {
-        Some(format!("permission denied by deny rule: {reason}"))
+    let denial = if let Some(denied) = denied {
+        Some(DenialOutcome {
+            reason: format!("permission denied by deny rule: {}", denied.reason),
+            // A deny rule that keys on a specific argument value/path is
+            // arg-scoped (re-issuing with an allowed value can succeed); a
+            // bare/`Any`/`Bool`/predicate deny is a hard, tool-wide ceiling.
+            recoverable: denied.arg_scoped,
+        })
     } else {
         match allowed.as_ref() {
             Some(AllowRuleMatch::Matched(_)) | None => None,
-            Some(AllowRuleMatch::NoMatch) => Some(format!(
-                "permission denied: tool '{tool_name}' is not allowed by this agent's permissions"
-            )),
-            Some(AllowRuleMatch::Rejected(reason)) => Some(format!("permission denied: {reason}")),
+            // The tool itself is not in this agent's allow-list: a hard
+            // ceiling, so retrying the call can never succeed.
+            Some(AllowRuleMatch::NoMatch) => Some(DenialOutcome {
+                reason: format!(
+                    "permission denied: tool '{tool_name}' is not allowed by this agent's permissions"
+                ),
+                recoverable: false,
+            }),
+            // A path-scope allow rule rejected this specific path: the tool is
+            // permitted, only this path is out of scope — recoverable, mirroring
+            // the `ArgConstraint` allow-list gate (harn#3670).
+            Some(AllowRuleMatch::Rejected(reason)) => Some(DenialOutcome {
+                reason: format!("permission denied: {reason}"),
+                recoverable: true,
+            }),
         }
     };
 
-    let Some(reason) = denial_reason else {
+    let Some(DenialOutcome {
+        reason,
+        recoverable,
+    }) = denial
+    else {
         let allow_reason = match allowed {
             Some(AllowRuleMatch::Matched(reason)) => {
                 format!("permission granted by allow rule: {reason}")
@@ -554,9 +614,12 @@ async fn check_one_dynamic_permission(
         crate::orchestration::HookControl::Block {
             reason: block_reason,
         } => {
+            // A hook block is an approval-style refusal — retrying yields the
+            // same answer — so it stays terminal regardless of arg scope.
             return Ok(PermissionCheck::Denied {
                 reason: block_reason,
                 escalated: true,
+                recoverable: false,
             });
         }
         crate::orchestration::HookControl::Decision {
@@ -579,9 +642,12 @@ async fn check_one_dynamic_permission(
                     .unwrap_or_else(|| format!("permission denied by session hook: {reason}"));
                 fire_permission_replied(ctx, session_id, tool_name, args, "deny", &denied_reason)
                     .await;
+                // A session-hook `deny` decision is an approval-style refusal;
+                // stays terminal.
                 return Ok(PermissionCheck::Denied {
                     reason: denied_reason,
                     escalated: true,
+                    recoverable: false,
                 });
             }
             _ => {}
@@ -591,9 +657,13 @@ async fn check_one_dynamic_permission(
     }
 
     let Some(on_escalation) = policy.on_escalation.as_ref() else {
+        // No escalation path: surface the policy denial, carrying the arg-scope
+        // discriminant so the dispatch boundary can coach a retry for an
+        // arg/path-scoped miss and stay terminal for a hard ceiling.
         return Ok(PermissionCheck::Denied {
             reason,
             escalated: false,
+            recoverable,
         });
     };
 
@@ -615,9 +685,12 @@ async fn check_one_dynamic_permission(
             .reason
             .unwrap_or_else(|| "permission escalation denied".to_string());
         fire_permission_replied(ctx, session_id, tool_name, args, "deny", &deny_reason).await;
+        // The escalation approver rejected the call — like a host-rejected
+        // approval, a retry yields the same answer — so it stays terminal.
         Ok(PermissionCheck::Denied {
             reason: deny_reason,
             escalated: true,
+            recoverable: false,
         })
     }
 }
@@ -657,6 +730,20 @@ enum AllowRuleMatch {
     NoMatch,
 }
 
+/// A resolved dynamic-permission denial plus whether it is arg/path-scoped
+/// (recoverable) or a hard ceiling (terminal).
+struct DenialOutcome {
+    reason: String,
+    recoverable: bool,
+}
+
+/// A matched deny rule plus whether that rule keys on a specific argument
+/// value/path (arg-scoped, recoverable) rather than denying the whole tool.
+struct DeniedMatch {
+    reason: String,
+    arg_scoped: bool,
+}
+
 struct MatcherEvaluation {
     matched: bool,
     reason: Option<String>,
@@ -669,7 +756,7 @@ async fn first_matching_deny_rule(
     tool_name: &str,
     args: &serde_json::Value,
     session_id: &str,
-) -> Result<Option<String>, VmError> {
+) -> Result<Option<DeniedMatch>, VmError> {
     for rule in rules {
         if !crate::orchestration::glob_match(&rule.tool_pattern, tool_name) {
             continue;
@@ -677,16 +764,21 @@ async fn first_matching_deny_rule(
         let evaluation = evaluate_matcher(ctx, &rule.matcher, args, session_id).await?;
         if matches!(rule.matcher, PermissionMatcher::PathScope(_)) {
             if let Some(reason) = evaluation.rejection {
-                return Ok(Some(reason));
+                // Path-scope rejection names a specific out-of-scope path.
+                return Ok(Some(DeniedMatch {
+                    reason,
+                    arg_scoped: true,
+                }));
             }
             continue;
         }
         if evaluation.matched {
-            return Ok(Some(
-                evaluation
+            return Ok(Some(DeniedMatch {
+                reason: evaluation
                     .reason
                     .unwrap_or_else(|| rule.tool_pattern.clone()),
-            ));
+                arg_scoped: rule.matcher.denial_is_arg_scoped(),
+            }));
         }
     }
     Ok(None)
@@ -1325,6 +1417,156 @@ mod tests {
         .expect("check allow rules");
         assert!(
             matches!(result, AllowRuleMatch::Rejected(reason) if reason.contains("outside anchor"))
+        );
+    }
+
+    fn denial_recoverable(check: PermissionCheck) -> bool {
+        match check {
+            PermissionCheck::Denied { recoverable, .. } => recoverable,
+            PermissionCheck::Granted { reason, .. } => {
+                panic!("expected a denial, got grant: {reason}")
+            }
+        }
+    }
+
+    /// A path-scope allow rule that rejects this specific path is arg/path-scoped:
+    /// the tool is permitted, only the path is out of scope, so the denial is
+    /// RECOVERABLE (mirrors the ArgConstraint allow-list gate, harn#3670).
+    #[tokio::test(flavor = "current_thread")]
+    async fn path_scope_allow_rejection_is_recoverable() {
+        crate::reset_thread_local_state();
+        let temp = tempfile::tempdir().expect("tempdir");
+        let anchor = anchor(temp.path());
+        let outside_path = path_string(&temp.path().join("harn-anchor-z").join("file.txt"));
+        let session_id =
+            crate::agent_sessions::open_or_create(Some("dyn-perm-path-scope".to_string()));
+        crate::agent_sessions::set_workspace_anchor(&session_id, Some(anchor)).expect("set anchor");
+        let policy = DynamicPermissionPolicy {
+            allow: vec![PermissionRule {
+                tool_pattern: "Read".to_string(),
+                matcher: PermissionMatcher::PathScope(PathScopeMatcher {
+                    scope: PathScopeMode::AnchorOnly,
+                    arg_keys: vec!["path".to_string()],
+                    on_violation: PathScopeAction::Deny,
+                }),
+            }],
+            deny: Vec::new(),
+            on_escalation: None,
+        };
+        let mut grants = BTreeSet::new();
+        let check = check_one_dynamic_permission(
+            None,
+            &policy,
+            0,
+            &mut grants,
+            "Read",
+            &serde_json::json!({"path": outside_path}),
+            &session_id,
+        )
+        .await
+        .expect("permission check");
+        assert!(
+            denial_recoverable(check),
+            "path-scope allow rejection must be recoverable"
+        );
+    }
+
+    /// A tool that matches no allow rule is a hard ceiling: the tool itself is
+    /// not permitted, so the denial is TERMINAL (not recoverable).
+    #[tokio::test(flavor = "current_thread")]
+    async fn tool_not_in_allow_list_is_terminal() {
+        crate::reset_thread_local_state();
+        let session_id =
+            crate::agent_sessions::open_or_create(Some("dyn-perm-tool-ceiling".to_string()));
+        let policy = DynamicPermissionPolicy {
+            allow: vec![PermissionRule {
+                tool_pattern: "Read".to_string(),
+                matcher: PermissionMatcher::Any,
+            }],
+            deny: Vec::new(),
+            on_escalation: None,
+        };
+        let mut grants = BTreeSet::new();
+        let check = check_one_dynamic_permission(
+            None,
+            &policy,
+            0,
+            &mut grants,
+            "exec",
+            &serde_json::json!({"command": "ls"}),
+            &session_id,
+        )
+        .await
+        .expect("permission check");
+        assert!(
+            !denial_recoverable(check),
+            "a tool outside the allow-list is a hard ceiling and must be terminal"
+        );
+    }
+
+    /// A deny rule keyed on a specific argument value is arg-scoped: re-issuing
+    /// with an allowed value can succeed, so the denial is RECOVERABLE.
+    #[tokio::test(flavor = "current_thread")]
+    async fn arg_keyed_deny_rule_is_recoverable() {
+        crate::reset_thread_local_state();
+        let session_id =
+            crate::agent_sessions::open_or_create(Some("dyn-perm-arg-deny".to_string()));
+        let policy = DynamicPermissionPolicy {
+            allow: Vec::new(),
+            deny: vec![PermissionRule {
+                tool_pattern: "exec".to_string(),
+                matcher: PermissionMatcher::Patterns(vec!["rm *".to_string()]),
+            }],
+            on_escalation: None,
+        };
+        let mut grants = BTreeSet::new();
+        let check = check_one_dynamic_permission(
+            None,
+            &policy,
+            0,
+            &mut grants,
+            "exec",
+            &serde_json::json!({"command": "rm -rf /"}),
+            &session_id,
+        )
+        .await
+        .expect("permission check");
+        assert!(
+            denial_recoverable(check),
+            "an arg-keyed deny rule is arg-scoped and must be recoverable"
+        );
+    }
+
+    /// A bare/`Any` deny rule denies the whole tool: a hard ceiling, so the
+    /// denial is TERMINAL.
+    #[tokio::test(flavor = "current_thread")]
+    async fn whole_tool_deny_rule_is_terminal() {
+        crate::reset_thread_local_state();
+        let session_id =
+            crate::agent_sessions::open_or_create(Some("dyn-perm-tool-deny".to_string()));
+        let policy = DynamicPermissionPolicy {
+            allow: Vec::new(),
+            deny: vec![PermissionRule {
+                tool_pattern: "exec".to_string(),
+                matcher: PermissionMatcher::Any,
+            }],
+            on_escalation: None,
+        };
+        let mut grants = BTreeSet::new();
+        let check = check_one_dynamic_permission(
+            None,
+            &policy,
+            0,
+            &mut grants,
+            "exec",
+            &serde_json::json!({"command": "ls"}),
+            &session_id,
+        )
+        .await
+        .expect("permission check");
+        assert!(
+            !denial_recoverable(check),
+            "a whole-tool deny rule is a hard ceiling and must be terminal"
         );
     }
 }


### PR DESCRIPTION
## Why

[#3670](https://github.com/burin-labs/harn/pull/3670) made the argument allow-list gate (`DenialGate::ArgConstraint`) **recoverable**: an argument outside the allowed scope is a fixable slip (the tool is permitted, only this value is wrong), so the dispatch boundary coaches a retry with a corrected value instead of a terminal "do not retry".

But the dynamic-permission gate (`DenialGate::DynamicPermission`) was **always** built via `ToolDenial::terminal(...)` at the dispatch site, regardless of whether the dynamic policy denied the whole tool (a hard ceiling) or just a specific argument value/path (the tool is otherwise permitted). The latter is the exact same fixable-slip shape as `ArgConstraint` — coaching a retry with an allowed value is correct — yet the model was told to give up the turn.

## What (narrow scope)

- `PermissionCheck::Denied` now carries a `recoverable` discriminant. The dynamic-permission evaluation sets it `true` **only** when the denial is arg/path-scoped:
  - a path-scope **allow** rule rejected this specific path (`AllowRuleMatch::Rejected`)
  - a **deny** rule keyed on a specific argument value/path (`Patterns` / `KeyedPatterns` / `PathScope` matcher)
  
  and `false` for hard ceilings: tool not in the allow-list, or a bare/`Any`/`Bool`/predicate deny that denies the whole tool.
- The dispatch site routes a recoverable `DynamicPermission` denial through `ToolDenial::retryable(...)` and a hard one through `terminal(...)`, mirroring exactly how the `ArgConstraint` branch already chooses.

## What stays terminal (intentionally untouched)

- **Hook blocks** and **`on_escalation` rejections** — approval-style refusals; a retry yields the same answer — remain `recoverable: false`.
- **`DenialGate::ApprovalUnavailable`**: no approver exists, so a retry just loops the model.
- **`WireOutcome::Rejected` / `HostRejected`**: the user said no.

  Both are built elsewhere via `terminal(...)` and are not touched by this change.

## Tests

- `permissions.rs`: `path_scope_allow_rejection_is_recoverable`, `arg_keyed_deny_rule_is_recoverable` (recoverable); `tool_not_in_allow_list_is_terminal`, `whole_tool_deny_rule_is_terminal` (terminal) — assert the `recoverable` flag straight off `check_one_dynamic_permission`.
- `agent_host_primitives.rs`: `arg_scoped_dynamic_permission_denial_is_coached_as_recoverable`, `hard_dynamic_permission_ceiling_stays_terminal`, `approval_unavailable_and_host_rejected_stay_terminal` — mirror #3670's routing tests.

`cargo test -p harn-vm` (permissions + denied_tool_routing_tests), `cargo fmt`, and `cargo clippy -p harn-vm --all-targets` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)