### PR TITLE
[codex] fix(vm): inherit sub-agent workspace anchors for write scope

### DIFF
--- a/changelog.d/dispatch-child-write-scope.fixed.md
+++ b/changelog.d/dispatch-child-write-scope.fixed.md
@@ -1,0 +1,2 @@
+Fixed sub-agent worker write scopes so unanchored child agents inherit the parent
+workspace anchor as their default execution cwd.

--- a/crates/harn-vm/src/stdlib/agents_sub_agent.rs
+++ b/crates/harn-vm/src/stdlib/agents_sub_agent.rs
@@ -130,11 +130,14 @@ pub(super) fn parse_sub_agent_request(args: &[VmValue]) -> Result<ParsedSubAgent
             .collect::<Result<Vec<_>, _>>()?,
         None => inherited_reminders_from_parent(parent_session_id.as_deref()),
     };
-    let workspace_anchor = parse_sub_agent_workspace_anchor(&mut parser)?;
+    let requested_workspace_anchor = parse_sub_agent_workspace_anchor(&mut parser)?;
     parser.finish_strict(&[])?;
-    if let Some(anchor) = workspace_anchor.as_ref() {
-        validate_child_anchor_against_parent(parent_session_id.as_deref(), anchor)?;
-    }
+    let workspace_anchor = resolve_sub_agent_workspace_anchor(
+        parent_session_id.as_deref(),
+        requested_workspace_anchor,
+    )?;
+    let mut execution = policies.execution;
+    default_sub_agent_execution_cwd(&mut execution, workspace_anchor.as_ref());
 
     Ok(ParsedSubAgentRequest {
         spec: SubAgentRunSpec {
@@ -150,7 +153,7 @@ pub(super) fn parse_sub_agent_request(args: &[VmValue]) -> Result<ParsedSubAgent
         },
         background,
         carry_policy: policies.carry_policy,
-        execution: policies.execution,
+        execution,
         worker_policy: policies.worker_policy,
     })
 }
@@ -167,6 +170,36 @@ fn parse_sub_agent_workspace_anchor(
     let anchor = crate::workspace_anchor::parse_anchor_dict(value)
         .map_err(|message| VmError::Runtime(format!("{SUB_AGENT_RUN_FN}: anchor: {message}")))?;
     Ok(Some(anchor))
+}
+
+fn resolve_sub_agent_workspace_anchor(
+    parent_session_id: Option<&str>,
+    requested: Option<crate::workspace_anchor::WorkspaceAnchor>,
+) -> Result<Option<crate::workspace_anchor::WorkspaceAnchor>, VmError> {
+    match requested {
+        Some(anchor) => {
+            validate_child_anchor_against_parent(parent_session_id, &anchor)?;
+            Ok(Some(anchor))
+        }
+        None => Ok(parent_session_id.and_then(crate::agent_sessions::workspace_anchor)),
+    }
+}
+
+fn default_sub_agent_execution_cwd(
+    execution: &mut agents_workers::WorkerExecutionProfile,
+    anchor: Option<&crate::workspace_anchor::WorkspaceAnchor>,
+) {
+    if execution
+        .cwd
+        .as_deref()
+        .is_some_and(|cwd| !cwd.trim().is_empty())
+    {
+        return;
+    }
+    let Some(anchor) = anchor else {
+        return;
+    };
+    execution.cwd = Some(anchor.primary.to_string_lossy().into_owned());
 }
 
 /// Reject child anchors that escape the parent's anchor + mounted
@@ -1231,6 +1264,86 @@ mod tests {
 
     fn path_string(path: &std::path::Path) -> String {
         path.to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn parse_sub_agent_request_inherits_parent_anchor_as_execution_cwd() {
+        crate::agent_sessions::reset_session_store();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path().join("project");
+        let project_text = path_string(&project);
+        let parent_id =
+            crate::agent_sessions::open_or_create(Some("anchor-inherit-parent".to_string()));
+        crate::agent_sessions::set_workspace_anchor(
+            &parent_id,
+            Some(crate::workspace_anchor::WorkspaceAnchor {
+                primary: project.clone(),
+                additional_roots: Vec::new(),
+                anchored_at: "2026-05-24T00:00:00Z".to_string(),
+            }),
+        )
+        .unwrap();
+        let _guard = crate::agent_sessions::enter_current_session(parent_id.clone());
+
+        let parsed = parse_sub_agent_request(&[normalized_request(Vec::new())]).unwrap();
+
+        assert_eq!(
+            parsed.spec.parent_session_id.as_deref(),
+            Some(parent_id.as_str())
+        );
+        assert_eq!(
+            parsed.spec.workspace_anchor.as_ref().unwrap().primary,
+            project
+        );
+        assert_eq!(
+            parsed.execution.cwd.as_deref(),
+            Some(project_text.as_str()),
+            "unanchored child workers default their sandbox execution cwd to the parent workspace"
+        );
+    }
+
+    #[test]
+    fn parse_sub_agent_request_preserves_explicit_execution_cwd() {
+        crate::agent_sessions::reset_session_store();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path().join("project");
+        let child = project.join("child");
+        let explicit_cwd = dir.path().join("explicit-cwd");
+        let explicit_cwd_text = path_string(&explicit_cwd);
+        let parent_id =
+            crate::agent_sessions::open_or_create(Some("anchor-explicit-cwd-parent".to_string()));
+        crate::agent_sessions::set_workspace_anchor(
+            &parent_id,
+            Some(crate::workspace_anchor::WorkspaceAnchor {
+                primary: project,
+                additional_roots: Vec::new(),
+                anchored_at: "2026-05-24T00:00:00Z".to_string(),
+            }),
+        )
+        .unwrap();
+        let _guard = crate::agent_sessions::enter_current_session(parent_id);
+
+        let parsed = parse_sub_agent_request(&[normalized_request(vec![
+            ("anchor", anchor_dict(&path_string(&child), Vec::new())),
+            (
+                "execution",
+                VmValue::dict(crate::value::DictMap::from_iter([(
+                    crate::value::intern_key("cwd"),
+                    VmValue::String(arcstr::ArcStr::from(explicit_cwd_text.clone())),
+                )])),
+            ),
+        ])])
+        .unwrap();
+
+        assert_eq!(
+            parsed.spec.workspace_anchor.as_ref().unwrap().primary,
+            child
+        );
+        assert_eq!(
+            parsed.execution.cwd.as_deref(),
+            Some(explicit_cwd_text.as_str()),
+            "explicit execution.cwd remains authoritative"
+        );
     }
 
     #[test]

--- a/crates/harn-vm/tests/agent_fanout.rs
+++ b/crates/harn-vm/tests/agent_fanout.rs
@@ -22,6 +22,8 @@
 
 use harn_vm::bridge::HostBridge;
 use harn_vm::value::VmError;
+use std::collections::BTreeMap;
+use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
@@ -50,6 +52,86 @@ fn run_with_bridge(source: &str) -> Result<String, String> {
                     .await
                     .map_err(|e: VmError| format!("{e:?}"));
                 harn_vm::llm::clear_current_host_bridge();
+                result?;
+                Ok(vm.output().to_string())
+            })
+            .await
+    })
+}
+
+fn run_with_bridge_in_parent_workspace(
+    source: &str,
+    parent_cwd: &Path,
+    parent_session_id: &str,
+    project_root: &Path,
+) -> Result<String, String> {
+    harn_vm::reset_thread_local_state();
+    let chunk = harn_vm::compile_source(source)?;
+    let parent_cwd = parent_cwd.to_string_lossy().into_owned();
+    let project_root = project_root.to_path_buf();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| e.to_string())?;
+    rt.block_on(async {
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async {
+                let bridge = Arc::new(HostBridge::from_parts(
+                    Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+                    Arc::new(AtomicBool::new(false)),
+                    Arc::new(Mutex::new(())),
+                    1,
+                ));
+                harn_vm::llm::install_current_host_bridge(bridge.clone());
+
+                let parent_id =
+                    harn_vm::agent_sessions::open_or_create(Some(parent_session_id.to_string()));
+                harn_vm::agent_sessions::set_workspace_anchor(
+                    &parent_id,
+                    Some(harn_vm::workspace_anchor::WorkspaceAnchor {
+                        primary: project_root.clone(),
+                        additional_roots: Vec::new(),
+                        anchored_at: "2026-06-30T00:00:00Z".to_string(),
+                    }),
+                )?;
+                let _session_guard = harn_vm::agent_sessions::enter_current_session(parent_id);
+
+                harn_vm::stdlib::process::set_thread_execution_context(Some(
+                    harn_vm::orchestration::RunExecutionRecord {
+                        cwd: Some(parent_cwd),
+                        source_dir: None,
+                        env: BTreeMap::new(),
+                        adapter: None,
+                        repo_path: None,
+                        worktree_path: None,
+                        branch: None,
+                        base_ref: None,
+                        cleanup: None,
+                    },
+                ));
+                harn_vm::orchestration::push_execution_policy(
+                    harn_vm::orchestration::CapabilityPolicy {
+                        capabilities: BTreeMap::from([(
+                            "workspace".to_string(),
+                            vec!["read_text".to_string(), "write_text".to_string()],
+                        )]),
+                        side_effect_level: Some("workspace_write".to_string()),
+                        ..harn_vm::orchestration::CapabilityPolicy::default()
+                    },
+                );
+
+                let mut vm = harn_vm::Vm::new();
+                harn_vm::register_vm_stdlib(&mut vm);
+                let result = vm
+                    .execute(&chunk)
+                    .await
+                    .map_err(|e: VmError| format!("{e:?}"));
+
+                harn_vm::orchestration::pop_execution_policy();
+                harn_vm::stdlib::process::set_thread_execution_context(None);
+                harn_vm::llm::clear_current_host_bridge();
+
                 result?;
                 Ok(vm.output().to_string())
             })
@@ -330,6 +412,120 @@ pipeline main(task) {{
         );
     }
     eprintln!("WAVES CONFIRMED: 5 requests across waves of 2 all completed in input order with own markers");
+}
+
+#[test]
+fn fanout_child_write_inherits_parent_workspace_anchor_for_scope() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let process_root = temp.path().join("process-root");
+    let project_root = temp.path().join("fixture-project");
+    std::fs::create_dir_all(&process_root).expect("process root");
+    std::fs::create_dir_all(&project_root).expect("project root");
+    let target = project_root.join("child-output.txt");
+    let target_literal = serde_json::to_string(&target.to_string_lossy()).expect("json string");
+
+    let source = format!(
+        r#"{PRELUDE}
+pipeline main(task) {{
+  clear_tool_hooks()
+  let registry = tool_registry()
+  let tools = tool_define(
+    registry,
+    "write_child_file",
+    "Write a fixture file from inside a child sub-agent.",
+    {{
+      parameters: {{}},
+      handler: {{ _args ->
+        write_file({target_literal}, "child-ok")
+        return "wrote child-output.txt"
+      }},
+    }},
+  )
+  let call_count = shared_cell(
+    {{scope: "task_group", key: "fanout-child-write-scope", initial: 0}},
+  )
+  let mock_llm = {{ _call ->
+    let snap = shared_snapshot(call_count)
+    let n = snap.value
+    shared_cas(call_count, snap, n + 1)
+    if n == 0 {{
+      return {{
+        ok: true,
+        value: {{
+          text: "",
+          tool_calls: [{{id: "call_write", name: "write_child_file", arguments: {{}}}}],
+          provider: "mock",
+          model: "mock",
+        }},
+      }}
+    }}
+    return {{
+      ok: true,
+      value: {{
+        text: "<user_response>child wrote the file</user_response>\n<done>##DONE##</done>",
+        tool_calls: [],
+        provider: "mock",
+        model: "mock",
+      }},
+    }}
+  }}
+  let results = agent_fanout(
+    [
+      {{
+        task: "write the child output file",
+        label: "writer",
+        options: {{
+          provider: "mock",
+          model: "fanout-model",
+          tools: tools,
+          tool_format: "native",
+          llm_caller: mock_llm,
+          loop_until_done: true,
+          done_judge: false,
+          max_iterations: 3,
+          final_wrapup: false,
+        }},
+      }},
+    ],
+    {{max_parallel: 1}},
+  )
+  log("COUNT=" + to_string(len(results)))
+  emit_rows(results)
+  if results[0]?.error != nil {{
+    log("ERR=" + json_stringify(results[0]?.error))
+  }}
+}}
+"#
+    );
+
+    let raw = run_with_bridge_in_parent_workspace(
+        &source,
+        &process_root,
+        "fanout-parent-workspace-anchor",
+        &project_root,
+    )
+    .expect("fanout child write pipeline must run");
+    let lines = out_lines(&raw);
+    eprintln!("--- harn output ---\n{}", lines.join("\n"));
+
+    let rows = parse_rows(&lines);
+    assert_eq!(rows.len(), 1, "lines: {lines:?}");
+    assert_eq!(rows[0].label, "writer", "lines: {lines:?}");
+    assert!(
+        rows[0].ok,
+        "child write result should be ok; lines: {lines:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&target).expect("child output file"),
+        "child-ok"
+    );
+    assert!(
+        !process_root.join("child-output.txt").exists(),
+        "child write should land in the inherited project root, not the process cwd"
+    );
+    eprintln!(
+        "CHILD-WRITE-SCOPE CONFIRMED: child tool write succeeded under the parent workspace anchor"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes burin-labs/burin-code#3288 by making unanchored dispatch sub-agents inherit the parent session workspace anchor as their default worker execution cwd. This keeps Harn file builtin write-scope rooted at the `--project` workspace instead of falling back to the process cwd when Burin runs evals from the repo with `--project <fixture>`.

The fix is intentionally in Harn runtime/session setup rather than Burin host fallback code: path resolution was already correct, but the child worker execution/write scope was not anchored to the project. Explicit child anchors and explicit worker `execution.cwd` remain authoritative.

## Validation

- `cargo fmt --all`
- `CARGO_TARGET_DIR=/Users/ksinder/projects/harn-worktrees/dispatch-child-write-scope/target/codex3288 cargo test -p harn-vm parse_sub_agent_request_ -- --nocapture`
- `CARGO_TARGET_DIR=/Users/ksinder/projects/harn-worktrees/dispatch-child-write-scope/target/codex3288 cargo test -p harn-vm --test agent_fanout -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- signed commit pre-commit hook, including changed-package `cargo clippy -p harn-vm -- -D warnings` and highlight keyword drift check
- pre-push targeted local checks

## Notes

The new integration regression sets parent process/execution cwd to a separate directory, installs the parent session workspace anchor on a fixture project, dispatches a child native-tool write to the project, and asserts the child write succeeds in the project while no file appears under the process cwd.

Codex: 2