### PR TITLE
[codex] fix A2A progress sink lifetime

### DIFF
--- a/changelog.d/a2a-progress-stream.fixed.md
+++ b/changelog.d/a2a-progress-stream.fixed.md
@@ -1,0 +1,2 @@
+A2A streaming tasks keep progress-event sinks registered until terminal task publication,
+preventing final progress updates from being dropped at dispatch shutdown.

--- a/crates/harn-serve/src/adapters/a2a/tasks.rs
+++ b/crates/harn-serve/src/adapters/a2a/tasks.rs
@@ -108,6 +108,7 @@ impl A2aServer {
             tasks: self.tasks.clone(),
         });
         harn_vm::agent_events::register_sink(session_id.clone(), sink);
+        let _sink_registration = AgentEventSinkRegistration::new(session_id.clone());
 
         let result = self
             .executor
@@ -132,10 +133,6 @@ impl A2aServer {
                 auth_principal: None,
             })
             .await;
-
-        // Drop the sink so a re-used task id can't deliver to the old
-        // task's event stream.
-        harn_vm::agent_events::clear_session_sinks(&session_id);
 
         if self.is_cancelled(&task.id) {
             return;
@@ -541,5 +538,24 @@ impl A2aServer {
                 }
             }
         });
+    }
+}
+
+struct AgentEventSinkRegistration {
+    session_id: String,
+}
+
+impl AgentEventSinkRegistration {
+    fn new(session_id: String) -> Self {
+        Self { session_id }
+    }
+}
+
+impl Drop for AgentEventSinkRegistration {
+    fn drop(&mut self) {
+        // Keep the sink registered until the terminal task transition has
+        // been published. Progress events can otherwise be lost as the VM
+        // dispatch result crosses back to the transport runtime.
+        harn_vm::agent_events::clear_session_sinks(&self.session_id);
     }
 }

--- a/crates/harn-serve/src/adapters/a2a/tests/tasks.rs
+++ b/crates/harn-serve/src/adapters/a2a/tests/tasks.rs
@@ -1,5 +1,42 @@
 use super::protocol::server_with_api_key_policy;
 use super::*;
+
+async fn collect_task_stream_until_terminal(
+    mut rx: UnboundedReceiver<JsonValue>,
+) -> Vec<JsonValue> {
+    let mut events = Vec::new();
+    loop {
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), rx.next())
+            .await
+            .unwrap_or_else(|_| {
+                panic!(
+                    "timed out waiting for stream event: {}",
+                    events_json(&events)
+                )
+            });
+        let Some(event) = event else {
+            break;
+        };
+        let terminal = event
+            .pointer("/result/status/state")
+            .and_then(JsonValue::as_str)
+            .is_some_and(is_terminal_status);
+        events.push(event);
+        if terminal {
+            break;
+        }
+    }
+    events
+}
+
+fn is_terminal_status(status: &str) -> bool {
+    matches!(status, "completed" | "failed" | "cancelled" | "rejected")
+}
+
+fn events_json(events: &[JsonValue]) -> String {
+    serde_json::to_string_pretty(events).unwrap_or_else(|_| "<unprintable events>".to_string())
+}
+
 #[tokio::test]
 async fn send_message_dispatches_to_shared_core_export() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -349,23 +386,10 @@ pub fn triage(task: string) -> string {
         .clone()
         .process_rpc(request, AuthRequest::default())
         .await;
-    let RpcOutcome::Sse(mut rx) = processed.outcome else {
+    let RpcOutcome::Sse(rx) = processed.outcome else {
         panic!("expected sse response");
     };
-    let mut events = Vec::new();
-    while let Some(event) = tokio::time::timeout(std::time::Duration::from_secs(2), rx.next())
-        .await
-        .expect("stream event")
-    {
-        let done = event
-            .pointer("/result/status/state")
-            .and_then(JsonValue::as_str)
-            == Some("completed");
-        events.push(event);
-        if done {
-            break;
-        }
-    }
+    let events = collect_task_stream_until_terminal(rx).await;
 
     let task_id = events[0]["result"]["taskId"].as_str().expect("task id");
     assert!(events.iter().any(|event| {
@@ -434,30 +458,32 @@ pub fn triage(task: string) -> string {
     );
 
     let processed = server.process_rpc(request, AuthRequest::default()).await;
-    let RpcOutcome::Sse(mut rx) = processed.outcome else {
+    let RpcOutcome::Sse(rx) = processed.outcome else {
         panic!("expected sse response");
     };
-    let mut events = Vec::new();
-    while let Some(event) = tokio::time::timeout(std::time::Duration::from_secs(2), rx.next())
-        .await
-        .expect("stream event")
-    {
-        let done = event
-            .pointer("/result/status/state")
-            .and_then(JsonValue::as_str)
-            == Some("completed");
-        events.push(event);
-        if done {
-            break;
-        }
-    }
+    let events = collect_task_stream_until_terminal(rx).await;
 
-    let progress = events
+    let progress_index = events
         .iter()
-        .find(|event| {
+        .position(|event| {
             event.pointer("/result/kind").and_then(JsonValue::as_str) == Some("status-update")
         })
-        .expect("progress status update");
+        .unwrap_or_else(|| panic!("progress status update missing: {}", events_json(&events)));
+    let completed_index = events
+        .iter()
+        .position(|event| {
+            event
+                .pointer("/result/status/state")
+                .and_then(JsonValue::as_str)
+                == Some("completed")
+        })
+        .unwrap_or_else(|| panic!("completion status update missing: {}", events_json(&events)));
+    assert!(
+        progress_index < completed_index,
+        "progress must stream before completion: {}",
+        events_json(&events)
+    );
+    let progress = &events[progress_index];
     assert_eq!(
         progress.pointer("/result/type").and_then(JsonValue::as_str),
         Some("status")
@@ -482,12 +508,6 @@ pub fn triage(task: string) -> string {
             "Agent is checking progress.\n\nPlan:\n- [x] Inspect code. (priority: high)\n- [ ] Run A2A stream. (in progress)"
         )
     );
-    assert!(events.iter().any(|event| {
-        event
-            .pointer("/result/status/state")
-            .and_then(JsonValue::as_str)
-            == Some("completed")
-    }));
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- Keeps the A2A per-task agent-event sink registered until `run_task_to_completion` exits instead of clearing it immediately after VM dispatch returns.
- Strengthens the A2A streaming progress regression test to collect until terminal status, assert progress-before-completion ordering, and print the full event stream on failures.
- Adds a changelog fragment for the A2A streaming reliability fix.

## Why

The v0.8.165 release audit hit a rare `streaming_agent_progress_emits_status_update_before_completion` failure. Exact and full-suite reruns on tornadough passed, pointing at a shutdown-window flake rather than a deterministic schema failure. The old lifecycle cleared the progress sink before terminal task publication, leaving a narrow gap where late VM/runtime progress delivery could be dropped.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/private/tmp/harn-target-a2a-codex HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-serve --lib adapters::a2a::tests::tasks::streaming_agent_progress_emits_status_update_before_completion -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/harn-target-a2a-codex HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-serve --lib adapters::a2a::tests -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/harn-target-a2a-codex HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-serve --lib -- --nocapture`
- pre-commit hook including markdown, Rust fmt, Rust prompt-prose self-test/check, and changed-package clippy
- pre-push targeted local checks
