### PR TITLE
fix(orchestrator): wait for topic pumps before readiness

### DIFF
--- a/changelog.d/pump-startup-ready.fixed.md
+++ b/changelog.d/pump-startup-ready.fixed.md
@@ -1,0 +1,4 @@
+- **Orchestrator pump startup readiness.** The in-process orchestrator harness now
+  waits for pending, inbox, cron, and waitpoint pumps to subscribe before it
+  reports startup readiness, preventing immediately accepted trigger requests
+  from racing ahead of the pump cursor and being skipped under CI scheduling.

--- a/crates/harn-cli/src/commands/orchestrator/harness/lifecycle.rs
+++ b/crates/harn-cli/src/commands/orchestrator/harness/lifecycle.rs
@@ -22,7 +22,7 @@ use super::audit::{
 use super::config::{DrainConfig, OrchestratorConfig, PumpConfig};
 use super::pumps::{
     spawn_cron_pump, spawn_inbox_pump, spawn_pending_pump, spawn_waitpoint_cancel_pump,
-    spawn_waitpoint_resume_pump, spawn_waitpoint_sweeper, PumpDrainGate,
+    spawn_waitpoint_resume_pump, spawn_waitpoint_sweeper, PumpDrainGate, PumpHandle,
 };
 use super::reload::{handle_reload_request, RuntimeCtx};
 use super::routing::{
@@ -32,10 +32,39 @@ use super::routing::{
 };
 use super::shutdown::{graceful_shutdown, GracefulShutdownCtx};
 use super::ReadyState;
-use super::{PENDING_TOPIC, STATE_SNAPSHOT_FILE};
+use super::{CRON_TICK_TOPIC, PENDING_TOPIC, STATE_SNAPSHOT_FILE};
 use crate::package::{self, Manifest};
 
 const MANIFEST_WATCH_DEBOUNCE: Duration = Duration::from_millis(200);
+
+async fn wait_for_pump_startup(
+    pending_pumps: &mut [(String, PumpHandle)],
+    inbox_pumps: &mut [(String, PumpHandle)],
+    cron_pump: &mut PumpHandle,
+    waitpoint_pump: &mut PumpHandle,
+    waitpoint_cancel_pump: &mut PumpHandle,
+) -> Result<Vec<String>, OrchestratorError> {
+    let mut topics = Vec::new();
+    for (topic, pump) in pending_pumps {
+        pump.wait_ready(topic).await?;
+        topics.push(topic.clone());
+    }
+    for (topic, pump) in inbox_pumps {
+        pump.wait_ready(topic).await?;
+        topics.push(topic.clone());
+    }
+    cron_pump.wait_ready(CRON_TICK_TOPIC).await?;
+    topics.push(CRON_TICK_TOPIC.to_string());
+    waitpoint_pump
+        .wait_ready(harn_vm::WAITPOINT_RESUME_TOPIC)
+        .await?;
+    topics.push(harn_vm::WAITPOINT_RESUME_TOPIC.to_string());
+    waitpoint_cancel_pump
+        .wait_ready(harn_vm::TRIGGER_CANCEL_REQUESTS_TOPIC)
+        .await?;
+    topics.push(harn_vm::TRIGGER_CANCEL_REQUESTS_TOPIC.to_string());
+    Ok(topics)
+}
 
 pub(super) async fn orchestrator_task(
     config: OrchestratorConfig,
@@ -313,21 +342,21 @@ async fn orchestrator_lifecycle(
             ));
         }
     }
-    let cron_pump = spawn_cron_pump(
+    let mut cron_pump = spawn_cron_pump(
         event_log.clone(),
         dispatcher.clone(),
         pump_config,
         metrics_registry.clone(),
         pump_drain_gate.clone(),
     )?;
-    let waitpoint_pump = spawn_waitpoint_resume_pump(
+    let mut waitpoint_pump = spawn_waitpoint_resume_pump(
         event_log.clone(),
         dispatcher.clone(),
         pump_config,
         metrics_registry.clone(),
         pump_drain_gate.clone(),
     )?;
-    let waitpoint_cancel_pump = spawn_waitpoint_cancel_pump(
+    let mut waitpoint_cancel_pump = spawn_waitpoint_cancel_pump(
         event_log.clone(),
         dispatcher.clone(),
         pump_config,
@@ -376,6 +405,23 @@ async fn orchestrator_lifecycle(
         "[harn] activated connectors: {}",
         format_activation_summary(&connector_runtime.activations)
     );
+
+    let ready_pump_topics = wait_for_pump_startup(
+        &mut pending_pumps,
+        &mut inbox_pumps,
+        &mut cron_pump,
+        &mut waitpoint_pump,
+        &mut waitpoint_cancel_pump,
+    )
+    .await?;
+    append_lifecycle_event(
+        &event_log,
+        "pumps_ready",
+        json!({
+            "topics": ready_pump_topics,
+        }),
+    )
+    .await?;
 
     listener.mark_ready();
     eprintln!("[harn] HTTP listener ready on {}", listener.url());

--- a/crates/harn-cli/src/commands/orchestrator/harness/pumps.rs
+++ b/crates/harn-cli/src/commands/orchestrator/harness/pumps.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use futures::StreamExt;
 use serde::Deserialize;
 use serde_json::json;
-use tokio::sync::watch;
+use tokio::sync::{oneshot, watch};
 use tokio::task::JoinSet;
 
 use harn_vm::event_log::{AnyEventLog, ConsumerId, EventLog};
@@ -107,10 +107,24 @@ impl PumpDrainReport {
 
 pub(super) struct PumpHandle {
     mode_tx: watch::Sender<PumpMode>,
+    ready_rx: Option<oneshot::Receiver<Result<(), String>>>,
     join: tokio::task::JoinHandle<Result<PumpDrainReport, OrchestratorError>>,
 }
 
 impl PumpHandle {
+    pub(super) async fn wait_ready(&mut self, topic_name: &str) -> Result<(), OrchestratorError> {
+        let ready_rx = self.ready_rx.take().ok_or_else(|| {
+            OrchestratorError::Serve(format!("pump {topic_name} readiness already consumed"))
+        })?;
+        match ready_rx.await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(error)) => {
+                Err(format!("pump {topic_name} failed to initialize: {error}").into())
+            }
+            Err(_) => Err(format!("pump {topic_name} exited before signaling readiness").into()),
+        }
+    }
+
     pub(super) async fn drain(
         self,
         log: &Arc<AnyEventLog>,
@@ -143,6 +157,15 @@ impl PumpHandle {
             Ok(result) => result,
             Err(error) => Err(format!("pump task join failed: {error}").into()),
         }
+    }
+}
+
+fn signal_pump_ready(
+    ready_tx: &mut Option<oneshot::Sender<Result<(), String>>>,
+    result: Result<(), String>,
+) {
+    if let Some(sender) = ready_tx.take() {
+        let _ = sender.send(result);
     }
 }
 
@@ -260,26 +283,44 @@ pub(super) fn spawn_inbox_pump(
     let topic = harn_vm::event_log::Topic::new(topic_name).map_err(|error| error.to_string())?;
     let consumer = pump_consumer_id(&topic)?;
     let inbox_task_release_file = inbox_task_test_release_file();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let mut ready_tx = Some(ready_tx);
     let (mode_tx, mut mode_rx) = watch::channel(PumpMode::Running);
     let join = tokio::task::spawn_local(async move {
-        let start_from = event_log
-            .consumer_cursor(&topic, &consumer)
-            .await
-            .map_err(|error| format!("failed to read consumer cursor for {topic}: {error}"))?
-            .or(event_log
-                .latest(&topic)
-                .await
-                .map_err(|error| format!("failed to read topic head {topic}: {error}"))?);
-        let mut stream = event_log
-            .clone()
-            .subscribe(&topic, start_from)
-            .await
-            .map_err(|error| format!("failed to subscribe topic {topic}: {error}"))?;
+        let start_from = match event_log.consumer_cursor(&topic, &consumer).await {
+            Ok(cursor) => match event_log.latest(&topic).await {
+                Ok(latest) => cursor.or(latest),
+                Err(error) => {
+                    let message = format!("failed to read topic head {topic}: {error}");
+                    signal_pump_ready(&mut ready_tx, Err(message.clone()));
+                    return Err(message.into());
+                }
+            },
+            Err(error) => {
+                let message = format!("failed to read consumer cursor for {topic}: {error}");
+                signal_pump_ready(&mut ready_tx, Err(message.clone()));
+                return Err(message.into());
+            }
+        };
+        let mut stream = match event_log.clone().subscribe(&topic, start_from).await {
+            Ok(stream) => stream,
+            Err(error) => {
+                let message = format!("failed to subscribe topic {topic}: {error}");
+                signal_pump_ready(&mut ready_tx, Err(message.clone()));
+                return Err(message.into());
+            }
+        };
         let mut stats = PumpStats {
             last_seen: start_from.unwrap_or(0),
             processed: 0,
         };
-        record_pump_metrics(&metrics_registry, &event_log, &topic, stats.last_seen, 0).await?;
+        if let Err(error) =
+            record_pump_metrics(&metrics_registry, &event_log, &topic, stats.last_seen, 0).await
+        {
+            signal_pump_ready(&mut ready_tx, Err(error.to_string()));
+            return Err(error);
+        }
+        signal_pump_ready(&mut ready_tx, Ok(()));
         let mut drain_progress = None;
         let mut tasks = JoinSet::new();
 
@@ -503,7 +544,11 @@ pub(super) fn spawn_inbox_pump(
                 stop_reason: PumpDrainStopReason::Drained,
             }))
     });
-    Ok(PumpHandle { mode_tx, join })
+    Ok(PumpHandle {
+        mode_tx,
+        ready_rx: Some(ready_rx),
+        join,
+    })
 }
 
 pub(super) fn spawn_waitpoint_resume_pump(
@@ -604,26 +649,44 @@ where
 {
     let consumer = pump_consumer_id(&topic)?;
     let mut pump_drain_gate_rx = pump_drain_gate.subscribe();
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let mut ready_tx = Some(ready_tx);
     let (mode_tx, mut mode_rx) = watch::channel(PumpMode::Running);
     let join = tokio::task::spawn_local(async move {
-        let start_from = event_log
-            .consumer_cursor(&topic, &consumer)
-            .await
-            .map_err(|error| format!("failed to read consumer cursor for {topic}: {error}"))?
-            .or(event_log
-                .latest(&topic)
-                .await
-                .map_err(|error| format!("failed to read topic head {topic}: {error}"))?);
-        let mut stream = event_log
-            .clone()
-            .subscribe(&topic, start_from)
-            .await
-            .map_err(|error| format!("failed to subscribe topic {topic}: {error}"))?;
+        let start_from = match event_log.consumer_cursor(&topic, &consumer).await {
+            Ok(cursor) => match event_log.latest(&topic).await {
+                Ok(latest) => cursor.or(latest),
+                Err(error) => {
+                    let message = format!("failed to read topic head {topic}: {error}");
+                    signal_pump_ready(&mut ready_tx, Err(message.clone()));
+                    return Err(message.into());
+                }
+            },
+            Err(error) => {
+                let message = format!("failed to read consumer cursor for {topic}: {error}");
+                signal_pump_ready(&mut ready_tx, Err(message.clone()));
+                return Err(message.into());
+            }
+        };
+        let mut stream = match event_log.clone().subscribe(&topic, start_from).await {
+            Ok(stream) => stream,
+            Err(error) => {
+                let message = format!("failed to subscribe topic {topic}: {error}");
+                signal_pump_ready(&mut ready_tx, Err(message.clone()));
+                return Err(message.into());
+            }
+        };
         let mut stats = PumpStats {
             last_seen: start_from.unwrap_or(0),
             processed: 0,
         };
-        record_pump_metrics(&metrics_registry, &event_log, &topic, stats.last_seen, 0).await?;
+        if let Err(error) =
+            record_pump_metrics(&metrics_registry, &event_log, &topic, stats.last_seen, 0).await
+        {
+            signal_pump_ready(&mut ready_tx, Err(error.to_string()));
+            return Err(error);
+        }
+        signal_pump_ready(&mut ready_tx, Ok(()));
         let mut drain_progress = None;
         loop {
             if let Some(progress) = drain_progress {
@@ -711,7 +774,11 @@ where
                 stop_reason: PumpDrainStopReason::Drained,
             }))
     });
-    Ok(PumpHandle { mode_tx, join })
+    Ok(PumpHandle {
+        mode_tx,
+        ready_rx: Some(ready_rx),
+        join,
+    })
 }
 
 // ── Drain helpers ─────────────────────────────────────────────────────────────

--- a/crates/harn-cli/src/commands/orchestrator/harness_tests.rs
+++ b/crates/harn-cli/src/commands/orchestrator/harness_tests.rs
@@ -131,3 +131,66 @@ async fn stream_trigger_route_uses_generic_stream_connector_in_process() {
         .await
         .expect("harness shutdown");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn harness_start_waits_for_topic_pumps_before_ready() {
+    let _env_lock = crate::tests::common::env_lock::lock_env().lock().await;
+    let _secret_providers = crate::env_guard::ScopedEnvVar::set("HARN_SECRET_PROVIDERS", "env");
+
+    let temp = tempfile::TempDir::new().unwrap();
+    let marker_path = temp.path().join("stream-handler.json");
+    write_test_file(temp.path(), "harn.toml", stream_manifest_fixture());
+    write_test_file(
+        temp.path(),
+        "lib.harn",
+        &stream_handler_fixture(&marker_path),
+    );
+
+    let config =
+        OrchestratorConfig::for_test(temp.path().join("harn.toml"), temp.path().join("state"));
+    let harness = OrchestratorHarness::start(config)
+        .await
+        .expect("harness start");
+    let event_log = harness.event_log();
+    let topic = Topic::new("orchestrator.lifecycle").unwrap();
+    let lifecycle = event_log
+        .read_range(&topic, None, usize::MAX)
+        .await
+        .expect("read lifecycle");
+
+    let (pumps_ready_id, pumps_ready) = lifecycle
+        .iter()
+        .find(|(_, event)| event.kind == "pumps_ready")
+        .expect("pumps_ready lifecycle event");
+    let (startup_id, _) = lifecycle
+        .iter()
+        .find(|(_, event)| event.kind == "startup")
+        .expect("startup lifecycle event");
+    assert!(
+        pumps_ready_id < startup_id,
+        "pumps_ready must precede startup: lifecycle={lifecycle:?}"
+    );
+
+    let topics = pumps_ready
+        .payload
+        .get("topics")
+        .and_then(serde_json::Value::as_array)
+        .expect("pumps_ready topics");
+    for expected in [
+        "orchestrator.triggers.pending",
+        harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC,
+        "connectors.cron.tick",
+        harn_vm::WAITPOINT_RESUME_TOPIC,
+        harn_vm::TRIGGER_CANCEL_REQUESTS_TOPIC,
+    ] {
+        assert!(
+            topics.iter().any(|topic| topic.as_str() == Some(expected)),
+            "missing pump topic {expected}: topics={topics:?}"
+        );
+    }
+
+    harness
+        .shutdown(std::time::Duration::from_secs(5))
+        .await
+        .expect("harness shutdown");
+}

--- a/crates/harn-cli/tests/orchestrator_http/a2a.rs
+++ b/crates/harn-cli/tests/orchestrator_http/a2a.rs
@@ -140,8 +140,39 @@ async fn stream_trigger_route_uses_generic_stream_connector() {
         .send()
         .await
         .unwrap();
-    assert_status(response, StatusCode::OK).await;
+    let status = response.status();
+    let body = response.text().await.unwrap();
+    assert_eq!(status, StatusCode::OK, "status={status} body={body}");
+    let accepted: JsonValue = serde_json::from_str(&body).unwrap();
+    assert_eq!(
+        accepted.get("status").and_then(JsonValue::as_str),
+        Some("accepted"),
+        "body={accepted}"
+    );
+    assert_eq!(
+        accepted.get("trigger_id").and_then(JsonValue::as_str),
+        Some("ws-stream"),
+        "body={accepted}"
+    );
+    assert!(
+        accepted
+            .get("event_id")
+            .and_then(JsonValue::as_str)
+            .is_some(),
+        "body={accepted}"
+    );
 
+    let event_log = harness.event_log();
+    await_topic_event(&event_log, "orchestrator.triggers.pending", |event| {
+        event.kind == "trigger_event"
+    })
+    .await;
+    await_topic_event(
+        &event_log,
+        harn_vm::TRIGGER_INBOX_ENVELOPES_TOPIC,
+        |event| event.kind == "event_ingested",
+    )
+    .await;
     await_pump_dispatch_completed(&harness).await;
     let marker: JsonValue =
         serde_json::from_str(&fs::read_to_string(&marker_path).unwrap()).unwrap();


### PR DESCRIPTION
## Summary
- wait for orchestrator topic pumps to subscribe and establish startup cursors before reporting harness readiness
- emit a `pumps_ready` lifecycle event with the initialized topics
- strengthen stream-trigger regression coverage so accepted requests and queue boundaries are observed before completion

Supersedes #3746, which was closed because it had already entered the merge queue on the pre-v0.8.159 base and GitHub rejected updating the queued branch.

## Validation
- git diff --check
- cargo test -p harn-cli harness_start_waits_for_topic_pumps_before_ready
- cargo test -p harn-cli stream_trigger_route_uses_generic_stream_connector_in_process
- cargo test -p harn-cli --test orchestrator_http stream_trigger_route_uses_generic_stream_connector
- repo pre-push targeted checks

Co-Authored-By: Codex <codex@openai.com>