### PR TITLE
Force a deterministic English message locale for spawned tool commands

### DIFF
--- a/changelog.d/locale-forcing.fixed.md
+++ b/changelog.d/locale-forcing.fixed.md
@@ -1,0 +1,11 @@
+**Verify/build/test subprocesses now run under a deterministic English message
+locale.** Spawned tool commands inherited the user's shell locale, so a
+non-Anglosphere user whose environment set `LC_ALL`/`LANG` to a localized value
+got translated (non-English) compiler and test output — silently breaking every
+downstream matcher that keys on English diagnostics (deterministic syntax
+repair, error-signature grounding, completion/pass-fail classification). Both
+spawn paths (`process.exec` builder and the `harn-hostlib` real spawner) now
+strip an inherited `LC_ALL` and pin `LC_MESSAGES=C` plus `DOTNET_CLI_UI_LANGUAGE=en`
+(the .NET CLI ignores `LC_*`), while deliberately leaving `LC_CTYPE`/`LANG`
+untouched so UTF-8 handling of non-ASCII source is preserved. An explicit
+caller-supplied `env`/`env_remove` still wins, matching the `TMPDIR` overlay.

--- a/crates/harn-hostlib/src/process/real.rs
+++ b/crates/harn-hostlib/src/process/real.rs
@@ -82,6 +82,26 @@ impl ProcessSpawner for RealSpawner {
             command.env(key, value);
         }
 
+        // Pin tool *message* output to a deterministic English/UTF-8 locale so
+        // downstream English-diagnostic matchers (deterministic syntax repair,
+        // error-signature grounding, completion/pass-fail classification) do not
+        // misfire for a non-Anglosphere user whose shell localizes compiler/test
+        // output. A user-inherited `LC_ALL` overrides `LC_MESSAGES`, so strip it
+        // first — unless the caller pinned it. Then apply the overlay with the
+        // same caller-wins rule as the TMPDIR overlay above.
+        if !spec
+            .env
+            .contains_key(process_sandbox::MESSAGE_LOCALE_OVERRIDE_ENV)
+        {
+            command.env_remove(process_sandbox::MESSAGE_LOCALE_OVERRIDE_ENV);
+        }
+        for (key, value) in process_sandbox::deterministic_message_locale_env() {
+            if spec.env.contains_key(&key) {
+                continue;
+            }
+            command.env(key, value);
+        }
+
         if spec.configure_process_group {
             configure_background_process_group(&mut command);
         }

--- a/crates/harn-vm/src/process_sandbox.rs
+++ b/crates/harn-vm/src/process_sandbox.rs
@@ -19,7 +19,7 @@
 
 pub use crate::stdlib::sandbox::{
     active_backend_available, active_backend_name, active_workspace_tmpdir_env,
-    check_fs_path_scope, command_output, enforce_process_cwd, process_spawn_error,
-    process_violation_error, std_command_for, tokio_command_for, FsAccess, ProcessCommandConfig,
-    SandboxViolation,
+    check_fs_path_scope, command_output, deterministic_message_locale_env, enforce_process_cwd,
+    process_spawn_error, process_violation_error, std_command_for, tokio_command_for, FsAccess,
+    ProcessCommandConfig, SandboxViolation, MESSAGE_LOCALE_OVERRIDE_ENV,
 };

--- a/crates/harn-vm/src/stdlib/host.rs
+++ b/crates/harn-vm/src/stdlib/host.rs
@@ -930,6 +930,22 @@ pub(crate) fn build_sandboxed_command(
         }
         cmd.env(key, value);
     }
+    // Pin tool *message* output to a deterministic English/UTF-8 locale so
+    // downstream English-diagnostic matchers (deterministic syntax repair,
+    // error-signature grounding, completion/pass-fail classification) do not
+    // misfire for a non-Anglosphere user whose shell localizes compiler/test
+    // output. A user-inherited `LC_ALL` overrides `LC_MESSAGES`, so strip it
+    // first — unless the caller pinned it via `env`/`env_remove` — then apply
+    // the overlay with the same caller-wins rule as the TMPDIR overlay above.
+    if !caller_env_keys.contains(crate::process_sandbox::MESSAGE_LOCALE_OVERRIDE_ENV) {
+        cmd.env_remove(crate::process_sandbox::MESSAGE_LOCALE_OVERRIDE_ENV);
+    }
+    for (key, value) in crate::process_sandbox::deterministic_message_locale_env() {
+        if caller_env_keys.contains(&key) {
+            continue;
+        }
+        cmd.env(key, value);
+    }
     Ok(cmd)
 }
 
@@ -1272,9 +1288,10 @@ async fn host_tool_call_builtin(
 #[cfg(test)]
 mod tests {
     use super::{
-        capability_manifest_with_mocks, clear_host_call_bridge, dispatch_host_operation,
-        dispatch_host_tool_call, dispatch_host_tool_list, dispatch_mock_host_call, push_host_mock,
-        reset_host_state, resolve_process_exec_cwd, set_host_call_bridge, HostCallBridge, HostMock,
+        build_sandboxed_command, capability_manifest_with_mocks, clear_host_call_bridge,
+        dispatch_host_operation, dispatch_host_tool_call, dispatch_host_tool_list,
+        dispatch_mock_host_call, push_host_mock, reset_host_state, resolve_process_exec_cwd,
+        set_host_call_bridge, HostCallBridge, HostMock,
     };
     use crate::value::VmDictExt;
 
@@ -1284,6 +1301,98 @@ mod tests {
     };
 
     use crate::value::{VmError, VmValue};
+
+    /// Collect a built command's env mutations as `(name, Option<value>)`,
+    /// where `None` marks a variable the command removes from the inherited
+    /// environment.
+    fn command_env(
+        cmd: &tokio::process::Command,
+    ) -> std::collections::BTreeMap<String, Option<String>> {
+        cmd.as_std()
+            .get_envs()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().into_owned(),
+                    v.map(|value| value.to_string_lossy().into_owned()),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn build_sandboxed_command_forces_deterministic_message_locale() {
+        // A verify command spawned by a non-Anglosphere user whose *shell*
+        // exports LC_ALL (inherited via the parent env, NOT pinned by the
+        // caller's `env` dict) must still emit English diagnostics, or the
+        // downstream English-keyed matchers (syntax repair, error grounding,
+        // pass/fail classification) misfire. In merge mode the child inherits
+        // the parent env implicitly, so the builder must issue an explicit
+        // LC_ALL removal — observable here as a `(key, None)` mutation — and
+        // pin LC_MESSAGES=C + DOTNET_CLI_UI_LANGUAGE=en. The caller pins no
+        // locale key here, so the overlay engages.
+        let mut params = crate::value::DictMap::new();
+        params.put_str("mode", "argv");
+        params.put(
+            "argv",
+            VmValue::List(Arc::new(vec![VmValue::string("/bin/true")])),
+        );
+        params.put_str("env_mode", "merge");
+        let mut caller_env = crate::value::DictMap::new();
+        // An innocuous caller env key that must NOT suppress the locale overlay.
+        caller_env.put_str("CARGO_TARGET_DIR", "/tmp/target");
+        params.put("env", VmValue::dict_map(caller_env));
+
+        let cmd = build_sandboxed_command(&params, "process.exec").expect("build command");
+        let env = command_env(&cmd);
+
+        assert_eq!(
+            env.get("LC_ALL"),
+            Some(&None),
+            "the builder must remove LC_ALL from the child so an inherited shell \
+             value cannot override the forced LC_MESSAGES"
+        );
+        assert_eq!(
+            env.get("LC_MESSAGES"),
+            Some(&Some("C".to_string())),
+            "LC_MESSAGES must be pinned to C for untranslated (English) tool output"
+        );
+        assert_eq!(
+            env.get("DOTNET_CLI_UI_LANGUAGE"),
+            Some(&Some("en".to_string())),
+            ".NET ignores LC_* and needs its own UI-language override"
+        );
+    }
+
+    #[test]
+    fn build_sandboxed_command_respects_a_caller_pinned_locale() {
+        // A caller that explicitly pins the locale keys (or LC_ALL) wins over
+        // the deterministic overlay — same caller-wins rule as TMPDIR.
+        let mut params = crate::value::DictMap::new();
+        params.put_str("mode", "argv");
+        params.put(
+            "argv",
+            VmValue::List(Arc::new(vec![VmValue::string("/bin/true")])),
+        );
+        params.put_str("env_mode", "merge");
+        let mut caller_env = crate::value::DictMap::new();
+        caller_env.put_str("LC_ALL", "fr_FR.UTF-8");
+        caller_env.put_str("LC_MESSAGES", "fr_FR.UTF-8");
+        params.put("env", VmValue::dict_map(caller_env));
+
+        let cmd = build_sandboxed_command(&params, "process.exec").expect("build command");
+        let env = command_env(&cmd);
+
+        assert_eq!(
+            env.get("LC_ALL"),
+            Some(&Some("fr_FR.UTF-8".to_string())),
+            "a caller that pins LC_ALL keeps it — the overlay must not strip an explicit value"
+        );
+        assert_eq!(
+            env.get("LC_MESSAGES"),
+            Some(&Some("fr_FR.UTF-8".to_string())),
+            "a caller-pinned LC_MESSAGES wins over the C overlay"
+        );
+    }
 
     #[test]
     fn process_exec_relative_cwd_resolves_against_execution_root() {

--- a/crates/harn-vm/src/stdlib/sandbox/mod.rs
+++ b/crates/harn-vm/src/stdlib/sandbox/mod.rs
@@ -628,6 +628,43 @@ pub fn active_workspace_tmpdir_env() -> Vec<(String, String)> {
     env
 }
 
+/// Environment overlay that pins a child tool's *message* output to a
+/// deterministic, English, UTF-8-preserving locale, as `(key, value)` pairs.
+///
+/// Build/test/verify commands inherit the parent environment, so a user whose
+/// shell sets `LC_ALL=ja_JP.UTF-8` (or `LANG=de_DE.UTF-8`) would otherwise get
+/// *localized* compiler/test output. Every downstream matcher that keys on
+/// English diagnostics — deterministic syntax repair, error-signature
+/// grounding, completion/pass-fail classification — would then silently
+/// misfire for a non-Anglosphere user. Forcing a stable message locale is the
+/// root-cause fix: it keeps the English matchers correct by construction,
+/// without shipping per-locale translations of every toolchain.
+///
+/// `LC_MESSAGES=C` forces untranslated (English) messages for gettext-based
+/// tools (gcc/clang, git-l10n, GNU coreutils, gradle) while deliberately *not*
+/// touching `LC_CTYPE`/`LANG`, so UTF-8 handling of non-ASCII source and
+/// identifiers is preserved (unlike the blunt `LC_ALL=C`, which forces an ASCII
+/// ctype and can mangle non-ASCII identifiers in diagnostics). The .NET CLI
+/// ignores `LC_*` and localizes from its own variable / the OS UI language, so
+/// `DOTNET_CLI_UI_LANGUAGE=en` is required in addition.
+///
+/// A user-inherited `LC_ALL` would override `LC_MESSAGES`, so the spawn sites
+/// additionally strip `LC_ALL` (unless the caller pinned it) before applying
+/// this overlay. Both are subject to the caller-pinned-key rule (like the
+/// `TMPDIR` overlay): an explicit `env`/`env_remove` still wins.
+pub fn deterministic_message_locale_env() -> Vec<(String, String)> {
+    vec![
+        ("LC_MESSAGES".to_string(), "C".to_string()),
+        ("DOTNET_CLI_UI_LANGUAGE".to_string(), "en".to_string()),
+    ]
+}
+
+/// The environment variable a user-inherited value of which would override
+/// [`deterministic_message_locale_env`]'s `LC_MESSAGES`. Spawn sites strip this
+/// (unless the caller pinned it) so the forced message locale actually takes
+/// effect. Kept as a named constant so both spawn paths stay in sync.
+pub const MESSAGE_LOCALE_OVERRIDE_ENV: &str = "LC_ALL";
+
 fn default_process_cwd_for_policy(policy: &CapabilityPolicy) -> Result<PathBuf, VmError> {
     let roots = normalized_workspace_roots(policy);
     let current = std::env::current_dir().map_err(|error| {
@@ -1627,6 +1664,31 @@ mod tests {
                 "{key} must point at the workspace-local temp dir"
             );
         }
+    }
+
+    #[test]
+    fn deterministic_message_locale_env_forces_english_utf8_safe_messages() {
+        let env: std::collections::BTreeMap<_, _> =
+            deterministic_message_locale_env().into_iter().collect();
+        // gettext tools (gcc/clang, git-l10n, coreutils, gradle) honor
+        // LC_MESSAGES; `C` yields untranslated English.
+        assert_eq!(env.get("LC_MESSAGES").map(String::as_str), Some("C"));
+        // .NET ignores LC_* and localizes from its own variable.
+        assert_eq!(
+            env.get("DOTNET_CLI_UI_LANGUAGE").map(String::as_str),
+            Some("en")
+        );
+        // Deliberately NOT setting LC_ALL/LC_CTYPE/LANG so UTF-8 handling of
+        // non-ASCII source and identifiers is preserved (unlike `LC_ALL=C`).
+        assert!(
+            !env.contains_key("LC_ALL"),
+            "must not force LC_ALL (would clobber UTF-8 ctype)"
+        );
+        assert!(!env.contains_key("LC_CTYPE"));
+        assert!(!env.contains_key("LANG"));
+        // The override-strip constant names the one variable that would defeat
+        // LC_MESSAGES if inherited.
+        assert_eq!(MESSAGE_LOCALE_OVERRIDE_ENV, "LC_ALL");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Verify/build/test subprocesses inherit the user's shell locale. A non-Anglosphere user whose environment sets `LC_ALL`/`LANG` to a localized value (e.g. `de_DE.UTF-8`, `ja_JP.UTF-8`) gets **translated, non-English** compiler and test output. Every downstream matcher that keys on English diagnostics — deterministic syntax repair, error-signature grounding, completion/pass-fail classification — then silently misfires.

Empirically confirmed: `LC_ALL=de_DE.UTF-8 dotnet …` emits German; `DOTNET_CLI_UI_LANGUAGE=en` restores English (the .NET CLI ignores `LC_*` and localizes from its own variable). gettext toolchains (gcc/clang, git-l10n, gradle, coreutils) honor `LC_MESSAGES`.

## Fix

Both spawn paths — the `process.exec` VM builder (`stdlib::host::build_sandboxed_command`) and the `harn-hostlib` real spawner — now, with the same caller-wins rule as the existing `TMPDIR` overlay:

- **strip an inherited `LC_ALL`** (unless the caller pinned it) — it would otherwise override `LC_MESSAGES`;
- pin **`LC_MESSAGES=C`** (untranslated English for gettext tools);
- pin **`DOTNET_CLI_UI_LANGUAGE=en`** (.NET's own i18n var).

`LC_CTYPE`/`LANG` are deliberately left untouched so UTF-8 handling of non-ASCII source and identifiers is preserved — unlike the blunt `LC_ALL=C` (ASCII ctype) or `LC_ALL=C.UTF-8` (absent on macOS). An explicit caller `env`/`env_remove` still wins.

New `deterministic_message_locale_env()` + `MESSAGE_LOCALE_OVERRIDE_ENV` in the sandbox module (re-exported via `process_sandbox`).

## Design note

This joins the locale-forcing camp of the container harnesses (OpenHands/SWE-agent force `C.UTF-8`; Codex `unified_exec` forces `LC_ALL=C.UTF-8`) but adapts it for a **host-native** agent: `C.UTF-8` does not exist on macOS, and `LC_ALL=en_US.UTF-8` is known to break non-US-locale SSH users (Zed reverted exactly that). `LC_MESSAGES=C` + inherited UTF-8 ctype is the portable do-no-harm choice.

## Tests

- `deterministic_message_locale_env()` pure-fn test (contents + no LC_ALL/CTYPE/LANG).
- Two `build_sandboxed_command` integration tests over the built command's env mutations: inherited-`LC_ALL` strip + English pins, and caller-pinned-locale override.
- `cargo test -p harn-vm --lib locale` → 3 passed. `cargo check -p harn-hostlib` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)