### PR TITLE
[codex] add native harnpack unpack/repack for release audit

### DIFF
--- a/changelog.d/escalation-fallback-route.fixed.md
+++ b/changelog.d/escalation-fallback-route.fixed.md
@@ -1,1 +1,3 @@
-Fixed escalated provider-error fallback so it restores the primary tool format with the primary provider/model instead of leaking the escalated route's tool-calling mode into the retry.
+Fixed escalated provider-error fallback so it restores the primary provider,
+model, and tool format instead of leaking the escalated route's tool-calling
+mode into the retry.

--- a/changelog.d/pack-unpack-repack.added.md
+++ b/changelog.d/pack-unpack-repack.added.md
@@ -1,0 +1,3 @@
+Added `harn pack unpack` and `harn pack repack` for native `.harnpack`
+inspection, mutation, and release-audit workflows without requiring host
+`tar` or `zstd` binaries.

--- a/conformance/tests/harn_pack/pack_verify_strict_sbom_mismatch.harn
+++ b/conformance/tests/harn_pack/pack_verify_strict_sbom_mismatch.harn
@@ -16,7 +16,8 @@ pipeline default() {
     path_join(root, "hello.harnpack"),
   )
   __io_println(pack.success)
-  let unpack = exec_at(root, "sh", "-lc", "mkdir unpack && zstd -d -c hello.harnpack | tar -xf - -C unpack")
+  let unpack_dir = path_join(root, "unpack")
+  let unpack = exec_at(root, harn_bin, "pack", "unpack", "hello.harnpack", "--out", unpack_dir)
   __io_println(unpack.success)
   let tamper = exec_at(
     root,
@@ -27,12 +28,7 @@ pipeline default() {
     path_join(root, "unpack/sbom.spdx.json"),
   )
   __io_println(tamper.success)
-  let repack = exec_at(
-    root,
-    "sh",
-    "-lc",
-    "cd unpack && tar -cf - harnpack.json sbom.spdx.json sources bytecode | zstd -f -o ../tampered.harnpack",
-  )
+  let repack = exec_at(root, harn_bin, "pack", "repack", unpack_dir, "--out", "tampered.harnpack")
   __io_println(repack.success)
   let lenient = exec_at(
     root,

--- a/crates/harn-cli/src/cli/mod.rs
+++ b/crates/harn-cli/src/cli/mod.rs
@@ -149,7 +149,7 @@ pub(crate) use orchestrator::{
     OrchestratorTenantCreateArgs, OrchestratorTenantDeleteArgs, OrchestratorTenantLsArgs,
     OrchestratorTenantSuspendArgs,
 };
-pub use pack::{PackArgs, PackCommand, PackVerifyArgs};
+pub use pack::{PackArgs, PackCommand, PackRepackArgs, PackUnpackArgs, PackVerifyArgs};
 pub(crate) use package::{
     AddArgs, InstallArgs, PackageArgs, PackageArtifactsCommand, PackageCacheCommand,
     PackageCommand, PackageScaffoldCommand, PackageScaffoldOpenapiArgs, PackageSearchArgs,

--- a/crates/harn-cli/src/cli/pack.rs
+++ b/crates/harn-cli/src/cli/pack.rs
@@ -77,11 +77,51 @@ pub struct PackArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum PackCommand {
+    /// Expand a `.harnpack` bundle into a directory containing
+    /// `harnpack.json` plus the archive payload entries. Intended for
+    /// audit/debug workflows and tests that need to inspect or mutate a
+    /// bundle without depending on host `tar`/`zstd` binaries.
+    Unpack(PackUnpackArgs),
+
+    /// Reassemble a directory produced by `harn pack unpack` back into
+    /// a `.harnpack` bundle.
+    Repack(PackRepackArgs),
+
     /// Verify a `.harnpack` bundle: check the embedded Ed25519
     /// signature (if present), recompute the canonical bundle hash,
     /// and compare each archive entry's BLAKE3 against the manifest's
     /// recorded hashes. Exits non-zero on any mismatch.
     Verify(PackVerifyArgs),
+}
+
+#[derive(Debug, Args)]
+#[command(arg_required_else_help = true)]
+pub struct PackUnpackArgs {
+    /// Path to the `.harnpack` archive to unpack.
+    pub bundle: PathBuf,
+
+    /// Output directory to create.
+    #[arg(long, value_name = "DIR")]
+    pub out: PathBuf,
+
+    /// Replace the output path if it already exists.
+    #[arg(long, default_value_t = false)]
+    pub force: bool,
+}
+
+#[derive(Debug, Args)]
+#[command(arg_required_else_help = true)]
+pub struct PackRepackArgs {
+    /// Directory containing `harnpack.json` and archive payload entries.
+    pub dir: PathBuf,
+
+    /// Output `.harnpack` path.
+    #[arg(long, value_name = "PATH")]
+    pub out: PathBuf,
+
+    /// Replace the output file if it already exists.
+    #[arg(long, default_value_t = false)]
+    pub force: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/harn-cli/src/cli/tests/parse_packaging.rs
+++ b/crates/harn-cli/src/cli/tests/parse_packaging.rs
@@ -242,6 +242,49 @@ fn test_parses_pack_verify_subcommand() {
 }
 
 #[test]
+fn test_parses_pack_unpack_and_repack_subcommands() {
+    use crate::cli::PackCommand;
+
+    let cli = Cli::parse_from([
+        "harn",
+        "pack",
+        "unpack",
+        "bundle.harnpack",
+        "--out",
+        "bundle-dir",
+        "--force",
+    ]);
+    let Command::Pack(args) = cli.command.unwrap() else {
+        panic!("expected pack command");
+    };
+    let Some(PackCommand::Unpack(unpack)) = args.command else {
+        panic!("expected pack unpack subcommand");
+    };
+    assert_eq!(unpack.bundle, PathBuf::from("bundle.harnpack"));
+    assert_eq!(unpack.out, PathBuf::from("bundle-dir"));
+    assert!(unpack.force);
+
+    let cli = Cli::parse_from([
+        "harn",
+        "pack",
+        "repack",
+        "bundle-dir",
+        "--out",
+        "bundle.harnpack",
+        "--force",
+    ]);
+    let Command::Pack(args) = cli.command.unwrap() else {
+        panic!("expected pack command");
+    };
+    let Some(PackCommand::Repack(repack)) = args.command else {
+        panic!("expected pack repack subcommand");
+    };
+    assert_eq!(repack.dir, PathBuf::from("bundle-dir"));
+    assert_eq!(repack.out, PathBuf::from("bundle.harnpack"));
+    assert!(repack.force);
+}
+
+#[test]
 fn test_parses_install_integrity_flags() {
     let cli = Cli::parse_from(["harn", "install", "--locked", "--offline"]);
 

--- a/crates/harn-cli/src/commands/pack.rs
+++ b/crates/harn-cli/src/commands/pack.rs
@@ -11,6 +11,8 @@
 //! signature (if any), and cross-checks every per-module BLAKE3.
 
 use std::collections::BTreeMap;
+use std::env;
+use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::process;
 
@@ -25,13 +27,13 @@ use harn_vm::orchestration::{
     ConnectorRequirement, Ed25519Signature, EnvironmentRequirements, HarnpackEntry, ModuleEntry,
     RetryPolicySpec, SBOMDoc, SBOMPackage, SBOMRelationship, ToolEntry, WorkflowBundle,
     WorkflowBundlePolicy, WorkflowBundleReplayMetadata, WorkflowBundleTrigger,
-    WORKFLOW_BUNDLE_SCHEMA_VERSION,
+    HARNPACK_MANIFEST_PATH, WORKFLOW_BUNDLE_SCHEMA_VERSION,
 };
 use harn_vm::Compiler;
 use harn_vm::{AutonomyTier, TrustRecord};
 use serde::{Deserialize, Serialize};
 
-use crate::cli::{PackArgs, PackCommand, PackVerifyArgs};
+use crate::cli::{PackArgs, PackCommand, PackRepackArgs, PackUnpackArgs, PackVerifyArgs};
 use crate::command_error;
 use crate::json_envelope::{to_string_pretty, JsonEnvelope, JsonOutput, JsonWarning};
 use crate::parse_source_file;
@@ -41,6 +43,7 @@ use crate::skill_provenance;
 /// [`PackJsonData`] changes shape in a way that agents need to detect.
 pub const PACK_SCHEMA_VERSION: u32 = 2;
 pub const PACK_SBOM_ARCHIVE_PATH: &str = "sbom.spdx.json";
+const DEFAULT_PACK_FILE_MODE: u32 = 0o644;
 
 /// JSON payload emitted under `JsonEnvelope.data` for `harn pack`.
 #[derive(Debug, Clone, Serialize)]
@@ -100,6 +103,8 @@ impl JsonOutput for PackJsonOutput {
 pub fn run(args: PackArgs) {
     if let Some(command) = args.command {
         match command {
+            PackCommand::Unpack(unpack_args) => return run_unpack(unpack_args),
+            PackCommand::Repack(repack_args) => return run_repack(repack_args),
             PackCommand::Verify(verify_args) => return run_verify(verify_args),
         }
     }
@@ -285,6 +290,435 @@ impl PackError {
             message: message.into(),
         }
     }
+}
+
+#[derive(Debug)]
+pub struct PackUnpackOutcome {
+    pub output_dir: PathBuf,
+    pub content_entry_count: usize,
+}
+
+#[derive(Debug)]
+pub struct PackRepackOutcome {
+    pub output_path: PathBuf,
+    pub size_bytes: u64,
+    pub content_entry_count: usize,
+}
+
+pub fn run_unpack(args: PackUnpackArgs) {
+    match unpack(&args) {
+        Ok(outcome) => {
+            println!(
+                "unpacked {} to {} ({} payload entries)",
+                args.bundle.display(),
+                outcome.output_dir.display(),
+                outcome.content_entry_count
+            );
+        }
+        Err(err) => command_error(&err.message),
+    }
+}
+
+pub fn run_repack(args: PackRepackArgs) {
+    match repack(&args) {
+        Ok(outcome) => {
+            println!(
+                "repacked {} to {} ({} payload entries, {} bytes)",
+                args.dir.display(),
+                outcome.output_path.display(),
+                outcome.content_entry_count,
+                outcome.size_bytes
+            );
+        }
+        Err(err) => command_error(&err.message),
+    }
+}
+
+pub fn unpack(args: &PackUnpackArgs) -> Result<PackUnpackOutcome, PackError> {
+    let bytes = fs::read(&args.bundle).map_err(|err| {
+        PackError::new(
+            "unpack.read_failed",
+            format!("failed to read {}: {err}", args.bundle.display()),
+        )
+    })?;
+    let archive = read_harnpack(&bytes).map_err(|err| {
+        PackError::new(
+            "unpack.archive_failed",
+            format!("failed to parse {}: {err}", args.bundle.display()),
+        )
+    })?;
+    prepare_unpack_dir(&args.out, args.force)?;
+
+    let manifest_bytes = serde_json::to_vec_pretty(&archive.manifest).map_err(|err| {
+        PackError::new(
+            "unpack.manifest_failed",
+            format!("failed to encode {HARNPACK_MANIFEST_PATH}: {err}"),
+        )
+    })?;
+    write_unpack_file(
+        &args.out,
+        Path::new(HARNPACK_MANIFEST_PATH),
+        &manifest_bytes,
+        DEFAULT_PACK_FILE_MODE,
+    )?;
+    for entry in &archive.contents {
+        write_unpack_file(&args.out, &entry.path, &entry.bytes, entry.mode)?;
+    }
+
+    Ok(PackUnpackOutcome {
+        output_dir: args.out.clone(),
+        content_entry_count: archive.contents.len(),
+    })
+}
+
+pub fn repack(args: &PackRepackArgs) -> Result<PackRepackOutcome, PackError> {
+    if !args.dir.is_dir() {
+        return Err(PackError::new(
+            "repack.input_not_directory",
+            format!("input is not a directory: {}", args.dir.display()),
+        ));
+    }
+    reject_repack_output_inside_input(&args.dir, &args.out)?;
+    if args.out.exists() && !args.force {
+        return Err(PackError::new(
+            "repack.output_exists",
+            format!(
+                "output path already exists: {} (re-run with --force to replace it)",
+                args.out.display()
+            ),
+        ));
+    }
+    if args.out.is_dir() {
+        return Err(PackError::new(
+            "repack.output_is_directory",
+            format!("output path is a directory: {}", args.out.display()),
+        ));
+    }
+
+    let manifest_path = args.dir.join(HARNPACK_MANIFEST_PATH);
+    let manifest = load_workflow_bundle_any_version(&manifest_path).map_err(|err| {
+        PackError::new(
+            "repack.manifest_failed",
+            format!("failed to read {}: {err}", manifest_path.display()),
+        )
+    })?;
+    let contents = collect_repack_entries(&args.dir)?;
+    let archive_bytes = build_harnpack(&manifest, &contents).map_err(|err| {
+        PackError::new(
+            "repack.archive_failed",
+            format!("failed to assemble {}: {err}", args.out.display()),
+        )
+    })?;
+    if let Some(parent) = args
+        .out
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).map_err(|err| {
+            PackError::new(
+                "repack.write_failed",
+                format!("failed to create {}: {err}", parent.display()),
+            )
+        })?;
+    }
+    fs::write(&args.out, &archive_bytes).map_err(|err| {
+        PackError::new(
+            "repack.write_failed",
+            format!("failed to write {}: {err}", args.out.display()),
+        )
+    })?;
+
+    Ok(PackRepackOutcome {
+        output_path: args.out.clone(),
+        size_bytes: archive_bytes.len() as u64,
+        content_entry_count: contents.len(),
+    })
+}
+
+fn prepare_unpack_dir(out: &Path, force: bool) -> Result<(), PackError> {
+    if out.exists() {
+        if !force {
+            return Err(PackError::new(
+                "unpack.output_exists",
+                format!(
+                    "output path already exists: {} (re-run with --force to replace it)",
+                    out.display()
+                ),
+            ));
+        }
+        let metadata = fs::symlink_metadata(out).map_err(|err| {
+            PackError::new(
+                "unpack.read_failed",
+                format!("failed to stat {}: {err}", out.display()),
+            )
+        })?;
+        if metadata.file_type().is_symlink() {
+            return Err(PackError::new(
+                "unpack.output_symlink",
+                format!("refusing to replace symlink {}", out.display()),
+            ));
+        }
+        if metadata.is_dir() {
+            require_prior_unpack_dir(out)?;
+            fs::remove_dir_all(out).map_err(|err| {
+                PackError::new(
+                    "unpack.remove_failed",
+                    format!("failed to remove {}: {err}", out.display()),
+                )
+            })?;
+        } else if metadata.is_file() {
+            fs::remove_file(out).map_err(|err| {
+                PackError::new(
+                    "unpack.remove_failed",
+                    format!("failed to remove {}: {err}", out.display()),
+                )
+            })?;
+        } else {
+            return Err(PackError::new(
+                "unpack.output_unsupported",
+                format!("refusing to replace non-file output path {}", out.display()),
+            ));
+        }
+    }
+    fs::create_dir_all(out).map_err(|err| {
+        PackError::new(
+            "unpack.write_failed",
+            format!("failed to create {}: {err}", out.display()),
+        )
+    })
+}
+
+fn require_prior_unpack_dir(out: &Path) -> Result<(), PackError> {
+    if is_current_dir(out) {
+        return Err(PackError::new(
+            "unpack.output_unsafe",
+            format!("refusing to replace current directory {}", out.display()),
+        ));
+    }
+    let manifest = out.join(HARNPACK_MANIFEST_PATH);
+    if manifest.is_file() {
+        return Ok(());
+    }
+    Err(PackError::new(
+        "unpack.output_not_harnpack_dir",
+        format!(
+            "refusing to remove {} because it does not contain {}; choose a fresh --out dir or remove it manually",
+            out.display(),
+            HARNPACK_MANIFEST_PATH
+        ),
+    ))
+}
+
+fn is_current_dir(path: &Path) -> bool {
+    let Ok(path) = path.canonicalize() else {
+        return false;
+    };
+    let Ok(cwd) = env::current_dir().and_then(|cwd| cwd.canonicalize()) else {
+        return false;
+    };
+    path == cwd
+}
+
+fn write_unpack_file(
+    root: &Path,
+    archive_path: &Path,
+    bytes: &[u8],
+    mode: u32,
+) -> Result<(), PackError> {
+    let safe_path = normalize_safe_archive_path(archive_path)?;
+    let destination = root.join(&safe_path);
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            PackError::new(
+                "unpack.write_failed",
+                format!("failed to create {}: {err}", parent.display()),
+            )
+        })?;
+    }
+    fs::write(&destination, bytes).map_err(|err| {
+        PackError::new(
+            "unpack.write_failed",
+            format!("failed to write {}: {err}", destination.display()),
+        )
+    })?;
+    set_file_mode(&destination, mode)?;
+    Ok(())
+}
+
+fn collect_repack_entries(root: &Path) -> Result<Vec<HarnpackEntry>, PackError> {
+    let mut entries = Vec::new();
+    collect_repack_entries_inner(root, root, &mut entries)?;
+    entries.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(entries)
+}
+
+fn reject_repack_output_inside_input(input_dir: &Path, out: &Path) -> Result<(), PackError> {
+    let input = input_dir.canonicalize().map_err(|err| {
+        PackError::new(
+            "repack.read_failed",
+            format!("failed to canonicalize {}: {err}", input_dir.display()),
+        )
+    })?;
+    let out_parent = out
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let out_file_name = out.file_name().ok_or_else(|| {
+        PackError::new(
+            "repack.output_invalid",
+            format!("output path must include a file name: {}", out.display()),
+        )
+    })?;
+    let out_parent = out_parent.canonicalize().unwrap_or_else(|_| {
+        if out_parent.is_absolute() {
+            out_parent.to_path_buf()
+        } else {
+            env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(out_parent)
+        }
+    });
+    let output = out_parent.join(out_file_name);
+    if output.starts_with(&input) {
+        return Err(PackError::new(
+            "repack.output_inside_input",
+            format!(
+                "refusing to write {} inside input directory {}; choose an output path outside the unpacked tree",
+                out.display(),
+                input_dir.display()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn collect_repack_entries_inner(
+    root: &Path,
+    current: &Path,
+    entries: &mut Vec<HarnpackEntry>,
+) -> Result<(), PackError> {
+    let mut children = fs::read_dir(current)
+        .map_err(|err| {
+            PackError::new(
+                "repack.read_failed",
+                format!("failed to read {}: {err}", current.display()),
+            )
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|err| {
+            PackError::new(
+                "repack.read_failed",
+                format!("failed to read {}: {err}", current.display()),
+            )
+        })?;
+    children.sort_by_key(|entry| entry.path());
+
+    for child in children {
+        let path = child.path();
+        let metadata = fs::symlink_metadata(&path).map_err(|err| {
+            PackError::new(
+                "repack.read_failed",
+                format!("failed to stat {}: {err}", path.display()),
+            )
+        })?;
+        if metadata.file_type().is_symlink() {
+            return Err(PackError::new(
+                "repack.unsupported_entry",
+                format!("refusing to pack symlink {}", path.display()),
+            ));
+        }
+        if metadata.is_dir() {
+            collect_repack_entries_inner(root, &path, entries)?;
+            continue;
+        }
+        if !metadata.is_file() {
+            return Err(PackError::new(
+                "repack.unsupported_entry",
+                format!("refusing to pack non-file entry {}", path.display()),
+            ));
+        }
+
+        let rel = path.strip_prefix(root).map_err(|err| {
+            PackError::new(
+                "repack.path_failed",
+                format!(
+                    "failed to relativize {} against {}: {err}",
+                    path.display(),
+                    root.display()
+                ),
+            )
+        })?;
+        let archive_path = normalize_safe_archive_path(rel)?;
+        if archive_path == Path::new(HARNPACK_MANIFEST_PATH) {
+            continue;
+        }
+        let bytes = fs::read(&path).map_err(|err| {
+            PackError::new(
+                "repack.read_failed",
+                format!("failed to read {}: {err}", path.display()),
+            )
+        })?;
+        entries.push(HarnpackEntry::new(archive_path, bytes).with_mode(file_mode(&metadata)));
+    }
+    Ok(())
+}
+
+fn normalize_safe_archive_path(path: &Path) -> Result<PathBuf, PackError> {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => normalized.push(part),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(PackError::new(
+                    "pack.unsafe_archive_path",
+                    format!("archive path may not contain '..': {}", path.display()),
+                ));
+            }
+            Component::Prefix(_) | Component::RootDir => {
+                return Err(PackError::new(
+                    "pack.unsafe_archive_path",
+                    format!("archive path must be relative: {}", path.display()),
+                ));
+            }
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        return Err(PackError::new(
+            "pack.unsafe_archive_path",
+            "archive path may not be empty",
+        ));
+    }
+    Ok(normalized)
+}
+
+#[cfg(unix)]
+fn file_mode(metadata: &fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+
+    metadata.permissions().mode() & 0o7777
+}
+
+#[cfg(not(unix))]
+fn file_mode(_metadata: &fs::Metadata) -> u32 {
+    DEFAULT_PACK_FILE_MODE
+}
+
+#[cfg(unix)]
+fn set_file_mode(path: &Path, mode: u32) -> Result<(), PackError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(mode)).map_err(|err| {
+        PackError::new(
+            "unpack.write_failed",
+            format!("failed to set permissions on {}: {err}", path.display()),
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn set_file_mode(_path: &Path, _mode: u32) -> Result<(), PackError> {
+    Ok(())
 }
 
 pub fn build(args: &BuildArgs) -> Result<PackOutcome, PackError> {

--- a/crates/harn-cli/tests/pack_cli.rs
+++ b/crates/harn-cli/tests/pack_cli.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 
 use ed25519_dalek::pkcs8::{spki::der::pem::LineEnding, DecodePrivateKey, EncodePublicKey};
 use ed25519_dalek::SigningKey;
-use harn_cli::cli::{PackArgs, PackVerifyArgs};
+use harn_cli::cli::{PackArgs, PackRepackArgs, PackUnpackArgs, PackVerifyArgs};
 use harn_cli::commands::pack;
 use harn_cli::commands::pack::BuildArgs;
 use harn_cli::tests::common::cwd_lock;
@@ -521,6 +521,118 @@ fn pack_verify_signed_bundle_passes_and_reports_signature_key() {
     );
     assert_eq!(report.module_count, 1);
     assert!(report.content_entry_count >= 3, "{report:?}");
+}
+
+#[test]
+fn pack_unpack_and_repack_round_trip_without_host_archive_tools() {
+    let workdir = TempDir::new().unwrap();
+    let entry = workdir.path().join("hello.harn");
+    fs::write(&entry, "__io_println(\"hi\")\n").unwrap();
+    let out = workdir.path().join("hello.harnpack");
+    build_pack(&pack_args(entry, out.clone()));
+
+    let unpack_dir = workdir.path().join("unpacked");
+    let unpacked = pack::unpack(&PackUnpackArgs {
+        bundle: out.clone(),
+        out: unpack_dir.clone(),
+        force: false,
+    })
+    .expect("unpack succeeds");
+    assert_eq!(unpacked.output_dir, unpack_dir);
+    assert!(unpacked.content_entry_count >= 3, "{unpacked:?}");
+    assert!(unpack_dir.join("harnpack.json").exists());
+    assert!(unpack_dir.join("sources/hello.harn").exists());
+    assert!(unpack_dir.join("bytecode/hello.harnbc").exists());
+
+    let repacked = workdir.path().join("repacked.harnpack");
+    let repacked_outcome = pack::repack(&PackRepackArgs {
+        dir: unpack_dir,
+        out: repacked.clone(),
+        force: false,
+    })
+    .expect("repack succeeds");
+    assert_eq!(repacked_outcome.output_path, repacked);
+    assert_eq!(
+        repacked_outcome.content_entry_count,
+        unpacked.content_entry_count
+    );
+    pack::verify(&PackVerifyArgs {
+        bundle: repacked.clone(),
+        allow_unsigned: true,
+        trust_policy: None,
+        require_trusted_signer: false,
+        strict: true,
+        json: false,
+    })
+    .expect("repacked bundle verifies");
+
+    let original = read_harnpack(&fs::read(&out).unwrap()).unwrap();
+    let round_trip = read_harnpack(&fs::read(&repacked).unwrap()).unwrap();
+    assert_eq!(round_trip.manifest, original.manifest);
+    assert_eq!(round_trip.contents, original.contents);
+}
+
+#[test]
+fn pack_unpack_force_only_replaces_prior_unpack_dir() {
+    let workdir = TempDir::new().unwrap();
+    let entry = workdir.path().join("hello.harn");
+    fs::write(&entry, "__io_println(\"hi\")\n").unwrap();
+    let bundle = workdir.path().join("hello.harnpack");
+    build_pack(&pack_args(entry, bundle.clone()));
+
+    let unrelated = workdir.path().join("unrelated");
+    fs::create_dir(&unrelated).unwrap();
+    fs::write(unrelated.join("notes.txt"), "do not delete\n").unwrap();
+    let err = pack::unpack(&PackUnpackArgs {
+        bundle: bundle.clone(),
+        out: unrelated.clone(),
+        force: true,
+    })
+    .expect_err("force must not remove an arbitrary directory");
+    assert_eq!(err.code, "unpack.output_not_harnpack_dir");
+    assert!(unrelated.join("notes.txt").exists());
+
+    let unpack_dir = workdir.path().join("unpacked");
+    pack::unpack(&PackUnpackArgs {
+        bundle,
+        out: unpack_dir.clone(),
+        force: false,
+    })
+    .expect("initial unpack succeeds");
+    fs::write(unpack_dir.join("stale.txt"), "old payload\n").unwrap();
+    pack::unpack(&PackUnpackArgs {
+        bundle: workdir.path().join("hello.harnpack"),
+        out: unpack_dir.clone(),
+        force: true,
+    })
+    .expect("force replaces a prior unpack directory");
+    assert!(!unpack_dir.join("stale.txt").exists());
+    assert!(unpack_dir.join("harnpack.json").exists());
+}
+
+#[test]
+fn pack_repack_refuses_output_inside_input_dir() {
+    let workdir = TempDir::new().unwrap();
+    let entry = workdir.path().join("hello.harn");
+    fs::write(&entry, "__io_println(\"hi\")\n").unwrap();
+    let bundle = workdir.path().join("hello.harnpack");
+    build_pack(&pack_args(entry, bundle.clone()));
+
+    let unpack_dir = workdir.path().join("unpacked");
+    pack::unpack(&PackUnpackArgs {
+        bundle,
+        out: unpack_dir.clone(),
+        force: false,
+    })
+    .expect("unpack succeeds");
+
+    let err = pack::repack(&PackRepackArgs {
+        dir: unpack_dir.clone(),
+        out: unpack_dir.join("nested.harnpack"),
+        force: false,
+    })
+    .expect_err("repack output inside input should be rejected");
+    assert_eq!(err.code, "repack.output_inside_input");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add native `harn pack unpack` and `harn pack repack` commands for archive inspection/mutation without host `tar`/`zstd`
- move the strict SBOM mismatch conformance fixture onto those commands
- harden `--force`/output handling so unpack/repack cannot delete arbitrary directories or pack its own output
- wrap the escalation fallback changelog fragment for markdownlint

## Validation
- pre-commit hook passed, including Rust formatting and clippy for `harn-cli`
- targeted conformance fixture was validated on tornadough before the safety amend
- hosted CI is the final build/test gate for the amended head