### PR TITLE
[codex] Polish path-dependent comments

### DIFF
--- a/crates/harn-cli/src/commands/serve.rs
+++ b/crates/harn-cli/src/commands/serve.rs
@@ -815,9 +815,8 @@ async fn authorize_script_rpc(
 /// before the runtime executes it. The list is deny-by-default: only
 /// `initialize` (required to establish the session) and `ping`
 /// (connectivity check) are exempt; every other method — including
-/// catalog and listing methods that previously bypassed auth and
-/// leaked the script's tool/resource/prompt surface — now goes through
-/// `AuthPolicy::authorize`.
+/// catalog and listing methods that expose the script's
+/// tool/resource/prompt surface — goes through `AuthPolicy::authorize`.
 ///
 /// New MCP methods (notifications/*, completion/complete,
 /// sampling/createMessage, elicitation/create, custom RPCs) are
@@ -1056,8 +1055,8 @@ mod tests {
         assert!(script_method_requires_auth("resources/read"));
         assert!(script_method_requires_auth("prompts/get"));
         // The reason for the inversion: every other method (catalog
-        // listings, notifications, sampling, elicitation, custom RPCs)
-        // now requires auth instead of leaking the script's surface.
+        // listings, notifications, sampling, elicitation, custom RPCs) must
+        // require auth before exposing the script's surface.
         assert!(script_method_requires_auth("tools/list"));
         assert!(script_method_requires_auth("resources/list"));
         assert!(script_method_requires_auth("prompts/list"));

--- a/crates/harn-cli/src/main.rs
+++ b/crates/harn-cli/src/main.rs
@@ -49,9 +49,8 @@ fn invoked_as() -> Option<String> {
 ///
 /// The sidecars speak a wire protocol over stdin/stdout and don't otherwise
 /// parse argv, so without this a `--version` probe would silently start the
-/// server and hang waiting on stdin. As standalone binaries they used to
-/// answer `--version`; the multi-call collapse dropped that. Regression fix
-/// for #2975.
+/// server and hang waiting on stdin. Keep this probe path aligned with the
+/// standalone sidecar binaries. Regression fix for #2975.
 fn run_sidecar(name: &str, serve: fn()) {
     match sidecar_query(std::env::args_os().skip(1)) {
         Some(SidecarQuery::Version) => println!("{name} {}", env!("CARGO_PKG_VERSION")),

--- a/crates/harn-hostlib/benches/ast_parse.rs
+++ b/crates/harn-hostlib/benches/ast_parse.rs
@@ -1,10 +1,9 @@
 //! Criterion benchmark for `hostlib_ast_parse_file` warm parse latency.
 //!
-//! Replaces the wall-clock perf budget assertions that previously lived
-//! in `crates/harn-hostlib/tests/ast_builtins.rs`. Wall-clock budgets in
-//! unit/integration tests flake on shared CI runners under contention;
-//! Criterion's statistical sampling tracks the same parse-latency signal
-//! (issue #564's 20ms target) without that flake.
+//! Uses Criterion's statistical sampling for the issue #564 parse-latency
+//! target instead of a wall-clock assertion in a unit/integration test. Shared
+//! CI runners can add enough contention to make a hard wall-clock budget
+//! flaky.
 //!
 //! Run with `cargo bench --bench ast_parse`.
 

--- a/crates/harn-opcode-macros/src/lib.rs
+++ b/crates/harn-opcode-macros/src/lib.rs
@@ -4,8 +4,8 @@
 //! `harn-vm/src/chunk.rs` emits the `Op` enum, the byte-to-variant mapping,
 //! the sync and async dispatch tables, the disassembly renderer, and the
 //! classification helpers (`op_reads_outer_name`, `is_adaptive_binary_op`).
-//! Adding or renaming an opcode is a one-line edit; coverage drift across
-//! the previously hand-maintained tables is now impossible.
+//! Adding or renaming an opcode is a one-line edit; generated tables keep
+//! dispatch, disassembly, and classification coverage aligned.
 
 extern crate proc_macro;
 

--- a/crates/harn-serve/src/adapters/acp/modes.rs
+++ b/crates/harn-serve/src/adapters/acp/modes.rs
@@ -692,8 +692,8 @@ mod tests {
 
     #[test]
     fn policy_for_code_with_config_applies_worktree_confinement() {
-        // When the embedder opts into sandboxing, ActAuto `code` mode now
-        // honors it as a Worktree-level OS sandbox instead of discarding it.
+        // When the embedder opts into sandboxing, ActAuto `code` mode must
+        // honor it as a Worktree-level OS sandbox.
         let roots = vec!["/work/project".to_string()];
         let sandbox = AcpSandboxConfig::with_read_only_roots(roots.clone());
         assert!(sandbox.is_configured());
@@ -823,8 +823,8 @@ mod tests {
 
     #[test]
     fn code_mode_honors_embedder_read_only_roots() {
-        // Previously full-access mode discarded embedder roots entirely. Now a
-        // configured embedder gets Worktree confinement with its roots applied.
+        // A configured embedder gets Worktree confinement with its declared
+        // read-only roots applied, even in full-access ACP code mode.
         let sandbox =
             AcpSandboxConfig::with_read_only_roots(vec!["/opt/burin/pipelines".to_string()]);
         let policy = policy_for_mode("code", &sandbox).expect("configured code mode has policy");

--- a/crates/harn-serve/src/permissions/mod.rs
+++ b/crates/harn-serve/src/permissions/mod.rs
@@ -1,9 +1,7 @@
 //! The single authoritative permission primitive for harn.
 //!
-//! Subsumes what used to live as four parallel implementations: the TUI
-//! permission policy, a host IDE approval modal, a cloud
-//! gateway middleware, and a cloud sandbox backend. Each of those
-//! surfaces now delegates to the same data model, store, and audit
+//! TUI policy, host IDE approvals, cloud gateway middleware, and cloud
+//! sandbox backends all delegate to the same data model, store, and audit
 //! channel exposed here, so a user's "remember this answer" rule flows
 //! between local sessions and supervised cloud agents identically.
 //!

--- a/crates/harn-stdlib/src/stdlib/agent/judge_internals.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/judge_internals.harn
@@ -1,10 +1,9 @@
 // std/agent/judge_internals — private helpers shared by `std/agent/judge`
 // (verify_completion + done_judge) and `std/agent/step_judge`. NOT
 // intended as a public surface: every export is prefixed `__judge_` and
-// the file is excluded from the docs sweep. Consolidates the bits that
-// used to be copy-pasted between the two callers (LLM-options
-// overrides, structured-output schema field names, and the
-// "raw_verdict -> {vetoed, feedback}" classifier).
+// the file is excluded from the docs sweep. Keep shared judge plumbing here:
+// LLM-option overrides, structured-output schema field names, and the
+// "raw_verdict -> {vetoed, feedback}" classifier.
 /**
  * Keys on `judge_cfg` that override `opts.llm_options` when present.
  * Listed once here so adding (or renaming) an LLM tuning knob is a

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -996,8 +996,8 @@ fn __visible_text(parsed, raw_text) {
  * malformation, not a dispatchable call. Some providers emit a stray
  * `{name: "", arguments: {}}` block alongside valid sibling calls (observed
  * live on go/rust eval runs: a turn carrying `[look, "", look]`). Dispatching
- * the nameless call resolves no tool and used to terminate the agent loop
- * silently — a pure harness failure that read as a model give-up
+ * the nameless call resolves no tool and can otherwise terminate the agent
+ * loop silently — a pure harness failure that reads as a model give-up
  * (result=INCOMPLETE, outcome_kind=null). Detect it here so callers can drop
  * the malformed call, keep the valid siblings, and inject parse-guidance.
  */
@@ -4392,10 +4392,9 @@ fn __agent_loop_run(message, session, initial_opts) {
 // Capture the PRIMARY provider/model once, before any post-turn escalation
 // can rebind `opts`. A failed escalated turn falls back to this for one
 // retry instead of unwinding the whole loop into a fake success.
-// NON-tracked provider failure. Previously this branch broke SILENTLY
-// (no event), so a fast pre-dispatch escalation failure unwound the
-// loop while ACP still returned the prior cheap-model text as a fake
-// success. Two fixes, always-correct:
+// Non-tracked provider failure. A fast pre-dispatch escalation failure must not
+// unwind the loop while ACP returns the prior cheap-model text as a fake
+// success. Two fixes, always correct:
 //   1. Always emit an observable provider_error `iteration_end` event.
 //   2. If this was an ESCALATED turn (current provider/model differs
 //      from the captured primary) and we have not already retried the

--- a/crates/harn-stdlib/src/stdlib/stdlib_semver.harn
+++ b/crates/harn-stdlib/src/stdlib/stdlib_semver.harn
@@ -5,10 +5,8 @@
 // Scope: parse "MAJOR.MINOR.PATCH" triples (no prerelease/build metadata),
 // strip/add the canonical leading `v`, compute single-step bumps, classify
 // which bump separates two versions, and unpack release branches / tags.
-// These helpers used to live in each release-tooling repo (harn-bump-fleet's
-// `lib/semver.harn`, harn's own `scripts/detect_bump_type.harn`); promoting
-// them to the stdlib removes the per-repo drift and the inconsistent error
-// messages.
+// Keep release-tooling repos on this stdlib implementation so SemVer parsing,
+// bump detection, and error messages do not drift between repos.
 //
 // Import with:
 //   import {

--- a/crates/harn-vm/src/bridge.rs
+++ b/crates/harn-vm/src/bridge.rs
@@ -250,10 +250,9 @@ impl InProcessHost {
 
 /// How a queued bridge injection is delivered into the agent loop.
 ///
-/// `AuditOnly` was previously called `WaitForCompletion`; the rename is
-/// truth-in-advertising (harn#2212). These injections drain at
-/// `loop_exit`, *after* the last LLM call has returned — so they land in
-/// the transcript audit but are **never rendered into a model prompt**.
+/// `AuditOnly` injections drain at `loop_exit`, *after* the last LLM call has
+/// returned, so they land in the transcript audit but are **never rendered into
+/// a model prompt**.
 /// Hosts that want the model to react to the reminder on its final
 /// iteration should use `FinishStep` instead, which drains at every
 /// `iteration_start` / `post_tool_dispatch` / `iteration_end` checkpoint.

--- a/crates/harn-vm/src/egress/mod.rs
+++ b/crates/harn-vm/src/egress/mod.rs
@@ -752,9 +752,9 @@ fn evaluate_resolved_addrs(
 
     // (2) NetPolicy deny CIDR/IP wins over allow: if ANY resolved address
     //     matches a deny IP/CIDR rule (port-aware), block. This is the gap
-    //     #3174 closes — a hostname that resolves into a denied CIDR was
-    //     previously never matched. Matching against the rule list (rather than
-    //     pre-reduced nets) preserves per-rule `:port` scoping.
+    //     #3174 covers: a hostname that resolves into a denied CIDR must be
+    //     blocked. Matching against the rule list (rather than pre-reduced
+    //     nets) preserves per-rule `:port` scoping.
     if let Some(rule) = configured.and_then(|c| {
         c.policy.deny.iter().find(|rule| {
             rule.is_ip_matcher()

--- a/crates/harn-vm/src/llm/api/options.rs
+++ b/crates/harn-vm/src/llm/api/options.rs
@@ -453,11 +453,8 @@ pub(crate) struct LlmCallOptions {
 /// Resolve effective request timeout: explicit value > `HARN_LLM_TIMEOUT` env >
 /// model-catalog `stream_timeout` > 120s default.
 ///
-/// `stream_timeout` (fractional seconds in the model catalog) was previously
-/// only projected into the config dict for pipelines — no transport consumed
-/// it, so a slow local model with `stream_timeout = 900.0` was still cut off
-/// (and a hung remote provider only bounded) by the generic 120s default.
-/// It now feeds the same whole-request deadline every provider applies via
+/// `stream_timeout` (fractional seconds in the model catalog) feeds the same
+/// whole-request deadline every provider applies via
 /// `reqwest::RequestBuilder::timeout`, which covers both the non-streaming
 /// response read and the streamed body.
 fn resolve_timeout(explicit: Option<u64>, model: &str) -> u64 {

--- a/crates/harn-vm/src/llm/api/transport.rs
+++ b/crates/harn-vm/src/llm/api/transport.rs
@@ -281,12 +281,12 @@ pub(crate) async fn vm_call_llm_api_with_body(
     // OpenAI-compat path (`chat_impl`), the *unregistered* OpenAI-compat
     // fallback in `vm_call_llm_api` (e.g. a `llamacpp` provider configured via
     // providers.toml but never `provider_register`-ed), and both the streaming
-    // (SSE/NDJSON) and non-streaming transports. Previously the remap lived
-    // only in `chat_impl`, so an unregistered `llamacpp` qwen3.6 route returned
-    // raw `[[CALL]]` text, the parser found zero `<tool_call>` blocks, and the
-    // agent dispatched no tools (convergence-fatal). The streamed live deltas
-    // are canonicalized separately by `canonicalizing_delta_tx`; this remaps the
-    // assembled `result.text` that the parser/transcript consume.
+    // (SSE/NDJSON) and non-streaming transports. Without this shared remap an
+    // unregistered `llamacpp` qwen3.6 route can return raw `[[CALL]]` text, the
+    // parser finds zero `<tool_call>` blocks, and the agent dispatches no tools
+    // (convergence-fatal). The streamed live deltas are canonicalized
+    // separately by `canonicalizing_delta_tx`; this remaps the assembled
+    // `result.text` that the parser/transcript consume.
     if crate::llm::capabilities::lookup(&opts.provider, &opts.model).reserved_tool_call_token {
         let wire_open = result.text.matches("[[CALL]]").count();
         result.text = crate::llm::tool_delimiter::wire_to_canonical(&result.text);
@@ -475,11 +475,11 @@ async fn vm_call_llm_api_with_body_inner(
             )
             .await
             {
-                // A `done_reason == "length"` truncation now returns Ok with an
-                // empty body and `stop_reason: Some("length")`, so it bypasses
-                // the retry guard below entirely — a deterministic token-cap cut
-                // would just re-truncate on every retry. Only the genuine
-                // empty-content parser bug (done_reason stop/absent) is retried.
+                // A `done_reason == "length"` truncation returns Ok with an
+                // empty body and `stop_reason: Some("length")`, bypassing the
+                // retry guard below. A deterministic token-cap cut would just
+                // re-truncate on every retry. Only the genuine empty-content
+                // parser bug (done_reason stop/absent) is retried.
                 Ok(result) => return Ok(result),
                 Err(err)
                     if is_ollama
@@ -834,13 +834,10 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
             Ok(None) => break,
             Err(error) => {
                 // A mid-body read failure (the whole-request reqwest timeout
-                // from `resolve_timeout`, a connection reset, ...) used to be
-                // swallowed here, silently truncating the stream and returning
-                // a zero-token "success" that the agent loop accepted as an
-                // empty assistant turn (observed live: an OpenRouter call hung
-                // 133s and came back with output_tokens=0). Surface it in the
-                // same transient stream-error class other transports use so
-                // the existing retry machinery picks it up.
+                // from `resolve_timeout`, a connection reset, ...) must surface
+                // as a transient stream error rather than a truncated
+                // zero-token success that the agent loop accepts as an empty
+                // assistant turn.
                 return Err(VmError::Thrown(VmValue::String(arcstr::ArcStr::from(
                     format!("{provider} stream error (mid-stream read): {error}"),
                 ))));
@@ -1061,8 +1058,8 @@ pub(super) async fn consume_sse_lines<R: tokio::io::AsyncBufRead + Unpin>(
             // `"'s"`, `" a"`, `" thinking"`. Concatenate them verbatim;
             // `extract_openai_message_field_as_text` + `append_paragraph`
             // would `.trim()` each fragment (losing inter-token spaces)
-            // and inject a newline between every chunk, producing the
-            // one-token-per-line reasoning text we used to surface as
+            // and inject a newline between every chunk, producing
+            // one-token-per-line reasoning text like
             // `"The\ntask\nis\nto\nextend"`. The non-streaming response
             // path still uses `append_paragraph` because there each
             // field arrives as a single complete block.
@@ -2677,7 +2674,7 @@ EOF
 mod sse_read_error_tests {
     //! Mid-stream read failures must surface as transient errors, not as a
     //! silently truncated zero-token "success". The whole-request reqwest
-    //! timeout (`resolve_timeout`, now fed by the model catalog's
+    //! timeout (`resolve_timeout`, including the model catalog's
     //! `stream_timeout`) materializes as exactly such a body-read error, so
     //! these tests drive `consume_sse_lines` with an erroring byte stream —
     //! the same shape `reqwest::Response::bytes_stream()` produces when the

--- a/crates/harn-vm/src/llm/capabilities.rs
+++ b/crates/harn-vm/src/llm/capabilities.rs
@@ -14,10 +14,9 @@
 //! - exposing a stable `Capabilities` struct that the `LlmProvider`
 //!   trait delegates to as the single source of truth.
 //!
-//! Before this module the Anthropic / OpenAI gates were spread across
-//! `providers/anthropic.rs` and `providers/openai_compat.rs`. Their
-//! generation parsers are still used here for `version_min`, but the
-//! boolean gates that used to live alongside them are now data.
+//! Provider adapters still supply generation parsers for `version_min`, but
+//! feature gates live in this data table instead of adapter-specific boolean
+//! branches.
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashSet};
@@ -1826,9 +1825,9 @@ fn extract_version(model: &str) -> Option<(u32, u32)> {
     claude_generation(model).or_else(|| gpt_generation(model))
 }
 
-// Model-pattern matching for capability rules. Shared workspace semantics
-// live in `harn-glob` (this used to be a hand-mirrored copy of the
-// `llm_config.rs` helper with a "keep them in sync" comment).
+// Model-pattern matching for capability rules. Shared workspace semantics live
+// in `harn-glob`; keep capability and provider matching on that helper instead
+// of mirroring glob behavior locally.
 use harn_glob::match_name as glob_match;
 
 #[cfg(test)]
@@ -1843,10 +1842,11 @@ mod tests {
         let caps = lookup("cerebras", model);
         assert_eq!(caps.thinking_modes, vec!["effort"]);
         assert!(caps.reasoning_effort_supported);
-        // tool_format is NOT asserted here: cerebras gpt-oss and zai-glm now
-        // diverge (gpt-oss harmonized to `json`, glm stays `native`), and this
-        // shared helper is about reasoning-effort behavior. Tool-format
-        // resolution is asserted in the dedicated harmonization tests.
+        // tool_format is NOT asserted here: cerebras gpt-oss and zai-glm have
+        // different defaults (gpt-oss harmonized to `json`, glm stays
+        // `native`), and this shared helper is about reasoning-effort
+        // behavior. Tool-format resolution is asserted in the dedicated
+        // harmonization tests.
         assert_eq!(caps.structured_output.as_deref(), Some("native"));
         assert_eq!(caps.structured_output_mode, "native_json");
         assert_eq!(caps.thinking_block_style, thinking_block_style);
@@ -2390,10 +2390,9 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
     #[test]
     fn local_gemma4_exposes_vision_like_hosted_siblings() {
         // harn#3585: Gemma 4 is multimodal on every served surface. The local
-        // OpenAI-compat route must declare vision so the derived structured caps
-        // and the emitted `capability_tags` agree with the gemini/openrouter/
-        // together siblings — previously the local route dropped `vision`,
-        // contradicting the model's real multimodality and the structured caps.
+        // OpenAI-compat route must declare vision so the derived structured
+        // caps and emitted `capability_tags` agree with the gemini/openrouter/
+        // together siblings.
         reset();
         for model in ["gemma-4-e4b-it", "gemma-4-e2b-it", "gemma-4-26b-a4b-it"] {
             let caps = lookup("local", model);
@@ -2576,11 +2575,9 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
 
     #[test]
     fn openrouter_anthropic_claude_models_support_native_tools() {
-        // Regression for #2319: without explicit openrouter rules,
-        // openrouter:anthropic/claude-* used to fall through the
-        // openrouter→openai family chain and miss the [[provider.anthropic]]
-        // matchers entirely, so native-tool requests HTTP 400'd with
-        // "option `tools` is not supported by ... (provider openrouter)".
+        // Regression for #2319: OpenRouter Anthropic slugs must match the
+        // Anthropic capability rules before the OpenRouter -> OpenAI family
+        // chain, otherwise native-tool requests get rejected as unsupported.
         reset();
         for model in [
             "anthropic/claude-haiku-4-5",
@@ -2721,11 +2718,10 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
         let caps = lookup("cerebras", "gpt-oss-120b");
         assert_eq!(caps.message_wire_format, "openai");
         assert_eq!(caps.native_tool_wire_format, "openai");
-        // gpt-oss uses NATIVE tool calls across cerebras/groq/together. The
-        // prior `json` pin was a defensive workaround for an empty-native-payload
-        // defect that no longer reproduces; under json/text gpt-oss emits a bare
-        // {"tool","arguments"} dialect the fenced-JSON parser rejects (zero
-        // parsed calls), so native is the only working channel.
+        // gpt-oss uses NATIVE tool calls across cerebras/groq/together. Under
+        // json/text it emits a bare {"tool","arguments"} dialect the
+        // fenced-JSON parser rejects (zero parsed calls), so native is the only
+        // working channel.
         assert!(caps.native_tools);
         assert_eq!(caps.preferred_tool_format.as_deref(), Some("native"));
     }
@@ -2962,10 +2958,9 @@ anthropic_beta_features = ["fine-grained-tool-streaming-2025-05-14"]
                 caps.text_tool_wire_format_supported,
                 "{provider}: text tools should remain available"
             );
-            // devstral has no reserved-token constraint, so it dropped its stale
-            // heredoc `text` pin and now inherits the global `json` (fenced-JSON)
-            // text-channel default. Heredoc stays reachable via an explicit
-            // `preferred_tool_format = "text"` pin.
+            // devstral has no reserved-token constraint, so it uses the global
+            // `json` (fenced-JSON) text-channel default. Heredoc stays
+            // reachable via an explicit `preferred_tool_format = "text"` pin.
             assert_eq!(
                 caps.preferred_tool_format.as_deref(),
                 Some("json"),
@@ -3411,9 +3406,9 @@ native_tools = true
         for (provider, model) in [
             // cerebras gpt-oss is native-clean (only throttled).
             ("cerebras", "gpt-oss-120b"),
-            // sambanova deepseek-v3.2 is native and interchangeable (minimax was
-            // reclassified native_unreliable upstream, so it is no longer a
-            // known-good native exemplar).
+            // sambanova deepseek-v3.2 is native and interchangeable; minimax is
+            // native_unreliable upstream and is not a known-good native
+            // exemplar.
             ("sambanova", "DeepSeek-V3.2"),
         ] {
             let decision = validate_tool_format(provider, model, "native");

--- a/crates/harn-vm/src/llm/catalog_sources/10-providers/all.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/10-providers/all.toml
@@ -285,13 +285,10 @@ latency_p50_ms = 1900
 method = "GET"
 path = "/models"
 
-# Moonshot AI — first-party host of the Kimi K2 family. OpenAI-compatible
-# `/v1/chat/completions`; the same models were previously only reachable
-# through OpenRouter/Together aggregator routes. Moonshot also exposes an
-# Anthropic-compatible `/anthropic` surface, but Harn dials the
-# OpenAI-compatible endpoint so the shared openai_chat_completions wire
-# format Just Works. Use the `.cn` base via MOONSHOT_BASE_URL for the
-# China region.
+# Moonshot AI — first-party host of the Kimi K2 family. Harn dials the
+# OpenAI-compatible `/v1/chat/completions` endpoint so the shared
+# openai_chat_completions wire format Just Works. Use the `.cn` base via
+# MOONSHOT_BASE_URL for the China region.
 [providers.moonshot]
 base_url = "https://api.moonshot.ai/v1"
 base_url_env = "MOONSHOT_BASE_URL"

--- a/crates/harn-vm/src/llm/catalog_sources/30-aliases/aliases.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/30-aliases/aliases.toml
@@ -333,10 +333,10 @@ tool_format = "native"
 
 # llama.cpp — Unsloth Dynamic 2.0 GGUF served by llama-server.
 # No `tool_format` pin: this non-native-quant id matches the `*qwen3.6*`
-# text-channel capability row, which now resolves to the global `json`
-# (fenced-JSON) default. json's ```tool fence sidesteps the reserved
-# <tool_call> token (so the reserved-token remap stays correct) and is
-# delimiter-safe vs heredoc. To force heredoc, set `tool_format = "text"`.
+# text-channel capability row's `json` (fenced-JSON) default. json's ```tool
+# fence sidesteps the reserved <tool_call> token (so the reserved-token remap
+# stays correct) and is delimiter-safe vs heredoc. To force heredoc, set
+# `tool_format = "text"`.
 [aliases."llamacpp-qwen3.6"]
 id = "qwen3.6-35b-a3b"
 provider = "llamacpp"
@@ -356,13 +356,11 @@ id = "qwen3.6-35b-a3b-ud-q4-k-xl"
 provider = "llamacpp"
 tool_format = "native"
 
-# MLX (Apple Silicon). Burin #2717 retired the never-downloaded dense vision
-# model `unsloth/Qwen3.6-27B-UD-MLX-4bit` (HF cache held only zero-byte
-# `.incomplete` blobs) and switched the local MLX route to the coding-tuned
-# Qwen3.6-35B-A3B MoE served via `mlx_lm.server`. Point every MLX alias at the
-# live MoE so `auto`/preset selection lands on real weights. These share the
-# `qwen3.6-35b-a3b` equivalence_group with the llama.cpp GGUF route, so eval
-# aggregation compares the two runtimes directly.
+# MLX (Apple Silicon). Local MLX routes use the coding-tuned Qwen3.6-35B-A3B
+# MoE served via `mlx_lm.server` (burin #2717). Keep every MLX alias pointed at
+# live MoE weights so `auto`/preset selection lands on real weights. These
+# share the `qwen3.6-35b-a3b` equivalence_group with the llama.cpp GGUF route,
+# so eval aggregation compares the two runtimes directly.
 [aliases."mlx-qwen3.6"]
 id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
 provider = "mlx"
@@ -375,8 +373,8 @@ provider = "mlx"
 id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-8bit"
 provider = "mlx"
 
-# Back-compat: the old 27B alias names now resolve to the live 35B-A3B MoE so
-# any pinned config keeps working instead of pointing at non-existent weights.
+# Back-compat: the old 27B alias names resolve to the live 35B-A3B MoE so any
+# pinned config keeps working instead of pointing at non-existent weights.
 [aliases.mlx-qwen36-27b]
 id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
 provider = "mlx"
@@ -489,11 +487,10 @@ provider = "xai"
 
 # Devstral (Mistral's agentic-coding tune).
 # No `tool_format` pin: these aliases inherit the `devstral-small-2*` capability
-# row's resolved default, now `json` (fenced-JSON) — the global text-channel
-# default. devstral has no reserved-token constraint, so the stale heredoc
-# `text` pin that used to sit here had no structural reason to exist; json is
-# delimiter-safe and root-cause-fixes heredoc's `<<EOF` content leak. To force
-# heredoc, set `tool_format = "text"` here or pin the capability row.
+# row's `json` (fenced-JSON) text-channel default. devstral has no
+# reserved-token constraint, so json is delimiter-safe and avoids heredoc's
+# `<<EOF` content leak. To force heredoc, set `tool_format = "text"` here or pin
+# the capability row.
 [aliases.devstral-small-2]
 id = "devstral-small-2:24b"
 provider = "ollama"
@@ -506,4 +503,4 @@ provider = "ollama"
 # Devstral Small 2 on Ollama is text-tool-only (see the `devstral-small-2*`
 # capability rule: native_tools = false). A `tool_format = "native"` pin here
 # would be silently half-supported — accepted by resolution but degraded to
-# the text protocol downstream — which the catalog validator now rejects.
+# the text protocol downstream — which the catalog validator rejects.

--- a/crates/harn-vm/src/llm/catalog_sources/30-aliases/tool-calling.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/30-aliases/tool-calling.toml
@@ -38,8 +38,8 @@ streaming_native = "pass"
 fallback_mode = "native"
 last_probe_at = "2026-06-05"
 
-# MLX route now serves the Qwen3.6-35B-A3B MoE via mlx_lm.server (burin #2717).
-# native is UNPROVEN on mlx_lm.server (the runtime profile requires a tool_probe
+# MLX route serves the Qwen3.6-35B-A3B MoE via mlx_lm.server (burin #2717).
+# Native is UNPROVEN on mlx_lm.server (the runtime profile requires a tool_probe
 # before native is trusted; the validated `native` precedent is the llama.cpp
 # sibling, a different server). Keep native = "unknown" so the readiness/probe
 # path verifies served identity + a one-tool probe before selecting native.

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/10-openai-gemini-mistral.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/10-openai-gemini-mistral.toml
@@ -251,8 +251,8 @@ api_dialect = "openai_chat"
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.15, output_per_mtok = 0.60, cache_read_per_mtok = 0.015 }
 architecture = { parameter_count_b = 119.0, active_parameter_count_b = 6.5, moe = true, license = "Apache-2.0", source_url = "https://docs.mistral.ai/models/model-cards/mistral-small-4-0-26-03", last_verified = "2026-06-05" }
-# Self-described metadata (matches the mistral-small-4-2603 equivalence group);
-# previously relied on cross-fragment leading-key bleed.
+# Inline metadata matches the mistral-small-4-2603 equivalence group and keeps
+# this row independent of fragment-order defaults.
 tier = "mid"
 open_weight = true
 strengths = ["cheap", "coding", "speed", "tool_use", "long_context"]

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/20-open-weight-openrouter.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/20-open-weight-openrouter.toml
@@ -72,11 +72,9 @@ api_dialect = "openai_chat"
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.15, output_per_mtok = 0.60 }
 architecture = { parameter_count_b = 117.0, active_parameter_count_b = 5.1, moe = true, license = "Apache-2.0", source_url = "https://developers.openai.com/api/docs/models/gpt-oss-120b", last_verified = "2026-06-05" }
-# Explicit metadata so this row is self-described. It was previously the last
-# model in this fragment with no inline tier/open_weight/strengths, so the next
-# fragment's (now-removed) leading bare keys bled in and mislabeled it as
-# `open_weight = false` with a spurious `vision` strength. GPT-OSS 120B is
-# Apache-2.0 (open weight) and text-only; it is Burin's cheap coding executor.
+# Explicit metadata keeps this row self-described across fragment boundaries.
+# GPT-OSS 120B is Apache-2.0 (open weight) and text-only; it is Burin's cheap
+# coding executor.
 # `tier`/`open_weight`/`strengths` match the rest of the openai-gpt-oss-120b
 # equivalence group (the validator requires one tier per logical model — the
 # conservative shared baseline is `frontier`).

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/25-openrouter-frontier-agents.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/25-openrouter-frontier-agents.toml
@@ -40,8 +40,8 @@ provider = "openrouter"
 context_window = 256000
 capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
 pricing = { input_per_mtok = 0.20, output_per_mtok = 1.15, cache_read_per_mtok = 0.04 }
-# Self-described metadata (matches the step-3.7-flash equivalence group);
-# previously relied on cross-fragment leading-key bleed.
+# Inline metadata matches the step-3.7-flash equivalence group and keeps this
+# row independent of fragment-order defaults.
 tier = "frontier"
 open_weight = false
 strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning"]

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/26-together-frontier-agents.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/26-together-frontier-agents.toml
@@ -52,8 +52,8 @@ provider = "together"
 context_window = 196608
 capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
 pricing = { input_per_mtok = 0.30, output_per_mtok = 1.20, cache_read_per_mtok = 0.06 }
-# Self-described metadata (matches the minimax-m2.7 equivalence group);
-# previously relied on cross-fragment leading-key bleed.
+# Inline metadata matches the minimax-m2.7 equivalence group and keeps this row
+# independent of fragment-order defaults.
 tier = "frontier"
 open_weight = true
 strengths = ["speed", "coding", "agentic", "tool_use", "reasoning", "long_context"]

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/30-cerebras.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/30-cerebras.toml
@@ -42,9 +42,8 @@ pricing = { input_per_mtok = 0.85, output_per_mtok = 1.20 }
 availability = "dedicated"
 deprecated = true
 deprecation_note = "Cerebras no longer returns this model from public discovery; use a provisioned dedicated endpoint alias if your organization still serves these weights."
-# Self-described metadata; previously relied on cross-fragment leading-key
-# bleed. Deprecated legacy route.
+# Inline metadata keeps this deprecated legacy route independent of
+# fragment-order defaults.
 tier = "mid"
 open_weight = true
 strengths = ["tool_use"]
-

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/40-minimax.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/40-minimax.toml
@@ -126,7 +126,7 @@ provider = "openrouter"
 context_window = 204800
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.33, output_per_mtok = 1.20 }
-# Self-described metadata; previously relied on cross-fragment leading-key bleed.
+# Inline metadata keeps this row independent of fragment-order defaults.
 tier = "frontier"
 open_weight = true
 strengths = ["coding", "agentic", "tool_use", "reasoning"]

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/50-zai.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/50-zai.toml
@@ -67,7 +67,7 @@ provider = "openrouter"
 context_window = 202752
 capabilities = ["tools", "streaming", "vision"]
 pricing = { input_per_mtok = 1.20, output_per_mtok = 4.00 }
-# Self-described metadata; previously relied on cross-fragment leading-key bleed.
+# Inline metadata keeps this row independent of fragment-order defaults.
 tier = "frontier"
 open_weight = true
 strengths = ["vision", "coding", "agentic"]

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/60-deepseek-openrouter-qwen.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/60-deepseek-openrouter-qwen.toml
@@ -73,7 +73,7 @@ name = "Qwen3.5 9B"
 provider = "openrouter"
 context_window = 131072
 capabilities = ["tools", "streaming"]
-# Self-described metadata; previously relied on cross-fragment leading-key bleed.
+# Inline metadata keeps this row independent of fragment-order defaults.
 tier = "small"
 open_weight = true
 strengths = ["cheap", "speed"]

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/70-local-ollama.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/70-local-ollama.toml
@@ -64,8 +64,7 @@ context_window = 262144
 runtime_context_window = 32768
 stream_timeout = 600.0
 capabilities = ["tools", "streaming"]
-# Self-described metadata; previously relied on cross-fragment leading-key bleed.
+# Inline metadata keeps this row independent of fragment-order defaults.
 tier = "mid"
 open_weight = true
 strengths = ["coding", "agentic"]
-

--- a/crates/harn-vm/src/llm/catalog_sources/60-models/95-moonshot-deepinfra-sambanova.toml
+++ b/crates/harn-vm/src/llm/catalog_sources/60-models/95-moonshot-deepinfra-sambanova.toml
@@ -1,5 +1,5 @@
-# Direct first-party / fast-inference routes for models that were
-# previously only reachable through aggregator providers.
+# Direct first-party / fast-inference routes for models also available through
+# aggregator providers.
 #
 # Each row is keyed by a `provider/<wire-id>` selector so it stays
 # collision-free with the same weights hosted elsewhere (e.g. the

--- a/crates/harn-vm/src/llm/providers.toml
+++ b/crates/harn-vm/src/llm/providers.toml
@@ -316,13 +316,10 @@ latency_p50_ms = 1900
 method = "GET"
 path = "/models"
 
-# Moonshot AI — first-party host of the Kimi K2 family. OpenAI-compatible
-# `/v1/chat/completions`; the same models were previously only reachable
-# through OpenRouter/Together aggregator routes. Moonshot also exposes an
-# Anthropic-compatible `/anthropic` surface, but Harn dials the
-# OpenAI-compatible endpoint so the shared openai_chat_completions wire
-# format Just Works. Use the `.cn` base via MOONSHOT_BASE_URL for the
-# China region.
+# Moonshot AI — first-party host of the Kimi K2 family. Harn dials the
+# OpenAI-compatible `/v1/chat/completions` endpoint so the shared
+# openai_chat_completions wire format Just Works. Use the `.cn` base via
+# MOONSHOT_BASE_URL for the China region.
 [providers.moonshot]
 base_url = "https://api.moonshot.ai/v1"
 base_url_env = "MOONSHOT_BASE_URL"
@@ -1138,10 +1135,10 @@ tool_format = "native"
 
 # llama.cpp — Unsloth Dynamic 2.0 GGUF served by llama-server.
 # No `tool_format` pin: this non-native-quant id matches the `*qwen3.6*`
-# text-channel capability row, which now resolves to the global `json`
-# (fenced-JSON) default. json's ```tool fence sidesteps the reserved
-# <tool_call> token (so the reserved-token remap stays correct) and is
-# delimiter-safe vs heredoc. To force heredoc, set `tool_format = "text"`.
+# text-channel capability row's `json` (fenced-JSON) default. json's ```tool
+# fence sidesteps the reserved <tool_call> token (so the reserved-token remap
+# stays correct) and is delimiter-safe vs heredoc. To force heredoc, set
+# `tool_format = "text"`.
 [aliases."llamacpp-qwen3.6"]
 id = "qwen3.6-35b-a3b"
 provider = "llamacpp"
@@ -1161,13 +1158,11 @@ id = "qwen3.6-35b-a3b-ud-q4-k-xl"
 provider = "llamacpp"
 tool_format = "native"
 
-# MLX (Apple Silicon). Burin #2717 retired the never-downloaded dense vision
-# model `unsloth/Qwen3.6-27B-UD-MLX-4bit` (HF cache held only zero-byte
-# `.incomplete` blobs) and switched the local MLX route to the coding-tuned
-# Qwen3.6-35B-A3B MoE served via `mlx_lm.server`. Point every MLX alias at the
-# live MoE so `auto`/preset selection lands on real weights. These share the
-# `qwen3.6-35b-a3b` equivalence_group with the llama.cpp GGUF route, so eval
-# aggregation compares the two runtimes directly.
+# MLX (Apple Silicon). Local MLX routes use the coding-tuned Qwen3.6-35B-A3B
+# MoE served via `mlx_lm.server` (burin #2717). Keep every MLX alias pointed at
+# live MoE weights so `auto`/preset selection lands on real weights. These
+# share the `qwen3.6-35b-a3b` equivalence_group with the llama.cpp GGUF route,
+# so eval aggregation compares the two runtimes directly.
 [aliases."mlx-qwen3.6"]
 id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
 provider = "mlx"
@@ -1180,8 +1175,8 @@ provider = "mlx"
 id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-8bit"
 provider = "mlx"
 
-# Back-compat: the old 27B alias names now resolve to the live 35B-A3B MoE so
-# any pinned config keeps working instead of pointing at non-existent weights.
+# Back-compat: the old 27B alias names resolve to the live 35B-A3B MoE so any
+# pinned config keeps working instead of pointing at non-existent weights.
 [aliases.mlx-qwen36-27b]
 id = "unsloth/Qwen3.6-35B-A3B-UD-MLX-4bit"
 provider = "mlx"
@@ -1294,11 +1289,10 @@ provider = "xai"
 
 # Devstral (Mistral's agentic-coding tune).
 # No `tool_format` pin: these aliases inherit the `devstral-small-2*` capability
-# row's resolved default, now `json` (fenced-JSON) — the global text-channel
-# default. devstral has no reserved-token constraint, so the stale heredoc
-# `text` pin that used to sit here had no structural reason to exist; json is
-# delimiter-safe and root-cause-fixes heredoc's `<<EOF` content leak. To force
-# heredoc, set `tool_format = "text"` here or pin the capability row.
+# row's `json` (fenced-JSON) text-channel default. devstral has no
+# reserved-token constraint, so json is delimiter-safe and avoids heredoc's
+# `<<EOF` content leak. To force heredoc, set `tool_format = "text"` here or pin
+# the capability row.
 [aliases.devstral-small-2]
 id = "devstral-small-2:24b"
 provider = "ollama"
@@ -1311,7 +1305,7 @@ provider = "ollama"
 # Devstral Small 2 on Ollama is text-tool-only (see the `devstral-small-2*`
 # capability rule: native_tools = false). A `tool_format = "native"` pin here
 # would be silently half-supported — accepted by resolution but degraded to
-# the text protocol downstream — which the catalog validator now rejects.
+# the text protocol downstream — which the catalog validator rejects.
 
 # --- source: 30-aliases/tool-calling.toml ---
 # ── Alias tool-calling probe state ───────────────────────────────────────────
@@ -1354,8 +1348,8 @@ streaming_native = "pass"
 fallback_mode = "native"
 last_probe_at = "2026-06-05"
 
-# MLX route now serves the Qwen3.6-35B-A3B MoE via mlx_lm.server (burin #2717).
-# native is UNPROVEN on mlx_lm.server (the runtime profile requires a tool_probe
+# MLX route serves the Qwen3.6-35B-A3B MoE via mlx_lm.server (burin #2717).
+# Native is UNPROVEN on mlx_lm.server (the runtime profile requires a tool_probe
 # before native is trusted; the validated `native` precedent is the llama.cpp
 # sibling, a different server). Keep native = "unknown" so the readiness/probe
 # path verifies served identity + a one-tool probe before selecting native.
@@ -1939,8 +1933,8 @@ api_dialect = "openai_chat"
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.15, output_per_mtok = 0.60, cache_read_per_mtok = 0.015 }
 architecture = { parameter_count_b = 119.0, active_parameter_count_b = 6.5, moe = true, license = "Apache-2.0", source_url = "https://docs.mistral.ai/models/model-cards/mistral-small-4-0-26-03", last_verified = "2026-06-05" }
-# Self-described metadata (matches the mistral-small-4-2603 equivalence group);
-# previously relied on cross-fragment leading-key bleed.
+# Inline metadata matches the mistral-small-4-2603 equivalence group and keeps
+# this row independent of fragment-order defaults.
 tier = "mid"
 open_weight = true
 strengths = ["cheap", "coding", "speed", "tool_use", "long_context"]
@@ -2020,11 +2014,9 @@ api_dialect = "openai_chat"
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.15, output_per_mtok = 0.60 }
 architecture = { parameter_count_b = 117.0, active_parameter_count_b = 5.1, moe = true, license = "Apache-2.0", source_url = "https://developers.openai.com/api/docs/models/gpt-oss-120b", last_verified = "2026-06-05" }
-# Explicit metadata so this row is self-described. It was previously the last
-# model in this fragment with no inline tier/open_weight/strengths, so the next
-# fragment's (now-removed) leading bare keys bled in and mislabeled it as
-# `open_weight = false` with a spurious `vision` strength. GPT-OSS 120B is
-# Apache-2.0 (open weight) and text-only; it is Burin's cheap coding executor.
+# Explicit metadata keeps this row self-described across fragment boundaries.
+# GPT-OSS 120B is Apache-2.0 (open weight) and text-only; it is Burin's cheap
+# coding executor.
 # `tier`/`open_weight`/`strengths` match the rest of the openai-gpt-oss-120b
 # equivalence group (the validator requires one tier per logical model — the
 # conservative shared baseline is `frontier`).
@@ -2075,8 +2067,8 @@ provider = "openrouter"
 context_window = 256000
 capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
 pricing = { input_per_mtok = 0.20, output_per_mtok = 1.15, cache_read_per_mtok = 0.04 }
-# Self-described metadata (matches the step-3.7-flash equivalence group);
-# previously relied on cross-fragment leading-key bleed.
+# Inline metadata matches the step-3.7-flash equivalence group and keeps this
+# row independent of fragment-order defaults.
 tier = "frontier"
 open_weight = false
 strengths = ["agentic", "coding", "long_context", "tool_use", "reasoning"]
@@ -2136,8 +2128,8 @@ provider = "together"
 context_window = 196608
 capabilities = ["tools", "streaming", "thinking", "prompt_caching"]
 pricing = { input_per_mtok = 0.30, output_per_mtok = 1.20, cache_read_per_mtok = 0.06 }
-# Self-described metadata (matches the minimax-m2.7 equivalence group);
-# previously relied on cross-fragment leading-key bleed.
+# Inline metadata matches the minimax-m2.7 equivalence group and keeps this row
+# independent of fragment-order defaults.
 tier = "frontier"
 open_weight = true
 strengths = ["speed", "coding", "agentic", "tool_use", "reasoning", "long_context"]
@@ -2221,8 +2213,8 @@ pricing = { input_per_mtok = 0.85, output_per_mtok = 1.20 }
 availability = "dedicated"
 deprecated = true
 deprecation_note = "Cerebras no longer returns this model from public discovery; use a provisioned dedicated endpoint alias if your organization still serves these weights."
-# Self-described metadata; previously relied on cross-fragment leading-key
-# bleed. Deprecated legacy route.
+# Inline metadata keeps this deprecated legacy route independent of
+# fragment-order defaults.
 tier = "mid"
 open_weight = true
 strengths = ["tool_use"]
@@ -2356,7 +2348,7 @@ provider = "openrouter"
 context_window = 204800
 capabilities = ["tools", "streaming"]
 pricing = { input_per_mtok = 0.33, output_per_mtok = 1.20 }
-# Self-described metadata; previously relied on cross-fragment leading-key bleed.
+# Inline metadata keeps this row independent of fragment-order defaults.
 tier = "frontier"
 open_weight = true
 strengths = ["coding", "agentic", "tool_use", "reasoning"]
@@ -2431,7 +2423,7 @@ provider = "openrouter"
 context_window = 202752
 capabilities = ["tools", "streaming", "vision"]
 pricing = { input_per_mtok = 1.20, output_per_mtok = 4.00 }
-# Self-described metadata; previously relied on cross-fragment leading-key bleed.
+# Inline metadata keeps this row independent of fragment-order defaults.
 tier = "frontier"
 open_weight = true
 strengths = ["vision", "coding", "agentic"]
@@ -2512,7 +2504,7 @@ name = "Qwen3.5 9B"
 provider = "openrouter"
 context_window = 131072
 capabilities = ["tools", "streaming"]
-# Self-described metadata; previously relied on cross-fragment leading-key bleed.
+# Inline metadata keeps this row independent of fragment-order defaults.
 tier = "small"
 open_weight = true
 strengths = ["cheap", "speed"]
@@ -2584,7 +2576,7 @@ context_window = 262144
 runtime_context_window = 32768
 stream_timeout = 600.0
 capabilities = ["tools", "streaming"]
-# Self-described metadata; previously relied on cross-fragment leading-key bleed.
+# Inline metadata keeps this row independent of fragment-order defaults.
 tier = "mid"
 open_weight = true
 strengths = ["coding", "agentic"]
@@ -2949,8 +2941,8 @@ open_weight = false
 strengths = ["coding", "agentic", "tool_use", "reasoning", "vision"]
 
 # --- source: 60-models/95-moonshot-deepinfra-sambanova.toml ---
-# Direct first-party / fast-inference routes for models that were
-# previously only reachable through aggregator providers.
+# Direct first-party / fast-inference routes for models also available through
+# aggregator providers.
 #
 # Each row is keyed by a `provider/<wire-id>` selector so it stays
 # collision-free with the same weights hosted elsewhere (e.g. the

--- a/crates/harn-vm/src/llm/reasoning_policy.rs
+++ b/crates/harn-vm/src/llm/reasoning_policy.rs
@@ -569,8 +569,8 @@ mod tests {
         // The capability matrix declares `auto_reasoning_overrides =
         // { agent = "off", verify = "off" }` on the ollama qwen3 rules
         // to neutralize the Qwen3 tool-call/thinking regression at the
-        // data layer. Previously this lived as a hard-coded
-        // `local_qwen_route` branch in resolve_policy.
+        // data layer. Keep route-specific exceptions in data rather than
+        // adding provider/model branches to `resolve_policy`.
         let opts = crate::value::DictMap::from_iter([
             (
                 crate::value::intern_key("provider"),

--- a/crates/harn-vm/src/llm/schema_recover.rs
+++ b/crates/harn-vm/src/llm/schema_recover.rs
@@ -1,8 +1,7 @@
 //! `schema_recover(text, schema, opts?)` — best-effort recovery of
 //! malformed LLM output against a target schema. Implements the
-//! three-tier fallback that scripts (notably an IDE host's
-//! `grade-lora-corpus.harn` `normalize_grader_output()`) used to
-//! hand-roll: parse → extract → regex → optional LLM repair.
+//! shared fallback scripts need for schema-shaped LLM output:
+//! parse → extract → regex → optional LLM repair.
 //!
 //! Pipeline (each stage runs only if the previous failed):
 //!

--- a/crates/harn-vm/src/mcp_presets.rs
+++ b/crates/harn-vm/src/mcp_presets.rs
@@ -1,9 +1,9 @@
 //! Canonical catalog of well-known MCP server presets (harn#2650).
 //!
-//! Thin clients (an IDE host's TUI and the macOS GUI) used to each carry
-//! their own hardcoded list of "one-click" MCP servers — Notion, Linear,
-//! GitHub, a local filesystem server, etc. Those lists drifted from each
-//! other. This module is the single harn-owned source of truth.
+//! Thin clients (an IDE host's TUI and the macOS GUI) read this shared
+//! harn-owned source of truth for "one-click" MCP servers — Notion, Linear,
+//! GitHub, a local filesystem server, etc. Keep client lists derived from this
+//! catalog so presets do not drift across surfaces.
 //!
 //! **Data, not code (harn#3348).** The catalog ships as bundled TOML
 //! (`mcp_presets.toml`, compiled in via `include_str!`) and is overlayable at
@@ -443,7 +443,7 @@ mod tests {
             notion.get("oauthScopes").is_none(),
             "Notion MCP does not currently expose configurable OAuth scopes"
         );
-        // Notion now ships a token_response identity descriptor (harn#3349).
+        // Notion declares a token_response identity descriptor (harn#3349).
         assert_eq!(notion["identity"]["resolution"], serde_json::json!("user"));
         assert_eq!(
             notion["identity"]["confidence"],

--- a/crates/harn-vm/src/orchestration/compact_lifecycle.rs
+++ b/crates/harn-vm/src/orchestration/compact_lifecycle.rs
@@ -496,8 +496,8 @@ pub fn emit_transcript_compacted_event_sync(
 }
 
 // ---------------------------------------------------------------------------
-// Internal payload + reminder helpers (previously duplicated across stdlib
-// builtins and the agent-session host).
+// Internal payload + reminder helpers shared by stdlib builtins and the
+// agent-session host.
 // ---------------------------------------------------------------------------
 
 enum HookPayloadStage<'a> {

--- a/crates/harn-vm/src/orchestration/compaction.rs
+++ b/crates/harn-vm/src/orchestration/compaction.rs
@@ -555,13 +555,12 @@ fn line_has_file_line_prefix(trimmed: &str) -> bool {
 /// True when a single line carries failure signal worth preserving verbatim
 /// when we shrink a large tool output. This is the ONE filter shared by both
 /// the microcompact path (`microcompact_tool_output`) and the observation-mask
-/// path (`default_mask_tool_result`) — previously the mask path had a weaker,
-/// divergent filter that dropped assertion-value lines, rustc continuation
-/// lines, and structured failing-line markers, silently shredding the failure
-/// detail the model re-reads to fix the bug.
+/// path (`default_mask_tool_result`). Keep these paths on one filter so
+/// assertion values, rustc continuation lines, and structured failing-line
+/// markers survive in the detail the model re-reads to fix the bug.
 ///
 /// In addition to keyword/positional error lines and `file:line` diagnostics,
-/// this keeps three structured kinds the mask path used to drop:
+/// this keeps three structured kinds that are easy to drop accidentally:
 ///   - assertion value lines with no `file:line` (`left:`, `right:`,
 ///     `expected:`, `actual:`, `got`, `want`) — the values the model needs to
 ///     see the actual-vs-expected mismatch.
@@ -1374,9 +1373,8 @@ pub(crate) async fn auto_compact_messages_with_result_with_ctx(
 
     // Clamp oversized tool-result bodies in the *kept* window so the live
     // context honors the policy's `tool_output_max_chars` (and the
-    // `compress_callback` override), not just the archived/summarized window —
-    // the two config fields were previously parsed and defaulted but never
-    // applied here. Runs before the hard-limit estimate so tier-2 escalation
+    // `compress_callback` override), not just the archived/summarized window.
+    // Runs before the hard-limit estimate so tier-2 escalation
     // keys off the post-clamp size. Only the text body is rewritten; `role`
     // and `tool_call_id` are preserved so tool_call/tool_result pairing stays
     // intact.
@@ -1720,7 +1718,7 @@ mod tests {
     #[test]
     fn auto_compact_clamps_oversized_tool_output_to_max_chars() {
         // A large tool result in the *kept* window must be clamped to honor
-        // `tool_output_max_chars` — the engine previously ignored that config.
+        // `tool_output_max_chars`.
         let big = "x".repeat(4000);
         let big_len = big.len();
         let mut messages = vec![

--- a/crates/harn-vm/src/orchestration/compaction_policy_registry.rs
+++ b/crates/harn-vm/src/orchestration/compaction_policy_registry.rs
@@ -1,10 +1,10 @@
 //! Per-session compaction policy declarations.
 //!
-//! `harn-serve` consumers (TUI, IDE, cloud) used to maintain their own
-//! "when do I compact?" logic alongside the engine. This registry lifts
-//! that decision into the runtime so any caller can `compaction_policy(...)`
+//! `harn-serve` consumers (TUI, IDE, cloud) share this runtime-owned
+//! "when do I compact?" decision instead of re-encoding thresholds at each
+//! surface. Any caller can `compaction_policy(...)`
 //! once and then `compaction_check(session_id)` / `compaction_run(...)`
-//! on every turn without re-encoding thresholds at the call site.
+//! on every turn.
 //!
 //! Policies are thread-local because `agent_sessions` is. A `None` lookup
 //! falls back to the default policy registered with the empty session key.

--- a/crates/harn-vm/src/orchestration/nested_invocation.rs
+++ b/crates/harn-vm/src/orchestration/nested_invocation.rs
@@ -571,7 +571,7 @@ mod tests {
     #[test]
     fn harn_script_keyword_in_comment_is_ignored() {
         let source = r#"
-            // exec("rm -rf /") is what we used to do but no longer
+            // exec("rm -rf /") is a comment-only token and must not trip policy.
             let x = read_file("README.md")
         "#;
         let report = enforce_nested_invocation_ceiling(

--- a/crates/harn-vm/src/orchestration/policy/types.rs
+++ b/crates/harn-vm/src/orchestration/policy/types.rs
@@ -630,11 +630,9 @@ impl<T> std::ops::Deref for EqIgnored<T> {
     }
 }
 
-/// Per-call auto-compaction settings. First-class replacement for
-/// what used to live on `TranscriptPolicy` — the mode/fork/compact
-/// lifecycle fields are gone; lifecycle is driven by explicit
-/// `agent_session_*` builtins. Only the per-call tuning for how the
-/// agent loop manages its context window survives.
+/// Per-call auto-compaction settings. Lifecycle is driven by explicit
+/// `agent_session_*` builtins; this policy only controls how the agent loop
+/// manages its context window.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct AutoCompactPolicy {

--- a/crates/harn-vm/src/redact/mod.rs
+++ b/crates/harn-vm/src/redact/mod.rs
@@ -1,10 +1,9 @@
 //! Unified redaction policy for persisted and rendered operational data.
 //!
 //! Harn writes transcripts, receipts, event logs, portal JSON, connector
-//! status snapshots, and workflow artifacts. Each of those surfaces was
-//! previously responsible for its own ad-hoc scrubbing of HTTP headers,
-//! URL query parameters, JSON tokens, and free-form strings. This module
-//! is the single source of truth for "what is sensitive" so the same
+//! status snapshots, and workflow artifacts. This module is the single source
+//! of truth for scrubbing HTTP headers, URL query parameters, JSON tokens, and
+//! free-form strings so the same
 //! representative secret cannot leak through two surfaces by accident.
 //!
 //! # Categories
@@ -633,9 +632,9 @@ mod tests {
         assert_eq!(value["list"][0]["name"], "alice");
         assert_eq!(value["clientSecret"], REDACTED_PLACEHOLDER);
         let free_form = value["free_form"].as_str().unwrap();
-        // Free-form pattern matches now produce the OA-06 named
-        // placeholder `<redacted:<pattern>:<len>>` so audit logs can
-        // attribute leaks to a specific provider.
+        // Free-form pattern matches produce the OA-06 named placeholder
+        // `<redacted:<pattern>:<len>>` so audit logs can attribute leaks to a
+        // specific provider.
         assert!(
             free_form.contains("<redacted:"),
             "expected named placeholder, got: {free_form}"

--- a/crates/harn-vm/src/stdlib.rs
+++ b/crates/harn-vm/src/stdlib.rs
@@ -283,9 +283,9 @@ fn stdlib_probe_vm() -> Vm {
 ///
 /// Backed by the `linkme::distributed_slice` declared on
 /// [`crate::stdlib::macros::ALL_BUILTIN_DEFS`] — every annotated fn
-/// contributes one entry automatically at link time, eliminating the
-/// per-module `MODULE_BUILTINS` arrays and the hand-maintained aggregator
-/// that used to live here.
+/// contributes one entry automatically at link time. Keep builtin registration
+/// on this distributed slice instead of per-module arrays plus a central
+/// hand-maintained aggregator.
 ///
 /// **Force-link warning** (linkme issue #36): rlib dead-code stripping
 /// can drop these statics when `harn-vm` is linked transitively. Every

--- a/crates/harn-vm/src/stdlib/collections.rs
+++ b/crates/harn-vm/src/stdlib/collections.rs
@@ -303,11 +303,9 @@ pub(crate) fn register_collection_builtins(vm: &mut Vm) {
 }
 
 /// Registers the native fast-paths for the `std/collections` and `std/json`
-/// option-builder helpers. The `std/*.harn` modules used to express these
-/// in pure Harn with `result + {[k]: v}` accumulators, paying a fresh
-/// `BTreeMap` allocation per inserted entry. The native paths cut every
-/// helper to one allocation and skip the per-entry callback dispatch
-/// `filter_nil`'s `.filter(closure)` form previously paid.
+/// option-builder helpers. The native paths build each result with one
+/// allocation and avoid per-entry callback dispatch for the `filter_nil`
+/// helpers.
 ///
 /// Implementations are individual `#[harn_builtin]`-annotated functions
 /// below; `register_dict_builder_builtins` walks the collected
@@ -421,10 +419,9 @@ const DICT_BUILDER_BUILTINS: &[&VmBuiltinDef] = &[
     &DICT_FROM_PAIRS_IMPL_DEF,
 ];
 
-// (Per-module MODULE_BUILTINS slice deleted — `#[harn_builtin]` now
-// auto-registers each emitted DEF via the linkme distributed slice
-// `crate::stdlib::macros::ALL_BUILTIN_DEFS`, so no aggregation here is
-// needed.)
+// `#[harn_builtin]` auto-registers each emitted DEF via the linkme distributed
+// slice `crate::stdlib::macros::ALL_BUILTIN_DEFS`, so this module needs no
+// separate builtin aggregation.
 
 /// Returns a shallow copy of `value`. Dicts and lists become fresh
 /// allocations independent of the source; primitives are returned by value.

--- a/crates/harn-vm/src/stdlib/host.rs
+++ b/crates/harn-vm/src/stdlib/host.rs
@@ -886,8 +886,8 @@ pub(crate) fn build_sandboxed_command(
         //     provided keys. This is the least-surprising behavior — a
         //     caller passing `env: {ONE_VAR: "x"}` keeps PATH/HOME/etc.
         //   - "replace": clear the parent env entirely, then set only the
-        //     provided keys. Must be requested explicitly now; previously
-        //     this was the (footgun) default whenever `env` was supplied.
+        //     provided keys. This is the footgun shape and must be requested
+        //     explicitly whenever `env` is supplied.
         let env_mode = optional_string(params, "env_mode");
         match env_mode.as_deref().unwrap_or("merge") {
             "replace" => {

--- a/crates/harn-vm/src/value/set.rs
+++ b/crates/harn-vm/src/value/set.rs
@@ -6,12 +6,9 @@ use super::{value_structural_hash_key, VmValue};
 /// Backing store for [`VmValue::Set`](super::VmValue::Set).
 ///
 /// A Harn set is an *ordered* collection that deduplicates by structural
-/// equality. Membership used to be answered by rebuilding a
-/// `HashSet<String>` of structural hash keys from the backing `Vec` on every
-/// `contains` / `union` / `intersect` / … call — O(n) work (plus an
-/// allocation) per query. `VmSet` keeps that index resident alongside the
-/// items, so membership is O(1) and the set-algebra builtins drop from
-/// rebuild-per-call to a single key computation per probe.
+/// equality. `VmSet` keeps a resident structural-hash index alongside the
+/// ordered items, so membership is O(1) and set-algebra builtins do one key
+/// computation per probe instead of rebuilding an index for each query.
 ///
 /// Invariants:
 /// * `keys` holds exactly one entry per item: `value_structural_hash_key(item)`.

--- a/crates/harn-vm/src/value/storage_json.rs
+++ b/crates/harn-vm/src/value/storage_json.rs
@@ -5,8 +5,8 @@
 //! covers the scalar / list / dict shapes those persistence paths actually
 //! store and maps every other value kind (closures, handles, …) to `null`
 //! rather than to a display string, because a persisted record should not carry
-//! a stringified handle. The three persistence modules previously each kept an
-//! identical private copy of this function; they now share this one.
+//! a stringified handle. Keep persistence callers on this shared conversion
+//! path so handle/closure treatment stays consistent.
 
 use crate::value::VmValue;
 

--- a/crates/harn-vm/src/vm/dispatch.rs
+++ b/crates/harn-vm/src/vm/dispatch.rs
@@ -651,8 +651,7 @@ fn builtin_def_metadata(
 /// Derive a [`VmBuiltinArity`] from a parsed [`BuiltinSignature`]. Required
 /// params count toward the floor; optional params and `has_rest` widen the
 /// ceiling. Returns `Variadic` for `(...args: any)`-shaped sigs that have
-/// no required params, matching how the DSL builder previously declared
-/// `Variadic` explicitly.
+/// no required params.
 fn arity_from_sig(sig: &harn_builtin_meta::BuiltinSignature) -> VmBuiltinArity {
     let required = sig.params.iter().filter(|p| !p.optional).count();
     let total = sig.params.len();

--- a/crates/harn-vm/src/vm/ops/arithmetic.rs
+++ b/crates/harn-vm/src/vm/ops/arithmetic.rs
@@ -221,9 +221,8 @@ impl super::super::Vm {
 
     /// Compute the next adaptive-binary cache state from the peeked
     /// previous state and the freshly-observed `shape`. Operates on
-    /// `Copy` state directly — the helper no longer needs to take the
-    /// wrapping `InlineCacheEntry` by value (which used to force the
-    /// caller to clone the enum on the miss path too).
+    /// `Copy` state directly so the miss path does not clone the wrapping
+    /// `InlineCacheEntry`.
     fn next_adaptive_binary_state(
         previous: Option<AdaptiveBinaryState>,
         shape: BinaryShape,

--- a/crates/harn-vm/src/vm/ops/collections.rs
+++ b/crates/harn-vm/src/vm/ops/collections.rs
@@ -712,9 +712,9 @@ impl super::super::Vm {
         VmError::TypeError(format!("cannot index into list with {}", index.type_name()))
     }
 
-    /// Index-assignment is only supported on lists and dicts. This used to
-    /// be a silent no-op (e.g. `s[0] = "Z"` on a string left `s` untouched);
-    /// it is now the same class of error the property path raises.
+    /// Index-assignment is only supported on lists and dicts. Strings and
+    /// other scalar values raise the same class of error as unsupported
+    /// property assignment.
     fn subscript_assign_type_error(target: &VmValue) -> VmError {
         VmError::TypeError(format!(
             "cannot assign by index into {}; only lists and dicts support \

--- a/scripts/generated_artifacts.toml
+++ b/scripts/generated_artifacts.toml
@@ -3,16 +3,14 @@
 #
 # WHY THIS FILE EXISTS
 # --------------------
-# The gen/check pairs used to be enumerated independently in FOUR places:
+# Generated-artifact drift guards must stay wired through four consumers:
 #   1. the `all:` recipe in the Makefile
 #   2. the audit step(s) in .github/workflows/ci.yml
 #   3. .githooks/pre-commit
 #   4. .githooks/pre-push
-# Nothing forced those four lists to agree, and they drifted: several
-# `check-*` drift guards that exist in the Makefile (and were even
-# advertised in a CI comment as "promoted so a stale artifact fails the
-# PR") never actually ran in any workflow. A contributor could edit
-# spec/openapi.yaml, ship stale bindings, and still get green CI.
+# The registry below is the authority that keeps those surfaces in sync. Without
+# it, a stale generated output can pass review when one consumer forgets to run
+# the corresponding `check-*` target.
 #
 # This registry is the one list. `scripts/check_generated_registry.harn`
 # (`make check-generated-registry`) audits the other consumers against
@@ -108,8 +106,8 @@ pre_commit = true
 pre_push = true
 
 # ---------------------------------------------------------------------------
-# Mirrors whose drift guard previously ran ONLY in `make all` (and so never
-# in any CI workflow). Flagged ci = true here; this PR wires them into CI.
+# Mirrors whose drift guards are required in both `make all` and CI. Keep this
+# section wired through the workflow audit before adding new generated outputs.
 # ---------------------------------------------------------------------------
 
 [[artifact]]

--- a/scripts/stress_subprocess_tests.sh
+++ b/scripts/stress_subprocess_tests.sh
@@ -4,9 +4,7 @@
 # relaxed `harn-subprocess` / `harn-cli-bin` nextest group caps
 # introduced by harn#949.
 #
-# Background: those test groups used to be capped at `max-threads = 4`
-# to avoid macOS dyld + AMFI cold-cache scheduler starvation. The
-# architectural fix is the per-process pre-warm in
+# Those test groups rely on the per-process pre-warm in
 # `crates/harn-cli/tests/test_util/process.rs::harn_e2e_command()`. This
 # script gives reviewers a reproducible way to verify the fix holds:
 # loop the harn-cli nextest run N times and report any flakes.


### PR DESCRIPTION
## Summary
- Reword stale path-dependent comments across runtime, CLI/server permission, stdlib agent loop, compaction, LLM capability/catalog, and generated-artifact docs.
- Keep comments focused on current invariants, footguns, and compatibility contracts instead of migration history.
- Regenerate the provider config snapshot after catalog-source comment updates.

## Verification
- `git diff --check`
- `cargo fmt --all --check`
- `CARGO_TARGET_DIR=/tmp/harn-comment-polish-target cargo build --quiet --bin harn`
- `HARN_BIN=/tmp/harn-comment-polish-target/debug/harn make check-provider-config`
- `HARN_BIN=/tmp/harn-comment-polish-target/debug/harn make check-provider-catalog`
- `HARN_BIN=/tmp/harn-comment-polish-target/debug/harn make check-generated-registry`
- `/tmp/harn-comment-polish-target/debug/harn fmt --check crates/harn-stdlib/src/stdlib/stdlib_semver.harn crates/harn-stdlib/src/stdlib/agent/judge_internals.harn crates/harn-stdlib/src/stdlib/agent/loop.harn`
- `/tmp/harn-comment-polish-target/debug/harn lint crates/harn-stdlib/src/stdlib/stdlib_semver.harn crates/harn-stdlib/src/stdlib/agent/judge_internals.harn crates/harn-stdlib/src/stdlib/agent/loop.harn` (passes with existing ambient-clock warnings in `agent/loop.harn`)
- pre-commit hook: generated registry, Rust/Harn formatting, staged Harn lint, clippy on changed packages, highlight keyword sync
- pre-push hook: generated registry, targeted local checks, affected Harn fmt/lint, highlight keyword check