### PR TITLE
feat(stdlib): add opt-in command lifecycle tools

### DIFF
--- a/changelog.d/agent-command-lifecycle-tools.added.md
+++ b/changelog.d/agent-command-lifecycle-tools.added.md
@@ -1,0 +1,2 @@
+- Added opt-in `poll_command`, `wait_command`, and `kill_command` lifecycle tools to
+  `agent_command_tools`, backed by the existing deterministic command handle builtins.

--- a/conformance/tests/agents/agent_host_tools.expected
+++ b/conformance/tests/agents/agent_host_tools.expected
@@ -16,6 +16,10 @@ true
 true
 true
 true
+true
+true
+true
+running
 running
 true
 completed

--- a/conformance/tests/agents/agent_host_tools.expected
+++ b/conformance/tests/agents/agent_host_tools.expected
@@ -1,6 +1,7 @@
 true
 release_read_output
 custom
+true
 alpha
 2
 true
@@ -12,3 +13,11 @@ true
 false
 true
 true
+true
+true
+true
+running
+true
+completed
+true
+false

--- a/conformance/tests/agents/agent_host_tools.harn
+++ b/conformance/tests/agents/agent_host_tools.harn
@@ -1,4 +1,4 @@
-import { agent_host_tools } from "std/agent/host_tools"
+import { agent_command_tools, agent_host_tools } from "std/agent/host_tools"
 
 pipeline main() {
   let root = path_join(harness.fs.temp_dir(), "harn-host-tools-" + uuid())
@@ -28,6 +28,7 @@ pipeline main() {
   __io_println(surface.valid)
   __io_println(tool_find(tools, "release_run").annotations.result_readers[0])
   __io_println(tool_find(tools, "release_run").annotations.fixture_marker)
+  __io_println(tool_find(tools, "poll_command") == nil)
   let read = agent_dispatch_tool_call(
     {id: "r1", name: "read_file", arguments: {path: "README.md", limit_bytes: 5}},
     tools,
@@ -77,4 +78,49 @@ pipeline main() {
   let blocked = agent_dispatch_tool_call({id: "c3", name: "release_run", arguments: {argv: ["echo", "no"]}}, tools)
   let blocked_data = json_parse(blocked.rendered_result)
   __io_println(blocked_data.blocked)
+  let lifecycle_tools = agent_command_tools(
+    nil,
+    {root: root, cwd: root, background_commands: true, allow_argv_prefixes: [["sh", "-c"]]},
+  )
+  __io_println(tool_find(lifecycle_tools, "poll_command") != nil)
+  __io_println(tool_find(lifecycle_tools, "wait_command") != nil)
+  __io_println(tool_find(lifecycle_tools, "kill_command") != nil)
+  let poll = agent_dispatch_tool_call(
+    {id: "p1", name: "poll_command", arguments: {handle_id: "missing-handle"}},
+    lifecycle_tools,
+  )
+  let poll_data = json_parse(poll.rendered_result)
+  __io_println(poll_data.status)
+  let background = agent_dispatch_tool_call(
+    {
+      id: "bg1",
+      name: "run_command",
+      arguments: {argv: ["sh", "-c", "printf toolwait"], background: true},
+    },
+    lifecycle_tools,
+  )
+  let background_data = json_parse(background.rendered_result)
+  __io_println(background_data.handle_id != nil)
+  let waited = agent_dispatch_tool_call(
+    {
+      id: "w1",
+      name: "wait_command",
+      arguments: {handle_id: background_data.handle_id, timeout_ms: 5000},
+    },
+    lifecycle_tools,
+  )
+  let waited_data = json_parse(waited.rendered_result)
+  __io_println(waited_data.status)
+  __io_println(
+    contains(
+      waited_data?.combined ?? waited_data?.stdout ?? waited_data?.inline_output ?? "",
+      "toolwait",
+    ),
+  )
+  let killed = agent_dispatch_tool_call(
+    {id: "k1", name: "kill_command", arguments: {handle_id: "missing-handle"}},
+    lifecycle_tools,
+  )
+  let killed_data = json_parse(killed.rendered_result)
+  __io_println(killed_data.cancelled)
 }

--- a/conformance/tests/agents/agent_host_tools.harn
+++ b/conformance/tests/agents/agent_host_tools.harn
@@ -85,12 +85,21 @@ pipeline main() {
   __io_println(tool_find(lifecycle_tools, "poll_command") != nil)
   __io_println(tool_find(lifecycle_tools, "wait_command") != nil)
   __io_println(tool_find(lifecycle_tools, "kill_command") != nil)
+  __io_println(!tool_find(lifecycle_tools, "poll_command").parameters.handle_id.required)
+  __io_println(!tool_find(lifecycle_tools, "wait_command").parameters.handle_id.required)
+  __io_println(!tool_find(lifecycle_tools, "kill_command").parameters.handle_id.required)
   let poll = agent_dispatch_tool_call(
     {id: "p1", name: "poll_command", arguments: {handle_id: "missing-handle"}},
     lifecycle_tools,
   )
   let poll_data = json_parse(poll.rendered_result)
   __io_println(poll_data.status)
+  let poll_alias = agent_dispatch_tool_call(
+    {id: "p2", name: "poll_command", arguments: {handle: "missing-handle-alias"}},
+    lifecycle_tools,
+  )
+  let poll_alias_data = json_parse(poll_alias.rendered_result)
+  __io_println(poll_alias_data.status)
   let background = agent_dispatch_tool_call(
     {
       id: "bg1",

--- a/crates/harn-stdlib/src/stdlib/agent/host_tools.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/host_tools.harn
@@ -52,6 +52,29 @@ fn __agent_host_tool_enabled(options, key, group) {
   return true
 }
 
+fn __agent_host_lifecycle_tool_enabled(options, key) {
+  let opts = __agent_host_options(options)
+  let enabled = opts?.enabled_tools ?? opts?.tools
+  let explicitly_enabled = __agent_host_list_contains(enabled, key)
+    || __agent_host_list_contains(enabled, "command_lifecycle")
+  let opted_in = opts?.background_commands ?? opts?.enable_background_commands ?? opts?.command_lifecycle_tools
+    ?? false
+  if !opted_in && !explicitly_enabled {
+    return false
+  }
+  let disabled = opts?.disabled_tools ?? []
+  if __agent_host_list_contains(disabled, "command")
+    || __agent_host_list_contains(disabled, "command_lifecycle")
+    || __agent_host_list_contains(disabled, key) {
+    return false
+  }
+  if enabled != nil && !explicitly_enabled && !__agent_host_list_contains(enabled, "all")
+    && !__agent_host_list_contains(enabled, "command") {
+    return false
+  }
+  return true
+}
+
 fn __agent_host_name(options, key, default_name) {
   let opts = __agent_host_options(options)
   return opts?.names?[key] ?? opts[key + "_name"] ?? default_name
@@ -549,6 +572,36 @@ fn __agent_host_command_result_readers(options, read_name, tail_name) {
   return readers
 }
 
+fn __agent_host_command_handle_id(args, tool_name: string) -> string {
+  let handle_id = trim(to_string(args?.handle_id ?? args?.handle ?? ""))
+  if handle_id != "" {
+    return handle_id
+  }
+  throw tool_name + ": pass handle_id from a background run_command result"
+}
+
+fn __agent_host_wait_command_request(args, tool_name: string, timeout_ms) {
+  var req = {handle_id: __agent_host_command_handle_id(args, tool_name)}
+  if timeout_ms != nil {
+    req = req + {timeout_ms: timeout_ms}
+  }
+  if args?.session_id != nil {
+    req = req + {session_id: args.session_id}
+  }
+  return req
+}
+
+fn __agent_host_cancel_command_request(args) {
+  var req = {handle_id: __agent_host_command_handle_id(args, "kill_command")}
+  if args?.wait_result_ms != nil {
+    req = req + {wait_result_ms: args.wait_result_ms}
+  }
+  if args?.timed_out != nil {
+    req = req + {timed_out: args.timed_out}
+  }
+  return req
+}
+
 /**
  * agent_read_tools adds root-scoped read, directory, outline, search, and git inspection tools.
  *
@@ -813,6 +866,104 @@ pub fn agent_command_tools(registry = nil, options = nil) {
             }
             return __agent_host_render(final_result, opts, key)
           },
+        },
+      ),
+    )
+  }
+  if __agent_host_lifecycle_tool_enabled(opts, "poll_command") {
+    let key = "poll_command"
+    tools = tool_define(
+      tools,
+      __agent_host_name(opts, key, "poll_command"),
+      __agent_host_description(
+        opts,
+        key,
+        "Check a background run_command handle without blocking. If the command is still running, returns status and live output artifact metadata; if it completed, returns the final command result.",
+      ),
+      __agent_host_config(
+        opts,
+        key,
+        {
+          parameters: {
+            handle_id: {type: "string"},
+            handle: {type: "string", required: false},
+            session_id: {type: "string", required: false},
+          },
+          returns: {type: "object"},
+          annotations: __agent_host_annotations(opts, key, {kind: "execute", side_effect_level: "read_only"}),
+          handler: { args -> __agent_host_render(
+            hostlib_tools_wait_command(__agent_host_wait_command_request(args, key, 0)),
+            opts,
+            key,
+          ) },
+        },
+      ),
+    )
+  }
+  if __agent_host_lifecycle_tool_enabled(opts, "wait_command") {
+    let key = "wait_command"
+    tools = tool_define(
+      tools,
+      __agent_host_name(opts, key, "wait_command"),
+      __agent_host_description(
+        opts,
+        key,
+        "Wait for a background run_command handle and return the final command result, or a running status if the timeout elapses first.",
+      ),
+      __agent_host_config(
+        opts,
+        key,
+        {
+          parameters: {
+            handle_id: {type: "string"},
+            handle: {type: "string", required: false},
+            timeout_ms: {type: "integer", required: false},
+            session_id: {type: "string", required: false},
+          },
+          returns: {type: "object"},
+          annotations: __agent_host_annotations(opts, key, {kind: "execute", side_effect_level: "read_only"}),
+          handler: { args -> __agent_host_render(
+            hostlib_tools_wait_command(
+              __agent_host_wait_command_request(
+                args,
+                key,
+                args?.timeout_ms ?? opts?.wait_command_timeout_ms ?? 60000,
+              ),
+            ),
+            opts,
+            key,
+          ) },
+        },
+      ),
+    )
+  }
+  if __agent_host_lifecycle_tool_enabled(opts, "kill_command") {
+    let key = "kill_command"
+    tools = tool_define(
+      tools,
+      __agent_host_name(opts, key, "kill_command"),
+      __agent_host_description(
+        opts,
+        key,
+        "Cancel a background run_command handle when it is no longer useful. Optionally wait briefly for the final killed-result payload.",
+      ),
+      __agent_host_config(
+        opts,
+        key,
+        {
+          parameters: {
+            handle_id: {type: "string"},
+            handle: {type: "string", required: false},
+            wait_result_ms: {type: "integer", required: false},
+            timed_out: {type: "boolean", required: false},
+          },
+          returns: {type: "object"},
+          annotations: __agent_host_annotations(opts, key, {kind: "execute", side_effect_level: "process_exec"}),
+          handler: { args -> __agent_host_render(
+            hostlib_tools_cancel_handle(__agent_host_cancel_command_request(args)),
+            opts,
+            key,
+          ) },
         },
       ),
     )

--- a/crates/harn-stdlib/src/stdlib/agent/host_tools.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/host_tools.harn
@@ -885,7 +885,7 @@ pub fn agent_command_tools(registry = nil, options = nil) {
         key,
         {
           parameters: {
-            handle_id: {type: "string"},
+            handle_id: {type: "string", required: false},
             handle: {type: "string", required: false},
             session_id: {type: "string", required: false},
           },
@@ -915,7 +915,7 @@ pub fn agent_command_tools(registry = nil, options = nil) {
         key,
         {
           parameters: {
-            handle_id: {type: "string"},
+            handle_id: {type: "string", required: false},
             handle: {type: "string", required: false},
             timeout_ms: {type: "integer", required: false},
             session_id: {type: "string", required: false},
@@ -952,7 +952,7 @@ pub fn agent_command_tools(registry = nil, options = nil) {
         key,
         {
           parameters: {
-            handle_id: {type: "string"},
+            handle_id: {type: "string", required: false},
             handle: {type: "string", required: false},
             wait_result_ms: {type: "integer", required: false},
             timed_out: {type: "boolean", required: false},


### PR DESCRIPTION
## Summary

- Add opt-in `poll_command`, `wait_command`, and `kill_command` tools to `agent_command_tools`.
- Keep the default command tool surface unchanged; lifecycle tools appear only when explicitly requested.
- Extend the agent host-tools conformance fixture and expected output.

## Why

Long-running command workflows should not force callers to reinvent lifecycle polling, waiting, or cancellation. This deepens the Harn-owned runtime/tooling surface while preserving current default behavior.

## Validation

- `CARGO_TARGET_DIR=/tmp/harn-agent-command-lifecycle-target cargo run --quiet --bin harn -- test conformance --filter agent_host_tools` (3/3 passed)
- `CARGO_TARGET_DIR=/tmp/harn-agent-command-lifecycle-target cargo run --quiet --bin harn -- fmt --check crates/harn-stdlib/src/stdlib/agent/host_tools.harn conformance/tests/agents/agent_host_tools.harn`
- `CARGO_TARGET_DIR=/tmp/harn-agent-command-lifecycle-target cargo check -p harn-stdlib`
- `git diff --check origin/main...HEAD`
- pre-push hook passed: markdown, targeted Rust checks, affected Harn fmt/lint, generated highlight keywords