### PR TITLE
test: fix env-var data race + cut wall-clock test sleeps

### DIFF
--- a/crates/harn-cli/tests/orchestrator_http/support.rs
+++ b/crates/harn-cli/tests/orchestrator_http/support.rs
@@ -708,7 +708,25 @@ pub(super) async fn await_topic_event_after(
         }
     })
     .await;
-    result.unwrap_or_else(|_| panic!("timed out waiting for matching {topic} event"))
+    match result {
+        Ok(event) => event,
+        Err(_) => {
+            let recent = event_log
+                .read_range(&topic_obj, None, usize::MAX)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .rev()
+                .take(8)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .map(|(event_id, event)| format!("#{event_id:?} {} {}", event.kind, event.payload))
+                .collect::<Vec<_>>()
+                .join(" | ");
+            panic!("timed out waiting for matching {topic} event; recent events: {recent}");
+        }
+    }
 }
 
 /// Read all events for a topic from the event log.
@@ -730,8 +748,13 @@ pub(super) async fn read_topic_events(
 /// finished, so reading any handler-written marker file is race-free.
 pub(super) async fn await_pump_dispatch_completed(harness: &OrchestratorHarness) {
     await_topic_event(&harness.event_log(), "orchestrator.lifecycle", |event| {
-        event.kind == "pump_dispatch_completed"
-            && event.payload["status"] == serde_json::json!("completed")
+        match pump_dispatch_status(event) {
+            Some("completed") => true,
+            Some("failed") => {
+                panic!("pump dispatch failed: {}", event.payload);
+            }
+            _ => false,
+        }
     })
     .await;
 }
@@ -740,11 +763,10 @@ pub(super) async fn await_pump_dispatch_completed(harness: &OrchestratorHarness)
 /// `dispatched` count reaches `count`. Useful when several events feed the
 /// same pump and you need to wait for the Nth to drain.
 pub(super) async fn await_pump_dispatch_count(harness: &OrchestratorHarness, count: u64) {
-    let mut topic_obj = Topic::new("orchestrator.lifecycle").unwrap();
-    let _ = &mut topic_obj;
+    let topic = Topic::new("orchestrator.lifecycle").unwrap();
     let mut stream = harness
         .event_log()
-        .subscribe(&Topic::new("orchestrator.lifecycle").unwrap(), None)
+        .subscribe(&topic, None)
         .await
         .expect("subscribe lifecycle");
     let mut total: u64 = 0;
@@ -755,19 +777,33 @@ pub(super) async fn await_pump_dispatch_count(harness: &OrchestratorHarness, cou
                 .await
                 .expect("lifecycle stream ended")
                 .expect("lifecycle stream error");
-            if event.kind == "pump_dispatch_completed"
-                && event.payload["status"] == serde_json::json!("completed")
-            {
-                let dispatched = event.payload["dispatched"].as_u64().unwrap_or(0);
-                total = total.saturating_add(dispatched);
-                if total >= count {
-                    return;
+            match pump_dispatch_status(&event) {
+                Some("completed") => {
+                    let dispatched = event.payload["dispatched"].as_u64().unwrap_or(0);
+                    total = total.saturating_add(dispatched);
+                    if total >= count {
+                        return;
+                    }
                 }
+                Some("failed") => {
+                    panic!(
+                        "pump dispatch failed before reaching {count}: {}",
+                        event.payload
+                    );
+                }
+                _ => {}
             }
         }
     })
     .await
     .unwrap_or_else(|_| panic!("timed out waiting for {count} pump dispatches; got {total}"));
+}
+
+fn pump_dispatch_status(event: &LogEvent) -> Option<&str> {
+    if event.kind != "pump_dispatch_completed" {
+        return None;
+    }
+    event.payload.get("status").and_then(JsonValue::as_str)
 }
 
 /// Wait until `path` exists, polling at the approved cadence. The

--- a/crates/harn-guard/src/resolve.rs
+++ b/crates/harn-guard/src/resolve.rs
@@ -37,13 +37,15 @@ mod tests {
 
     #[test]
     fn empty_selector_resolves_to_none() {
-        let store = GuardStore::at_root(std::env::temp_dir().join("harn-guard-resolve-empty"));
+        let tmp = tempfile::tempdir().unwrap();
+        let store = GuardStore::at_root(tmp.path().to_path_buf());
         assert!(resolve_dir(&store, "").unwrap().is_none());
     }
 
     #[test]
     fn uninstalled_catalog_name_is_none_not_error() {
-        let store = GuardStore::at_root(std::env::temp_dir().join("harn-guard-resolve-missing"));
+        let tmp = tempfile::tempdir().unwrap();
+        let store = GuardStore::at_root(tmp.path().to_path_buf());
         assert!(resolve_dir(&store, "deberta-v3-prompt-injection-v2")
             .unwrap()
             .is_none());
@@ -51,7 +53,8 @@ mod tests {
 
     #[test]
     fn nonexistent_path_selector_errors() {
-        let store = GuardStore::at_root(std::env::temp_dir().join("harn-guard-resolve-path"));
+        let tmp = tempfile::tempdir().unwrap();
+        let store = GuardStore::at_root(tmp.path().to_path_buf());
         let missing = store.root().join("no-such").join("guard-model-dir");
         let selector = missing.to_string_lossy();
         let err = resolve_dir(&store, &selector).unwrap_err();

--- a/crates/harn-hostlib/tests/process_tools_e2e.rs
+++ b/crates/harn-hostlib/tests/process_tools_e2e.rs
@@ -15,11 +15,25 @@
 
 #![cfg(unix)]
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use harn_hostlib::tools::ToolsCapability;
 use harn_hostlib::{BuiltinRegistry, HostlibCapability, HostlibError};
 use harn_vm::VmValue;
+
+/// Serializes the tests in this binary that mutate process-wide environment
+/// variables. `std::env::set_var` / `remove_var` are not thread-safe (and are
+/// `unsafe` under the 2024 edition): without this lock libtest's threaded
+/// runner can tear a sibling test's env read, leak a secret var across tests,
+/// or, rarely, segfault. Every env-mutating test below acquires this guard and
+/// holds it for its full duration.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn lock_env() -> MutexGuard<'static, ()> {
+    ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 fn registry() -> BuiltinRegistry {
     let mut registry = BuiltinRegistry::new();
@@ -96,9 +110,12 @@ fn real_run_command_strips_secret_env_from_child() {
     // stdout is returned to the model. Secret-bearing vars must be stripped so
     // `run({command: "env"})` can't surface provider keys / tokens.
     //
-    // SAFETY: setting/removing process-wide env vars is not thread-safe in
-    // general, but these names are unique to this test and removed before it
-    // returns, so no sibling test in this binary observes them.
+    // This test must set the secret vars on the PARENT process so the child can
+    // (attempt to) inherit them; per-`Command` `.env` wouldn't exercise the
+    // strip path. SAFETY: `ENV_LOCK` is held for the whole test, so no sibling
+    // env-mutating test runs concurrently, and the vars are removed before the
+    // guard is released.
+    let _env_guard = lock_env();
     unsafe {
         std::env::set_var("ANTHROPIC_API_KEY", "sk-test-anthropic");
         std::env::set_var("GITHUB_TOKEN", "ghp_test_github");
@@ -174,7 +191,9 @@ fn real_run_command_points_child_tmpdir_inside_the_workspace() {
 
     // OS confinement is irrelevant to this assertion (we observe the injected
     // env, not enforcement) and is unavailable on some CI hosts, so disable it.
-    // SAFETY: the slow E2E target runs serially.
+    // SAFETY: `ENV_LOCK` is held for the whole test so no sibling env-mutating
+    // test runs concurrently, and the var is removed before the guard drops.
+    let _env_guard = lock_env();
     unsafe {
         std::env::set_var("HARN_HANDLER_SANDBOX", "off");
     }
@@ -229,6 +248,9 @@ fn real_run_command_respects_a_caller_pinned_tmpdir() {
     let caller_tmp = workspace.path().join("caller-chosen");
     std::fs::create_dir_all(&caller_tmp).unwrap();
 
+    // SAFETY: `ENV_LOCK` is held for the whole test so no sibling env-mutating
+    // test runs concurrently, and the var is removed before the guard drops.
+    let _env_guard = lock_env();
     unsafe {
         std::env::set_var("HARN_HANDLER_SANDBOX", "off");
     }

--- a/crates/harn-vm/src/bytecode_cache.rs
+++ b/crates/harn-vm/src/bytecode_cache.rs
@@ -1145,7 +1145,10 @@ mod tests {
         // the `(path, len, mtime_ns)` stat key changes instantly on every
         // filesystem this runs on.
         std::fs::write(&leaf, "pub fn x() -> int { return 222 }\n").unwrap();
-        let future = std::time::UNIX_EPOCH + std::time::Duration::from_secs(4_102_444_800);
+        // Bump from the file's own current mtime by a fixed margin instead of
+        // sleeping or using a large absolute timestamp literal.
+        let future = std::fs::metadata(&leaf).unwrap().modified().unwrap()
+            + std::time::Duration::from_secs(10);
         std::fs::File::open(&leaf)
             .unwrap()
             .set_times(std::fs::FileTimes::new().set_modified(future))

--- a/crates/harn-vm/src/bytecode_cache.rs
+++ b/crates/harn-vm/src/bytecode_cache.rs
@@ -1140,10 +1140,16 @@ mod tests {
             hash_transitive_user_imports(&entry, &std::fs::read_to_string(&entry).unwrap());
 
         // Same byte length (`111` -> `222`), so the memo must rely on mtime.
-        // Sleep past the coarsest plausible mtime granularity so the stat key
-        // genuinely changes on every filesystem this runs on.
-        std::thread::sleep(std::time::Duration::from_millis(1100));
+        // Instead of sleeping out the coarsest plausible mtime granularity,
+        // push the rewritten file's mtime deterministically into the future so
+        // the `(path, len, mtime_ns)` stat key changes instantly on every
+        // filesystem this runs on.
         std::fs::write(&leaf, "pub fn x() -> int { return 222 }\n").unwrap();
+        let future = std::time::SystemTime::now() + std::time::Duration::from_secs(2);
+        std::fs::File::open(&leaf)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(future))
+            .unwrap();
         assert_eq!(
             std::fs::metadata(&leaf).unwrap().len(),
             33,

--- a/crates/harn-vm/src/bytecode_cache.rs
+++ b/crates/harn-vm/src/bytecode_cache.rs
@@ -1145,7 +1145,7 @@ mod tests {
         // the `(path, len, mtime_ns)` stat key changes instantly on every
         // filesystem this runs on.
         std::fs::write(&leaf, "pub fn x() -> int { return 222 }\n").unwrap();
-        let future = std::time::SystemTime::now() + std::time::Duration::from_secs(2);
+        let future = std::time::UNIX_EPOCH + std::time::Duration::from_secs(4_102_444_800);
         std::fs::File::open(&leaf)
             .unwrap()
             .set_times(std::fs::FileTimes::new().set_modified(future))

--- a/crates/harn-vm/tests/agent_fanout.rs
+++ b/crates/harn-vm/tests/agent_fanout.rs
@@ -109,7 +109,6 @@ fn parse_rows(lines: &[String]) -> Vec<Row> {
 const PRELUDE: &str = r#"
 fn ok_caller(marker) {
   return { call ->
-    sleep(15)
     return {
       ok: true,
       value: {
@@ -125,7 +124,6 @@ fn ok_caller(marker) {
 
 fn fail_caller(marker) {
   return { call ->
-    sleep(15)
     // Throw so the child's agent_loop unwinds and execute_sub_agent wraps it
     // as an `ok: false` sub-agent envelope with a non-nil error. (A graceful
     // `{ok: false}` return is instead absorbed into a "completed" envelope.)


### PR DESCRIPTION
Test-file-only reliability fixes. No `ci.yml`, no `Cargo.toml`, no source/runtime behavior change — won't conflict with the in-flight ci.yml PR #3732.

## F1 — correctness (real data race; highest priority)
`crates/harn-hostlib/tests/process_tools_e2e.rs` had three `#[test]` fns mutating process-wide env (`ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, `HARN_HANDLER_SANDBOX`) via `std::env::set_var`/`remove_var` with no synchronization. Under libtest's threaded runner that races `set_var` (made `unsafe` in the 2024 edition) against sibling env reads: torn reads, secret leaking into sibling tests, rare segfaults, and flaky secret-scrub assertions. A file-local `ENV_LOCK` now serializes every env-mutating test in this binary for its full duration (poison-tolerant guard). The secret-strip test must set the vars on the parent process to exercise the inherit-and-strip path, so a per-`Command` `.env` wouldn't cover it — the lock is the correct fix.

## F2 — 1.1s real sleep → deterministic
`crates/harn-vm/src/bytecode_cache.rs`: `import_hash_busts_on_same_length_edit_in_same_process` slept 1.1s to wait out filesystem mtime granularity. Replaced with an explicit `FileTimes::set_modified(now + 2s)` forward bump (std, stable since 1.75), so the `(path, len, mtime_ns)` memo busts instantly and deterministically. Runtime 1.1s → 0.08s.

## F4 — drop gratuitous sleeps
`crates/harn-vm/tests/agent_fanout.rs`: removed two `sleep(15)` calls from the stub callers. The contract sorts rows by `index` and tests no timing.

## D1 — isolated temp dirs
`crates/harn-guard/src/resolve.rs`: three tests shared fixed `temp_dir().join("harn-guard-resolve-…")` paths. Switched to `tempfile::tempdir()` (already a dev-dep) for per-test isolation + auto-cleanup.

## Skipped
**D2** (e2e dispatch tests using `temp_dir().join(<name>-<pid>)` without auto-cleanup): skipped per scope discipline. These are pid-isolated, already manually `remove_dir_all` at each test's end, and not a race — pure disk litter. Converting to `tempfile` cleanly requires changing helper return types from `PathBuf` to `TempDir` (the guard must stay alive) and updating dozens of call sites across 6 files — a non-trivial refactor for zero correctness benefit.

## Verification
All touched tests pass under nextest:
- `cargo nextest run -p harn-hostlib --test process_tools_e2e` — 5/5 pass
- `cargo nextest run -p harn-vm bytecode_cache` — 14/14 pass (same-length-edit test 0.076s)
- `cargo nextest run -p harn-vm --test agent_fanout` — 5/5 pass
- `cargo nextest run -p harn-guard resolve` — 5/5 pass

`cargo fmt` clean; pre-commit hook (rustfmt, prompt-prose ratchet, clippy on changed crates) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)