### PR TITLE
Add structured Postgres SQL fragment helpers

### DIFF
--- a/changelog.d/postgres-query-fragments.added.md
+++ b/changelog.d/postgres-query-fragments.added.md
@@ -1,0 +1,4 @@
+- **Postgres query helpers can now compose trusted SQL fragments structurally.**
+  `std/postgres/query` adds `sql_fragment`, `sql_and`, `sql_or`, `sql_not`, and
+  `jsonb_object` so Harn data-access modules can build reusable predicates and
+  JSON envelope projections without ad hoc string concatenation.

--- a/conformance/tests/stdlib/postgres_query_helpers.expected
+++ b/conformance/tests/stdlib/postgres_query_helpers.expected
@@ -41,3 +41,11 @@ many
 true
 true
 true
+SELECT jsonb_build_object('id', "receipts"."id"::text, 'owner''s note', "receipts"."note", 'created_at', to_json("receipts"."created_at")#>>'{}') AS record FROM "receipts" WHERE (((("receipts"."tenant_id" IS NULL) OR ("receipts"."tenant_id" = "receipts"."owner_tenant_id"))) AND ((NOT ("receipts"."status" = 'archived')))) AND id = $1::uuid
+r1
+true
+true
+true
+true
+true
+true

--- a/conformance/tests/stdlib/postgres_query_helpers.harn
+++ b/conformance/tests/stdlib/postgres_query_helpers.harn
@@ -4,6 +4,7 @@ import {
   exec,
   ident,
   ident_path,
+  jsonb_object,
   many,
   named,
   named_raw_sql,
@@ -16,6 +17,10 @@ import {
   run,
   select_clause,
   sql,
+  sql_and,
+  sql_fragment,
+  sql_not,
+  sql_or,
   timestamptz_json,
   uuid_text,
 } from "std/postgres/query"
@@ -191,4 +196,58 @@ LIMIT {limit}
   }
   __io_println(is_err(raw_named_empty))
   __io_println(regex_match("nope", to_string(unwrap_err(raw_named_empty))) != nil)
+  let record_projection = jsonb_object(
+    [
+      {key: "id", value: sql_fragment("{id}::text", {id: ident_path(["receipts", "id"])})},
+      {key: "owner's note", value: ident_path(["receipts", "note"])},
+      {
+        key: "created_at",
+        value: sql_fragment("to_json({created_at})#>>'{{}}'", {created_at: ident_path(["receipts", "created_at"])}),
+      },
+    ],
+  )
+  let active_scope = sql_and(
+    [
+      sql_or(
+        [
+          sql_fragment("{tenant} IS NULL", {tenant: ident_path(["receipts", "tenant_id"])}),
+          sql_fragment(
+            "{tenant} = {owner}",
+            {tenant: ident_path(["receipts", "tenant_id"]), owner: ident_path(["receipts", "owner_tenant_id"])},
+          ),
+        ],
+      ),
+      sql_not(sql_fragment("{status} = 'archived'", {status: ident_path(["receipts", "status"])})),
+    ],
+  )
+  let composed_query = sql(
+    "SELECT {record} AS record FROM {table} WHERE {predicate} AND id = {id}::uuid",
+    {record: record_projection, table: ident("receipts"), predicate: active_scope, id: "r1"},
+  )
+  __io_println(composed_query.sql)
+  __io_println(composed_query.params?[0])
+  let fragment_with_bound_value = try {
+    sql_fragment("{column} = {value}", {column: ident("id"), value: "r1"})
+  }
+  __io_println(is_err(fragment_with_bound_value))
+  let empty_and = try {
+    sql_and([])
+  }
+  __io_println(is_err(empty_and))
+  let empty_jsonb_object = try {
+    jsonb_object([])
+  }
+  __io_println(is_err(empty_jsonb_object))
+  let missing_jsonb_value = try {
+    jsonb_object([{key: "id"}])
+  }
+  __io_println(is_err(missing_jsonb_value))
+  let raw_predicate_string = try {
+    sql_and(["archived = false"])
+  }
+  __io_println(is_err(raw_predicate_string))
+  let raw_jsonb_value_string = try {
+    jsonb_object([{key: "id", value: "id::text"}])
+  }
+  __io_println(is_err(raw_jsonb_value_string))
 }

--- a/crates/harn-stdlib/src/stdlib/postgres/query.harn
+++ b/crates/harn-stdlib/src/stdlib/postgres/query.harn
@@ -436,6 +436,28 @@ pub fn unsafe_sql(fragment: string) -> PgSqlFragment {
   return __sql_fragment(fragment)
 }
 
+/**
+ * Build a trusted SQL fragment from a source-controlled template.
+ *
+ * This is the structural-fragment companion to [`sql`]. Placeholders must
+ * render to trusted SQL fragments (`ident(...)`, `ident_path(...)`,
+ * `unsafe_sql(...)`, `columns(...)`, `jsonb_object(...)`, etc.); ordinary
+ * values are rejected because fragments cannot carry bind parameters. Keep
+ * dynamic data in the outer `sql(...)` / `named_sql(...)` template instead.
+ *
+ * @effects: []
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: sql_fragment("{column} IS NOT NULL", {column: ident("created_at")})
+ */
+pub fn sql_fragment(template: string, values: dict = {}) -> PgSqlFragment {
+  let rendered = __render_sql_template(template, values)
+  if len(rendered.params) != 0 {
+    throw "std/postgres/query: SQL fragment placeholders must be trusted SQL fragments; bind values through sql/named_sql"
+  }
+  return __sql_fragment(rendered.sql)
+}
+
 fn __projection_part_text(part) -> string {
   if __is_sql_fragment(part) {
     return __sql_fragment_text(part)
@@ -447,6 +469,125 @@ fn __projection_part_text(part) -> string {
     return part
   }
   throw "std/postgres/query: projection part must be a SQL fragment or string"
+}
+
+fn __sql_string_literal(value: string) -> string {
+  if type_of(value) != "string" {
+    throw "std/postgres/query: SQL string literal must be a string"
+  }
+  return "'" + replace(value, "'", "''") + "'"
+}
+
+fn __trusted_fragment_text(value, label: string) -> string {
+  if !__is_sql_fragment(value) {
+    throw "std/postgres/query: " + label + " must be a trusted SQL fragment"
+  }
+  return __sql_fragment_text(value)
+}
+
+fn __predicate_part_text(part) -> string {
+  let sql = __trusted_fragment_text(part, "predicate part")
+  if trim(sql) == "" {
+    throw "std/postgres/query: predicate part must be non-empty"
+  }
+  return sql
+}
+
+/**
+ * Combine predicate fragments with `AND`, wrapping each child and the result in
+ * parentheses so later composition cannot change precedence.
+ *
+ * @effects: []
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: sql_and([sql_fragment("a"), sql_fragment("b")])
+ */
+pub fn sql_and(parts: list) -> PgSqlFragment {
+  if type_of(parts) != "list" {
+    throw "std/postgres/query: sql_and requires a list of predicate fragments"
+  }
+  if len(parts) == 0 {
+    throw "std/postgres/query: sql_and requires at least one predicate fragment"
+  }
+  var rendered = []
+  for part in parts {
+    rendered = rendered.push("(" + __predicate_part_text(part) + ")")
+  }
+  return __sql_fragment("(" + join(rendered, " AND ") + ")")
+}
+
+/**
+ * Combine predicate fragments with `OR`, wrapping each child and the result in
+ * parentheses so later composition cannot change precedence.
+ *
+ * @effects: []
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: sql_or([sql_fragment("a"), sql_fragment("b")])
+ */
+pub fn sql_or(parts: list) -> PgSqlFragment {
+  if type_of(parts) != "list" {
+    throw "std/postgres/query: sql_or requires a list of predicate fragments"
+  }
+  if len(parts) == 0 {
+    throw "std/postgres/query: sql_or requires at least one predicate fragment"
+  }
+  var rendered = []
+  for part in parts {
+    rendered = rendered.push("(" + __predicate_part_text(part) + ")")
+  }
+  return __sql_fragment("(" + join(rendered, " OR ") + ")")
+}
+
+/**
+ * Negate one predicate fragment, preserving precedence with explicit
+ * parentheses.
+ *
+ * @effects: []
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: sql_not(sql_fragment("archived"))
+ */
+pub fn sql_not(part) -> PgSqlFragment {
+  return __sql_fragment("(NOT (" + __predicate_part_text(part) + "))")
+}
+
+/**
+ * Render a `jsonb_build_object(...)` expression from static keys and trusted
+ * SQL value expressions.
+ *
+ * Each field is `{key: string, value: PgSqlFragment}`. Keys are emitted as SQL
+ * string literals with quote escaping; values must already be trusted SQL
+ * fragments. The result is a single trusted expression, suitable for
+ * envelope/projection slots like `SELECT {record} AS record`.
+ *
+ * @effects: []
+ * @errors: validation
+ * @api_stability: experimental
+ * @example: jsonb_object([{key: "id", value: sql_fragment("{id}::text", {id: ident_path(["t", "id"])})}])
+ */
+pub fn jsonb_object(fields: list) -> PgSqlFragment {
+  if type_of(fields) != "list" {
+    throw "std/postgres/query: jsonb_object requires a list of fields"
+  }
+  if len(fields) == 0 {
+    throw "std/postgres/query: jsonb_object requires at least one field"
+  }
+  var rendered = []
+  for field in fields {
+    if type_of(field) != "dict" {
+      throw "std/postgres/query: jsonb_object field must be a dict"
+    }
+    if !contains(field.keys(), "key") || type_of(field.key) != "string" || trim(field.key) == "" {
+      throw "std/postgres/query: jsonb_object field key must be a non-empty string"
+    }
+    if !contains(field.keys(), "value") {
+      throw "std/postgres/query: jsonb_object field value is required"
+    }
+    rendered = rendered.push(__sql_string_literal(field.key))
+    rendered = rendered.push(__trusted_fragment_text(field.value, "jsonb_object field value"))
+  }
+  return __sql_fragment("jsonb_build_object(" + join(rendered, ", ") + ")")
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds structural composition helpers to `std/postgres/query` so Harn data-access code can build trusted SQL fragments, predicate trees, and JSON envelope projections without brittle ad hoc string concatenation.

The new APIs are `sql_fragment`, `sql_and`, `sql_or`, `sql_not`, and `jsonb_object`. Composition points require trusted SQL fragments; raw dynamic values are rejected so callers keep bind values in outer `sql`/`named_sql` templates or use the existing explicit `unsafe_sql` escape hatch.

## Validation

- `harn fmt --check crates/harn-stdlib/src/stdlib/postgres/query.harn conformance/tests/stdlib/postgres_query_helpers.harn`
- `cargo run --quiet --bin harn -- check crates/harn-stdlib/src/stdlib/postgres/query.harn`
- `cargo run --quiet --bin harn -- test conformance --filter postgres_query_helpers`
- `CARGO_TARGET_DIR=$PWD/target-codex2-query-fragments cargo test -p harn-stdlib`
- `make fmt-harn`
- `make lint-harn`
- `make conformance`
- `cargo fmt --all -- --check`
- `git diff --check`

## Follow-up

After this lands and is released, I will migrate the harn-cloud placement-policy SQL paths onto these helpers so the safer composition API is used immediately in production data-access code.