### PR TITLE
fix(cli): isolate conformance runtime state

### DIFF
--- a/changelog.d/conformance-state-isolation.fixed.md
+++ b/changelog.d/conformance-state-isolation.fixed.md
@@ -1,0 +1,2 @@
+Isolate `harn test conformance` runtime state per case so ignored `.harn/metadata`
+output from earlier runs cannot make metadata fixtures flaky.

--- a/crates/harn-cli/src/commands/test.rs
+++ b/crates/harn-cli/src/commands/test.rs
@@ -731,7 +731,10 @@ async fn execute_conformance_source(
         .prefix("harn-conformance-state-")
         .tempdir()
         .map_err(|error| format!("tempdir for conformance state: {error}"))?;
-    let state_dir = state_temp_dir.path().to_string_lossy().into_owned();
+    let state_dir = state_temp_dir.path().join(".harn");
+    std::fs::create_dir_all(&state_dir)
+        .map_err(|error| format!("create conformance state dir: {error}"))?;
+    let state_dir = state_dir.to_string_lossy().into_owned();
     let _state_dir_guard =
         ScopedEnvVar::set(harn_vm::runtime_paths::HARN_STATE_DIR_ENV, &state_dir);
     let harness_sidecar = match testbench.harness.as_ref() {

--- a/crates/harn-cli/src/commands/test.rs
+++ b/crates/harn-cli/src/commands/test.rs
@@ -727,6 +727,13 @@ async fn execute_conformance_source(
     harn_vm::reset_thread_local_state();
     install_cli_llm_mock_mode(llm_mock_mode)
         .map_err(|error| format!("llm mock setup error: {error}"))?;
+    let state_temp_dir = tempfile::Builder::new()
+        .prefix("harn-conformance-state-")
+        .tempdir()
+        .map_err(|error| format!("tempdir for conformance state: {error}"))?;
+    let state_dir = state_temp_dir.path().to_string_lossy().into_owned();
+    let _state_dir_guard =
+        ScopedEnvVar::set(harn_vm::runtime_paths::HARN_STATE_DIR_ENV, &state_dir);
     let harness_sidecar = match testbench.harness.as_ref() {
         Some(path) => Some(HarnessSidecar::load(path)?),
         None => None,

--- a/crates/harn-cli/tests/conformance_json_cli.rs
+++ b/crates/harn-cli/tests/conformance_json_cli.rs
@@ -125,6 +125,53 @@ fn conformance_json_fails_on_failures_and_unexpected_xfail_passes() {
 }
 
 #[test]
+fn conformance_json_ignores_fixture_parent_runtime_state() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    write_fixture(
+        temp.path(),
+        "metadata/isolated.harn",
+        "pipeline test(task) {\n  assert_eq(metadata_get(\".\", \"classification\"), nil)\n  let stale = metadata_stale(\".\")\n  assert_eq(stale.any_stale, false)\n  log(\"isolated\")\n}\n",
+        "[harn] isolated\n",
+    );
+    let stale_state = temp
+        .path()
+        .join("conformance")
+        .join("metadata")
+        .join(".harn")
+        .join("metadata")
+        .join("classification");
+    std::fs::create_dir_all(&stale_state).expect("create stale metadata dir");
+    std::fs::write(
+        stale_state.join("entries.json"),
+        r#"{
+  "backend": "filesystem",
+  "entries": {
+    ".": {
+      "structureHash": "stale"
+    }
+  },
+  "namespace": "classification",
+  "version": 1
+}
+"#,
+    )
+    .expect("write stale metadata");
+
+    let output = run_conformance_json(temp.path());
+    assert!(
+        output.status.success(),
+        "exit={:?} stderr={} stdout={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let parsed = parse_stdout(&output);
+    let data = assert_envelope(&parsed, CONFORMANCE_TEST_SCHEMA_VERSION);
+    assert_eq!(data["summary"]["pass"], 1);
+    assert_eq!(result(data, "metadata/isolated.harn")["outcome"], "pass");
+}
+
+#[test]
 fn conformance_json_schema_catalog_entry_is_registered() {
     let output = Command::new(binary_path())
         .args(["--json-schemas", "--command", "test conformance"])

--- a/crates/harn-cli/tests/conformance_json_cli.rs
+++ b/crates/harn-cli/tests/conformance_json_cli.rs
@@ -130,7 +130,7 @@ fn conformance_json_ignores_fixture_parent_runtime_state() {
     write_fixture(
         temp.path(),
         "metadata/isolated.harn",
-        "pipeline test(task) {\n  assert_eq(metadata_get(\".\", \"classification\"), nil)\n  let stale = metadata_stale(\".\")\n  assert_eq(stale.any_stale, false)\n  log(\"isolated\")\n}\n",
+        "pipeline test(task) {\n  assert_eq(metadata_get(\".\", \"classification\"), nil)\n  let stale = metadata_stale(\".\")\n  assert_eq(stale.any_stale, false)\n  let paths = runtime_paths()\n  assert_eq(paths.state_root.ends_with(\".harn\"), true)\n  assert_eq(paths.worktree_root.ends_with(\".harn/worktrees\"), true)\n  log(\"isolated\")\n}\n",
         "[harn] isolated\n",
     );
     let stale_state = temp


### PR DESCRIPTION
## Summary
- Give each `harn test conformance` case its own temporary `HARN_STATE_DIR` so ignored runtime metadata beside fixtures cannot poison later runs.
- Add an end-to-end JSON conformance regression that pre-populates stale `.harn/metadata` next to a fixture and proves the test still sees a clean metadata store.

## Root Cause
The conformance runner used the fixture parent as the metadata/store base. Release retries left ignored `conformance/tests/stdlib/.harn/metadata` state behind, so `metadata_builtins.harn` and `host_project_metadata_fallback.harn` read prior classification hashes and failed their clean-store assertions. A fresh `HARN_STATE_DIR` made the failing filter pass, confirming state leakage rather than metadata semantics.

## Validation
- `CARGO_TARGET_DIR=/tmp/harn-conformance-state-target cargo test -p harn-cli --test conformance_json_cli conformance_json_ignores_fixture_parent_runtime_state -- --nocapture`
- `HARN_LLM_CALLS_DISABLED=1 /tmp/harn-conformance-state-target/debug/harn test conformance --filter 'metadata_builtins|host_project_metadata_fallback' --json`\n- `CARGO_TARGET_DIR=/tmp/harn-conformance-state-target cargo test -p harn-cli --test conformance_json_cli -- --nocapture`\n- `CARGO_TARGET_DIR=/tmp/harn-conformance-state-target cargo clippy -p harn-cli --all-targets -- -D warnings`\n- `cargo fmt --all -- --check`\n- `git diff --check`\n- pre-commit and pre-push hooks passed\n