### PR TITLE
fix: surface config I/O errors, throw on bad ed25519 key, DRY + polish

### DIFF
--- a/changelog.d/3731.fixed.md
+++ b/changelog.d/3731.fixed.md
@@ -1,0 +1,1 @@
+Surface real `harn.toml` read errors (permission denied, bad symlink) instead of silently falling back to default config, and make `ed25519_verify` throw on malformed public-key input (wrong length / non-hex) instead of reporting it as a failed signature.

--- a/conformance/tests/stdlib/agent_probe.harn
+++ b/conformance/tests/stdlib/agent_probe.harn
@@ -79,7 +79,7 @@ pipeline test_agent_probe(_task) {
   // --- stub kinds return unknown with confidence 0.4
   let test_stub = probe("test", "anything", opts + {now: "2026-05-23T22:00:06Z"})
   assert_eq(test_stub.outcome, "unknown")
-  assert(contains(test_stub.observed, "not yet implemented"))
+  assert(contains(test_stub.observed, "not supported"))
   let inspect_stub = probe("Inspect", "anything", opts + {now: "2026-05-23T22:00:07Z"})
   assert_eq(inspect_stub.outcome, "unknown")
   // --- validation errors

--- a/crates/harn-cli/src/commands/connector.rs
+++ b/crates/harn-cli/src/commands/connector.rs
@@ -1782,7 +1782,7 @@ pub fn payload_schema() {
 }
 
 pub fn init(ctx) {
-  if ctx.capabilities.secret_get != true {
+  if !ctx.capabilities.secret_get {
     throw "secret_get capability missing"
   }
 }

--- a/crates/harn-cli/src/config.rs
+++ b/crates/harn-cli/src/config.rs
@@ -134,7 +134,6 @@ pub enum ConfigError {
         path: PathBuf,
         message: String,
     },
-    #[allow(dead_code)]
     Io {
         path: PathBuf,
         error: std::io::Error,
@@ -201,7 +200,19 @@ pub fn load_for_path(start: &Path) -> Result<HarnConfig, ConfigError> {
 fn parse_manifest(path: &Path) -> Result<HarnConfig, ConfigError> {
     let content = match fs::read_to_string(path) {
         Ok(c) => c,
-        Err(_) => return Ok(HarnConfig::default()),
+        // The manifest existed at `is_file()` time; if it vanished in the
+        // race window, fall back to defaults. Any other I/O error (permission
+        // denied, bad symlink) is surfaced so a misconfigured manifest never
+        // silently degrades to default config.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(HarnConfig::default());
+        }
+        Err(error) => {
+            return Err(ConfigError::Io {
+                path: path.to_path_buf(),
+                error,
+            });
+        }
     };
     let raw: RawManifest = toml::from_str(&content).map_err(|e| ConfigError::Parse {
         path: path.to_path_buf(),

--- a/crates/harn-hostlib/src/fs.rs
+++ b/crates/harn-hostlib/src/fs.rs
@@ -261,6 +261,15 @@ fn sessions() -> &'static Mutex<BTreeMap<String, SessionState>> {
     SESSIONS.get_or_init(|| Mutex::new(BTreeMap::new()))
 }
 
+/// Lock the session map, panicking with one canonical message if a prior
+/// holder poisoned the mutex. Every accessor goes through here so the poison
+/// policy and message live in exactly one place.
+fn lock_sessions() -> std::sync::MutexGuard<'static, BTreeMap<String, SessionState>> {
+    sessions()
+        .lock()
+        .expect("hostlib fs session mutex poisoned")
+}
+
 /// Remember the workspace root associated with a live session.
 ///
 /// ACP calls this when a prompt starts so Harn code can call
@@ -270,9 +279,7 @@ pub fn configure_session_root(session_id: &str, root: &Path) {
         return;
     }
     let root = normalize_logical(root);
-    let mut guard = sessions()
-        .lock()
-        .expect("hostlib fs session mutex poisoned");
+    let mut guard = lock_sessions();
     match guard.get_mut(session_id) {
         Some(state) if state.entries.is_empty() => {
             state.root = root;
@@ -295,9 +302,7 @@ pub fn configured_session_root(session_id: &str) -> Option<PathBuf> {
     if session_id.trim().is_empty() {
         return None;
     }
-    let guard = sessions()
-        .lock()
-        .expect("hostlib fs session mutex poisoned");
+    let guard = lock_sessions();
     guard.get(session_id).map(|state| state.root.clone())
 }
 
@@ -308,9 +313,7 @@ pub fn set_mode(
     root: Option<&Path>,
 ) -> Result<SetModeResult, HostlibError> {
     validate_session_id(SET_MODE_BUILTIN, session_id)?;
-    let mut guard = sessions()
-        .lock()
-        .expect("hostlib fs session mutex poisoned");
+    let mut guard = lock_sessions();
     let mut state = state_for_locked(&mut guard, session_id, root.map(normalize_logical))?;
     let previous_mode = state.mode;
     state.mode = mode;
@@ -325,9 +328,7 @@ pub fn set_mode(
 /// Return the staged status for a session.
 pub fn staged_status(session_id: &str) -> Result<StagedStatus, HostlibError> {
     validate_session_id(STATUS_BUILTIN, session_id)?;
-    let mut guard = sessions()
-        .lock()
-        .expect("hostlib fs session mutex poisoned");
+    let mut guard = lock_sessions();
     let state = state_for_locked(&mut guard, session_id, None)?;
     let status = status_from_state(&state);
     guard.insert(session_id.to_string(), state);
@@ -337,9 +338,7 @@ pub fn staged_status(session_id: &str) -> Result<StagedStatus, HostlibError> {
 /// Commit staged changes for all paths or for a filtered path list.
 pub fn commit_staged(session_id: &str, paths: &[String]) -> Result<CommitResult, HostlibError> {
     validate_session_id(COMMIT_BUILTIN, session_id)?;
-    let mut guard = sessions()
-        .lock()
-        .expect("hostlib fs session mutex poisoned");
+    let mut guard = lock_sessions();
     let mut state = state_for_locked(&mut guard, session_id, None)?;
     let selected = selected_paths(&state, paths);
     let mut committed_paths = Vec::new();
@@ -387,9 +386,7 @@ pub fn commit_staged(session_id: &str, paths: &[String]) -> Result<CommitResult,
 /// Discard staged changes for all paths or for a filtered path list.
 pub fn discard_staged(session_id: &str, paths: &[String]) -> Result<DiscardResult, HostlibError> {
     validate_session_id(DISCARD_BUILTIN, session_id)?;
-    let mut guard = sessions()
-        .lock()
-        .expect("hostlib fs session mutex poisoned");
+    let mut guard = lock_sessions();
     let mut state = state_for_locked(&mut guard, session_id, None)?;
     let selected = selected_paths(&state, paths);
     let mut discarded_paths = Vec::new();
@@ -415,9 +412,7 @@ pub fn discard_staged(session_id: &str, paths: &[String]) -> Result<DiscardResul
 /// their preview is rendered.
 pub fn remove_session_state(session_id: &str, root: Option<&Path>) -> Result<(), HostlibError> {
     validate_session_id(DISCARD_BUILTIN, session_id)?;
-    let mut guard = sessions()
-        .lock()
-        .expect("hostlib fs session mutex poisoned");
+    let mut guard = lock_sessions();
     let state = match guard.remove(session_id) {
         Some(state) => state,
         None => load_state(session_id, root.map(normalize_logical)).map_err(|err| {
@@ -443,9 +438,7 @@ pub(crate) fn read(
     explicit_session_id: Option<&str>,
 ) -> Option<std::io::Result<Vec<u8>>> {
     let session_id = active_session_id(explicit_session_id)?;
-    let mut guard = sessions()
-        .lock()
-        .expect("hostlib fs session mutex poisoned");
+    let mut guard = lock_sessions();
     let state = state_for_locked(&mut guard, &session_id, None).ok()?;
     let result = if state.mode == FsMode::Staged {
         overlay_read(&state, path)
@@ -474,9 +467,7 @@ pub(crate) fn read_dir(
     explicit_session_id: Option<&str>,
 ) -> Option<std::io::Result<Vec<OverlayDirEntry>>> {
     let session_id = active_session_id(explicit_session_id)?;
-    let mut guard = sessions()
-        .lock()
-        .expect("hostlib fs session mutex poisoned");
+    let mut guard = lock_sessions();
     let state = state_for_locked(&mut guard, &session_id, None).ok()?;
     let result = if state.mode == FsMode::Staged {
         Some(overlay_read_dir(&state, path))
@@ -498,9 +489,7 @@ pub(crate) fn stage_write_or_none(
     let Some(session_id) = active_session_id(explicit_session_id) else {
         return Ok(None);
     };
-    let mut guard = sessions()
-        .lock()
-        .expect("hostlib fs session mutex poisoned");
+    let mut guard = lock_sessions();
     let mut state = state_for_locked(&mut guard, &session_id, None)?;
     if state.mode != FsMode::Staged {
         guard.insert(session_id, state);
@@ -557,9 +546,7 @@ pub(crate) fn stage_delete_or_none(
     let Some(session_id) = active_session_id(explicit_session_id) else {
         return Ok(None);
     };
-    let mut guard = sessions()
-        .lock()
-        .expect("hostlib fs session mutex poisoned");
+    let mut guard = lock_sessions();
     let mut state = state_for_locked(&mut guard, &session_id, None)?;
     if state.mode != FsMode::Staged {
         guard.insert(session_id, state);
@@ -720,9 +707,7 @@ fn safe_text_patch_staged(
     let Some(session) = active_session_id(session_id) else {
         return Ok(None);
     };
-    let mut guard = sessions()
-        .lock()
-        .expect("hostlib fs session mutex poisoned");
+    let mut guard = lock_sessions();
     let mut state = state_for_locked(&mut guard, &session, None)?;
     if state.mode != FsMode::Staged {
         guard.insert(session, state);

--- a/crates/harn-stdlib/src/stdlib/agent/probe.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/probe.harn
@@ -350,7 +350,7 @@ fn __probe_envelope(kind, outcome, observed, evidence, opts) -> ProbeResult {
 }
 
 fn __probe_unsupported(kind, body, opts) -> ProbeResult {
-  let observed = "probe kind `" + kind + "` is not yet implemented (MVP supports eval, typecheck)"
+  let observed = "probe kind `" + kind + "` is not supported (supported kinds: eval, typecheck)"
   let evidence = __probe_evidence(kind, body, nil, observed, nil, nil)
   return __probe_envelope(kind, "unknown", observed, evidence, opts)
 }

--- a/crates/harn-vm/src/stdlib/crypto.rs
+++ b/crates/harn-vm/src/stdlib/crypto.rs
@@ -1209,24 +1209,35 @@ fn ed25519_verify_impl(args: &[VmValue], _out: &mut String) -> Result<VmValue, V
     let msg = bytes_or_string_input(Some(&args[1]))?;
     let sig_hex = args[2].display();
 
-    let pub_bytes = match hex::decode(&pub_hex) {
-        Ok(b) => b,
-        Err(_) => return Ok(VmValue::Bool(false)),
-    };
+    // The public key is the caller's trusted reference material. Malformed key
+    // input is a programming error (wrong variable, hex/base64 mixup), so we
+    // throw rather than silently report "verification failed" forever. The
+    // signature, by contrast, is the untrusted thing being checked: a bad-hex
+    // or wrong-length signature simply does not verify (`false`), and we never
+    // throw on attacker-controlled input.
+    let pub_bytes = hex::decode(&pub_hex).map_err(|e| {
+        VmError::Thrown(VmValue::String(arcstr::ArcStr::from(format!(
+            "ed25519_verify: public_hex is not valid hex: {e}"
+        ))))
+    })?;
+    let pub_arr: [u8; 32] = pub_bytes.as_slice().try_into().map_err(|_| {
+        VmError::Thrown(VmValue::String(arcstr::ArcStr::from(format!(
+            "ed25519_verify: public key must be 32 bytes, got {}",
+            pub_bytes.len()
+        ))))
+    })?;
+    let verifying = VerifyingKey::from_bytes(&pub_arr).map_err(|e| {
+        VmError::Thrown(VmValue::String(arcstr::ArcStr::from(format!(
+            "ed25519_verify: invalid public key: {e}"
+        ))))
+    })?;
+
     let sig_bytes = match hex::decode(&sig_hex) {
         Ok(b) => b,
         Err(_) => return Ok(VmValue::Bool(false)),
     };
-    let pub_arr: [u8; 32] = match pub_bytes.as_slice().try_into() {
-        Ok(a) => a,
-        Err(_) => return Ok(VmValue::Bool(false)),
-    };
     let sig_arr: [u8; 64] = match sig_bytes.as_slice().try_into() {
         Ok(a) => a,
-        Err(_) => return Ok(VmValue::Bool(false)),
-    };
-    let verifying = match VerifyingKey::from_bytes(&pub_arr) {
-        Ok(v) => v,
         Err(_) => return Ok(VmValue::Bool(false)),
     };
     let signature = Signature::from_bytes(&sig_arr);


### PR DESCRIPTION
A bundle of small, independently-verified correctness/quality fixes from a recon pass over the toolchain at HEAD.

### 1. `config`: stop silently swallowing manifest read errors *(bug)*
`parse_manifest` is only reached after `candidate.is_file()` succeeds, yet it mapped **every** read error to `Ok(HarnConfig::default())`. A `harn.toml` that exists but can't be read (permission denied, bad symlink, deleted mid-race) silently degraded to default config — the classic "my config isn't taking effect" mystery. Now real I/O errors surface via the existing `ConfigError::Io` variant (which was dead — carrying `#[allow(dead_code)]`); only `NotFound` (the race window) stays graceful. Retires the dead-code allow.

### 2. `crypto`: `ed25519_verify` throws on malformed *public key* *(robustness)*
The builtin collapsed all failure modes to `false`, so a malformed public key (wrong variable, hex/base64 mixup) presented as a forever-failing signature. Now malformed **public-key** material throws (a caller bug worth surfacing), while malformed/wrong-length **signatures** still return `false` and **never throw** — they're untrusted input, so failing verification (not raising) is the security-correct, DoS-safe behavior. Valid-key + real-mismatch behavior is unchanged (conformance still green).

### 3. `connector` scaffold: don't emit lint-failing code *(consistency)*
`harn connector new` emitted `if ctx.capabilities.secret_get != true`, which trips Harn's own `comparison-to-bool` lint on the user's first `harn lint`. Emit `if !ctx.capabilities.secret_get` — matching the canonical `notion` connector fixture.

### 4. `hostlib fs`: DRY the session lock *(refactor)*
Collapse 12 copies of `sessions().lock().expect("hostlib fs session mutex poisoned")` into one `lock_sessions()` helper.

### 5. `probe`: drop pre-1.0 hedging prose *(polish)*
`"… is not yet implemented (MVP supports eval, typecheck)"` → `"… is not supported (supported kinds: eval, typecheck)"`.

## Verification
- `cargo check -p harn-vm -p harn-hostlib -p harn-cli` → clean
- `cargo clippy` (same crates) → clean
- `cargo fmt --check` + `harn fmt --check` (changed `.harn`) → clean
- `harn test conformance --filter agent_probe` → PASS (assertion updated to new message)
- `harn test conformance --filter crypto_modern` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)