### PR TITLE
[codex] tools: expose live output for running command handles

### DIFF
--- a/changelog.d/async-command-output-spin.fixed.md
+++ b/changelog.d/async-command-output-spin.fixed.md
@@ -1,0 +1,3 @@
+- **Background command output.** Running command handles now expose their live
+  output artifacts before completion, so hosts can poll or read in-progress
+  build and test diagnostics instead of spinning blind.

--- a/crates/harn-hostlib/src/tools/long_running.rs
+++ b/crates/harn-hostlib/src/tools/long_running.rs
@@ -221,6 +221,7 @@ pub(crate) fn spawn_long_running_with_options(
     let handle_id = format!("hto-{:x}-{id}", std::process::id());
     let command_id = proc::next_command_id();
     let started_at = proc::now_rfc3339();
+    let _artifacts = proc::register_live_artifacts(&command_id, Some(&handle_id))?;
 
     let mut all_argv = vec![program];
     all_argv.extend(args.iter().cloned());

--- a/crates/harn-hostlib/src/tools/proc.rs
+++ b/crates/harn-hostlib/src/tools/proc.rs
@@ -33,7 +33,10 @@ use crate::tools::response::ResponseBuilder;
 mod artifacts;
 mod toolchain_path;
 
-pub(crate) use self::artifacts::{persist_artifacts, planned_artifact_paths, resolve_output_path};
+pub(crate) use self::artifacts::{
+    live_artifact_snapshot, live_artifact_tail, persist_artifacts, planned_artifact_paths,
+    register_live_artifacts, resolve_output_path,
+};
 
 static COMMAND_COUNTER: AtomicU64 = AtomicU64::new(1);
 

--- a/crates/harn-hostlib/src/tools/proc/artifacts.rs
+++ b/crates/harn-hostlib/src/tools/proc/artifacts.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant, SystemTime};
@@ -78,6 +79,42 @@ pub(crate) fn persist_artifacts(
     Ok(artifacts)
 }
 
+pub(crate) fn register_live_artifacts(
+    command_id: &str,
+    handle_id: Option<&str>,
+) -> Result<CommandArtifacts, HostlibError> {
+    maybe_sweep_stale_artifacts();
+    let artifacts = planned_artifact_paths(command_id);
+    std::fs::create_dir_all(artifacts.output_path.parent().unwrap()).map_err(|e| {
+        HostlibError::Backend {
+            builtin: "hostlib_tools_run_command",
+            message: format!("failed to create command artifact dir: {e}"),
+        }
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(
+            artifacts.output_path.parent().unwrap(),
+            std::fs::Permissions::from_mode(0o700),
+        );
+    }
+    std::fs::File::create(&artifacts.stdout_path).map_err(|e| HostlibError::Backend {
+        builtin: "hostlib_tools_run_command",
+        message: format!("failed to create stdout artifact: {e}"),
+    })?;
+    std::fs::File::create(&artifacts.stderr_path).map_err(|e| HostlibError::Backend {
+        builtin: "hostlib_tools_run_command",
+        message: format!("failed to create stderr artifact: {e}"),
+    })?;
+    std::fs::File::create(&artifacts.output_path).map_err(|e| HostlibError::Backend {
+        builtin: "hostlib_tools_run_command",
+        message: format!("failed to create combined output artifact: {e}"),
+    })?;
+    register_artifacts(command_id, handle_id, &artifacts);
+    Ok(artifacts)
+}
+
 pub(crate) fn planned_artifact_paths(command_id: &str) -> CommandArtifacts {
     let dir = std::env::temp_dir().join(format!("harn-command-{command_id}"));
     CommandArtifacts {
@@ -105,12 +142,47 @@ pub(crate) fn resolve_output_path(
         .map(|a| a.output_path.clone())
 }
 
+pub(crate) fn live_artifact_snapshot(
+    command_id: Option<&str>,
+    handle_id: Option<&str>,
+) -> Option<CommandArtifacts> {
+    let mut artifacts = lookup_artifacts(command_id, handle_id)?;
+    artifacts.byte_count = std::fs::metadata(&artifacts.output_path)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+    Some(artifacts)
+}
+
+pub(crate) fn live_artifact_tail(
+    command_id: Option<&str>,
+    handle_id: Option<&str>,
+    max_bytes: u64,
+) -> Option<String> {
+    let artifacts = lookup_artifacts(command_id, handle_id)?;
+    let mut file = std::fs::File::open(&artifacts.output_path).ok()?;
+    let len = file.metadata().ok()?.len();
+    let offset = len.saturating_sub(max_bytes);
+    file.seek(SeekFrom::Start(offset)).ok()?;
+
+    let mut bytes = Vec::with_capacity(len.saturating_sub(offset) as usize);
+    file.take(max_bytes).read_to_end(&mut bytes).ok()?;
+    Some(String::from_utf8_lossy(&bytes).into_owned())
+}
+
 fn register_artifacts(command_id: &str, handle_id: Option<&str>, artifacts: &CommandArtifacts) {
     let mut store = ARTIFACTS.lock().expect("command artifact store poisoned");
     store.insert(command_id.to_string(), artifacts.clone());
     if let Some(handle_id) = handle_id {
         store.insert(handle_id.to_string(), artifacts.clone());
     }
+}
+
+fn lookup_artifacts(command_id: Option<&str>, handle_id: Option<&str>) -> Option<CommandArtifacts> {
+    let store = ARTIFACTS.lock().expect("command artifact store poisoned");
+    command_id
+        .and_then(|id| store.get(id))
+        .or_else(|| handle_id.and_then(|id| store.get(id)))
+        .cloned()
 }
 
 fn maybe_sweep_stale_artifacts() {

--- a/crates/harn-hostlib/src/tools/wait_command.rs
+++ b/crates/harn-hostlib/src/tools/wait_command.rs
@@ -6,9 +6,12 @@ use harn_vm::VmValue;
 
 use crate::error::HostlibError;
 use crate::tools::payload::{optional_string, optional_u64, require_dict_arg, require_string};
+use crate::tools::proc;
 use crate::tools::response::ResponseBuilder;
 
 pub(crate) const NAME: &str = "hostlib_tools_wait_command";
+
+const RUNNING_INLINE_OUTPUT_MAX_BYTES: u64 = 32 * 1024;
 
 pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
     let map = require_dict_arg(NAME, args)?;
@@ -44,12 +47,30 @@ pub(crate) fn handle(args: &[VmValue]) -> Result<VmValue, HostlibError> {
         }
     }
 
-    Ok(ResponseBuilder::new()
-        .str("handle_id", handle_id)
+    let mut builder = ResponseBuilder::new()
+        .str("handle_id", handle_id.clone())
         .str("status", "running")
         .bool("completed", false)
-        .bool("timed_out", false)
-        .build())
+        .bool("timed_out", false);
+    if let Some(artifacts) = proc::live_artifact_snapshot(None, Some(&handle_id)) {
+        builder = builder
+            .str("output_path", artifacts.output_path.display().to_string())
+            .str("stdout_path", artifacts.stdout_path.display().to_string())
+            .str("stderr_path", artifacts.stderr_path.display().to_string())
+            .int("line_count", artifacts.line_count as i64)
+            .int("byte_count", artifacts.byte_count as i64)
+            .str("output_sha256", artifacts.output_sha256);
+        if let Some(output) =
+            proc::live_artifact_tail(None, Some(&handle_id), RUNNING_INLINE_OUTPUT_MAX_BYTES)
+        {
+            if !output.is_empty() {
+                builder = builder
+                    .str("combined", output.clone())
+                    .str("inline_output", output);
+            }
+        }
+    }
+    Ok(builder.build())
 }
 
 fn drain_matching_result(session_id: &str, handle_id: &str) -> Option<VmValue> {

--- a/crates/harn-hostlib/tests/process_tools.rs
+++ b/crates/harn-hostlib/tests/process_tools.rs
@@ -658,6 +658,7 @@ fn run_command_long_running_returns_handle_immediately() {
     );
     assert_eq!(require_str(&resp, "status"), "running");
     assert!(require_str(&resp, "command_id").starts_with("cmd_"));
+    let output_path = require_str(&resp, "output_path");
     assert!(require_int(&resp, "pid") > 0);
     assert!(require_int(&resp, "process_group_id") > 0);
     assert!(require_str(&resp, "started_at").contains('T'));
@@ -666,6 +667,13 @@ fn run_command_long_running_returns_handle_immediately() {
         cmd.contains("sleep"),
         "command should contain 'sleep', got {cmd}"
     );
+
+    let mut read_req = dict();
+    read_req.insert("handle_id".into(), vstr(&handle_id));
+    let read_resp = require_dict(call("hostlib_tools_read_command_output", read_req).unwrap());
+    assert_eq!(require_str(&read_resp, "path"), output_path);
+    assert_eq!(require_int(&read_resp, "total_bytes"), 0);
+    assert_eq!(require_str(&read_resp, "content"), "");
 
     // Block on waiter completion before returning so the test stays
     // deterministic — cancel signals the notifier itself.
@@ -732,6 +740,23 @@ fn run_command_background_after_returns_progress_snapshot() {
     assert_eq!(require_str(&resp, "stdout"), "started\n");
     assert!(require_str(&resp, "output_path").contains("harn-command-"));
     let handle_id = require_str(&resp, "handle_id");
+
+    let mut read_req = dict();
+    read_req.insert("handle_id".into(), vstr(&handle_id));
+    read_req.insert("length".into(), VmValue::Int(200));
+    let read_resp = require_dict(call("hostlib_tools_read_command_output", read_req).unwrap());
+    assert_eq!(require_str(&read_resp, "content"), "started\n");
+    assert!(require_str(&read_resp, "path").contains("combined.txt"));
+    assert_eq!(require_int(&read_resp, "total_bytes"), 8);
+
+    let mut wait_req = dict();
+    wait_req.insert("handle_id".into(), vstr(&handle_id));
+    wait_req.insert("timeout_ms".into(), VmValue::Int(0));
+    let waited = require_dict(call("hostlib_tools_wait_command", wait_req).unwrap());
+    assert_eq!(require_str(&waited, "status"), "running");
+    assert_eq!(require_str(&waited, "combined"), "started\n");
+    assert_eq!(require_str(&waited, "inline_output"), "started\n");
+    assert_eq!(require_int(&waited, "byte_count"), 8);
 
     let completion_rx = register_completion_notifier(&handle_id);
     let mut cancel_req = dict();
@@ -903,6 +928,9 @@ fn wait_command_reports_running_when_handle_has_not_completed() {
     assert_eq!(require_str(&waited, "status"), "running");
     assert_eq!(require_str(&waited, "handle_id"), handle_id);
     assert!(!require_bool(&waited, "completed"));
+    assert!(require_str(&waited, "output_path").contains("combined.txt"));
+    assert_eq!(require_int(&waited, "byte_count"), 0);
+    assert_eq!(require_int(&waited, "line_count"), 0);
 
     let mut cancel_req = dict();
     cancel_req.insert("handle_id".into(), vstr(&handle_id));


### PR DESCRIPTION
## What changed

- Registers live command artifact paths when a background handle is spawned, before the process completes.
- Allows `read_command_output` to resolve a running handle's combined output artifact immediately.
- Adds running `wait_command` artifact metadata plus a bounded 32 KiB live output tail (`combined` / `inline_output`) so hosts can show in-progress diagnostics instead of blind polling.
- Covers the running-handle path with deterministic hostlib regressions.

## Why

C# eval forensics showed models repeatedly polling/running `dotnet test` without seeing the in-progress `Passed!` / `Failed!` / `CS1503` evidence. Escalation already fires, but escalating to a model that still cannot see command output does not fix the cell. This moves the live-output seam into Harn's process layer so Burin and other hosts can surface red evidence while the command is still running.

## Validation

- `cargo fmt --all -- --check`
- `RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo test -p harn-hostlib --test process_tools running -- --nocapture`
- `RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo test -p harn-hostlib --test process_tools run_command_background_after_returns_progress_snapshot -- --nocapture`
- `RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo clippy -p harn-hostlib --lib --tests -- -D warnings`
- `git diff --check`
- pre-commit hook: markdown lint, rust format, prompt-prose ratchet, changed-package clippy
- pre-push hook: markdown lint and targeted local checks
