### PR TITLE
feat(mcp): emit mcp_catalog_changed on a server's list_changed notification

### DIFF
--- a/changelog.d/mcp-catalog-changed.added.md
+++ b/changelog.d/mcp-catalog-changed.added.md
@@ -1,0 +1,4 @@
+MCP servers that announce a changed tool/resource/prompt list
+(`notifications/*/list_changed`) now emit an `mcp_catalog_changed` agent event,
+so a connected client re-fetches the catalog and surfaces newly added tools
+within the same session — no restart.

--- a/crates/harn-vm/src/mcp/notifications.rs
+++ b/crates/harn-vm/src/mcp/notifications.rs
@@ -110,6 +110,22 @@ pub(crate) fn emit_mcp_auth_required_event(
     });
 }
 
+/// Emit an `AgentEvent::McpCatalogChanged` when a connected server announces
+/// that its tool/resource/prompt list changed (`notifications/*/list_changed`).
+/// A thin ACP client (an IDE host's TUI/GUI) treats this as a cue to re-fetch
+/// the catalog so newly added tools become visible without a restart. No-op
+/// outside an agent session.
+pub(crate) fn emit_mcp_catalog_changed_event(server_name: &str, reason: &str) {
+    let Some(session_id) = crate::llm::current_agent_session_id() else {
+        return;
+    };
+    crate::agent_events::emit_event(&crate::agent_events::AgentEvent::McpCatalogChanged {
+        session_id,
+        server: Some(server_name.to_string()),
+        reason: reason.to_string(),
+    });
+}
+
 pub(crate) fn relay_log_notification(server_name: &str, msg: &serde_json::Value) {
     let Some(session_id) = crate::llm::current_agent_session_id() else {
         return;
@@ -154,6 +170,15 @@ pub(crate) fn relay_resource_notification(
         "params": msg.get("params").cloned().unwrap_or(serde_json::Value::Null),
     });
     emit_mcp_notification_event(&session_id, server_name, method, "notification", &payload);
+    // A `*/list_changed` notification means the server's advertised
+    // tools/resources/prompts changed. Additionally emit the catalog-change cue
+    // so a thin client re-fetches `mcp/catalog` and surfaces the new tools this
+    // session — the `mcp_notification` relay above still runs so the agent loop
+    // sees the raw message too. `resources/updated` is a content change, not a
+    // catalog change, so it is intentionally excluded.
+    if method.ends_with("/list_changed") {
+        emit_mcp_catalog_changed_event(server_name, "list_changed");
+    }
     let content = serde_json::to_string(&payload).unwrap_or_default();
     crate::orchestration::agent_inbox::push(
         &session_id,

--- a/crates/harn-vm/src/mcp/tests.rs
+++ b/crates/harn-vm/src/mcp/tests.rs
@@ -966,6 +966,50 @@ fn install_capturing_agent_sink(
     events
 }
 
+#[test]
+fn list_changed_notification_emits_catalog_changed_cue() {
+    let session_id = crate::agent_sessions::open_or_create(Some("mcp-list-changed".to_string()));
+    let _session_guard = crate::agent_sessions::enter_current_session(session_id.clone());
+    let captured = install_capturing_agent_sink(&session_id);
+
+    // A `tools/list_changed` notification emits the catalog-change cue so a thin
+    // client re-fetches the catalog and surfaces the new tools this session.
+    super::notifications::relay_resource_notification(
+        "calc",
+        "notifications/tools/list_changed",
+        &serde_json::json!({ "method": "notifications/tools/list_changed" }),
+    );
+    // A content-only `resources/updated` is not a catalog change and must not.
+    super::notifications::relay_resource_notification(
+        "calc",
+        "notifications/resources/updated",
+        &serde_json::json!({ "method": "notifications/resources/updated" }),
+    );
+
+    let events = captured.lock().unwrap().clone();
+    let catalog_changed: Vec<_> = events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event,
+                crate::agent_events::AgentEvent::McpCatalogChanged { .. }
+            )
+        })
+        .collect();
+    assert_eq!(
+        catalog_changed.len(),
+        1,
+        "exactly one catalog-changed cue for the single list_changed notification"
+    );
+    match catalog_changed[0] {
+        crate::agent_events::AgentEvent::McpCatalogChanged { server, reason, .. } => {
+            assert_eq!(server.as_deref(), Some("calc"));
+            assert_eq!(reason, "list_changed");
+        }
+        _ => unreachable!(),
+    }
+}
+
 fn test_stored_mcp_token(resource: &str, access_token: &str) -> crate::mcp_oauth::StoredMcpToken {
     crate::mcp_oauth::StoredMcpToken {
         access_token: access_token.to_string(),


### PR DESCRIPTION
## What
The `mcp_catalog_changed` agent event already exists and is projected over the ACP `_harn/agentEvent` channel, and thin clients (the IDE-host TUI/GUI) already react to it by re-fetching `mcp/catalog`. But it was **never emitted in production**: a connected server announcing new tools via `notifications/tools/list_changed` (or `resources/`/`prompts/list_changed`) only produced a generic `mcp_notification`, so newly added tools never surfaced without a manual refresh.

This emits `AgentEvent::McpCatalogChanged { server: Some(..), reason: "list_changed" }` from the resource-notification relay whenever the inbound method ends with `/list_changed`. The raw `mcp_notification` relay still runs (the agent loop keeps seeing the message), and content-only `notifications/resources/updated` is intentionally excluded — it is not a catalog change.

## Why
Closes the "new tools on an existing server" loop: a client re-fetches the catalog and surfaces the new tools **within the same session, no restart** — matching the MCP spec's intent for `tools/list_changed`. The Burin TUI already consumes this event (`queue_mcp_catalog_refresh`), so it takes effect as soon as this ships.

## Verification
- New unit test `mcp::tests::list_changed_notification_emits_catalog_changed_cue`: a `tools/list_changed` notification emits exactly one catalog-changed cue (correct `server` + `reason`), while `resources/updated` emits none. Passes (`cargo test -p harn-vm`); `cargo fmt` clean.

## Follow-on
Consuming this in Burin needs a Harn release cut + `.harn-version` repin. Related frontier follow-ons (separate): handle `403 insufficient_scope` for in-flow step-up auth, and include `authorizeUrl` on the `mcp_auth_required` event to save a client round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)