### PR TITLE
fix(tools): tool-call parse error for a raw multi-line value teaches the heredoc form

### DIFF
--- a/changelog.d/toolcall-heredoc-recovery.fixed.md
+++ b/changelog.d/toolcall-heredoc-recovery.fixed.md
@@ -1,0 +1,5 @@
+Tool-call parse errors for an unquoted multi-line value (e.g. a raw code body
+pasted after `content:`/`new_text:`) now name the heredoc recovery
+(`key: <<BODY … BODY`) instead of dead-ending on "unexpected character starting
+a value", so a weak value model can self-heal instead of looping on the same
+malformed edit.

--- a/crates/harn-vm/src/llm/tools/tests/core_parser.rs
+++ b/crates/harn-vm/src/llm/tools/tests/core_parser.rs
@@ -520,6 +520,39 @@ fn explicit_parse_error_for_unknown_label_prefix_on_known_tool() {
 }
 
 #[test]
+fn raw_multiline_body_value_error_teaches_heredoc() {
+    // The dominant real cause of "unexpected character starting a value" from
+    // weak value models: pasting a RAW multi-line body after `content:` instead
+    // of quoting it or using a heredoc. The parser skips the leading `//`
+    // comment then trips on the pasted code's brace. The error must NAME the
+    // heredoc recovery so the next turn can self-heal, not dead-end on
+    // "unexpected character".
+    let tools = sample_tool_registry();
+    let text = "edit({ action: \"replace_range\", path: \"a.zig\", content: // helper\n} })";
+    let result = parse_bare_calls_in_body(text, Some(&tools));
+    assert!(
+        result.calls.is_empty(),
+        "a raw-body call should not parse: {:?}",
+        result.calls
+    );
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "one parse error expected: {:?}",
+        result.errors
+    );
+    let err = &result.errors[0];
+    assert!(
+        err.contains("heredoc"),
+        "error must teach the heredoc recovery: {err}"
+    );
+    assert!(
+        err.contains("<<"),
+        "error must show the heredoc marker: {err}"
+    );
+}
+
+#[test]
 fn parses_gemma_fenced_tool_code_block() {
     // The full-response `unwrap_exact_code_wrapper` path handles Gemma's
     // other native form: ```tool_code\nrun({...})\n```

--- a/crates/harn-vm/src/llm/tools/ts_value_parser.rs
+++ b/crates/harn-vm/src/llm/tools/ts_value_parser.rs
@@ -136,8 +136,21 @@ impl<'a> TsValueParser<'a> {
             b'.' if self.bytes.get(self.pos + 1).is_some_and(u8::is_ascii_digit) => {
                 self.parse_number()
             }
+            // The dominant real-world cause of this error from weak value models
+            // is pasting a RAW multi-line body (a code block for `content` /
+            // `new_text` / `new_body` / `old_string`) directly after `key:`
+            // instead of quoting it or using a heredoc — the parser skips any
+            // leading `//` comment and then trips on the first brace/paren of the
+            // pasted code. The bare "unexpected character" message is a dead end:
+            // it never names the heredoc form the parser already supports (see
+            // `b'<' if ... => parse_heredoc` above), so a model loops re-emitting
+            // the same raw body. Name the recovery so the next turn can self-heal.
             other => Err(format!(
-                "unexpected character `{}` starting a value",
+                "unexpected character `{}` starting a value. For a multi-line body \
+                 (e.g. `content`/`new_text`/`new_body`/`old_string`), do not paste raw text — \
+                 wrap it in a heredoc: put `<key>: <<BODY` on the key line, then the body lines \
+                 verbatim, then `BODY` alone on its own closing line. For a short value, wrap it \
+                 in double quotes.",
                 other as char
             )),
         }


### PR DESCRIPTION
## Problem (first-hand from a cheap-model eval loop)

`TsValueParser`'s catch-all `unexpected character \`X\` starting a value` is the error a weak value model hits when it pastes a **raw multi-line body** (a code block for `content` / `new_text` / `new_body` / `old_string`) directly after `key:` instead of quoting it or using a heredoc. The parser skips any leading `//` comment, then trips on the first brace/paren of the pasted code.

The bare message was a **dead end** — it never named the heredoc form the parser already supports (`key: <<TAG … TAG`). Observed: a cheap model (gpt-oss-120b) burned **23 iterations** re-emitting the same raw body, never once using `<<`, and the eval cell false-read as "capability" when it was a tool-format loop.

## Fix

Name the recovery in the error: for a multi-line body, wrap it in a heredoc (`<key>: <<BODY`, body lines verbatim, `BODY` on its own closing line); for a short value, use double quotes. This is the single source of truth for value syntax, so every caller (top-level arg + nested array element) benefits from one edit.

Adds a test reproducing the raw-body case and asserting the error names the heredoc marker. `cargo test -p harn-vm --lib llm::tools` → 267 passed, 0 failed (no existing assertion regressed).

## Why it's the right shape
- **DRY:** one edit at the value-parser error site, not per-tool.
- **Generalizable:** names no cell/language; helps any model that pastes a raw multiline body.
- **Not overfit:** teaches a format-recovery, not an answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)