### PR TITLE
fix(ci): keep release run artifacts best-effort

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -608,6 +608,10 @@ jobs:
       - name: Upload binary-size report
         if: always() && matrix.target == 'x86_64-unknown-linux-gnu'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        # The size report is diagnostic. The budget check above is the hard
+        # gate; do not let transient Actions artifact-store failures block a
+        # release artifact that otherwise built and packaged successfully.
+        continue-on-error: true
         with:
           name: harn-binary-size-${{ matrix.target }}
           path: dist/binary-size-${{ matrix.target }}
@@ -616,6 +620,11 @@ jobs:
       - name: Upload artifact (unix)
         if: needs.setup.outputs.is_release == 'true' && runner.os != 'Windows'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        # The GitHub Release upload below is the authoritative shipping path.
+        # Keep this secondary run artifact best-effort so a transient
+        # artifact-store outage cannot fail a signed/notarized/packageable leg
+        # before it publishes the official archive.
+        continue-on-error: true
         with:
           name: harn-${{ matrix.target }}
           path: dist/harn-${{ matrix.target }}.tar.gz
@@ -624,6 +633,11 @@ jobs:
       - name: Upload artifact (windows)
         if: needs.setup.outputs.is_release == 'true' && runner.os == 'Windows'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        # The GitHub Release upload below is the authoritative shipping path.
+        # Keep this secondary run artifact best-effort so a transient
+        # artifact-store outage cannot fail a signed/packageable leg before it
+        # publishes the official archive.
+        continue-on-error: true
         with:
           name: harn-${{ matrix.target }}
           path: dist/harn-${{ matrix.target }}.zip

--- a/changelog.d/release-artifact-store-best-effort.fixed.md
+++ b/changelog.d/release-artifact-store-best-effort.fixed.md
@@ -1,0 +1,5 @@
+- **Release binary publishing now treats Actions run-artifact uploads as
+  best-effort.** Official GitHub Release archives still publish through the
+  hard `gh release upload` path, so transient artifact-store outages no longer
+  block otherwise valid signed release artifacts before checksum and smoke gates
+  can run.


### PR DESCRIPTION
## Summary

- make diagnostic/browseable Actions artifact uploads best-effort in the release binary workflow
- keep official GitHub Release archive publication on the hard `gh release upload` path
- add a changelog fragment for the release-pipeline hardening

## Why

v0.8.163 proved the failure mode: the x86_64 macOS binary built, signed, notarized, and packaged, but `actions/upload-artifact` hit a transient artifact-store/network error before the official GitHub Release upload step. That left the release missing an otherwise valid archive until a rerun.

This keeps checksum/release-smoke integrity intact: if packaging is broken, `gh release upload` and the final release job still fail. Only the secondary run-artifact copy is best-effort.

## Validation

- `make lint-actions`
- `make lint-md`
- `git diff --check`

Note: local pre-commit/pre-push generated-registry checks were intentionally not completed because they cold-build the Harn CLI from this isolated worktree while a foreign eval is active on the machine. Hosted CI will run that gate on an isolated runner.