### PR TITLE
Normalize canonical run argv tool calls

### DIFF
--- a/changelog.d/canonical-run-command-array.fixed.md
+++ b/changelog.d/canonical-run-command-array.fixed.md
@@ -1,0 +1,2 @@
+Canonical native `run` tool calls now normalize `command`/`cmd` argv arrays into
+Harn command strings, matching the existing `container.exec` alias recovery path.

--- a/crates/harn-vm/src/llm/api/response.rs
+++ b/crates/harn-vm/src/llm/api/response.rs
@@ -1796,6 +1796,41 @@ mod tests {
     }
 
     #[test]
+    fn openai_parser_normalizes_canonical_run_argv_command() {
+        let response = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_run_argv",
+                            "type": "function",
+                            "function": {
+                                "name": "run",
+                                "arguments": "{\"command\":[\"bash\",\"lc\",\"ls -R\"]}"
+                            }
+                        }
+                    ]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 20}
+        });
+
+        let result = parse_llm_response(
+            &response,
+            "fireworks",
+            "accounts/fireworks/models/gpt-oss-120b",
+            false,
+            false,
+        )
+        .expect("parser succeeds");
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0]["name"], "run");
+        assert_eq!(result.tool_calls[0]["arguments"]["command"], "ls -R");
+    }
+
+    #[test]
     fn openai_parser_records_tool_search_call_as_query_event() {
         // OpenAI's Responses API (harn#71) surfaces the server-hosted
         // tool_search as a `tool_search_call` entry in the `tool_calls`

--- a/crates/harn-vm/src/llm/tools/compat.rs
+++ b/crates/harn-vm/src/llm/tools/compat.rs
@@ -108,6 +108,13 @@ fn resolve_semantic_alias(
     name: String,
     arguments: serde_json::Value,
 ) -> (String, serde_json::Value) {
+    // Canonical `run` calls can still arrive with Codex/OpenAI-style argv
+    // payloads (`{"command":["bash","lc","..."]}`) from native providers.
+    // Normalize those arguments even when no alias rewrite is needed.
+    if name == "run" {
+        return (name, remap_command_args(arguments));
+    }
+
     // 1. Browser-namespace aliases (Codex / Aider-style file-explorer vocab).
     //    Strip a known `*_browser.` prefix, then map the verb to look/search.
     if let Some((canonical, mapped_args)) = resolve_browser_alias(&name, &arguments) {
@@ -570,6 +577,38 @@ mod tests {
         );
         assert_eq!(name, "run");
         assert_eq!(mapped["command"], "git commit -m 'fix tool calls'");
+    }
+
+    #[test]
+    fn normalizes_canonical_run_argv_command_string() {
+        let (name, mapped) = normalize_tool_call_shape(
+            "run",
+            serde_json::json!({"command": ["bash", "lc", "ls -R"]}),
+        );
+        assert_eq!(name, "run");
+        assert_eq!(mapped["command"], "ls -R");
+    }
+
+    #[test]
+    fn normalizes_canonical_run_cmd_alias() {
+        let (name, mapped) = normalize_tool_call_shape(
+            "run",
+            serde_json::json!({"cmd": ["bash", "-lc", "swift test"], "timeout_ms": 1000}),
+        );
+        assert_eq!(name, "run");
+        assert_eq!(mapped["command"], "swift test");
+        assert_eq!(mapped["timeout_ms"], 1000);
+        assert!(mapped.get("cmd").is_none());
+    }
+
+    #[test]
+    fn normalizes_namespaced_run_argv_command_string() {
+        let (name, mapped) = normalize_tool_call_shape(
+            "functions.run",
+            serde_json::json!({"command": ["git", "status", "--short"]}),
+        );
+        assert_eq!(name, "run");
+        assert_eq!(mapped["command"], "git status --short");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- normalize canonical native `run` tool calls that arrive with Codex/OpenAI argv payloads such as `{"command":["bash","lc","ls -R"]}`
- reuse the existing `remap_command_args` recovery path already used for shell aliases like `container.exec`
- add an OpenAI parser regression for Fireworks/gpt-oss-style native tool calls so provider-boundary parsing returns a dispatchable `run({ command: ... })`

## Root Cause

A swift-feat holdout artifact showed fw-gpt-oss emitting native canonical `run` calls with `command` as an argv array. Harn already normalized argv arrays when the tool name was a shell alias (`container.exec`, `exec`, etc.), but a canonical `run` skipped that argument cleanup, failed validation, and burned turns without giving the model a useful execution/edit loop.

## Validation

- `cargo fmt -p harn-vm`
- `CARGO_TARGET_DIR=/private/tmp/harn-target-run-command-argv-normalization cargo test -p harn-vm normalizes_canonical_run -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/harn-target-run-command-argv-normalization cargo test -p harn-vm normalizes_namespaced_run -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/harn-target-run-command-argv-normalization cargo test -p harn-vm aliases_container_exec -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/harn-target-run-command-argv-normalization cargo test -p harn-vm openai_parser_normalizes_canonical_run_argv_command -- --nocapture`
- `CARGO_TARGET_DIR=/private/tmp/harn-target-run-command-argv-normalization cargo test -p harn-vm openai_parser_ -- --nocapture`
- `git diff --check`
- Harn pre-commit ratchets: markdown, Rust formatting, changed-package clippy
- Harn pre-push targeted checks: markdown and `cargo check -p harn-vm --tests`

Meter note: this is a mechanism fix from first-hand swift-feat artifacts, not a PASS claim. It still needs Harn release, Burin repin, fetch-harn, and N>=5 meter validation before crediting a cell flip.
