### PR TITLE
[codex] Fix session event sinks across worker threads

### DIFF
--- a/changelog.d/agent-event-cross-thread-sinks.fixed.md
+++ b/changelog.d/agent-event-cross-thread-sinks.fixed.md
@@ -1,0 +1,3 @@
+Session-scoped agent event sinks now deliver across worker threads in test builds,
+matching production registry semantics and stabilizing A2A progress streaming
+coverage under full-suite execution.

--- a/crates/harn-vm/src/agent_events/registry.rs
+++ b/crates/harn-vm/src/agent_events/registry.rs
@@ -37,14 +37,10 @@ pub fn register_sink(session_id: impl Into<String>, sink: Arc<dyn AgentEventSink
 pub fn clear_session_sinks(session_id: &str) {
     #[cfg(test)]
     {
-        let owner = std::thread::current().id();
-        let mut reg = external_sinks().write().expect("sink registry poisoned");
-        if let Some(sinks) = reg.get_mut(session_id) {
-            sinks.retain(|sink| sink.owner != owner);
-            if sinks.is_empty() {
-                reg.remove(session_id);
-            }
-        }
+        external_sinks()
+            .write()
+            .expect("sink registry poisoned")
+            .remove(session_id);
     }
     #[cfg(not(test))]
     {
@@ -136,15 +132,8 @@ pub fn emit_event(event: &AgentEvent) {
         let reg = external_sinks().read().expect("sink registry poisoned");
         #[cfg(test)]
         {
-            let owner = std::thread::current().id();
             reg.get(event.session_id())
-                .map(|sinks| {
-                    sinks
-                        .iter()
-                        .filter(|sink| sink.owner == owner)
-                        .map(|sink| sink.sink.clone())
-                        .collect()
-                })
+                .map(|sinks| sinks.iter().map(|sink| sink.sink.clone()).collect())
                 .unwrap_or_default()
         }
         #[cfg(not(test))]
@@ -260,12 +249,11 @@ pub fn reset_wildcard_sinks() {
 pub fn session_external_sink_count(session_id: &str) -> usize {
     #[cfg(test)]
     {
-        let owner = std::thread::current().id();
         return external_sinks()
             .read()
             .expect("sink registry poisoned")
             .get(session_id)
-            .map(|sinks| sinks.iter().filter(|sink| sink.owner == owner).count())
+            .map(Vec::len)
             .unwrap_or(0);
     }
     #[cfg(not(test))]

--- a/crates/harn-vm/src/agent_events/tests.rs
+++ b/crates/harn-vm/src/agent_events/tests.rs
@@ -59,6 +59,30 @@ fn session_scoped_sink_routing() {
 }
 
 #[test]
+fn session_scoped_sink_routing_crosses_worker_threads() {
+    reset_all_sinks();
+    let delivered = Arc::new(AtomicUsize::new(0));
+    let session_id = format!("session-cross-thread-{}", uuid::Uuid::now_v7());
+    register_sink(&session_id, Arc::new(CountingSink(delivered.clone())));
+
+    let emit_session_id = session_id.clone();
+    std::thread::spawn(move || {
+        emit_event(&AgentEvent::IterationStart {
+            session_id: emit_session_id,
+            iteration: 0,
+            provider: String::new(),
+            model: String::new(),
+        });
+    })
+    .join()
+    .expect("worker thread");
+
+    assert_eq!(delivered.load(Ordering::SeqCst), 1);
+    clear_session_sinks(&session_id);
+    assert_eq!(session_external_sink_count(&session_id), 0);
+}
+
+#[test]
 fn newly_opened_child_session_inherits_current_external_sinks() {
     reset_all_sinks();
     let delivered = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
## Summary
- make test-build session-scoped AgentEventSink delivery match production session-id semantics across worker threads
- keep wildcard sink owner filtering intact for process-wide test isolation
- add a cross-thread session sink regression covering the release-audit A2A progress path

## Validation
- CARGO_TARGET_DIR=/private/tmp/harn-target-agent-sinks cargo fmt --all -- --check
- git diff --check
- CARGO_TARGET_DIR=/private/tmp/harn-target-agent-sinks HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-vm --lib agent_events::tests::session_scoped_sink_routing_crosses_worker_threads -- --nocapture
- CARGO_TARGET_DIR=/private/tmp/harn-target-agent-sinks HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-vm --lib agent_events::tests -- --nocapture
- CARGO_TARGET_DIR=/private/tmp/harn-target-agent-sinks HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-serve --lib adapters::a2a::tests::tasks::streaming_agent_progress_emits_status_update_before_completion -- --nocapture
- CARGO_TARGET_DIR=/private/tmp/harn-target-agent-sinks HARN_LLM_CALLS_DISABLED=1 cargo test -p harn-serve --lib -- --nocapture