### PR TITLE
fix(vm): strip orphan tool-call/prose residue + bare verdict JSON from visible text

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -333,7 +333,7 @@ jobs:
         with:
           ref: ${{ needs.setup.outputs.ref }}
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
 

--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -98,7 +98,7 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "Detected bump type: $BUMP"
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         if: steps.bump.outputs.skip != 'true'
         with:
           components: clippy, rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: rustfmt
       - run: make fmt-check
@@ -185,9 +185,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y mold
           mold --version
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         if: matrix.rust_components == ''
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         if: matrix.rust_components != ''
         with:
           components: ${{ matrix.rust_components }}
@@ -367,7 +367,7 @@ jobs:
       - run: make check-bindings
       - run: make lint-test-patterns
       - run: make test-pr-gate-scripts
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement. A
         # cold compile is a valid fallback; the audit result should not hinge
@@ -500,7 +500,7 @@ jobs:
           # Linux fast feedback. Merge-queue and main pushes keep the shallow
           # checkout because they run the full workspace unconditionally.
           fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         continue-on-error: true
         with:
@@ -672,7 +672,7 @@ jobs:
       RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
@@ -787,7 +787,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'e2e')
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement. The
         # upstream action sometimes fails on merge_group / restricted-token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,7 +773,7 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
-          version: "1.25.2"
+          version: "1.26.1"
           advanced-security: false
           annotations: true
           min-severity: medium

--- a/.github/workflows/cli-cold-start-budget.yml
+++ b/.github/workflows/cli-cold-start-budget.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement.
         continue-on-error: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e'))
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement. The
         # upstream action sometimes fails on merge_group / restricted-token

--- a/.github/workflows/flake-detection.yml
+++ b/.github/workflows/flake-detection.yml
@@ -65,7 +65,7 @@ jobs:
             echo "No touched Rust test files detected; skipping flake rerun."
           fi
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         if: steps.touched.outputs.has_tests == 'true'
 
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -53,7 +53,7 @@ jobs:
             runner: macos-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       # Mirror the documented `cargo install harn-cli`. No `--locked`: a user
       # typing the documented command gets a fresh dependency resolution, and

--- a/.github/workflows/lean-embedding.yml
+++ b/.github/workflows/lean-embedding.yml
@@ -38,6 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: Measure lean vs full embedding surface
         run: ./scripts/measure_lean_embedding.sh

--- a/.github/workflows/macos-nightly.yml
+++ b/.github/workflows/macos-nightly.yml
@@ -41,7 +41,7 @@ jobs:
     if: github.repository == 'burin-labs/harn'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement. The
         # upstream action sometimes fails on merge_group / restricted-token

--- a/.github/workflows/ported-handler-loc.yml
+++ b/.github/workflows/ported-handler-loc.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement.
         continue-on-error: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -364,7 +364,7 @@ jobs:
           fi
           echo "Publishing from $(git rev-parse --short HEAD) ($publish_ref)"
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy, rustfmt
 

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -244,7 +244,7 @@ jobs:
           chmod +x "$out_dir"/harn*
           "$HARN_BINARY" --version
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         if: needs.resolve.outputs.mode == 'source'
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         if: needs.resolve.outputs.mode == 'source' && matrix.platform != 'windows'

--- a/.github/workflows/thread-parity.yml
+++ b/.github/workflows/thread-parity.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement. The

--- a/.github/workflows/windows-nightly.yml
+++ b/.github/workflows/windows-nightly.yml
@@ -40,7 +40,7 @@ jobs:
     if: github.repository == 'burin-labs/harn'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement. The
         # upstream action sometimes fails on merge_group / restricted-token

--- a/changelog.d/3755.fixed.md
+++ b/changelog.d/3755.fixed.md
@@ -1,0 +1,1 @@
+- Strip orphan tool-call/prose residue and bare internal verdict JSON from agent visible text.

--- a/changelog.d/3755.fixed.md
+++ b/changelog.d/3755.fixed.md
@@ -1,1 +1,0 @@
-- Strip orphan tool-call/prose residue and bare internal verdict JSON from agent visible text.

--- a/changelog.d/3757.fixed.md
+++ b/changelog.d/3757.fixed.md
@@ -1,0 +1,3 @@
+- **Visible assistant text sanitization now strips orphan protocol residue in the
+  VM (#3757).** Final messages no longer surface truncated tool/prose markers
+  or bare internal verdict JSON as user-visible assistant text.

--- a/crates/harn-vm/src/visible_text.rs
+++ b/crates/harn-vm/src/visible_text.rs
@@ -313,6 +313,63 @@ fn strip_inline_internal_planning_json(text: &str, partial: bool) -> String {
     stripped
 }
 
+fn protocol_residue_regex() -> &'static Regex {
+    // Orphan / truncated protocol-tag litter that the well-formed block
+    // patterns above cannot match: a closing tag with no surviving opener, and
+    // the right-anchored `</tool_call>` truncations (`tool_call>`, `ol_call>`,
+    // `l_call>`, `_call>`) plus `</assistant_prose>` / `_prose>` / `</done>` /
+    // `/done>` fragments that weak open-weight models (incl. the GLM default)
+    // emit mid-stream. These are control-token residue, never legitimate
+    // narration, so they are stripped unconditionally — including from the
+    // FINAL transcript, which the partial-only strippers below never see.
+    // Bounds are tight (anchored on `_call>` / explicit tag names) to avoid
+    // touching ordinary prose like "x > y" or words ending in "e".
+    // Scope is deliberately limited to the UNAMBIGUOUS corruption families that
+    // never occur in real prose: right-anchored `</tool_call>` truncations
+    // (`</tool_call>`, `tool_call>`, `ol_call>`, `l_call>`, `_call>`, with the
+    // `<|tool_call|>` channel variant) and the `<assistant_prose>` close-tag
+    // truncations (`</assistant_prose>`, `assistant_prose>`, `nt_prose>`,
+    // `_prose>`). We do NOT blanket-strip `<user_response>`/`<done>`/
+    // `<tool_result>` here — those are owned by the position/fence-aware logic
+    // above and have legitimate inline-mention forms (see the placeholder/fence
+    // tests), so touching them regresses those guarantees.
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"<?/?\|?(?:t?o?o?l?)_call\|?>|<?/?\|?[a-z]*_prose>")
+            .expect("valid protocol residue regex")
+    })
+}
+
+fn strip_protocol_residue(text: &str) -> String {
+    // Fence-aware, matching the rest of this module: a fenced code block may
+    // legitimately show `</tool_call>` as an example, so residue inside a
+    // markdown fence is preserved; only standalone litter is removed.
+    protocol_residue_regex()
+        .replace_all(text, |caps: &regex::Captures| {
+            let matched = caps.get(0).expect("capture group 0 always present");
+            if inside_markdown_fence(text, matched.start()) {
+                matched.as_str().to_string()
+            } else {
+                String::new()
+            }
+        })
+        .to_string()
+}
+
+fn strip_bare_internal_json(text: &str) -> String {
+    // A finalized turn whose entire visible body is an internal control object
+    // — e.g. the completion judge's `{"verdict":...,"reasoning":...}` — must
+    // never surface as the agent's message. The fenced/inline planner strips
+    // above only catch ```json fences and `{"mode":...}`; a bare top-level
+    // verdict/reasoning blob slips through. Only strips when the WHOLE trimmed
+    // body is recognized internal JSON, so legitimate prose that merely quotes
+    // JSON is untouched.
+    if looks_like_internal_planning_json(text) {
+        return String::new();
+    }
+    text.to_string()
+}
+
 fn strip_partial_marker_suffix(text: &str) -> String {
     const MARKERS: [&str; 13] = [
         "<|tool_call|>",
@@ -360,6 +417,12 @@ pub fn sanitize_visible_assistant_text(text: &str, partial: bool) -> String {
     sanitized = extract_visible_prose(&sanitized);
     sanitized = strip_internal_json_fences(&sanitized);
     sanitized = strip_inline_internal_planning_json(&sanitized, partial);
+    // Unconditional: orphan/truncated control-token residue and bare internal
+    // control JSON leak into FINAL transcripts too, where the partial-only
+    // strippers below never run. Bare-JSON check runs on the trimmed body so a
+    // verdict blob surrounded by whitespace is still recognized.
+    sanitized = strip_protocol_residue(&sanitized);
+    sanitized = strip_bare_internal_json(sanitized.trim());
     if partial {
         sanitized = strip_unclosed_internal_blocks(&sanitized);
         sanitized = strip_partial_marker_suffix(&sanitized);
@@ -435,6 +498,55 @@ mod tests {
         assert_eq!(sanitize_visible_assistant_text(raw, false), "");
         let raw = r#"{"status":"ok","message":"hello"}"#;
         assert_eq!(sanitize_visible_assistant_text(raw, false), raw);
+    }
+
+    #[test]
+    fn sanitize_strips_orphan_tool_call_residue_and_truncations() {
+        // Real leak: weak/GLM models emit truncated `</tool_call>` fragments as
+        // standalone visible text. None match the well-formed block patterns.
+        assert_eq!(sanitize_visible_assistant_text("_call>", false), "");
+        assert_eq!(sanitize_visible_assistant_text("l_call>l_call>", false), "");
+        assert_eq!(
+            sanitize_visible_assistant_text("Done.\n})\n</tool_call>_call>", false),
+            "Done.\n})"
+        );
+        assert_eq!(
+            sanitize_visible_assistant_text("Implemented.</assistant_prose>", false),
+            "Implemented."
+        );
+        // `_prose>` close-tag truncation (no opening tag) is also litter.
+        assert_eq!(
+            sanitize_visible_assistant_text("Implemented.\nnt_prose>", false),
+            "Implemented."
+        );
+        // Fence-aware: a fenced example showing the tag is preserved verbatim.
+        let fenced = "```\n</tool_call>\n```\nDone.";
+        assert_eq!(sanitize_visible_assistant_text(fenced, false), fenced);
+    }
+
+    #[test]
+    fn sanitize_does_not_touch_ordinary_prose_or_inequalities() {
+        // Guard against over-eager residue stripping.
+        let raw = "Use a_call> only as— wait, compare x > y and y > z here.";
+        // `a_call>` IS residue-shaped (`_call>` truncation); ensure the rest survives.
+        let out = sanitize_visible_assistant_text(raw, false);
+        assert!(out.contains("compare x > y and y > z here."), "got: {out}");
+        assert_eq!(
+            sanitize_visible_assistant_text("The phrase tool call is normal prose.", false),
+            "The phrase tool call is normal prose."
+        );
+    }
+
+    #[test]
+    fn sanitize_drops_bare_completion_judge_verdict_json() {
+        let raw = r#"{"verdict":"done","reasoning":"All tests pass.","next_step":""}"#;
+        assert_eq!(sanitize_visible_assistant_text(raw, false), "");
+        // A bare verdict blob surrounded by whitespace is still recognized.
+        let padded = "\n  {\"verdict\":\"continue\",\"reasoning\":\"does not compile\"}  \n";
+        assert_eq!(sanitize_visible_assistant_text(padded, false), "");
+        // Legitimate non-internal JSON is preserved (consistent with existing behavior).
+        let keep = r#"{"status":"ok","message":"hello"}"#;
+        assert_eq!(sanitize_visible_assistant_text(keep, false), keep);
     }
 
     #[test]


### PR DESCRIPTION
## Why

Across **625 real Burin conversations**, the user-visible assistant stream leaks control-token litter on weak/open-weight models — and **zero** on frontier (first-hand `lastModel`-bucketed scan of persisted `messages[].text`):

| signal | total | gpt-oss-120b | **GLM-5.2 (TUI default)** | sonnet-4.6 |
|---|---|---|---|---|
| `_call>` / `</tool_call>` residue | 27% | 32% | **70%** | **0%** |
| bare `{"verdict":…}` judge JSON | 11% | — | **52%** | **0%** |
| `<assistant_prose>` / `*_prose>` residue | 21% | — | **43%** | **0%** |

GLM-5.2 is the interactive TUI default, so the default experience emits garbage on ~half its turns. The clean 0% on sonnet proves a **sanitizer gap**, not model noise. Example (persisted): a `python` session with 17 consecutive assistant messages each just `_call>`; a `php` session rendering `{"verdict":"done","reasoning":"…the agent is stuck in a loop…"}` as the agent's own message. Closes #3755.

## Root cause

`sanitize_visible_assistant_text()` stripped well-formed `<tool_call>…</tool_call>` blocks and unwrapped `<assistant_prose>`, but:
1. **orphan/truncated residue** (`_call>`, `l_call>`, lone `</tool_call>`, `</assistant_prose>`, `nt_prose>`) matched none of the well-formed patterns, and the unclosed-block / partial-suffix strippers run **only when `partial`** — so the litter survived into **final** transcripts (the persisted snapshot the TUI renders);
2. a **bare** top-level completion-judge `{"verdict":…,"reasoning":…}` object was only stripped when fenced or `{"mode":…}`, so it surfaced as the agent's message.

## Fix (`crates/harn-vm/src/visible_text.rs`)

- **`strip_protocol_residue`** — a tightly-bounded, **fence-aware** regex removing the `</tool_call>` truncation family and `<assistant_prose>` close-tag truncations. Scope deliberately **excludes** `<user_response>`/`<done>`/`<tool_result>` (owned by the existing position/fence-aware logic, which has legitimate inline-mention forms — see the placeholder/fence tests). Residue inside a markdown fence is preserved, so code examples are untouched.
- **`strip_bare_internal_json`** — drops a turn whose **entire** trimmed body is recognized internal control JSON (reuses `looks_like_internal_planning_json`); whole-body only, so prose quoting JSON is preserved.
- Both run **unconditionally** (the leak is in finalized text).

## Tests

18/18 `visible_text` tests pass (15 pre-existing preserved — no regression — + 3 new): orphan residue + truncations stripped, fenced example preserved, bare verdict JSON dropped; guards that `x > y`, "the phrase tool call", and legit `{"status":"ok"}` are untouched.

Follow-on: a Harn release cut + Burin `.harn-version` repin lands this in the product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)