### PR TITLE
feat(capabilities): consistency gate for native-unreliable model families + fix NVIDIA GLM-5 outlier

### DIFF
--- a/changelog.d/3729.fixed.md
+++ b/changelog.d/3729.fixed.md
@@ -1,0 +1,3 @@
+- **Model capability matrix.** GLM-5 family routes now fail the capability
+  audit if a provider pins the unreliable native tool channel, and the NVIDIA
+  GLM-5 row is corrected to the text tool format (#3729).

--- a/changelog.d/native-unreliable-family-gate.added.md
+++ b/changelog.d/native-unreliable-family-gate.added.md
@@ -1,0 +1,7 @@
+Added a capability-matrix consistency gate that forbids any route from pinning
+the provider-native tool channel for a model family whose native channel is
+unreliable as a weight-intrinsic property (starting with GLM-5.x, which leaks
+`<tool_call>` markup into assistant content instead of returning native tool
+calls). Fixed the NVIDIA GLM-5 route — the lone outlier that pinned `native`
+while the rest of the family uses the clean text channel — so a value model can
+no longer silently thrash on a single mis-pinned provider.

--- a/crates/harn-vm/src/llm/capabilities.toml
+++ b/crates/harn-vm/src/llm/capabilities.toml
@@ -2843,7 +2843,9 @@ thinking_block_style = "inline"
 [[provider.nvidia]]
 model_match = "*glm-5*"
 native_tools = true
-preferred_tool_format = "native"
+preferred_tool_format = "text"
+tool_mode_parity = "native_unreliable"
+tool_mode_parity_notes = "GLM-5.x's native channel emits `<tool_call><arg_key>...` markup as content instead of OpenAI message.tool_calls — a weight-intrinsic behavior reproduced across every GLM-5 host probed (zai/Baseten live, Together + OpenRouter agent-loop smoke, DeepInfra, Fireworks glm-5p*). NVIDIA serves the same weights, so the same leak applies; pin the clean heredoc text channel for family parity. Flagged by the native_unreliable-family consistency gate."
 structured_output = "native"
 thinking_modes = ["enabled"]
 prompt_caching = true

--- a/crates/harn-vm/src/llm/capability_audit.rs
+++ b/crates/harn-vm/src/llm/capability_audit.rs
@@ -32,9 +32,24 @@
 //!     builders see mutually incompatible capability facts and harness authors
 //!     get provider-specific surprises instead of one normalized toolchain.
 //!
-//! Both checks are driven entirely by capability-row fields, so adding a new
-//! footgun route is a data edit (set the flag / forget the pin) rather than a
-//! code change — and forgetting the pin trips this gate.
+//!   * **native-unreliable family consistency** — for a model family whose
+//!     provider-native tool channel is unreliable as a *weight-intrinsic*
+//!     property (it leaks tool markup into content / bills empty native
+//!     completions on every host that serves those weights), EVERY route must
+//!     steer to a text channel. A single outlier host pinning
+//!     `preferred_tool_format = "native"` while its siblings pin text is exactly
+//!     how a value model silently thrashes on one provider. This is the only
+//!     check keyed on a model-family substring (see
+//!     [`NATIVE_UNRELIABLE_TOOL_FAMILIES`]) rather than pure capability fields,
+//!     and the bar to add a family is deliberately high: weight-intrinsic
+//!     unreliability reproduced across independent hosts, never one rehoster's
+//!     flakiness (which belongs in that host's own row).
+//!
+//! The first three checks are driven entirely by capability-row fields and the
+//! fourth by a tiny evidence-gated family list, so adding/closing a footgun
+//! route is a data edit (set the flag / forget the pin / pin native for an
+//! unreliable family) rather than a code change — and the mistake trips this
+//! gate.
 //!
 //! The audit is wired into `harn provider catalog build-capabilities --check` (see
 //! `harn-cli`), which runs under `make check-provider-capabilities` /
@@ -48,6 +63,29 @@ use crate::llm::capabilities::CapabilitiesFile;
 /// channel. Mirrors the guarded set in
 /// [`crate::llm::reasoning_policy`].
 const TOOL_TASKS: [&str; 3] = ["agent", "code", "verify"];
+
+/// Model families whose **provider-native** tool channel is unreliable as a
+/// *weight-intrinsic* property — the model itself emits tool-call markup as
+/// assistant content (or bills empty native completions) on every host that
+/// serves those weights, regardless of provider. For such a family, EVERY route
+/// must steer to a text channel (`preferred_tool_format` = `text`/`json`) and
+/// declare `tool_mode_parity = "native_unreliable"`; a route that pins
+/// `preferred_tool_format = "native"` is a footgun (it re-opens the leak this
+/// host can't fix server-side). Each entry is `(model_match-substring, evidence)`.
+///
+/// The bar for entry is HIGH on purpose: a quirk earns a row here only when it is
+/// demonstrated to be intrinsic to the weights (reproduced across independent
+/// hosts), NOT merely observed on one rehoster. Host-specific native flakiness
+/// belongs in that host's own row, not this cross-host invariant — e.g. a
+/// first-party authoritative endpoint may serve native cleanly while third-party
+/// rehosters do not, and that difference must be measured per host, not assumed.
+const NATIVE_UNRELIABLE_TOOL_FAMILIES: &[(&str, &str)] = &[(
+    "glm-5",
+    "GLM-5.x's native channel emits `<tool_call><arg_key>...` markup as assistant \
+     content instead of OpenAI message.tool_calls — reproduced across every GLM-5 host \
+     probed (zai/Baseten live, Together + OpenRouter agent-loop smoke, DeepInfra, Fireworks \
+     glm-5p*). Pin a text channel + tool_mode_parity = \"native_unreliable\".",
+)];
 
 /// A single footgun finding: a capability row that violates an opinionated
 /// provider/model/config invariant.
@@ -189,6 +227,37 @@ pub fn audit_capabilities(file: &CapabilitiesFile) -> CapabilityAuditReport {
                         tool-choice declaration."
                         .to_string(),
                 });
+            }
+
+            // Footgun 4: a route pins the provider-native tool channel for a model
+            // family whose native channel is unreliable as a weight-intrinsic
+            // property (see NATIVE_UNRELIABLE_TOOL_FAMILIES). One outlier host
+            // pinning `native` while every sibling host pins text is exactly how a
+            // value model silently thrashes (the model leaks tool markup into
+            // content / bills empty native completions, and this host can't fix it
+            // server-side). The family verdict must hold on every route.
+            let pins_native = rule
+                .preferred_tool_format
+                .as_deref()
+                .map(|format| format.eq_ignore_ascii_case("native"))
+                .unwrap_or(false);
+            if pins_native {
+                let model_match_lower = rule.model_match.to_ascii_lowercase();
+                for (family, evidence) in NATIVE_UNRELIABLE_TOOL_FAMILIES {
+                    if model_match_lower.contains(family) {
+                        report.footguns.push(CapabilityFootgun {
+                            provider: provider.clone(),
+                            model_match: rule.model_match.clone(),
+                            message: format!(
+                                "pins preferred_tool_format = \"native\" for the \
+                                 native-unreliable `{family}` family. {evidence} Steer this \
+                                 route to a text channel (preferred_tool_format = \"text\" or \
+                                 \"json\") and set tool_mode_parity = \"native_unreliable\" so \
+                                 the family verdict is consistent across hosts."
+                            ),
+                        });
+                    }
+                }
             }
         }
     }
@@ -337,6 +406,55 @@ preferred_tool_format = "native"
         assert!(report.footguns[0]
             .message
             .contains("preferred_tool_format = \"native\""));
+    }
+
+    #[test]
+    fn flags_native_unreliable_family_pinning_native() {
+        // A GLM-5 route that pins the native channel (the nvidia outlier shape):
+        // native_tools = true keeps Footgun 3 quiet, so the ONLY footgun is the
+        // family-consistency gate.
+        let report = audit_toml(
+            r#"
+[[provider.nvidia]]
+model_match = "*glm-5*"
+native_tools = true
+preferred_tool_format = "native"
+"#,
+        );
+        assert_eq!(report.footguns.len(), 1, "{}", report.render());
+        assert!(report.footguns[0]
+            .message
+            .contains("native-unreliable `glm-5` family"));
+    }
+
+    #[test]
+    fn native_unreliable_family_on_text_channel_is_clean() {
+        // The family verdict satisfied: text channel + native_unreliable.
+        let report = audit_toml(
+            r#"
+[[provider.nvidia]]
+model_match = "*glm-5*"
+native_tools = true
+preferred_tool_format = "text"
+tool_mode_parity = "native_unreliable"
+"#,
+        );
+        assert!(report.is_clean(), "{}", report.render());
+    }
+
+    #[test]
+    fn native_pin_for_non_family_model_is_clean() {
+        // A native pin is fine for a model NOT in the native-unreliable family
+        // list — the gate is scoped to families with weight-intrinsic evidence.
+        let report = audit_toml(
+            r#"
+[[provider.someprov]]
+model_match = "some-reliable-native-model-*"
+native_tools = true
+preferred_tool_format = "native"
+"#,
+        );
+        assert!(report.is_clean(), "{}", report.render());
     }
 
     #[test]

--- a/crates/harn-vm/src/llm/capability_sources/20-providers/38-nvidia.toml
+++ b/crates/harn-vm/src/llm/capability_sources/20-providers/38-nvidia.toml
@@ -146,7 +146,9 @@ thinking_block_style = "inline"
 [[provider.nvidia]]
 model_match = "*glm-5*"
 native_tools = true
-preferred_tool_format = "native"
+preferred_tool_format = "text"
+tool_mode_parity = "native_unreliable"
+tool_mode_parity_notes = "GLM-5.x's native channel emits `<tool_call><arg_key>...` markup as content instead of OpenAI message.tool_calls — a weight-intrinsic behavior reproduced across every GLM-5 host probed (zai/Baseten live, Together + OpenRouter agent-loop smoke, DeepInfra, Fireworks glm-5p*). NVIDIA serves the same weights, so the same leak applies; pin the clean heredoc text channel for family parity. Flagged by the native_unreliable-family consistency gate."
 structured_output = "native"
 thinking_modes = ["enabled"]
 prompt_caching = true

--- a/docs/src/provider-matrix.md
+++ b/docs/src/provider-matrix.md
@@ -118,7 +118,7 @@ Regenerate with `make gen-provider-matrix` and verify with `make check-provider-
 | `nvidia` | `*minimax-m3*` | `any` | `adaptive` | yes | no | no | yes | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `nvidia` | `*minimax-m2.7*` | `any` | `enabled` | no | no | no | no | yes | no | `delimited` | `markdown` | `delimited` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
 | `nvidia` | `*kimi-k2.6*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
-| `nvidia` | `*glm-5*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | yes |
+| `nvidia` | `*glm-5*` | `any` | `enabled` | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `text` | yes | yes | `native_unreliable` | yes | yes |
 | `nvidia` | `*step-3.7-flash*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `interchangeable` | yes | yes |
 | `nvidia` | `*mistral*` | `any` | no | no | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `none` | `native` | yes | yes | `unknown` | yes | no |
 | `nvidia` | `*gemma-4*` | `any` | `enabled` | yes | no | no | no | yes | no | `native` | `markdown` | `native_json` | no | `system` | `json` | `inline` | `native` | yes | yes | `unknown` | yes | no |
@@ -318,7 +318,7 @@ This section starts from the checked-in provider catalog. Recommended format fol
 | `nvidia` | `nvidia/openai/gpt-oss-120b` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `nvidia` | `nvidia/openai/gpt-oss-20b` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
 | `nvidia` | `nvidia/step-3.7-flash` | `native` | `interchangeable` | - | - | - | - | - | `data not yet collected` |
-| `nvidia` | `nvidia/z-ai/glm-5.1` | `native` | `unknown` | - | - | - | - | - | `data not yet collected` |
+| `nvidia` | `nvidia/z-ai/glm-5.1` | `text` | `native_unreliable` | - | - | - | - | - | `data not yet collected` |
 | `ollama` | `devstral-small-2:24b` | `json` | `text_only` | - | - | - | - | - | `data not yet collected` |
 | `ollama` | `gemma4:12b-mlx` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |
 | `ollama` | `gemma4:12b-mxfp8` | `text` | `text_only` | - | - | - | - | - | `data not yet collected` |

--- a/spec/provider-catalog/provider-catalog.json
+++ b/spec/provider-catalog/provider-catalog.json
@@ -8626,8 +8626,9 @@
       "tool_support": {
         "native": true,
         "text": true,
-        "preferred_format": "native",
-        "parity": "unknown",
+        "preferred_format": "text",
+        "parity": "native_unreliable",
+        "parity_notes": "GLM-5.x's native channel emits `<tool_call><arg_key>...` markup as content instead of OpenAI message.tool_calls — a weight-intrinsic behavior reproduced across every GLM-5 host probed (zai/Baseten live, Together + OpenRouter agent-loop smoke, DeepInfra, Fireworks glm-5p*). NVIDIA serves the same weights, so the same leak applies; pin the clean heredoc text channel for family parity. Flagged by the native_unreliable-family consistency gate.",
         "tool_search": []
       },
       "structured_output": "native",


### PR DESCRIPTION
## Make "one tool-parity verdict per model" a CI invariant

Value models like **GLM-5.2** are unreliable on the provider-native tool channel as a **weight-intrinsic** property: GLM-5.x emits `<tool_call><arg_key>...` markup as assistant *content* instead of OpenAI `message.tool_calls` on every host that serves the weights (reproduced zai/Baseten live, Together + OpenRouter agent-loop smoke, DeepInfra, Fireworks `glm-5p*`). The whole family is correctly pinned `text` + `tool_mode_parity = "native_unreliable"` — **except NVIDIA**, which pinned `preferred_tool_format = "native"`. That lone outlier silently re-opens the markup leak: the value model works on five hosts and thrashes on the sixth, with nothing flagging it.

### Change
- **New capability_audit footgun** (`NATIVE_UNRELIABLE_TOOL_FAMILIES`): for a curated, evidence-gated family list (currently `glm-5`), any route pinning the native tool channel fails the audit. The bar to add a family is deliberately high — weight-intrinsic unreliability reproduced across **independent** hosts, never one rehoster's flakiness. This is the one check keyed on a model-family substring rather than pure capability fields, and the doc + the const comment say so explicitly.
- **Fix the NVIDIA `*glm-5*` row** → text + `native_unreliable`, matching the family. Regenerated `capabilities.toml`.

### Why this is the DRY abstraction
Harn already resolves quirks declaratively via the capability matrix + `validate_tool_format`. This closes the last gap for value models: a single mis-pinned provider can no longer make a model silently thrash. Adding/closing a footgun stays a **data edit**; the gate catches the mistake in CI.

### Deliberately NOT touched — Qwen-3.6 hosted routes (routed to measurement)
DeepInfra `qwen3.6` is pinned text/`native_unreliable` with N=5 evidence, but **DashScope** (Qwen's authoritative first-party host) pins `native`. Whether DashScope's native is *actually* unreliable is a per-host question that needs **measurement**, not inference from a third-party rehoster — a first-party endpoint may serve native cleanly. Flipping it blind would be an unmeasured routing change. Flagged for the meter lane instead of guessed.

### Verification
- `cargo test -p harn-vm --lib capability_audit` → 14/14 incl. the 3 new Footgun-4 tests and `shipped_matrix_has_no_footguns` (regenerated matrix clean — no remaining native-pinned glm-5 rows, no false positives).
- `make check-provider-capabilities` → snapshot up to date (drift clean). `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)