### PR TITLE
fix(vm): inline parallel subtasks inherit the agent session so files_written survives fan-out

### DIFF
--- a/changelog.d/files-written-fanout-inline-subtask.fixed.md
+++ b/changelog.d/files-written-fanout-inline-subtask.fixed.md
@@ -1,0 +1,9 @@
+- **`files_written` on the fan-out path.** A sub-agent's edits are no longer
+  dropped from its receipt when the agent loop dispatches the turn's tool calls
+  through `parallel` / `parallel settle`. Those subtasks now run under an
+  isolated copy of the spawning agent's full ambient scope (session, execution
+  context, mutation session, policies), so a dispatched tool's write attributes
+  to the agent's session even while a fan-out worker's scope is swapped out.
+  Previously the receipt reported `files_written: []` for a child that really
+  did edit files, which a downstream host renders as "wrote 0 file(s)" /
+  "0/N units completed" and can trigger wasteful parent re-work.

--- a/crates/harn-vm/src/orchestration/ambient_scope.rs
+++ b/crates/harn-vm/src/orchestration/ambient_scope.rs
@@ -128,6 +128,48 @@ impl AmbientExecutionScope {
         }
     }
 
+    /// Capture an isolated COPY of the FULL current ambient context for an
+    /// inline concurrent subtask — the `parallel` / `parallel_each` /
+    /// `parallel settle` primitives that an agent loop uses to dispatch a turn's
+    /// tool calls (and that user pipelines use for fan-out map bodies).
+    ///
+    /// Unlike [`capture_inherited`] — which resets `session_stack` and leaves the
+    /// re-pushed policy/render slots empty because a fan-out WORKER opens its own
+    /// agent session and pushes its own execution/approval policy — an inline
+    /// subtask is the SAME logical agent as the task that spawned it. It runs
+    /// that agent's tool calls concurrently and never re-establishes any of this
+    /// context itself, so it must inherit every slot, INCLUDING the active
+    /// session. That session is what the hostlib write chokepoint
+    /// (`fs_snapshot::auto_capture_for_write` -> `active_session_id`) reads to
+    /// record `files_written`.
+    ///
+    /// Without this, a subtask spawned while the parent's `scope_ambient` is
+    /// swapped out (e.g. a fan-out worker awaiting the parallel-tool join — the
+    /// subtasks are polled by the `LocalSet` as independent tasks, NOT nested in
+    /// the parent's poll) reads an empty or sibling `CURRENT_SESSION_STACK`, so
+    /// its writes are dropped from the session's changed-path record and the
+    /// sub-agent receipt reports `files_written: []` for a child that really did
+    /// edit files. The single-worker path hid this because nothing competes for
+    /// the thread-local there.
+    pub(crate) fn capture_for_inline_subtask() -> Self {
+        Self {
+            execution: clone_via_swap(swap_execution_policy_stack),
+            approval: clone_via_swap(swap_approval_policy_stack),
+            command: clone_via_swap(swap_command_policy_stack),
+            permissions: clone_via_swap(swap_dynamic_permission_stack),
+            runtime_context: clone_via_swap(swap_runtime_context_overlay_stack),
+            autonomy: clone_via_swap(swap_autonomy_policy_stack),
+            llm_render: clone_via_swap(swap_llm_render_stack),
+            connector_ctx: clone_via_swap(swap_active_harn_connector_ctx),
+            session_stack: clone_via_swap(swap_current_session_stack),
+            execution_context: clone_via_swap(swap_thread_execution_context),
+            source_dir: clone_via_swap(swap_source_dir),
+            mutation_session: clone_via_swap(swap_mutation_session),
+            trusted_depth: clone_via_swap(swap_trusted_bridge_depth),
+            command_hook_depth: clone_via_swap(swap_command_policy_hook_depth),
+        }
+    }
+
     /// Install this scope into the ambient thread-locals, returning whatever was
     /// installed before so the caller can restore it. O(1) per stack.
     fn swap_in(self) -> Self {
@@ -496,6 +538,117 @@ mod tests {
         assert!(
             crate::agent_sessions::take_session_changed_paths(&parent_session).is_empty(),
             "child writes must not attribute to parent"
+        );
+    }
+
+    /// `files_written` fan-out regression: an agent loop dispatches a turn's tool
+    /// calls through `parallel` / `parallel settle`, which run each call as an
+    /// INDEPENDENT `LocalSet` task — not nested in the worker's poll. While the
+    /// worker awaits that join its `scope_ambient` is swapped out, so a subtask
+    /// that does NOT carry the worker's session reads an empty/sibling
+    /// `CURRENT_SESSION_STACK` and its write is dropped from the receipt
+    /// (the real bug behind a "wrote 0 file(s)" / "0/N units completed" report).
+    /// [`capture_for_inline_subtask`] is what `vm::ops::parallel` wraps each
+    /// subtask with so the write attributes to the agent's session. Two
+    /// contending workers prove each subtask sees ITS worker's session — and a
+    /// `capture_inherited` CONTROL proves the contention is real (an
+    /// un-inherited subtask genuinely sees no session, so the assertion is not
+    /// vacuous).
+    #[tokio::test]
+    async fn inline_subtask_scope_carries_worker_session_under_contention() {
+        let parent_session = format!("parent-{}", uuid::Uuid::now_v7());
+        let alpha_session = format!("alpha-{}", uuid::Uuid::now_v7());
+        let beta_session = format!("beta-{}", uuid::Uuid::now_v7());
+        for session in [&parent_session, &alpha_session, &beta_session] {
+            crate::agent_sessions::clear_session_changed_paths(session);
+        }
+
+        let _parent_guard = crate::agent_sessions::enter_current_session(parent_session.clone());
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                // One fan-out worker: opens its own session (never the parent's),
+                // yields, then dispatches an inline subtask exactly like the agent
+                // loop's `parallel settle` tool dispatch.
+                let run_worker = |worker_session: String, path: &'static str| {
+                    let worker_scope = AmbientExecutionScope::capture_inherited();
+                    tokio::task::spawn_local(scope_ambient(worker_scope, async move {
+                        assert!(
+                            crate::agent_sessions::current_session_id().is_none(),
+                            "fan-out worker must not inherit the parent session"
+                        );
+                        let _guard =
+                            crate::agent_sessions::enter_current_session(worker_session.clone());
+                        tokio::task::yield_now().await;
+
+                        // CONTROL: a subtask spawned WITHOUT inline-subtask
+                        // scoping does not see the worker session — this is the
+                        // dropped-write bug, and proves the contention is real.
+                        let control = tokio::task::spawn_local(scope_ambient(
+                            AmbientExecutionScope::capture_inherited(),
+                            async move {
+                                tokio::task::yield_now().await;
+                                tokio::task::yield_now().await;
+                                crate::agent_sessions::current_session_id()
+                            },
+                        ))
+                        .await
+                        .unwrap();
+                        assert!(
+                            control.is_none(),
+                            "control subtask must NOT inherit the worker session"
+                        );
+
+                        // FIX: the inline-subtask scope carries the worker session,
+                        // so the dispatched tool's write records against it.
+                        let observed = tokio::task::spawn_local(scope_ambient(
+                            AmbientExecutionScope::capture_for_inline_subtask(),
+                            async move {
+                                tokio::task::yield_now().await;
+                                tokio::task::yield_now().await;
+                                let session = crate::agent_sessions::current_session_id();
+                                if let Some(ref session) = session {
+                                    crate::agent_sessions::record_session_changed_path(
+                                        session, path,
+                                    );
+                                }
+                                session
+                            },
+                        ))
+                        .await
+                        .unwrap();
+                        observed
+                    }))
+                };
+
+                let alpha = run_worker(alpha_session.clone(), "src/alpha.rs");
+                let beta = run_worker(beta_session.clone(), "src/beta.rs");
+                assert_eq!(
+                    alpha.await.unwrap().as_deref(),
+                    Some(alpha_session.as_str()),
+                    "alpha's inline subtask must observe alpha's worker session"
+                );
+                assert_eq!(
+                    beta.await.unwrap().as_deref(),
+                    Some(beta_session.as_str()),
+                    "beta's inline subtask must observe beta's worker session"
+                );
+            })
+            .await;
+
+        assert_eq!(
+            crate::agent_sessions::take_session_changed_paths(&alpha_session),
+            vec!["src/alpha.rs".to_string()],
+            "alpha's dispatched write attributes to alpha's session"
+        );
+        assert_eq!(
+            crate::agent_sessions::take_session_changed_paths(&beta_session),
+            vec!["src/beta.rs".to_string()],
+            "beta's dispatched write attributes to beta's session"
+        );
+        assert!(
+            crate::agent_sessions::take_session_changed_paths(&parent_session).is_empty(),
+            "inline-subtask writes must not attribute to the parent"
         );
     }
 

--- a/crates/harn-vm/src/vm/ops/parallel.rs
+++ b/crates/harn-vm/src/vm/ops/parallel.rs
@@ -85,6 +85,31 @@ where
         .collect())
 }
 
+/// Wrap an inline concurrent subtask future (a `parallel` / `parallel_each` /
+/// `parallel settle` map body, or a `spawn` block) so it runs under an isolated
+/// COPY of the spawning task's FULL ambient scope — the active agent session,
+/// execution context, mutation session, and capability/approval policies — in
+/// addition to its pool-registry scope.
+///
+/// The scope snapshot is captured EAGERLY here, synchronously in the spawn
+/// loop, while the spawning task's `scope_ambient` is still swapped in, so each
+/// subtask carries the agent's CURRENT session. That session is what the hostlib
+/// write chokepoint (`fs_snapshot::auto_capture_for_write` -> `active_session_id`)
+/// reads to record `files_written`. Without it, a subtask polled while a fan-out
+/// worker's scope is swapped out (the subtasks are independent `LocalSet` tasks,
+/// not nested in the parent's poll) reads an empty/sibling session and its
+/// writes vanish from the sub-agent receipt — the single-worker path hid this
+/// because nothing competed for the thread-local there.
+fn scope_inline_subtask<F: std::future::Future + 'static>(
+    registry: Arc<crate::stdlib::pool::PoolRegistry>,
+    future: F,
+) -> impl std::future::Future<Output = F::Output> {
+    crate::orchestration::scope_ambient(
+        crate::orchestration::AmbientExecutionScope::capture_for_inline_subtask(),
+        crate::stdlib::pool::with_pool_registry_scope(registry, future),
+    )
+}
+
 async fn stream_capped_unordered<F, T>(
     futures: Vec<F>,
     cap: Option<usize>,
@@ -182,7 +207,7 @@ impl super::super::Vm {
                 task_ids.push(task_id);
                 let registry = child.pool_registry.clone();
                 let closure = closure.clone();
-                futures.push(crate::stdlib::pool::with_pool_registry_scope(
+                futures.push(scope_inline_subtask(
                     registry,
                     async move {
                         let arg = VmValue::Int(i as i64);
@@ -240,7 +265,7 @@ impl super::super::Vm {
                     let registry = child.pool_registry.clone();
                     let closure = closure.clone();
                     let item = item.clone();
-                    futures.push(crate::stdlib::pool::with_pool_registry_scope(
+                    futures.push(scope_inline_subtask(
                         registry,
                         async move {
                             let result = child
@@ -294,7 +319,7 @@ impl super::super::Vm {
                     let registry = child.pool_registry.clone();
                     let closure = closure.clone();
                     let item = item.clone();
-                    futures.push(crate::stdlib::pool::with_pool_registry_scope(
+                    futures.push(scope_inline_subtask(
                         registry,
                         async move {
                             child
@@ -351,7 +376,7 @@ impl super::super::Vm {
                     let registry = child.pool_registry.clone();
                     let closure = closure.clone();
                     let item = item.clone();
-                    futures.push(crate::stdlib::pool::with_pool_registry_scope(
+                    futures.push(scope_inline_subtask(
                         registry,
                         async move {
                             let result = child
@@ -419,7 +444,7 @@ impl super::super::Vm {
             child.cancel_token = Some(cancel_token.clone());
             let registry = child.pool_registry.clone();
             let scheduled_activity = self.wait_for_graph.register_task(runtime_task_id.clone());
-            let handle = tokio::task::spawn_local(crate::stdlib::pool::with_pool_registry_scope(
+            let handle = tokio::task::spawn_local(scope_inline_subtask(
                 registry,
                 async move {
                     let _scheduled_activity = scheduled_activity;

--- a/crates/harn-vm/src/vm/ops/parallel.rs
+++ b/crates/harn-vm/src/vm/ops/parallel.rs
@@ -207,19 +207,13 @@ impl super::super::Vm {
                 task_ids.push(task_id);
                 let registry = child.pool_registry.clone();
                 let closure = closure.clone();
-                futures.push(scope_inline_subtask(
-                    registry,
-                    async move {
-                        let arg = VmValue::Int(i as i64);
-                        let result = child
-                            .call_closure_args(&closure, CallArgs::One(&arg))
-                            .await?;
-                        Ok::<(VmValue, String), VmError>((
-                            result,
-                            std::mem::take(&mut child.output),
-                        ))
-                    },
-                ));
+                futures.push(scope_inline_subtask(registry, async move {
+                    let arg = VmValue::Int(i as i64);
+                    let result = child
+                        .call_closure_args(&closure, CallArgs::One(&arg))
+                        .await?;
+                    Ok::<(VmValue, String), VmError>((result, std::mem::take(&mut child.output)))
+                }));
             }
             let _wait = self
                 .wait_for_graph
@@ -265,18 +259,15 @@ impl super::super::Vm {
                     let registry = child.pool_registry.clone();
                     let closure = closure.clone();
                     let item = item.clone();
-                    futures.push(scope_inline_subtask(
-                        registry,
-                        async move {
-                            let result = child
-                                .call_closure_args(&closure, CallArgs::One(&item))
-                                .await?;
-                            Ok::<(VmValue, String), VmError>((
-                                result,
-                                std::mem::take(&mut child.output),
-                            ))
-                        },
-                    ));
+                    futures.push(scope_inline_subtask(registry, async move {
+                        let result = child
+                            .call_closure_args(&closure, CallArgs::One(&item))
+                            .await?;
+                        Ok::<(VmValue, String), VmError>((
+                            result,
+                            std::mem::take(&mut child.output),
+                        ))
+                    }));
                 }
                 let _wait = self
                     .wait_for_graph
@@ -319,14 +310,11 @@ impl super::super::Vm {
                     let registry = child.pool_registry.clone();
                     let closure = closure.clone();
                     let item = item.clone();
-                    futures.push(scope_inline_subtask(
-                        registry,
-                        async move {
-                            child
-                                .call_closure_args(&closure, CallArgs::One(&item))
-                                .await
-                        },
-                    ));
+                    futures.push(scope_inline_subtask(registry, async move {
+                        child
+                            .call_closure_args(&closure, CallArgs::One(&item))
+                            .await
+                    }));
                 }
 
                 let (tx, rx) = tokio::sync::mpsc::channel::<Result<VmValue, VmError>>(1);
@@ -376,16 +364,13 @@ impl super::super::Vm {
                     let registry = child.pool_registry.clone();
                     let closure = closure.clone();
                     let item = item.clone();
-                    futures.push(scope_inline_subtask(
-                        registry,
-                        async move {
-                            let result = child
-                                .call_closure_args(&closure, CallArgs::One(&item))
-                                .await;
-                            let output = std::mem::take(&mut child.output);
-                            (result, output)
-                        },
-                    ));
+                    futures.push(scope_inline_subtask(registry, async move {
+                        let result = child
+                            .call_closure_args(&closure, CallArgs::One(&item))
+                            .await;
+                        let output = std::mem::take(&mut child.output);
+                        (result, output)
+                    }));
                 }
                 let _wait = self
                     .wait_for_graph
@@ -444,14 +429,11 @@ impl super::super::Vm {
             child.cancel_token = Some(cancel_token.clone());
             let registry = child.pool_registry.clone();
             let scheduled_activity = self.wait_for_graph.register_task(runtime_task_id.clone());
-            let handle = tokio::task::spawn_local(scope_inline_subtask(
-                registry,
-                async move {
-                    let _scheduled_activity = scheduled_activity;
-                    let result = child.call_closure_args(&closure, CallArgs::Empty).await?;
-                    Ok((result, std::mem::take(&mut child.output)))
-                },
-            ));
+            let handle = tokio::task::spawn_local(scope_inline_subtask(registry, async move {
+                let _scheduled_activity = scheduled_activity;
+                let result = child.call_closure_args(&closure, CallArgs::Empty).await?;
+                Ok((result, std::mem::take(&mut child.output)))
+            }));
             self.spawned_tasks.insert(
                 task_id.clone(),
                 VmTaskHandle {


### PR DESCRIPTION
## The bug

A sub-agent's per-child `files_written` (the #29 receipt field) drains **empty**
on the concurrent fan-out path, even though the child really did edit files. A
host renders that as `wrote 0 file(s)` / `0/N units completed` and can trigger
wasteful parent re-work — the classic weak-model "redo everything" trap.

Reproduced end-to-end (real `burin-headless` 5-child `dispatch` fan-out,
claude-sonnet-4-6, on v0.8.157 which carries #3714): the render says
**"0/5 units completed", "wrote 0 file(s)"** while all four target files are on
disk. The sonnet parent even diagnosed it ("the children couldn't track file
writes through the harness") and recovered; a weaker model would redo the work.

## Root cause

The agent loop dispatches a turn's tool calls through `parallel settle`
(`loop.harn`). The `vm::ops::parallel` spawn sites (`parallel`, `parallel_each`,
`parallel_each_stream`, `parallel settle`, and `spawn`) wrap each child future
in `with_pool_registry_scope` **but not `scope_ambient`**. So a dispatched
tool runs as an independent `LocalSet` task, not nested in the spawning task's
poll.

On the fan-out path the worker's own `scope_ambient` has **swapped its
`CURRENT_SESSION_STACK` out** while it awaits the parallel join, so the tool
subtask reads an empty/sibling session. `fs_snapshot::auto_capture_for_write`
-> `active_session_id()` is then empty, `record_session_changed_path` is
skipped, and the receipt's `take_session_changed_paths(spec.session_id)` drains
empty. The single-worker path hid this because nothing competes for the
thread-local there.

**#3714 was necessary but not sufficient.** It fixed scope *preservation*
across a worker's own awaits, but its test recorded a changed path *directly
inside* `scope_ambient`, never crossing the real `parallel` spawn — a false
green. Sessions are NOT mismatched: every key resolves to `spec.session_id`
(`loop_options.session_id` -> `agent_session_host` resolved -> push -> drain).

## The fix

Add `AmbientExecutionScope::capture_for_inline_subtask()` — an isolated copy of
the **full** current ambient scope, *including* the active `session_stack`
(unlike `capture_inherited`, which resets the session because a fan-out WORKER
opens its own). An inline subtask is the same logical agent as its spawning
task, so it must inherit everything. A small `scope_inline_subtask(registry,
future)` helper wraps every `vm::ops::parallel` spawn site with it.

This does not touch fan-out **worker** isolation: workers spawn through the host
`__host_worker_spawn` -> `agents_workers::execution.rs`, which keeps its own
`scope_ambient(capture_inherited())` (session reset). Only the in-agent
parallel/spawn subtasks change.

## Verification

- New contention regression test `inline_subtask_scope_carries_worker_session_under_contention`
  reproduces the exact failure (two contending workers; each dispatches an
  independent subtask while its scope is swapped out) and includes a
  `capture_inherited` **control** proving the assertion is non-vacuous (an
  un-inherited subtask genuinely sees no session).
- `cargo test -p harn-vm --lib`: **4134 passed, 0 failed.**
- `cargo test -p harn-vm --test agent_fanout`: **5 passed, 0 failed.**
- `cargo fmt` clean; `cargo clippy -p harn-vm` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)