### PR TITLE
[codex] fix(agent): allow terminal callback recovery

### DIFF
--- a/changelog.d/terminal-callback-budget-exit.fixed.md
+++ b/changelog.d/terminal-callback-budget-exit.fixed.md
@@ -1,0 +1,1 @@
+Add a bounded terminal callback hook so agent loops can recover iteration-cap or stuck exits.

--- a/crates/harn-stdlib/src/stdlib/agent/loop.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/loop.harn
@@ -17,6 +17,7 @@ import { agent_loop_options, agent_tool_format } from "std/agent/options"
 import {
   agent_apply_tool_surface_narrowing,
   agent_compute_post_turn,
+  agent_compute_terminal_callback,
   agent_reset_tool_surface_narrowing,
 } from "std/agent/postturn"
 import {
@@ -2500,6 +2501,20 @@ fn __agent_loop_record_budget_stop(decisions, iteration, current_max, reason) {
   )
 }
 
+fn __agent_loop_record_terminal_callback_continue(decisions, iteration, old_limit, new_limit) {
+  return decisions
+    .push(
+    {
+      iteration: iteration,
+      action: "extend",
+      old_limit: old_limit,
+      new_limit: new_limit,
+      reason: "terminal_callback_continue",
+      status: "",
+    },
+  )
+}
+
 fn __agent_loop_state_budget_fields(
   session_id,
   totals,
@@ -3137,6 +3152,21 @@ fn __agent_loop_wrapup_eligible_status(final_status) {
     || final_status == "stuck"
 }
 
+fn __agent_loop_terminal_callback_continue_allowed(final_status, stop_reason) {
+  if final_status == "stuck" {
+    return true
+  }
+  return final_status == "budget_exhausted" && (stop_reason ?? "") == "max_iterations"
+}
+
+fn __agent_loop_terminal_callback_extend_by(budget) {
+  let by = budget?.extend_by ?? 0
+  if type_of(by) == "int" && by > 0 {
+    return by
+  }
+  return 1
+}
+
 /**
  * Forced terminal wrap-up turn. When the loop exits on exhaustion/cap while the
  * last turn still called tools, the surfaced final text would otherwise be a
@@ -3258,6 +3288,7 @@ fn __agent_loop_run(message, session, initial_opts) {
       0
     }
     var in_terminal_verify_reserve = false
+    var terminal_callback_continues = 0
     while true {
       while iteration < current_max {
         let boundary_exhaustion = __agent_loop_budget_exhaustion(
@@ -4233,6 +4264,47 @@ fn __agent_loop_run(message, session, initial_opts) {
           continue
         }
         stop_reason = "reserved_terminal_verify_failed"
+      }
+      if final_status != ""
+        && suspend_result == nil
+        && terminal_error == nil
+        && terminal_callback_continues == 0
+        && __agent_loop_terminal_callback_continue_allowed(final_status, stop_reason) {
+        let terminal_outcome = agent_compute_terminal_callback(
+          session,
+          opts,
+          {
+            iteration: iteration,
+            final_status: final_status,
+            stop_reason: stop_reason ?? "",
+            max_iterations: current_max,
+            iteration_budget: budget,
+          },
+        )
+        if terminal_outcome.kind == "continue" {
+          terminal_callback_continues = terminal_callback_continues + 1
+          opts = __apply_post_turn_options(opts, terminal_outcome)
+          let old_limit = current_max
+          let extra = __agent_loop_terminal_callback_extend_by(budget)
+          current_max = max(current_max, iteration + extra)
+          budget_decisions = __agent_loop_record_terminal_callback_continue(budget_decisions, iteration, old_limit, current_max)
+          agent_emit_event(
+            session.session_id,
+            "loop_control_decision",
+            {
+              iteration: iteration,
+              action: "extend",
+              old_limit: old_limit,
+              new_limit: current_max,
+              reason: "terminal_callback_continue",
+              status: "",
+            },
+          )
+          final_status = ""
+          stop_reason = nil
+          budget_exhausted_emitted = false
+          continue
+        }
       }
       break
     }

--- a/crates/harn-stdlib/src/stdlib/agent/options.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/options.harn
@@ -757,6 +757,15 @@ fn __validate_loop_control(value) {
   }
 }
 
+fn __validate_terminal_callback(value) {
+  if value == nil {
+    return
+  }
+  if type_of(value) != "closure" {
+    throw "agent_loop: `terminal_callback` must be a closure or nil; got " + type_of(value)
+  }
+}
+
 fn __validate_llm_caller(value) {
   if value == nil {
     return
@@ -1049,6 +1058,9 @@ fn __validate_transcript_projection(value) {
 fn __validate_agent_loop_callback_options(opts) {
   if __has_key(opts, "loop_control") {
     __validate_loop_control(opts.loop_control)
+  }
+  if __has_key(opts, "terminal_callback") {
+    __validate_terminal_callback(opts.terminal_callback)
   }
   if __has_key(opts, "llm_caller") {
     __validate_llm_caller(opts.llm_caller)

--- a/crates/harn-stdlib/src/stdlib/agent/postturn.harn
+++ b/crates/harn-stdlib/src/stdlib/agent/postturn.harn
@@ -105,6 +105,15 @@ fn __interpret_verdict(verdict) {
   return {kind: "none"}
 }
 
+fn __terminal_callback_verdict(opts, payload) {
+  let cb = opts?.terminal_callback
+  if cb == nil {
+    return {kind: "none"}
+  }
+  let verdict = cb(payload)
+  return __interpret_verdict(verdict)
+}
+
 fn __successful_tool_names(dispatch) {
   return __tool_names_by_status(dispatch, true)
 }
@@ -576,19 +585,19 @@ fn __completion_result(opts, payload, stop_reason) {
   return {kind: "break", stop_reason: stop_reason, needs_verify: false, done_judge_due: false}
 }
 
-fn __post_turn_verdict_result(session, opts, verdict) {
+fn __post_turn_verdict_result(session, opts, verdict, feedback_kind = "post_turn") {
   if verdict.kind == "stop" {
     return {kind: "break", stop_reason: "post_turn_stop", needs_verify: opts?.verify_completion != nil}
   }
   if verdict.kind == "inject" {
-    agent_session_inject_feedback(session.session_id, "post_turn", verdict.message)
+    agent_session_inject_feedback(session.session_id, feedback_kind, verdict.message)
     return {kind: "continue"}
   }
   if verdict.kind != "rich" {
     return nil
   }
   if verdict.message != nil {
-    agent_session_inject_feedback(session.session_id, "post_turn", verdict.message)
+    agent_session_inject_feedback(session.session_id, feedback_kind, verdict.message)
   }
   if verdict.stop {
     let stop_reason = if verdict?.stop_reason != nil && verdict.stop_reason != "" {
@@ -1071,7 +1080,7 @@ pub fn agent_compute_post_turn(session, llm_result, dispatch, opts, iteration) {
     )
   }
   let verdict = __post_turn_callback_verdict(opts, payload)
-  let verdict_result = __post_turn_verdict_result(session, opts, verdict)
+  let verdict_result = __post_turn_verdict_result(session, opts, verdict, "terminal_callback")
   if verdict_result != nil {
     return __post_turn_with_narrowing(verdict_result, narrowing)
   }
@@ -1097,6 +1106,49 @@ pub fn agent_compute_post_turn(session, llm_result, dispatch, opts, iteration) {
     {kind: "continue", done_judge_due: false, nudged_this_turn: confirmation_nudged || action_nudged},
     narrowing,
   )
+}
+
+/**
+ * agent_compute_terminal_callback gives host policy one bounded chance to
+ * transform a non-successful loop terminal (for example max-iteration exhaustion
+ * over a still-red workspace) into a normal continuation with `next_options`.
+ * It intentionally uses a distinct `terminal_callback` option instead of
+ * replaying `post_turn_callback`, so ordinary no-tool/no-write nudges do not
+ * accidentally reinterpret every terminal budget exit as a normal turn.
+ *
+ * @effects: [host]
+ * @errors: []
+ */
+pub fn agent_compute_terminal_callback(session, opts, terminal) {
+  let payload = {
+    session_id: session.session_id,
+    session: {id: session.session_id},
+    terminal: true,
+    iteration: terminal?.iteration ?? 0,
+    final_status: terminal?.final_status ?? "",
+    stop_reason: terminal?.stop_reason ?? "",
+    budget_exhausted: (terminal?.final_status ?? "") == "budget_exhausted",
+    max_iterations: terminal?.max_iterations ?? 0,
+    iteration_budget: terminal?.iteration_budget,
+    has_tool_calls: false,
+    dispatch: {results: []},
+    tool_results: [],
+    tool_count: 0,
+    tool_names: [],
+    successful_tool_names: [],
+    rejected_tool_names: [],
+    session_successful_tools: opts?._session_successful_tools ?? [],
+    session_rejected_tools: opts?._session_rejected_tools ?? [],
+    text: "",
+    visible_text: "",
+    last_assistant_text: "",
+  }
+  let verdict = __terminal_callback_verdict(opts, payload)
+  let verdict_result = __post_turn_verdict_result(session, opts, verdict)
+  if verdict_result != nil {
+    return verdict_result
+  }
+  return {kind: "none"}
 }
 
 fn visible_text_excerpt(text) {

--- a/tests/agent/terminal_callback_test.harn
+++ b/tests/agent/terminal_callback_test.harn
@@ -1,0 +1,55 @@
+// Run: harn test tests/agent/terminal_callback_test.harn
+//
+// In-process regression coverage for terminal callback rescue. This uses the
+// mock LLM script and explicit callback verdicts, so it proves the loop
+// mechanics without sleeps, wall-clock polling, API calls, or broad eval
+// machinery.
+import { llm_text, with_llm_script } from "std/testing"
+
+pipeline test_terminal_callback_can_continue_max_iteration_exit(task) {
+  with_llm_script(
+    [
+      llm_text("The first turn still needs work."),
+      llm_text("The rescue turn completed the task. ##DONE##"),
+    ],
+    { ->
+      let result = agent_loop(
+        "Continue once, then finish.",
+        nil,
+        {
+          provider: "mock",
+          loop_until_done: true,
+          iteration_budget: {mode: "fixed", initial: 1, max: 1, extend_by: 0, expose_decisions: true},
+          post_turn_callback: { _info -> return {message: "Keep going until the done sentinel is present."} },
+          terminal_callback: { info ->
+            assert_eq(info?.final_status, "budget_exhausted")
+            assert_eq(info?.stop_reason, "max_iterations")
+            assert(info?.budget_exhausted ?? false, "payload must expose a budget_exhausted boolean")
+            return {
+              message: "Terminal callback granted a bounded rescue turn.",
+              next_options: {llm_options: {temperature: 0.0}},
+            }
+          },
+        },
+      )
+      assert_eq(result.status, "done")
+      assert(result.llm.iterations >= 2, "terminal callback must allow the scripted rescue turn")
+      let decisions = result?.adaptive_budget?.decisions ?? []
+      assert(
+        len(decisions) > 0 && decisions[len(decisions) - 1]?.reason == "terminal_callback_continue",
+        "adaptive budget decisions should record the terminal rescue extension",
+      )
+      let messages = result?.transcript?.messages ?? []
+      var saw_terminal_feedback = false
+      for message in messages {
+        if contains(message?.content ?? "", "<runtime_feedback kind=\"terminal_callback\">") {
+          saw_terminal_feedback = true
+        }
+      }
+      assert(
+        saw_terminal_feedback,
+        "terminal callback feedback should be labeled separately from post_turn feedback",
+      )
+    },
+  )
+}


### PR DESCRIPTION
## Summary

Adds an explicit `terminal_callback` hook to `agent_loop` so host policy gets one bounded chance to recover `budget_exhausted/max_iterations` or `stuck` terminals. The continuation reuses the existing post-turn verdict machinery, records a `loop_control_decision` with reason `terminal_callback_continue`, and never applies to hard wall-clock or cost budget exits.

## Why

Structured zig-feat forensics showed a red workspace reaching a terminal stall/max-iteration boundary with no escalation receipt because ordinary post-turn callbacks no longer run at that boundary. This adds the Harn-owned seam; Burin can then consume it with its existing verification-escalation actuator after the next Harn release/repin.

## Validation

- `CARGO_TARGET_DIR=/tmp/codex-harn-terminal-target cargo run --quiet --bin harn -- test tests/agent/terminal_callback_test.harn`
- `git diff --check HEAD`
- pre-commit: markdown, staged Harn format/lint, highlight keyword sync
- pre-push: markdown, targeted harn-stdlib cargo check, affected Harn format/lint, highlight keyword check

Note: pre-push still reports the pre-existing ambient clock deprecation warnings in `agent/loop.harn`; the new `agent_compute_terminal_callback` stdlib metadata warning was fixed before opening this PR.