### PR TITLE
feat(session-bundle): classify suspended vs. closed liveness on event-stream export (#3682)

### DIFF
--- a/changelog.d/3682.added.md
+++ b/changelog.d/3682.added.md
@@ -1,0 +1,7 @@
+- **Session-bundle liveness.** Exporting a session bundle from an event stream
+  now classifies the session's liveness: a stream without a terminal
+  `SessionClosed` event — a loop frozen mid-turn for cross-compute migration, or
+  a time-traveled replay prefix — is labeled `suspended` (with a machine-readable
+  `session_liveness` metadata tag and a null `finished_at`) instead of being
+  silently reported as `completed`. This is the discriminator a resume host needs
+  to continue a pending turn rather than replay a finished run.

--- a/crates/harn-vm/src/session_bundle.rs
+++ b/crates/harn-vm/src/session_bundle.rs
@@ -37,6 +37,86 @@ pub const SESSION_BUNDLE_SCHEMA_VERSION: u32 = 1;
 pub const SESSION_BUNDLE_SCHEMA_ID: &str = "https://harnlang.com/schemas/session-bundle.v1.json";
 pub const REPLAY_ONLY_PLACEHOLDER: &str = "[withheld]";
 
+/// Bundle `source.status` for a session reconstructed from an event stream that
+/// has no terminal `SessionClosed` event — a live loop frozen mid-turn for
+/// cross-compute migration (#3682), or a time-traveled prefix truncated before
+/// the close. The next action is still pending, so a consumer must CONTINUE the
+/// loop, not treat it as finished.
+pub const SESSION_BUNDLE_STATUS_SUSPENDED: &str = "suspended";
+
+/// Bundle `source.status` fallback for a session that closed without an
+/// explicit status on its terminal `SessionClosed` event.
+pub const SESSION_BUNDLE_STATUS_COMPLETED: &str = "completed";
+
+/// `metadata` key carrying the machine-readable liveness verdict
+/// (`"suspended"` | `"closed"`) so a resume host can decide continue-vs-replay
+/// without string-matching the human-facing `status`.
+pub const SESSION_BUNDLE_LIVENESS_KEY: &str = "session_liveness";
+
+/// Liveness of an agent session reconstructed from its event log.
+///
+/// Derived purely from the event stream: a session is [`Closed`] only when the
+/// stream contains a terminal `SessionClosed` event. Any other stream is
+/// [`Suspended`] — its next action is still pending.
+///
+/// [`Closed`]: AgentSessionLiveness::Closed
+/// [`Suspended`]: AgentSessionLiveness::Suspended
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AgentSessionLiveness {
+    /// The stream ends in a `SessionClosed` event. `status` is that event's
+    /// status, or [`SESSION_BUNDLE_STATUS_COMPLETED`] when it was empty.
+    Closed { status: String, finished_at_ms: i64 },
+    /// No terminal `SessionClosed` event: the loop is frozen mid-flight and a
+    /// consumer must resume it rather than replay it as a finished run.
+    Suspended,
+}
+
+impl AgentSessionLiveness {
+    /// The human-facing `source.status` string for this liveness.
+    pub fn status(&self) -> &str {
+        match self {
+            AgentSessionLiveness::Closed { status, .. } => status,
+            AgentSessionLiveness::Suspended => SESSION_BUNDLE_STATUS_SUSPENDED,
+        }
+    }
+
+    /// The machine-readable [`SESSION_BUNDLE_LIVENESS_KEY`] tag.
+    pub fn tag(&self) -> &'static str {
+        match self {
+            AgentSessionLiveness::Closed { .. } => "closed",
+            AgentSessionLiveness::Suspended => "suspended",
+        }
+    }
+
+    /// Whether a consumer must CONTINUE the loop (vs. treat it as finished).
+    pub fn is_suspended(&self) -> bool {
+        matches!(self, AgentSessionLiveness::Suspended)
+    }
+}
+
+/// Classify an agent session's liveness from its replay event stream by finding
+/// the last terminal `SessionClosed` event. The keystone discriminator behind
+/// portable suspend/resume (#3682): without it, a frozen-mid-flight or
+/// time-traveled session is silently mislabeled `completed` and a resume host
+/// replays it instead of continuing the pending turn.
+pub fn agent_session_liveness(events: &[AgentSessionReplayEvent]) -> AgentSessionLiveness {
+    events
+        .iter()
+        .rev()
+        .find_map(|entry| match &entry.event {
+            AgentEvent::SessionClosed { status, .. } => Some(AgentSessionLiveness::Closed {
+                status: if status.is_empty() {
+                    SESSION_BUNDLE_STATUS_COMPLETED.to_string()
+                } else {
+                    status.clone()
+                },
+                finished_at_ms: entry.occurred_at_ms,
+            }),
+            _ => None,
+        })
+        .unwrap_or(AgentSessionLiveness::Suspended)
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SessionBundleExportMode {
     Local,
@@ -732,18 +812,18 @@ pub fn session_bundle_from_agent_session_events(
 
     let stable_id = sanitize_topic_component(session_id);
     let started_at = rfc3339_from_epoch_ms(events[0].occurred_at_ms);
-    let finished_at = events.iter().rev().find_map(|entry| match &entry.event {
-        AgentEvent::SessionClosed { .. } => Some(rfc3339_from_epoch_ms(entry.occurred_at_ms)),
-        _ => None,
-    });
-    let status = events
-        .iter()
-        .rev()
-        .find_map(|entry| match &entry.event {
-            AgentEvent::SessionClosed { status, .. } if !status.is_empty() => Some(status.clone()),
-            _ => None,
-        })
-        .unwrap_or_else(|| "completed".to_string());
+    // Liveness, not a `completed` default: a stream without a terminal
+    // `SessionClosed` event (a frozen-mid-flight loop, or a time-traveled
+    // prefix) is `suspended`, so `finished_at` stays null and a resume host
+    // continues the pending turn rather than replaying a "finished" run.
+    let liveness = agent_session_liveness(events);
+    let finished_at = match &liveness {
+        AgentSessionLiveness::Closed { finished_at_ms, .. } => {
+            Some(rfc3339_from_epoch_ms(*finished_at_ms))
+        }
+        AgentSessionLiveness::Suspended => None,
+    };
+    let status = liveness.status().to_string();
     let run_id = session_id.to_string();
     let workflow_id = "agent_session".to_string();
     let created_at = finished_at.clone().unwrap_or_else(|| started_at.clone());
@@ -824,6 +904,10 @@ pub fn session_bundle_from_agent_session_events(
             deterministic_events: deterministic_events_from_agent_session(events)?,
             ..BundleReplay::default()
         },
+        metadata: BTreeMap::from([(
+            SESSION_BUNDLE_LIVENESS_KEY.to_string(),
+            json!(liveness.tag()),
+        )]),
         ..SessionBundle::default()
     })
 }

--- a/crates/harn-vm/src/session_bundle/tests.rs
+++ b/crates/harn-vm/src/session_bundle/tests.rs
@@ -727,3 +727,174 @@ fn sort_redaction_entries(value: &mut JsonValue) {
             .cmp(b.get("path").and_then(JsonValue::as_str).unwrap_or(""))
     });
 }
+
+// --- Agent-session liveness (#3682 portable suspend/resume keystone) ---
+
+fn replay_event(event_id: u64, occurred_at_ms: i64, event: AgentEvent) -> AgentSessionReplayEvent {
+    let kind = match &event {
+        AgentEvent::UserMessage { .. } => "user_message",
+        AgentEvent::AgentMessageChunk { .. } => "agent_message_chunk",
+        AgentEvent::SessionClosed { .. } => "session_closed",
+        _ => "event",
+    }
+    .to_string();
+    AgentSessionReplayEvent {
+        event_id,
+        kind,
+        occurred_at_ms,
+        event,
+    }
+}
+
+fn user_turn(session_id: &str, event_id: u64, occurred_at_ms: i64) -> AgentSessionReplayEvent {
+    replay_event(
+        event_id,
+        occurred_at_ms,
+        AgentEvent::UserMessage {
+            session_id: session_id.to_string(),
+            message_id: format!("m{event_id}"),
+            content: vec![json!({ "type": "text", "text": "do the thing" })],
+        },
+    )
+}
+
+fn assistant_turn(session_id: &str, event_id: u64, occurred_at_ms: i64) -> AgentSessionReplayEvent {
+    replay_event(
+        event_id,
+        occurred_at_ms,
+        AgentEvent::AgentMessageChunk {
+            session_id: session_id.to_string(),
+            content: "working on it".to_string(),
+        },
+    )
+}
+
+fn session_closed(
+    session_id: &str,
+    event_id: u64,
+    occurred_at_ms: i64,
+    status: &str,
+) -> AgentSessionReplayEvent {
+    replay_event(
+        event_id,
+        occurred_at_ms,
+        AgentEvent::SessionClosed {
+            session_id: session_id.to_string(),
+            reason: "done".to_string(),
+            status: status.to_string(),
+            metadata: json!({}),
+        },
+    )
+}
+
+#[test]
+fn liveness_is_closed_when_session_closed_present() {
+    let sid = "sess-closed";
+    let events = vec![
+        user_turn(sid, 1, 1_000),
+        assistant_turn(sid, 2, 1_500),
+        session_closed(sid, 3, 2_000, "succeeded"),
+    ];
+    assert_eq!(
+        agent_session_liveness(&events),
+        AgentSessionLiveness::Closed {
+            status: "succeeded".to_string(),
+            finished_at_ms: 2_000,
+        }
+    );
+}
+
+#[test]
+fn liveness_falls_back_to_completed_for_empty_close_status() {
+    let sid = "sess-empty-status";
+    let events = vec![user_turn(sid, 1, 1_000), session_closed(sid, 2, 2_000, "")];
+    let liveness = agent_session_liveness(&events);
+    assert_eq!(liveness.status(), SESSION_BUNDLE_STATUS_COMPLETED);
+    assert!(!liveness.is_suspended());
+}
+
+#[test]
+fn liveness_is_suspended_when_no_session_closed() {
+    // A live loop frozen mid-turn (or a time-traveled prefix) has no terminal
+    // SessionClosed event. It must NOT be labeled completed.
+    let sid = "sess-live";
+    let events = vec![user_turn(sid, 1, 1_000), assistant_turn(sid, 2, 1_500)];
+    let liveness = agent_session_liveness(&events);
+    assert_eq!(liveness, AgentSessionLiveness::Suspended);
+    assert!(liveness.is_suspended());
+    assert_eq!(liveness.status(), SESSION_BUNDLE_STATUS_SUSPENDED);
+}
+
+#[test]
+fn bundle_status_reflects_suspended_loop_not_completed() {
+    let sid = "sess-suspend-bundle";
+    let events = vec![user_turn(sid, 1, 1_000), assistant_turn(sid, 2, 1_500)];
+    let bundle = session_bundle_from_agent_session_events(sid, &events).expect("bundle");
+    assert_eq!(bundle.source.status, SESSION_BUNDLE_STATUS_SUSPENDED);
+    assert_eq!(bundle.source.finished_at, None);
+    assert_eq!(
+        bundle.metadata.get(SESSION_BUNDLE_LIVENESS_KEY),
+        Some(&json!("suspended"))
+    );
+    assert_eq!(
+        bundle
+            .replay
+            .replay_fixture
+            .as_ref()
+            .unwrap()
+            .expected_status,
+        SESSION_BUNDLE_STATUS_SUSPENDED
+    );
+}
+
+#[test]
+fn bundle_status_reflects_closed_loop() {
+    let sid = "sess-closed-bundle";
+    let events = vec![
+        user_turn(sid, 1, 1_000),
+        assistant_turn(sid, 2, 1_500),
+        session_closed(sid, 3, 2_000, "succeeded"),
+    ];
+    let bundle = session_bundle_from_agent_session_events(sid, &events).expect("bundle");
+    assert_eq!(bundle.source.status, "succeeded");
+    assert!(bundle.source.finished_at.is_some());
+    assert_eq!(
+        bundle.metadata.get(SESSION_BUNDLE_LIVENESS_KEY),
+        Some(&json!("closed"))
+    );
+}
+
+#[test]
+fn time_travel_prefix_is_suspended_not_completed() {
+    // Truncating a completed session to a mid-run prefix (the replay `--at`
+    // path) drops the SessionClosed event; the prefix is suspended.
+    let sid = "sess-timetravel";
+    let full = vec![
+        user_turn(sid, 1, 1_000),
+        assistant_turn(sid, 2, 1_500),
+        session_closed(sid, 3, 2_000, "succeeded"),
+    ];
+    assert!(!agent_session_liveness(&full).is_suspended());
+    let prefix = &full[..2];
+    assert_eq!(
+        agent_session_liveness(prefix),
+        AgentSessionLiveness::Suspended
+    );
+    let bundle = session_bundle_from_agent_session_events(sid, prefix).expect("bundle");
+    assert_eq!(bundle.source.status, SESSION_BUNDLE_STATUS_SUSPENDED);
+}
+
+#[test]
+fn suspended_bundle_export_is_deterministic_round_trip() {
+    // Byte-faithful freeze: re-exporting the same frozen stream yields an
+    // identical bundle (modulo nondeterministic producer/version fields), the
+    // determinism the resume side relies on.
+    let sid = "sess-determinism";
+    let events = vec![user_turn(sid, 1, 1_000), assistant_turn(sid, 2, 1_500)];
+    let first = session_bundle_from_agent_session_events(sid, &events).expect("first");
+    let second = session_bundle_from_agent_session_events(sid, &events).expect("second");
+    assert_eq!(
+        serde_json::to_value(&first).unwrap(),
+        serde_json::to_value(&second).unwrap()
+    );
+}


### PR DESCRIPTION
## What

The session-bundle event-stream exporter (`session_bundle_from_agent_session_events`) derived `source.status` from a terminal `SessionClosed` event and **defaulted to `completed` when none was present**. That silently mislabels two real cases:

1. A **live loop frozen mid-turn** for cross-compute migration (the #3682 keystone) — it has no close event yet.
2. A **time-traveled replay prefix** (`harn replay --at`, `replay.rs:478`) truncated before the close.

A resume host reading `completed` would replay the run as finished instead of continuing its pending next action.

## Change

- New `agent_session_liveness(events) -> AgentSessionLiveness`:
  - `Closed { status, finished_at_ms }` when the stream ends in `SessionClosed` (empty status falls back to `completed`).
  - `Suspended` otherwise.
- The exporter now sets `source.status = "suspended"`, leaves `finished_at` null, and records a **machine-readable `session_liveness` metadata tag** (`"suspended"` | `"closed"`) so a resume host can decide continue-vs-replay without string-matching the human-facing status. `replay_fixture.expected_status` follows suit.

## Why this slice

This is the foundational discriminator behind portable suspend/resume (#3682, P2-3): a bundle must self-describe whether its loop is finished or frozen. It also fixes a **latent bug in the existing time-travel replay** path, so it's root-cause and generalizable — not migration-only scaffolding. It is fully verifiable **same-process** (no second host needed), which is the right granularity for the first keystone slice.

## Verification

- 7 new unit tests: closed / empty-status / suspended classification; bundle `status` + `session_liveness` metadata + `expected_status`; the time-travel-prefix case; and export determinism (round-trip identical).
- `cargo fmt` + `cargo clippy -p harn-vm --lib --tests` clean.
- Full `harn-vm` lib suite green: **4140 passed, 0 failed**.

Part of #3682 (depends on the session/suspend primitive #1848 for the full freeze→resume loop; this slice lands the bundle-side liveness contract independently). Wedge epic #3681.

🤖 Generated with [Claude Code](https://claude.com/claude-code)