### PR TITLE
fix(vm): jail empty-workspace_roots writes to the project, not the process cwd

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -333,7 +333,7 @@ jobs:
         with:
           ref: ${{ needs.setup.outputs.ref }}
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # master
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
 

--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -98,7 +98,7 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "Detected bump type: $BUMP"
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         if: steps.bump.outputs.skip != 'true'
         with:
           components: clippy, rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: rustfmt
       - run: make fmt-check
@@ -185,9 +185,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y mold
           mold --version
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         if: matrix.rust_components == ''
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         if: matrix.rust_components != ''
         with:
           components: ${{ matrix.rust_components }}
@@ -367,7 +367,7 @@ jobs:
       - run: make check-bindings
       - run: make lint-test-patterns
       - run: make test-pr-gate-scripts
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement. A
         # cold compile is a valid fallback; the audit result should not hinge
@@ -500,7 +500,7 @@ jobs:
           # Linux fast feedback. Merge-queue and main pushes keep the shallow
           # checkout because they run the full workspace unconditionally.
           fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         continue-on-error: true
         with:
@@ -672,7 +672,7 @@ jobs:
       RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
@@ -787,7 +787,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'e2e')
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement. The
         # upstream action sometimes fails on merge_group / restricted-token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,7 +773,7 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
-          version: "1.25.2"
+          version: "1.26.1"
           advanced-security: false
           annotations: true
           min-severity: medium

--- a/.github/workflows/cli-cold-start-budget.yml
+++ b/.github/workflows/cli-cold-start-budget.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement.
         continue-on-error: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e'))
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement. The
         # upstream action sometimes fails on merge_group / restricted-token

--- a/.github/workflows/flake-detection.yml
+++ b/.github/workflows/flake-detection.yml
@@ -65,7 +65,7 @@ jobs:
             echo "No touched Rust test files detected; skipping flake rerun."
           fi
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         if: steps.touched.outputs.has_tests == 'true'
 
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -53,7 +53,7 @@ jobs:
             runner: macos-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       # Mirror the documented `cargo install harn-cli`. No `--locked`: a user
       # typing the documented command gets a fresh dependency resolution, and

--- a/.github/workflows/lean-embedding.yml
+++ b/.github/workflows/lean-embedding.yml
@@ -38,6 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: Measure lean vs full embedding surface
         run: ./scripts/measure_lean_embedding.sh

--- a/.github/workflows/macos-nightly.yml
+++ b/.github/workflows/macos-nightly.yml
@@ -41,7 +41,7 @@ jobs:
     if: github.repository == 'burin-labs/harn'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement. The
         # upstream action sometimes fails on merge_group / restricted-token

--- a/.github/workflows/ported-handler-loc.yml
+++ b/.github/workflows/ported-handler-loc.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement.
         continue-on-error: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -364,7 +364,7 @@ jobs:
           fi
           echo "Publishing from $(git rev-parse --short HEAD) ($publish_ref)"
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           components: clippy, rustfmt
 

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -244,7 +244,7 @@ jobs:
           chmod +x "$out_dir"/harn*
           "$HARN_BINARY" --version
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         if: needs.resolve.outputs.mode == 'source'
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         if: needs.resolve.outputs.mode == 'source' && matrix.platform != 'windows'

--- a/.github/workflows/thread-parity.yml
+++ b/.github/workflows/thread-parity.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement. The

--- a/.github/workflows/windows-nightly.yml
+++ b/.github/workflows/windows-nightly.yml
@@ -40,7 +40,7 @@ jobs:
     if: github.repository == 'burin-labs/harn'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         # sccache is a build-cache optimization, not a build requirement. The
         # upstream action sometimes fails on merge_group / restricted-token

--- a/changelog.d/dispatch-child-write-jail-project-root.fixed.md
+++ b/changelog.d/dispatch-child-write-jail-project-root.fixed.md
@@ -1,0 +1,6 @@
+- When a restricted policy declares no explicit `workspace_roots`, the file
+  write/read jail now falls back to the active session's workspace anchor and
+  the host-declared `HARN_PROJECT_ROOT` project before the process execution
+  cwd. Dispatched sub-agent workers running where the process cwd differs from
+  the project (the eval pattern) can now write into the project instead of
+  being rejected with a `HARN-CAP-201` sandbox violation rooted at the cwd.

--- a/crates/harn-vm/src/stdlib/sandbox/mod.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/mod.rs
@@ -859,8 +859,68 @@ pub(crate) fn unavailable(
     }
 }
 
+/// Writable workspace roots derived from the active agent session's
+/// workspace anchor: the anchor `primary` plus any `Extend` (writable)
+/// mounts. Read-only mounts are intentionally excluded — they are not
+/// writable jail roots (a read of one is permitted via the read-only-roots
+/// path, but a write must not be). Returns `None` when there is no current
+/// session or the session has no anchor, so the caller falls back to the
+/// process execution root.
+fn current_session_anchor_workspace_roots() -> Option<Vec<PathBuf>> {
+    let session_id = crate::agent_sessions::current_session_id()?;
+    let anchor = crate::agent_sessions::workspace_anchor(&session_id)?;
+    let mut roots = vec![anchor.primary.clone()];
+    for mounted in &anchor.additional_roots {
+        if matches!(
+            mounted.mount_mode,
+            crate::workspace_anchor::MountMode::Extend
+        ) {
+            roots.push(mounted.path.clone());
+        }
+    }
+    Some(roots)
+}
+
+/// The host-declared project root (`HARN_PROJECT_ROOT`), if set and
+/// non-empty. This mirrors the standalone project-root fallback the
+/// `workspace.project_root` host capability already uses
+/// (`stdlib::host`), so the write jail and the reported project root
+/// agree. It is the project a run is bound to even when the OS process
+/// cwd differs (the eval harness runs `burin-headless` from the repo with
+/// `--project <fixture>`, and the real IDE may launch from elsewhere).
+fn project_root_env_workspace_root() -> Option<PathBuf> {
+    std::env::var("HARN_PROJECT_ROOT")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
 fn normalized_workspace_roots(policy: &CapabilityPolicy) -> Vec<PathBuf> {
     if policy.workspace_roots.is_empty() {
+        // An empty `policy.workspace_roots` means no explicit write-jail was
+        // configured for this call. Historically this fell straight back to the
+        // process execution root, but under the eval pattern (process cwd !=
+        // `--project`) and dispatch fan-out children, the process cwd is the
+        // repo, not the project the run is bound to — so a write that correctly
+        // resolved INTO the project was rejected as outside the jail
+        // (HARN-CAP-201), the dispatched child wrote nothing, and the parent
+        // silently compensated. Prefer, in order: (1) the active agent
+        // session's workspace anchor (primary + writable `Extend` mounts) when
+        // the session is anchored; (2) the host-declared `HARN_PROJECT_ROOT`
+        // project root (robust across the session nesting that an unanchored
+        // dispatch child sees); (3) the process execution root, the historical
+        // default. Explicit `policy.workspace_roots` still take precedence
+        // (handled in the non-empty branch below).
+        if let Some(anchor_roots) = current_session_anchor_workspace_roots() {
+            return anchor_roots
+                .iter()
+                .map(|root| normalize_for_policy(root))
+                .collect();
+        }
+        if let Some(project_root) = project_root_env_workspace_root() {
+            return vec![normalize_for_policy(&project_root)];
+        }
         return vec![normalize_for_policy(
             &crate::stdlib::process::execution_root_path(),
         )];
@@ -1268,6 +1328,13 @@ mod tests {
 
     #[test]
     fn empty_workspace_roots_default_to_execution_root_for_fs_paths() {
+        // Serialize env mutation and clear HARN_PROJECT_ROOT so this asserts the
+        // pure execution-root fallback (the project-root-env preference is
+        // covered by the next test).
+        let _env_lock = crate::runtime_paths::test_env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        std::env::remove_var("HARN_PROJECT_ROOT");
         let dir = tempfile::tempdir().unwrap();
         crate::stdlib::process::set_thread_execution_context(Some(
             crate::orchestration::RunExecutionRecord {
@@ -1300,6 +1367,70 @@ mod tests {
 
         pop_execution_policy();
         crate::stdlib::process::set_thread_execution_context(None);
+    }
+
+    /// Regression for burin-labs/burin-code#3288. When a restricted policy has
+    /// no explicit `workspace_roots`, the write jail must follow the
+    /// host-declared `HARN_PROJECT_ROOT` project — NOT the process/execution
+    /// cwd. This is the eval/dispatch pattern: `burin-headless` runs from the
+    /// repo (`execution cwd = repo`) with `--project <fixture>` + matching
+    /// `HARN_PROJECT_ROOT`, and a dispatched sub-agent worker's writes resolve
+    /// into the fixture. Before the fix the empty-roots fallback used the
+    /// execution cwd (the repo), so the in-project write was rejected
+    /// (HARN-CAP-201) and the dispatched child wrote nothing.
+    #[test]
+    fn empty_workspace_roots_prefer_project_root_env_over_execution_root() {
+        let _env_lock = crate::runtime_paths::test_env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let project = tempfile::tempdir().unwrap();
+        let execution_cwd = tempfile::tempdir().unwrap();
+        std::env::set_var("HARN_PROJECT_ROOT", project.path());
+        crate::stdlib::process::set_thread_execution_context(Some(
+            crate::orchestration::RunExecutionRecord {
+                cwd: Some(execution_cwd.path().to_string_lossy().into_owned()),
+                source_dir: None,
+                env: Default::default(),
+                adapter: None,
+                repo_path: None,
+                worktree_path: None,
+                branch: None,
+                base_ref: None,
+                cleanup: None,
+            },
+        ));
+        push_execution_policy(CapabilityPolicy {
+            sandbox_profile: SandboxProfile::Worktree,
+            ..CapabilityPolicy::default()
+        });
+
+        // A write that resolves INTO the project is allowed even though the
+        // process/execution cwd is elsewhere.
+        assert!(
+            enforce_fs_path(
+                "write_file",
+                &project.path().join("test/created.ts"),
+                FsAccess::Write,
+            )
+            .is_ok(),
+            "write into HARN_PROJECT_ROOT must be allowed"
+        );
+        // A write under the execution cwd (the repo, in the eval pattern) is NOT
+        // the project and must still be rejected — the jail moved to the
+        // project, it did not widen to both.
+        assert!(
+            enforce_fs_path(
+                "write_file",
+                &execution_cwd.path().join("escape.ts"),
+                FsAccess::Write,
+            )
+            .is_err(),
+            "write under the execution cwd (outside the project) must be rejected"
+        );
+
+        pop_execution_policy();
+        crate::stdlib::process::set_thread_execution_context(None);
+        std::env::remove_var("HARN_PROJECT_ROOT");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Completes the fix for burin-labs/burin-code#3288 (dispatch sub-agent children could not write under the eval pattern where the process cwd differs from `--project`).

`normalized_workspace_roots` (the source of the sandbox write/read jail) fell straight back to the **process execution cwd** when a restricted policy declared no explicit `workspace_roots`. In the eval/dispatch pattern the process cwd is the repo, not `--project`, so a dispatched sub-agent worker's write that correctly resolved *into* the project was rejected with `HARN-CAP-201: ... outside workspace_roots [<repo>]`. The child wrote nothing (0/N units, empty `files_written`) and the parent silently compensated.

#3745 inherited the parent session anchor as the child's **execution cwd** (fixing reads), but the write jail is enforced against the policy's `workspace_roots`, which stays empty for an unanchored worker. This change makes the empty-`workspace_roots` fallback prefer, in order:

1. the active agent session's workspace anchor (primary + writable `Extend` mounts), when the session is anchored;
2. the host-declared `HARN_PROJECT_ROOT` project — robust across the session nesting an unanchored dispatch child sees, and consistent with the `workspace.project_root` host fallback in `stdlib::host`;
3. the process execution cwd — the historical default.

Explicit `policy.workspace_roots` still take precedence. The jail moves *to the project* (more restrictive than the old repo-wide default), it does not widen.

## Validation

- New unit regression test `empty_workspace_roots_prefer_project_root_env_over_execution_root`: with empty roots + `HARN_PROJECT_ROOT` set and the execution cwd elsewhere, a write into the project is allowed while a write under the execution cwd is rejected. Existing fallback test hardened (env-lock + clears `HARN_PROJECT_ROOT`) to keep asserting the pure execution-root path.
- `cargo test -p harn-vm --lib`: **4152 passed, 0 failed**.
- `cargo clippy -p harn-vm -- -D warnings`: clean. `cargo fmt --check`: clean.
- **End-to-end**: a 2-child `burin-headless` dispatch fan-out run from the repo with `--project <fixture>` (the exact eval invocation: cwd≠project, `HARN_PROJECT_ROOT`, sandbox off) went from `dispatch: 0/2 units, wrote 0 file` (HARN-CAP-201, parent-compensated) to `dispatch: 2/2 units, wrote 2 file(s)` with each child writing its integration test into the project itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)