### PR TITLE
[codex] feat(provider): repeat tool conformance probes

### DIFF
--- a/changelog.d/3730.added.md
+++ b/changelog.d/3730.added.md
@@ -1,0 +1,1 @@
+`harn provider tool-probe` accepts `--repeat` for live provider reliability checks and reports repeated summaries conservatively.

--- a/crates/harn-cli/src/cli/provider.rs
+++ b/crates/harn-cli/src/cli/provider.rs
@@ -173,6 +173,9 @@ pub(crate) struct ProviderToolProbeArgs {
     /// Override the marker the model must echo through the tool call.
     #[arg(long, default_value = harn_vm::llm::tool_conformance::DEFAULT_TOOL_PROBE_MARKER)]
     pub marker: String,
+    /// Repeat each live probe mode N times.
+    #[arg(long, default_value_t = 1, value_parser = clap::value_parser!(u16).range(1..=100))]
+    pub repeat: u16,
     /// Classify a saved provider response body instead of making a live request.
     #[arg(long = "response-fixture")]
     pub response_fixture: Option<PathBuf>,

--- a/crates/harn-cli/src/cli/tests/parse_providers.rs
+++ b/crates/harn-cli/src/cli/tests/parse_providers.rs
@@ -583,6 +583,8 @@ fn test_parses_provider_tool_probe_args() {
         "non-streaming",
         "--marker",
         "marker",
+        "--repeat",
+        "5",
         "--response-fixture",
         "fixture.json",
     ]);
@@ -598,6 +600,7 @@ fn test_parses_provider_tool_probe_args() {
     assert_eq!(args.base_url.as_deref(), Some("http://127.0.0.1:11434"));
     assert!(matches!(args.mode, ProviderToolProbeModeArg::NonStreaming));
     assert_eq!(args.marker, "marker");
+    assert_eq!(args.repeat, 5);
     assert_eq!(args.response_fixture, Some(PathBuf::from("fixture.json")));
     assert!(args.json);
 }

--- a/crates/harn-cli/src/commands/provider.rs
+++ b/crates/harn-cli/src/commands/provider.rs
@@ -203,6 +203,13 @@ async fn aggregate_tool_conformance_report(
     args: &ProviderToolProbeArgs,
 ) -> Result<harn_vm::llm::tool_conformance::ToolConformanceReport, String> {
     if let Some(path) = args.response_fixture.as_ref() {
+        if args.repeat != 1 {
+            return Err(
+                "error: --repeat is only supported for live provider tool probes; \
+                 --response-fixture classifies one saved response"
+                    .to_string(),
+            );
+        }
         let raw = std::fs::read_to_string(path)
             .map_err(|error| format!("error: failed to read {}: {error}", path.display()))?;
         Ok(
@@ -225,6 +232,7 @@ async fn aggregate_tool_conformance_report(
         options.base_url = args.base_url.clone();
         options.modes = modes_for_arg(args.mode);
         options.marker = args.marker.clone();
+        options.repeat = usize::from(args.repeat);
         options.timeout_secs = args.timeout_secs;
         Ok(harn_vm::llm::tool_conformance::run_tool_conformance_probe(options).await)
     }

--- a/crates/harn-cli/tests/providers_dispatch.rs
+++ b/crates/harn-cli/tests/providers_dispatch.rs
@@ -294,6 +294,36 @@ fn provider_tool_probe_fixture_human_is_byte_identical_across_runs() {
     );
 }
 
+#[test]
+fn provider_tool_probe_fixture_rejects_repeat() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let fixture = dir.path().join("response.json");
+    write_minimal_tool_fixture(&fixture);
+    let path = fixture.to_string_lossy().into_owned();
+    let output = run(
+        &[
+            "provider",
+            "tool-probe",
+            "mock",
+            "--model",
+            "mock",
+            "--response-fixture",
+            path.as_str(),
+            "--repeat",
+            "5",
+        ],
+        &[],
+    );
+    assert_eq!(output.exit_code, 1, "stderr={}", output.stderr);
+    assert!(
+        output
+            .stderr
+            .contains("--repeat is only supported for live"),
+        "stderr={}",
+        output.stderr
+    );
+}
+
 fn write_minimal_tool_fixture(path: &Path) {
     // An OpenAI-style response body the fixture classifier accepts.
     // The marker matches the default `DEFAULT_TOOL_PROBE_MARKER`. Even

--- a/crates/harn-vm/src/llm/tool_conformance.rs
+++ b/crates/harn-vm/src/llm/tool_conformance.rs
@@ -24,6 +24,7 @@ pub struct ToolConformanceProbeOptions {
     pub base_url: Option<String>,
     pub modes: Vec<ToolProbeMode>,
     pub marker: String,
+    pub repeat: usize,
     pub timeout_secs: u64,
 }
 
@@ -35,6 +36,7 @@ impl ToolConformanceProbeOptions {
             base_url: None,
             modes: vec![ToolProbeMode::NonStreaming, ToolProbeMode::Streaming],
             marker: DEFAULT_TOOL_PROBE_MARKER.to_string(),
+            repeat: 1,
             timeout_secs: 120,
         }
     }
@@ -205,18 +207,21 @@ pub async fn run_tool_conformance_probe(
         llm_config::provider_config(&provider).map(|def| llm_config::resolve_base_url(&def))
     });
     let mut cases = Vec::new();
-    for mode in normalized_modes(&options.modes) {
-        cases.push(
-            execute_live_probe_case(
-                &provider,
-                &model_id,
-                base_url.as_deref(),
-                mode,
-                &options.marker,
-                options.timeout_secs,
-            )
-            .await,
-        );
+    let modes = normalized_modes(&options.modes);
+    for _ in 0..options.repeat.max(1) {
+        for mode in &modes {
+            cases.push(
+                execute_live_probe_case(
+                    &provider,
+                    &model_id,
+                    base_url.as_deref(),
+                    *mode,
+                    &options.marker,
+                    options.timeout_secs,
+                )
+                .await,
+            );
+        }
     }
     report_from_cases(provider, model_id, base_url, options.marker, cases)
 }
@@ -284,43 +289,9 @@ fn report_from_cases(
 }
 
 fn summarize_cases(cases: &[ToolConformanceCase]) -> ToolCallingConformanceSummary {
-    let mut native = ToolProbeStatus::Unknown;
-    let mut streaming_native = ToolProbeStatus::Unknown;
-    let mut text = ToolProbeStatus::Unknown;
-
-    for case in cases {
-        if case.classification == ToolProbeClassification::StructuredNativeToolCall {
-            if case.mode == ToolProbeMode::Streaming {
-                streaming_native = if case.ok {
-                    ToolProbeStatus::Pass
-                } else {
-                    ToolProbeStatus::Fail
-                };
-            } else {
-                native = if case.ok {
-                    ToolProbeStatus::Pass
-                } else {
-                    ToolProbeStatus::Fail
-                };
-            }
-        } else if case.mode == ToolProbeMode::Streaming
-            && streaming_native == ToolProbeStatus::Unknown
-        {
-            streaming_native = ToolProbeStatus::Fail;
-        } else if case.mode == ToolProbeMode::NonStreaming && native == ToolProbeStatus::Unknown {
-            native = ToolProbeStatus::Fail;
-        }
-
-        if case.classification == ToolProbeClassification::ParseableHarnTextToolCall {
-            text = if case.ok {
-                ToolProbeStatus::Pass
-            } else {
-                ToolProbeStatus::Fail
-            };
-        } else if text == ToolProbeStatus::Unknown && case.text_tool_call_count > 0 {
-            text = ToolProbeStatus::Fail;
-        }
-    }
+    let native = summarize_native_mode(cases, ToolProbeMode::NonStreaming);
+    let streaming_native = summarize_native_mode(cases, ToolProbeMode::Streaming);
+    let text = summarize_text_mode(cases);
 
     let fallback_mode =
         if native == ToolProbeStatus::Pass || streaming_native == ToolProbeStatus::Pass {
@@ -343,6 +314,55 @@ fn summarize_cases(cases: &[ToolConformanceCase]) -> ToolCallingConformanceSumma
         streaming_native,
         fallback_mode,
         failure_reason,
+    }
+}
+
+fn summarize_native_mode(cases: &[ToolConformanceCase], mode: ToolProbeMode) -> ToolProbeStatus {
+    let mut saw_mode = false;
+    let mut all_passed = true;
+    for case in cases.iter().filter(|case| case.mode == mode) {
+        saw_mode = true;
+        if !(case.ok && case.classification == ToolProbeClassification::StructuredNativeToolCall) {
+            all_passed = false;
+        }
+    }
+    match (saw_mode, all_passed) {
+        (false, _) => ToolProbeStatus::Unknown,
+        (true, true) => ToolProbeStatus::Pass,
+        (true, false) => ToolProbeStatus::Fail,
+    }
+}
+
+fn summarize_text_mode(cases: &[ToolConformanceCase]) -> ToolProbeStatus {
+    let mut saw_text = false;
+    let mut saw_passing_mode = false;
+    for mode in [ToolProbeMode::NonStreaming, ToolProbeMode::Streaming] {
+        let mut saw_mode = false;
+        let mut saw_text_in_mode = false;
+        let mut all_mode_cases_passed = true;
+        for case in cases.iter().filter(|case| case.mode == mode) {
+            saw_mode = true;
+            saw_text_in_mode |= case.classification
+                == ToolProbeClassification::ParseableHarnTextToolCall
+                || case.text_tool_call_count > 0;
+            if !(case.ok
+                && case.classification == ToolProbeClassification::ParseableHarnTextToolCall)
+            {
+                all_mode_cases_passed = false;
+            }
+        }
+        saw_text |= saw_text_in_mode;
+        if saw_mode && saw_text_in_mode && all_mode_cases_passed {
+            saw_passing_mode = true;
+        }
+    }
+    if !saw_text {
+        return ToolProbeStatus::Unknown;
+    }
+    if saw_passing_mode {
+        ToolProbeStatus::Pass
+    } else {
+        ToolProbeStatus::Fail
     }
 }
 
@@ -1005,5 +1025,87 @@ mod tests {
             &report,
             "native_tool_probe"
         ));
+    }
+
+    #[test]
+    fn summary_requires_every_repeated_native_case_to_pass() {
+        let summary = summarize_cases(&[
+            probe_case(
+                ToolProbeMode::NonStreaming,
+                true,
+                ToolProbeClassification::StructuredNativeToolCall,
+            ),
+            probe_case(
+                ToolProbeMode::NonStreaming,
+                false,
+                ToolProbeClassification::ProseOnlyNonTool,
+            ),
+        ]);
+        assert_eq!(summary.native, ToolProbeStatus::Fail);
+        assert_eq!(summary.fallback_mode, ToolProbeFallbackMode::Disabled);
+    }
+
+    #[test]
+    fn summary_requires_every_repeated_text_case_to_pass() {
+        let summary = summarize_cases(&[
+            probe_case(
+                ToolProbeMode::NonStreaming,
+                true,
+                ToolProbeClassification::ParseableHarnTextToolCall,
+            ),
+            probe_case(
+                ToolProbeMode::NonStreaming,
+                false,
+                ToolProbeClassification::MalformedJsonArguments,
+            ),
+        ]);
+        assert_eq!(summary.native, ToolProbeStatus::Fail);
+        assert_eq!(summary.text, ToolProbeStatus::Fail);
+        assert_eq!(summary.fallback_mode, ToolProbeFallbackMode::Disabled);
+    }
+
+    #[test]
+    fn summary_preserves_nonstreaming_text_fallback_when_streaming_fails() {
+        let summary = summarize_cases(&[
+            probe_case(
+                ToolProbeMode::NonStreaming,
+                true,
+                ToolProbeClassification::ParseableHarnTextToolCall,
+            ),
+            probe_case(
+                ToolProbeMode::Streaming,
+                false,
+                ToolProbeClassification::ProseOnlyNonTool,
+            ),
+        ]);
+        assert_eq!(summary.native, ToolProbeStatus::Fail);
+        assert_eq!(summary.streaming_native, ToolProbeStatus::Fail);
+        assert_eq!(summary.text, ToolProbeStatus::Pass);
+        assert_eq!(summary.fallback_mode, ToolProbeFallbackMode::Text);
+    }
+
+    fn probe_case(
+        mode: ToolProbeMode,
+        ok: bool,
+        classification: ToolProbeClassification,
+    ) -> ToolConformanceCase {
+        let native_tool_call_count =
+            usize::from(classification == ToolProbeClassification::StructuredNativeToolCall);
+        let text_tool_call_count =
+            usize::from(classification == ToolProbeClassification::ParseableHarnTextToolCall);
+        ToolConformanceCase {
+            mode,
+            ok,
+            classification,
+            fallback_mode: ToolProbeFallbackMode::Disabled,
+            failure_reason: None,
+            http_status: None,
+            elapsed_ms: None,
+            native_tool_call_count,
+            text_tool_call_count,
+            parser_errors: Vec::new(),
+            protocol_violations: Vec::new(),
+            content_sample: None,
+        }
     }
 }

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1254,10 +1254,13 @@ emits JSON with native/text/disabled fallback classification.
 ```bash
 harn provider tool-probe ollama --model devstral-small-2
 harn provider tool-probe llamacpp --model local-qwen3.6 --mode non-streaming
+harn provider tool-probe dashscope --model qwen3.6-35b-a3b --mode non-streaming --repeat 5
 ```
 
 Use `--response-fixture` to classify a saved provider response without making a
-network request. `harn local switch` can consume the JSON with `--probe-result`.
+network request. Use `--repeat` for live reliability checks; repeated summaries
+only pass when every attempted probe for that mode succeeds. `harn local switch`
+can consume the JSON with `--probe-result`.
 
 ## harn local launch
 

--- a/docs/src/llm/providers.md
+++ b/docs/src/llm/providers.md
@@ -164,6 +164,7 @@ local lifecycle gates and eval harnesses:
 
 ```bash
 harn provider tool-probe ollama --model devstral-small-2 --mode both --json
+harn provider tool-probe dashscope --model qwen3.6-35b-a3b --mode non-streaming --repeat 5 --json
 harn local switch ollama-gemma4 --probe-result gemma4-tool-probe.json
 ```
 
@@ -171,7 +172,9 @@ The report classifies each mode as a structured native tool call, parseable
 Harn text tool call, raw model-specific tag, prose-only response, malformed
 arguments, empty response, HTTP error, or transport error. Its
 `tool_calling.fallback_mode` is the machine-readable choice downstream
-systems should record: `native`, `text`, or `disabled`.
+systems should record: `native`, `text`, or `disabled`. Use `--repeat` for
+provider reliability measurements; repeated summaries only pass when every
+attempt for that mode succeeds.
 
 ### Enterprise providers
 


### PR DESCRIPTION
## Summary
- add `harn provider tool-probe --repeat <N>` for live N-trial provider tool checks
- make repeated tool-probe summaries fail closed when any attempted case for that mode fails
- reject `--repeat` with `--response-fixture` so saved fixtures cannot masquerade as live reliability evidence

## Validation
- `cargo test -p harn-vm tool_conformance`
- `cargo test -p harn-cli provider_tool_probe_fixture_rejects_repeat`
- `cargo test -p harn-cli test_parses_provider_tool_probe_args`
- `cargo fmt --all -- --check`
- `git diff --check`
- `npx markdownlint-cli2 docs/src/llm/providers.md docs/src/cli-reference.md changelog.d/3730.added.md`
- `make check-docs-cli-flags`
- dogfood: `target/debug/harn provider tool-probe unknown-provider --model unknown-model --mode non-streaming --repeat 2 --json true` produced two failed cases and a disabled summary
- pre-commit and pre-push hooks passed

Refs #3730