### PR TITLE
feat(mcp): step-up OAuth on 403 insufficient_scope, not just 401

### DIFF
--- a/changelog.d/mcp-403-step-up.added.md
+++ b/changelog.d/mcp-403-step-up.added.md
@@ -1,0 +1,9 @@
+- **MCP HTTP transport now step-ups OAuth on a `403 insufficient_scope`
+  challenge, not just a `401`.** Per RFC 6750 §3.1, a `403` whose
+  `WWW-Authenticate: Bearer` header carries `error="insufficient_scope"` means
+  the presented token is valid but lacks a required scope. Harn now treats it
+  like a `401`: it emits `mcp_auth_required` (carrying the challenge's elevated
+  `scope`) and re-runs the authorization flow, so a tool call that needs an
+  additional scope recovers in place instead of dead-ending. A plain `403`
+  without an `insufficient_scope` challenge is still a hard denial and falls
+  through unchanged.

--- a/crates/harn-vm/src/mcp/tests.rs
+++ b/crates/harn-vm/src/mcp/tests.rs
@@ -479,6 +479,78 @@ async fn modern_http_401_auth_required_waits_for_oauth_and_retries_tool_call() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn modern_http_403_insufficient_scope_waits_for_step_up_and_retries_tool_call() {
+    let _guard = http_mcp_test_guard().await;
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let (base_url, mut requests, auth_challenged) =
+                spawn_insufficient_scope_modern_http_mcp_server().await;
+            let handle = modern_http_handle(&base_url).await;
+            let server_url = format!("{base_url}/mcp");
+            let resource = crate::mcp_auth::canonical_resource_indicator(&server_url).unwrap();
+            let session_id =
+                crate::agent_sessions::open_or_create(Some("mcp-scope-stepup".to_string()));
+            let _session_guard = crate::agent_sessions::enter_current_session(session_id.clone());
+            let _bridge_guard = CurrentHostBridgeGuard::install();
+            let captured_events = install_capturing_agent_sink(&session_id);
+
+            let notifier = tokio::spawn({
+                let resource = resource.clone();
+                async move {
+                    auth_challenged
+                        .await
+                        .expect("mock server should issue an insufficient_scope challenge");
+                    let token = test_stored_mcp_token(&resource, "fresh-token");
+                    crate::mcp_oauth::notify_authorization_completed(&token);
+                }
+            });
+
+            let result = call_mcp_tool(
+                &handle,
+                "execute_sql",
+                serde_json::json!({"region": "us-west1", "query": "select 1"}),
+            )
+            .await
+            .unwrap();
+            notifier.await.expect("auth notifier task should complete");
+            assert_eq!(result, serde_json::json!("ok"));
+
+            let discover = recv_recorded_request(&mut requests).await;
+            assert_modern_http_request(&discover, "server/discover", None);
+            let first_call = recv_recorded_request(&mut requests).await;
+            assert_modern_http_request(&first_call, "tools/call", Some("execute_sql"));
+            let retry_call = recv_recorded_request(&mut requests).await;
+            assert_modern_http_request(&retry_call, "tools/call", Some("execute_sql"));
+            assert_eq!(
+                retry_call.headers.get("authorization").map(String::as_str),
+                Some("Bearer fresh-token")
+            );
+
+            let events = captured_events.lock().unwrap().clone();
+            assert!(
+                events.iter().any(|event| matches!(
+                    event,
+                    crate::agent_events::AgentEvent::McpAuthRequired {
+                        session_id: event_session_id,
+                        server,
+                        resource: event_resource,
+                        scope: Some(scope),
+                    } if event_session_id == &session_id
+                        && server == "modern-http"
+                        && event_resource == &resource
+                        // The step-up event carries the elevated scope from the
+                        // insufficient_scope challenge, not just the base scope.
+                        && scope == "repo admin"
+                )),
+                "expected McpAuthRequired step-up event with elevated scope, got {events:?}"
+            );
+            crate::agent_events::clear_session_sinks(&session_id);
+            handle.disconnect().await.unwrap();
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn modern_http_401_without_interactive_host_returns_auth_error() {
     let _guard = http_mcp_test_guard().await;
     tokio::task::LocalSet::new()
@@ -818,6 +890,39 @@ async fn spawn_auth_required_modern_http_mcp_server() -> (
     mpsc::UnboundedReceiver<RecordedHttpRequest>,
     oneshot::Receiver<()>,
 ) {
+    // A `401 Unauthorized` with a Bearer challenge: no/invalid token.
+    spawn_challenge_then_ok_modern_http_mcp_server("401 Unauthorized", r#"Bearer scope="repo""#)
+        .await
+}
+
+async fn spawn_insufficient_scope_modern_http_mcp_server() -> (
+    String,
+    mpsc::UnboundedReceiver<RecordedHttpRequest>,
+    oneshot::Receiver<()>,
+) {
+    // A `403 Forbidden` with `error="insufficient_scope"`: a valid token that
+    // lacks a required scope. Resolvable by a step-up authorization requesting
+    // the elevated `scope` from the challenge.
+    spawn_challenge_then_ok_modern_http_mcp_server(
+        "403 Forbidden",
+        r#"Bearer error="insufficient_scope", scope="repo admin""#,
+    )
+    .await
+}
+
+/// Modern-HTTP MCP mock that answers the first `tools/call` (and any call
+/// without a `Bearer fresh-token`) with `status_line` + the given
+/// `WWW-Authenticate` `challenge`, then serves `200 OK` once the fresh token
+/// is presented. Used to exercise both the `401` and `403 insufficient_scope`
+/// step-up authorization paths through one code path.
+async fn spawn_challenge_then_ok_modern_http_mcp_server(
+    status_line: &'static str,
+    challenge: &'static str,
+) -> (
+    String,
+    mpsc::UnboundedReceiver<RecordedHttpRequest>,
+    oneshot::Receiver<()>,
+) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let (request_tx, request_rx) = mpsc::unbounded_channel();
@@ -848,8 +953,8 @@ async fn spawn_auth_required_modern_http_mcp_server() -> (
                 }
                 let _ = write_http_json(
                     &mut stream,
-                    "401 Unauthorized",
-                    &[("WWW-Authenticate", r#"Bearer scope="repo""#)],
+                    status_line,
+                    &[("WWW-Authenticate", challenge)],
                     serde_json::json!({"error": "authorization required"}),
                 )
                 .await;
@@ -860,8 +965,8 @@ async fn spawn_auth_required_modern_http_mcp_server() -> (
             {
                 let _ = write_http_json(
                     &mut stream,
-                    "401 Unauthorized",
-                    &[("WWW-Authenticate", r#"Bearer scope="repo""#)],
+                    status_line,
+                    &[("WWW-Authenticate", challenge)],
                     serde_json::json!({"error": "authorization required"}),
                 )
                 .await;

--- a/crates/harn-vm/src/mcp/transport.rs
+++ b/crates/harn-vm/src/mcp/transport.rs
@@ -244,13 +244,21 @@ pub(crate) async fn send_http_request(
             continue;
         }
 
-        if status == 401 {
+        // RFC 6750 §3.1: a `401` means no/invalid/expired token; a `403` with
+        // `error="insufficient_scope"` means the token is valid but lacks a
+        // required scope. Both carry a Bearer `WWW-Authenticate` challenge and
+        // both are resolved by re-running the OAuth flow — the emitted
+        // `mcp_auth_required` event carries the challenge's `scope`, so a
+        // step-up authorization requests exactly the elevated scope. A plain
+        // `403` without an `insufficient_scope` challenge is a genuine denial,
+        // not an authorization gap, so it falls through unchanged.
+        if status == 401 || (status == 403 && www_authenticate_insufficient_scope(&headers)) {
             emit_mcp_auth_required_event(server_name, &inner.url, &headers);
             if auth_retry_used {
                 return Err(mcp_auth_required_error(
                     server_name,
                     &inner.url,
-                    "server still returned 401 after authorization completed",
+                    "server still returned an authorization challenge after authorization completed",
                 ));
             }
             auth_retry_used = true;
@@ -305,6 +313,21 @@ pub(crate) async fn send_http_request(
         }
         return Ok(msg);
     }
+}
+
+/// True when any `WWW-Authenticate` Bearer challenge in the response headers
+/// carries `error="insufficient_scope"` (RFC 6750 §3.1). Paired with a `403`
+/// status, this is the cue to run a step-up authorization for the elevated
+/// scope rather than treating the response as a hard denial.
+fn www_authenticate_insufficient_scope(headers: &reqwest::header::HeaderMap) -> bool {
+    let challenges: Vec<&str> = headers
+        .get_all(reqwest::header::WWW_AUTHENTICATE)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .collect();
+    crate::mcp_auth::parse_www_authenticate_headers(challenges.iter().copied())
+        .iter()
+        .any(crate::mcp_auth::WwwAuthenticateChallenge::is_insufficient_scope)
 }
 
 async fn wait_for_http_mcp_authorization(

--- a/crates/harn-vm/src/mcp_auth.rs
+++ b/crates/harn-vm/src/mcp_auth.rs
@@ -40,6 +40,26 @@ impl WwwAuthenticateChallenge {
             .then(|| self.params.get("scope").map(String::as_str))
             .flatten()
     }
+
+    /// The RFC 6750 §3 `error` code carried by a Bearer challenge, e.g.
+    /// `invalid_token` or `insufficient_scope`. A resource server returns a
+    /// `403` with `error="insufficient_scope"` when the presented token is
+    /// valid but lacks a required scope — the cue to run a step-up
+    /// authorization requesting the additional scope from [`bearer_scope`].
+    pub fn bearer_error(&self) -> Option<&str> {
+        self.scheme
+            .eq_ignore_ascii_case("bearer")
+            .then(|| self.params.get("error").map(String::as_str))
+            .flatten()
+    }
+
+    /// True when this Bearer challenge signals `insufficient_scope` — a valid
+    /// token missing a required scope, resolvable by re-authorizing with the
+    /// elevated scope.
+    pub fn is_insufficient_scope(&self) -> bool {
+        self.bearer_error()
+            .is_some_and(|error| error.eq_ignore_ascii_case("insufficient_scope"))
+    }
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -1126,6 +1146,28 @@ mod tests {
             canonical_resource_indicator("https://mcp.example.com/mcp/").unwrap(),
             "https://mcp.example.com/mcp"
         );
+    }
+
+    #[test]
+    fn bearer_error_and_insufficient_scope_detection() {
+        let challenges =
+            parse_www_authenticate(r#"Bearer error="insufficient_scope", scope="repo admin""#);
+        let challenge = challenges.first().expect("one Bearer challenge");
+        assert_eq!(challenge.bearer_error(), Some("insufficient_scope"));
+        assert_eq!(challenge.bearer_scope(), Some("repo admin"));
+        assert!(challenge.is_insufficient_scope());
+
+        // A plain 401 Bearer challenge with no error param is not a scope gap.
+        let plain = parse_www_authenticate(r#"Bearer scope="repo""#);
+        let plain = plain.first().expect("one Bearer challenge");
+        assert_eq!(plain.bearer_error(), None);
+        assert!(!plain.is_insufficient_scope());
+
+        // A non-Bearer scheme never reports a Bearer error.
+        let basic = parse_www_authenticate(r#"Basic realm="x", error="insufficient_scope""#);
+        let basic = basic.first().expect("one challenge");
+        assert_eq!(basic.bearer_error(), None);
+        assert!(!basic.is_insufficient_scope());
     }
 
     #[test]


### PR DESCRIPTION
## What

The HTTP MCP transport enters the interactive authorization flow on a `403 Forbidden` that carries a `WWW-Authenticate: Bearer error=\"insufficient_scope\"` challenge — not just on a `401`.

## Why

Per RFC 6750 §3.1, a resource server returns:
- **`401`** when there is no token, or an invalid/expired one, and
- **`403` + `error=\"insufficient_scope\"`** when the presented token is valid but lacks a required scope.

Harn only handled the `401` case, so a tool call that needed an *additional* scope (the "additional scopes / re-auth" half of the MCP connect flow) dead-ended with an auth error even though it is recoverable by re-authorizing for the elevated scope.

## How

Treat a `403` carrying an `insufficient_scope` Bearer challenge exactly like a `401`:
- emit `mcp_auth_required` — which already extracts the challenge's `scope`, so the step-up requests exactly the elevated scope — and
- re-run the OAuth flow, then retry the tool call with the new token.

A plain `403` **without** an `insufficient_scope` challenge is a genuine denial and falls through unchanged, so this never loops on real permission errors; `auth_retry_used` also caps it at a single step-up.

- `WwwAuthenticateChallenge::bearer_error` / `is_insufficient_scope` — RFC 6750 §3 `error`-code parsing.
- Transport authorization branch gated on `401 || (403 && insufficient_scope)` via a small header helper.
- The 401 and 403 mock servers now share one parameterized helper (DRY).

## Verification

`cargo test -p harn-vm --lib` (isolated target), `cargo fmt --check`, `cargo clippy -p harn-vm --lib --tests` — all clean.

- `bearer_error_and_insufficient_scope_detection` — parser unit test (Bearer error/scope extraction; non-Bearer and no-error challenges correctly report `false`).
- `modern_http_403_insufficient_scope_waits_for_step_up_and_retries_tool_call` — end-to-end: `403` → emit `mcp_auth_required` with elevated scope `"repo admin"` → wait for OAuth completion → retry with `Bearer fresh-token` → `200 OK`.
- `modern_http_401_auth_required_waits_for_oauth_and_retries_tool_call` — the existing `401` path, unchanged, now sharing the parameterized mock.

## Rides the next release train

Independent of #3764 (emit `mcp_catalog_changed`). Both should ride the next harn release cut; Burin picks them up on the following `.harn-version` repin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)