### PR TITLE
ci: link Linux Rust with mold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,15 @@ jobs:
     # the macOS lane mirrors that decision.
     env:
       CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      # Link the Linux Rust lanes with mold. These jobs are link-bound
+      # (~99% sccache hit, so the stock GNU `ld` link is the wall-clock floor);
+      # mold is a drop-in faster linker. GOTCHA: a job-level RUSTFLAGS env var
+      # FULLY REPLACES the workflow-level `-D warnings` (env vars clobber, they
+      # do not merge — and they also clobber any `.cargo/config.toml` rustflags,
+      # of which there are none), so `-D warnings` is re-stated here and the mold
+      # link-arg appended. Linux-only: the windows/macos jobs never see this and
+      # keep the workflow-level `-D warnings`.
+      RUSTFLAGS: "-D warnings -Clink-arg=-fuse-ld=mold"
     strategy:
       fail-fast: true
       matrix:
@@ -160,6 +169,22 @@ jobs:
         with:
           fetch-depth: ${{ matrix.fetch_depth }}
       - uses: ./.github/actions/free-disk-space
+      # Install mold and steer rustc at it via RUSTFLAGS above. apt's `mold`
+      # only drops the binary in PATH; it does NOT replace /usr/bin/ld, so the
+      # stock linker stays intact and rustc opts in explicitly through the
+      # `-fuse-ld=mold` link-arg. ubuntu-latest's gcc cc-driver (>=12) supports
+      # `-fuse-ld=mold` directly. Mirrors the apt install used by burin-code.
+      - name: Install mold linker
+        timeout-minutes: 5
+        run: |
+          set -euo pipefail
+          if command -v mold >/dev/null 2>&1; then
+            mold --version
+            exit 0
+          fi
+          sudo apt-get update
+          sudo apt-get install -y mold
+          mold --version
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         if: matrix.rust_components == ''
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -311,12 +336,31 @@ jobs:
     # from the same link-time/disk trim.
     env:
       CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      # Link with mold, same as rust-builds (see that job's RUSTFLAGS note:
+      # job-level RUSTFLAGS clobbers the workflow `-D warnings`, so re-state it
+      # and append the mold link-arg). Linux-only.
+      RUSTFLAGS: "-D warnings -Clink-arg=-fuse-ld=mold"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Full history + tags so the changelog retroactive-edit check can
           # traverse BASE..HEAD and inspect commit trailers.
           fetch-depth: 0
+      # Install mold early so the later `cargo run --bin harn` link steps use
+      # it. apt's `mold` does not replace /usr/bin/ld; rustc opts in via the
+      # `-fuse-ld=mold` RUSTFLAGS link-arg above. Mirrors burin-code's apt
+      # install.
+      - name: Install mold linker
+        timeout-minutes: 5
+        run: |
+          set -euo pipefail
+          if command -v mold >/dev/null 2>&1; then
+            mold --version
+            exit 0
+          fi
+          sudo apt-get update
+          sudo apt-get install -y mold
+          mold --version
       # check-bindings runs the published Python and Go protocol bindings
       # against the committed JSON fixture. ubuntu-latest ships python3 and
       # go preinstalled, so no setup action is required.


### PR DESCRIPTION
## What

Adopt the [mold](https://github.com/rui314/mold) linker for harn's two Linux Rust CI lanes: `rust-builds` (matrix `lint`/`test`/`audit`) and `audit-scripts`. Both are `ubuntu-latest` and were linking with the stock GNU `ld`.

## Why

Prior analysis showed these jobs are **link-bound**: with ~99% sccache compile-hit, the remaining wall-clock floor is link time, not codegen. mold is a drop-in faster linker, so steering rustc at it is the highest-leverage CI speedup available here. (mold/lld/`-fuse-ld` appeared nowhere in the repo before this change — the lanes were on stock `ld`.)

## How

Each Linux lane gets an early `Install mold linker` step (apt, mirroring burin-code's existing install for the same harn-linked use case — no new third-party action, so the actions-hygiene/zizmor pin gate stays clean) and is steered at mold via `-Clink-arg=-fuse-ld=mold` in RUSTFLAGS.

`apt`'s `mold` only adds the binary to PATH; it does **not** replace `/usr/bin/ld` (equivalent to `make-default: false`), so the stock linker stays intact and rustc opts in explicitly. ubuntu-latest's gcc cc-driver (>=12) supports `-fuse-ld=mold` directly.

### RUSTFLAGS-vs-config.toml clobber gotcha

A **job-level** `RUSTFLAGS` env var **fully replaces** the workflow-level `RUSTFLAGS: "-D warnings"` (env vars clobber, they do not merge) — and would equally clobber any `.cargo/config.toml` `rustflags` (there are none on `main`; sccache is wired via the `configure-cargo-sccache` composite, not config.toml). So each Linux lane re-states `-D warnings` and appends the mold link-arg:

```
RUSTFLAGS: "-D warnings -Clink-arg=-fuse-ld=mold"
```

The existing `-D warnings` is preserved (never dropped), and no `-D warnings` is introduced anywhere it wasn't before.

### Scoped Linux-only

mold and the link-arg live in the `rust-builds` and `audit-scripts` **job** `env:` blocks only — never the workflow-level `env:` (a global RUSTFLAGS would break windows/macos). The `windows` job keeps inheriting the workflow `-D warnings` (no mold); the `macos` job keeps its own `-D warnings` (no mold). macOS already uses Apple's fast linker; mold is Linux-only.

## Validation

The real win is **CI-observable link time** on this PR — not measurable locally. The change **fails safe**: if mold is missing or the flag is wrong, the link step errors and CI goes red, so the merge queue won't merge a broken build. Local checks: `ci.yml` parses as YAML and `actionlint` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)